### PR TITLE
Run one default-limit Queue proof

### DIFF
--- a/workers/proof/README.md
+++ b/workers/proof/README.md
@@ -4,18 +4,21 @@ This is a non-production proof harness for exactly one faction-sheet PDF. Convex
 durable control plane. The Queue carries only a wake-up signal:
 
 ```text
-annual inert Cron (temporarily armed for one observation window)
-  -> stateless Convex empty/eligible poll
+annual inert Cron (not exercised)
+authenticated manual enqueue
   -> one minimal Queue message
   -> independent Queue consumer invocation
+  -> conditional fixed-key R2 claim
   -> before checkpoint -> one Browser Session -> PDF -> private R2 -> after checkpoint
 ```
 
 The Queue message contains only `schemaVersion`, `scheduledCutoff`, and diagnostic `triggerId`. It
 contains no faction payload, target id, claim, backlog state, or asset authority. This proof has no
-publisher schema or durable lease yet. Configuration-level consumer concurrency one plus a bounded
-in-process busy/duplicate guard prevent overlapping proof browsers; Ticket 2 replaces that proof
-guard with the real Convex lease.
+publisher schema or durable lease yet. Before any Convex checkpoint or Browser work, the consumer
+conditionally creates the fixed `proof/default-limit-experiment.claim.json` marker in the private R2
+bucket. Strong consistency lets exactly one isolate win; configuration-level concurrency one and the
+in-process guard remain secondary proof defenses. The marker is temporary proof state, not backlog
+or publication authority, and Ticket 2 replaces it with the real Convex lease.
 
 ## Local verification
 
@@ -38,8 +41,9 @@ tmp/asset-publishing-proof/local-proof.pdf
 tmp/asset-publishing-proof/storybook-reference.pdf
 ```
 
-The unit suite also verifies empty versus eligible dispatch, minimal message validation, duplicate
-and busy acknowledgement, bounded unexpected-error retry, render timeout, invalid PDF structure, R2
+The unit suite also verifies empty versus eligible dispatch, minimal message validation, two fresh
+consumer instances contending on one R2 claim backend, claim-store failure, duplicate and busy
+acknowledgement, zero-retry unexpected-error handling, render timeout, invalid PDF structure, R2
 failure, Convex checkpoint failure, and browser cleanup. There is no client-disconnect or Durable
 Object evidence path.
 
@@ -77,9 +81,10 @@ bunx wrangler r2 bucket dev-url get tanstack-start-asset-publisher-proof
 bunx wrangler r2 bucket domain list tanstack-start-asset-publisher-proof
 ```
 
-Expected: the bucket exists, its `r2.dev` URL is disabled, and it has no custom domain. Delete the
-old `proof/faction-sheet.pdf` object before collecting new evidence if it still exists. Do not delete
-the bucket.
+Expected: the bucket exists, its `r2.dev` URL is disabled, and it has no custom domain. Delete both
+`proof/default-limit-experiment.claim.json` and `proof/faction-sheet.pdf` before collecting new
+evidence if either exists, then verify the strongly consistent bucket object list is empty. Do not
+delete the bucket.
 
 Create exactly one Queue before deploying the Worker:
 
@@ -89,9 +94,14 @@ bunx wrangler queues list
 ```
 
 The checked config binds that Queue as producer `PROOF_QUEUE` and consumer with batch size one,
-consumer concurrency one, two retries, and a 60-second retry delay. It explicitly requests
-`limits.cpu_ms: 300000` so the Free-account proof does not accidentally measure only the default
-30-second Queue CPU limit. The checked Cron is the inert annual `0 0 1 1 *` schedule.
+consumer concurrency one, and `max_retries: 0`. It deliberately omits the entire Worker `limits`
+block, so this final experiment measures the actual default Queue-consumer CPU allowance on the
+Workers Free account. The checked Cron is the inert annual `0 0 1 1 *` schedule.
+
+The first deployment attempt is recorded history: Cloudflare rejected the reviewed custom
+`limits.cpu_ms: 300000` setting on Workers Free before any consumer, Browser Session, Cron, or R2
+write ran. That rejection authorized only this one default-limit, zero-retry experiment; it is not
+permission to add another CPU setting or broaden the evidence run.
 
 ## Production Convex proof endpoints
 
@@ -149,9 +159,9 @@ bun run proof:test
 bun run proof:dry-run
 ```
 
-The dry-run must list `CPU Time: 300000 ms` or otherwise show that `limits.cpu_ms: 300000` was
-accepted. The real Workers Free deploy must also accept that limit. If Wrangler or Cloudflare rejects
-it for the Free account, stop and record NO-GO; do not fall back to an accidental 30-second test.
+The dry-run must show the Queue, Browser, R2, Static Assets, and inert annual-Cron configuration. It
+must not show a custom Worker CPU limit. Do not add a `limits` block if Wrangler reports the
+provider default.
 
 The first deployment keeps the annual Cron and uses a placeholder only to discover the workers.dev
 origin. It must not invoke Browser Run:
@@ -179,7 +189,8 @@ rm -f "$PROOF_SECRETS_FILE"
 unset PROOF_SECRETS_FILE
 ```
 
-Do not arm a frequent Cron until the manual Queue proof succeeds.
+Do not arm a frequent or positive Cron at any point in this final experiment. The annual Cron stays
+inert throughout; the only wake-up is the one authenticated manual message below.
 
 `PROOF_RENDER_TIMEOUT_MS=45000` is one end-to-end Browser capture deadline covering Browser launch,
 navigation, readiness, bounds validation, PDF generation, and parsing. It is not reset per phase.
@@ -189,7 +200,7 @@ ordinary handled failure. Code rejects a deadline above six minutes, leaving at 
 seconds including cleanup before the future eight-minute production soft budget and far more before
 the Queue's 15-minute wall limit.
 
-## Manual Queue message first
+## One manual Queue message
 
 Start a tail before sending anything:
 
@@ -198,8 +209,8 @@ bunx wrangler tail faction-sheet-one-pdf-proof --format json \
   | tee /tmp/faction-sheet-queue-proof-tail.jsonl
 ```
 
-Send one explicit minimal message through the authenticated enqueue-only producer endpoint. The
-installed Wrangler CLI does not expose a direct Queue-message command:
+Send exactly one explicit minimal message through the authenticated enqueue-only producer endpoint.
+The installed Wrangler CLI does not expose a direct Queue-message command:
 
 ```bash
 export PROOF_TRIGGER_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
@@ -213,15 +224,17 @@ curl -fsS -X POST "$WORKER_URL/__proof/enqueue" \
   --data "$PROOF_MESSAGE"
 ```
 
-The endpoint validates and enqueues that message; it never captures inline. An empty request body is
-also allowed and generates a fresh cutoff and trigger id.
+The endpoint validates and enqueues that message; it never captures inline. Do not invoke it a
+second time, even after a failed or ambiguous consumer result. An empty request body remains locally
+supported but is not used for final evidence because the explicit message identifies the sole run.
 
 Require a Queue-consumer log with `action: "ack"`, `reason: "completed"`, attempt metadata, and a
 proof report showing:
 
 - `outcome: "success"` and `browserCloseOutcome: "closed"`;
 - exactly two pages within 0.5 mm of `150 x 195`;
-- one R2 operation and two correlated Convex calls;
+- one conditional claim-marker Class A write before proof work, one PDF R2 operation in the report,
+  and two correlated Convex calls;
 - finite before/after Convex latency, PDF bytes, browser duration, and wall duration;
 - empty console and request-failure arrays.
 
@@ -229,6 +242,9 @@ Download through authenticated Wrangler access into the same ignored comparison 
 
 ```bash
 mkdir -p tmp/asset-publishing-proof
+bunx wrangler r2 object get \
+  tanstack-start-asset-publisher-proof/proof/default-limit-experiment.claim.json \
+  --remote --file=tmp/asset-publishing-proof/default-limit-experiment.claim.json
 bunx wrangler r2 object get \
   tanstack-start-asset-publisher-proof/proof/faction-sheet.pdf \
   --remote --file=tmp/asset-publishing-proof/deployed-queue-proof.pdf
@@ -262,142 +278,22 @@ Record the exact three paths, hashes, reference identities printed by the regres
 and comparison result. Compare both pages for fonts, artwork, backgrounds, clipping, and physical
 size. A verbal comparison without reproducible files and hashes is not accepted evidence.
 
-## Failure and delivery observations
+## Failure and delivery policy
 
 The checked unit tests are the authoritative deterministic coverage for invalid checkpoint,
-render-timeout, invalid PDF, R2 failure, Convex failure, duplicate/busy delivery, and bounded retry.
-For deployed evidence, use only Queue executions; never restore the old inline HTTP or Durable Object
-path.
+render-timeout, invalid PDF, R2 failure, Convex failure, duplicate/busy delivery, and unexpected
+orchestration failure. Every delivery path acknowledges; none calls `message.retry`, and the Queue
+configuration permits no provider redelivery.
 
-To observe ordinary render failure, temporarily deploy `PROOF_FAILURE_MODE` as `render_timeout` or
-`reporting_error_after_capture`, send one manual Queue message, and then restore `none`. Each handled
-failure must log `action: "ack"`, `reason: "failed"`, zero R2 operations, and a closed browser. An
-unexpected orchestration throw retries at 60 seconds and is acknowledged as exhausted on attempt
-three; ordinary capture/checkpoint outcomes are acknowledged immediately to avoid a retry storm.
+The fixed claim is attempted before `runOnePdfProof`. A failed precondition means another isolate
+already won: acknowledge/log `duplicate` and do no Convex, Browser, or PDF work. A claim PUT error is
+acknowledged/logged `exhausted` and starts no proof work; because the sole attempt is then ambiguous,
+the deployed experiment is NO-GO.
 
-Sending the exact same `PROOF_MESSAGE` twice can demonstrate the bounded in-process duplicate guard
-when both deliveries reach the same isolate. Treat that as proof-harness evidence only, not durable
-deduplication. `max_concurrency: 1` is the account-level overlap fence for this proof; Ticket 2 must
-use Convex leases.
-
-## One bounded Cron observation window
-
-Keep the tail running. Run the entire observation from one shell with fail-closed cleanup armed
-before changing either control. Cleanup first forces Convex to `empty`, then restores the annual
-Cron. The helper verifies the empty endpoint; Cloudflare schedule verification still requires the
-dashboard because this Wrangler version has no trigger-list command.
-
-```bash
-set -Eeuo pipefail
-
-verify_convex_empty() {
-  local trigger_id cutoff response
-  trigger_id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
-  cutoff="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
-  response="$(curl -fsS "$CONVEX_PROOF_ELIGIBILITY_URL" \
-    -H "Authorization: Bearer $CONVEX_PROOF_TOKEN" \
-    -H 'Content-Type: application/json' \
-    --data "{\"schemaVersion\":1,\"scheduledCutoff\":\"$cutoff\",\"triggerId\":\"$trigger_id\"}")"
-  test "$(printf '%s' "$response" | jq -r '.eligibility')" = 'empty'
-}
-
-cleanup_proof_window() {
-  set_and_verify_empty || {
-    printf '%s\n' \
-      'UNVERIFIED CLEANUP: eligibility could not be proven empty.' \
-      'Do not restore or continue the observation; recover manually and record NO-GO.' >&2
-    return 1
-  }
-  bunx wrangler triggers deploy \
-    --name faction-sheet-one-pdf-proof \
-    --triggers '0 0 1 1 *' || {
-    printf '%s\n' \
-      'UNVERIFIED CLEANUP: eligibility is empty, but annual Cron restoration failed.' \
-      'Recover manually and record NO-GO.' >&2
-    return 1
-  }
-  printf '%s\n' \
-    'Cleanup submitted. Allow up to 15 minutes for trigger propagation.' \
-    'Do not call cleanup complete until the Cloudflare dashboard shows only 0 0 1 1 *' \
-    'and the tail shows no further frequent-trigger invocation after propagation.'
-}
-
-set_and_verify_empty() {
-  printf '%s' 'empty' \
-    | bunx convex env set ASSET_PUBLISHING_PROOF_ELIGIBILITY --prod
-  verify_convex_empty
-}
-
-cleanup_verified=0
-cleanup_on_exit() {
-  local original_status="$?"
-  trap - EXIT HUP INT TERM
-  if test "$cleanup_verified" != '1'; then
-    if ! cleanup_proof_window; then
-      printf '%s\n' \
-        'FAIL-CLOSED: automatic cleanup failed; this observation is unverified/NO-GO.' \
-        'Perform manual recovery before any further proof work.' >&2
-    else
-      printf '%s\n' \
-        'FAIL-CLOSED: cleanup commands ran, but propagation was not verified.' \
-        'This observation remains unverified/NO-GO until manual dashboard/tail verification.' >&2
-    fi
-    exit 97
-  fi
-  exit "$original_status"
-}
-trap cleanup_on_exit EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
-set_and_verify_empty
-
-bunx wrangler triggers deploy \
-  --name faction-sheet-one-pdf-proof \
-  --triggers '*/15 * * * *'
-```
-
-Allow up to 15 minutes for the schedule change to propagate. Verify the Cloudflare dashboard shows
-only `*/15 * * * *`. The empty firing must log `result: "empty"` and show no Queue send, browser
-invocation, R2 operation, or Convex checkpoint write. Then switch only the stateless proof mode:
-
-```bash
-printf '%s' 'eligible' \
-  | bunx convex env set ASSET_PUBLISHING_PROOF_ELIGIBILITY --prod
-```
-
-Observe the **FIRST** `result: "enqueued"` dispatch log. Before waiting for or inspecting the Queue
-consumer, immediately disable and verify eligibility:
-
-```bash
-set_and_verify_empty
-```
-
-Only after that command succeeds may you correlate the separate Queue-consumer invocation by
-`triggerId` and wait for one successful PDF. A failure to set or verify `empty` is immediate
-unverified/NO-GO and requires manual recovery; do not continue waiting as if the observation were
-safe. After the consumer result is recorded, restore the annual Cron through the ordered cleanup:
-
-```bash
-cleanup_proof_window
-```
-
-Allow up to 15 minutes for restoration to propagate. Confirm the eligibility probe is `empty`, the
-Cloudflare dashboard shows only `0 0 1 1 *`, and no further frequent invocation appears after the
-propagation window. Only then run `trap - EXIT HUP INT TERM` and record cleanup complete. If the
-shell is interrupted earlier, the EXIT/signal trap attempts the same ordered cleanup and exits 97;
-it never swallows failure or marks the run safe. Once the manual propagation checks pass, finish with:
-
-```bash
-cleanup_verified=1
-trap - EXIT HUP INT TERM
-```
-
-An unverified cleanup attempt is not cleanup completion.
-
-If the poll or Queue send fails, the Cron logs the error and performs no browser work. Convex remains
-authoritative; the later Cron is the retry.
+Do not deploy a failure mode or run deployed render-timeout, post-capture-failure, duplicate, busy,
+or positive-Cron Browser captures. Those paths remain unit-test evidence only. Keep
+`PROOF_FAILURE_MODE=none`, keep Convex eligibility `empty`, and preserve `max_concurrency: 1` as the
+proof-only overlap fence. Ticket 2 must replace that fence with Convex leases.
 
 ## Free-tier GO / NO-GO gate
 
@@ -411,20 +307,47 @@ Decision: GO | NO-GO
 Empty Cron CPU / outcome / Queue sends:
 Eligible Cron CPU / outcome / Queue sends:
 Queue consumer CPU / wall / memory / subrequests / exceededCpu:
-300000 ms CPU limit deploy acceptance / rejection:
-Queue message attempts / ack-or-retry result:
+Custom-limit rejection evidence reference:
+Default-limit confirmation / custom CPU setting absent:
+Queue message attempts / ack result:
 Browser Session duration / close outcome / daily usage:
 PDF bytes / pages / physical size / visual comparison:
-R2 operations / object verification:
+R2 claim-marker Class A write / PDF write / object verification:
 Convex before+after latency:
-Failure-mode outcomes:
 Unexpected console or network errors:
 Reason and follow-up:
 ```
 
-GO requires Cloudflare to accept the explicit 300000 ms limit and the independent Queue consumer to
-complete reliably on the actual Workers Free account without `exceededCpu` and with comfortable
-measured margin. A rejected limit, accidental default-30-second deployment, exceeded-resource result,
-unreadable or incorrectly sized PDF, unclosed browser, bytes passing through Convex, false success,
-unverified Cron cleanup, or unclear consumer metrics is NO-GO and returns to technical planning. Do
-not proceed to Ticket 2 and do not silently reintroduce Durable Objects.
+The Empty/Eligible Cron fields must record that both observations were intentionally not run and the
+annual trigger remained inert. GO requires the one independent default-limit Queue consumer to
+produce one clean, readable, correctly sized two-page PDF, close Browser Run, write once to private
+R2 after its single successful claim-marker write, complete both stateless Convex checkpoints, and
+leave unambiguous correlated metrics. Any
+`exceededCpu`, memory termination, unclosed or unclear Browser cleanup, invalid or unreadable output,
+unexpected extra delivery, or ambiguous evidence is definitive NO-GO. Do not send another message,
+proceed to Ticket 2, or silently reintroduce Durable Objects after NO-GO.
+
+## Cleanup after evidence
+
+After recording GO or NO-GO, remove the temporary Worker (which also removes its inert annual
+trigger), Queue, scoped Convex variables, claim marker, and proof PDF object. Retain the private
+Standard R2 bucket, but verify it is empty and still has neither `r2.dev` access nor a custom domain.
+
+```bash
+bunx wrangler delete --name faction-sheet-one-pdf-proof
+bunx wrangler queues delete faction-sheet-one-pdf-proof
+bunx convex env remove ASSET_PUBLISHING_PROOF_SECRET --prod
+bunx convex env remove ASSET_PUBLISHING_PROOF_ELIGIBILITY --prod
+bunx wrangler r2 object delete \
+  tanstack-start-asset-publisher-proof/proof/default-limit-experiment.claim.json --remote
+bunx wrangler r2 object delete \
+  tanstack-start-asset-publisher-proof/proof/faction-sheet.pdf --remote
+bunx wrangler r2 bucket info tanstack-start-asset-publisher-proof --json
+bunx wrangler r2 bucket dev-url get tanstack-start-asset-publisher-proof
+bunx wrangler r2 bucket domain list tanstack-start-asset-publisher-proof
+```
+
+Cleanup is complete only when the Worker and Queue no longer exist, both scoped Convex variables are
+absent, the strongly consistent R2 object list in the Cloudflare dashboard or API is empty, and the
+retained bucket remains private. The aggregate bucket-info object counter may lag and is not enough
+on its own. Remove local secret files and unset proof tokens as well. Do not delete the empty bucket.

--- a/workers/proof/claim.test.ts
+++ b/workers/proof/claim.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { acquireDefaultLimitExperimentClaim, DEFAULT_LIMIT_EXPERIMENT_CLAIM_KEY } from './claim';
+import type { ProofReport } from './core';
+import { createProofWakeUp } from './dispatch';
+import { ProofQueueConsumer, type ProofQueueDelivery } from './queue';
+
+const wakeUp = createProofWakeUp(
+  Date.parse('2026-07-16T12:00:00.000Z'),
+  '10a5318c-e0f2-49c6-bd19-5221a80643f7'
+);
+
+function delivery(id: string): ProofQueueDelivery & {
+  ack: ReturnType<typeof vi.fn>;
+  retry: ReturnType<typeof vi.fn>;
+} {
+  return { id, attempts: 1, body: wakeUp, ack: vi.fn(), retry: vi.fn() };
+}
+
+describe('default-limit experiment R2 one-shot claim', () => {
+  test('allows one fresh consumer instance and acks the other as a duplicate', async () => {
+    let markerExists = false;
+    const put = vi.fn(async () => {
+      if (markerExists) return null;
+      markerExists = true;
+      return { key: DEFAULT_LIMIT_EXPERIMENT_CLAIM_KEY };
+    });
+    const bucket = { put } as unknown as R2Bucket;
+    const acquireClaim = async (candidate: typeof wakeUp, message: ProofQueueDelivery) =>
+      await acquireDefaultLimitExperimentClaim(bucket, candidate, message);
+    const firstMessage = delivery('first-delivery');
+    const secondMessage = delivery('second-delivery');
+    const runProof = vi.fn(async () => ({ outcome: 'success' }) as ProofReport);
+    const log = vi.fn();
+
+    const dispositions = await Promise.all([
+      new ProofQueueConsumer(log).consume(firstMessage, acquireClaim, runProof),
+      new ProofQueueConsumer(log).consume(secondMessage, acquireClaim, runProof),
+    ]);
+
+    expect(dispositions).toContainEqual({ action: 'ack', reason: 'completed' });
+    expect(dispositions).toContainEqual({ action: 'ack', reason: 'duplicate' });
+    expect(runProof).toHaveBeenCalledOnce();
+    expect(firstMessage.ack).toHaveBeenCalledOnce();
+    expect(secondMessage.ack).toHaveBeenCalledOnce();
+    expect(firstMessage.retry).not.toHaveBeenCalled();
+    expect(secondMessage.retry).not.toHaveBeenCalled();
+    expect(put).toHaveBeenCalledTimes(2);
+    expect(put.mock.calls[0]?.[0]).toBe(DEFAULT_LIMIT_EXPERIMENT_CLAIM_KEY);
+    expect(put.mock.calls[0]?.[2]?.onlyIf).toBeInstanceOf(Headers);
+    expect(put.mock.calls[0]?.[2]?.onlyIf.get('if-none-match')).toBe('*');
+    expect(log).toHaveBeenCalledWith(expect.objectContaining({ reason: 'duplicate' }));
+  });
+
+  test('acks a claim-store failure as exhausted without starting proof work', async () => {
+    const bucket = {
+      put: vi.fn(async () => {
+        throw new Error('R2 claim unavailable');
+      }),
+    } as unknown as R2Bucket;
+    const acquireClaim = async (candidate: typeof wakeUp, message: ProofQueueDelivery) =>
+      await acquireDefaultLimitExperimentClaim(bucket, candidate, message);
+    const message = delivery('failed-claim');
+    const runProof = vi.fn(async () => ({ outcome: 'success' }) as ProofReport);
+    const log = vi.fn();
+
+    await expect(
+      new ProofQueueConsumer(log).consume(message, acquireClaim, runProof)
+    ).resolves.toEqual({ action: 'ack', reason: 'exhausted' });
+
+    expect(runProof).not.toHaveBeenCalled();
+    expect(bucket.put).toHaveBeenCalledOnce();
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(message.retry).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'ack',
+        error: 'R2 claim unavailable',
+        reason: 'exhausted',
+      })
+    );
+  });
+});

--- a/workers/proof/claim.ts
+++ b/workers/proof/claim.ts
@@ -1,0 +1,26 @@
+import type { ProofWakeUp } from './dispatch';
+import type { ProofQueueDelivery } from './queue';
+
+export const DEFAULT_LIMIT_EXPERIMENT_CLAIM_KEY = 'proof/default-limit-experiment.claim.json';
+
+export async function acquireDefaultLimitExperimentClaim(
+  bucket: R2Bucket,
+  wakeUp: ProofWakeUp,
+  message: ProofQueueDelivery
+): Promise<boolean> {
+  const marker = await bucket.put(
+    DEFAULT_LIMIT_EXPERIMENT_CLAIM_KEY,
+    JSON.stringify({
+      schemaVersion: 1,
+      messageId: message.id,
+      triggerId: wakeUp.triggerId,
+      scheduledCutoff: wakeUp.scheduledCutoff,
+      claimedAt: new Date().toISOString(),
+    }),
+    {
+      onlyIf: new Headers({ 'if-none-match': '*' }),
+      httpMetadata: { contentType: 'application/json' },
+    }
+  );
+  return marker !== null;
+}

--- a/workers/proof/core.test.ts
+++ b/workers/proof/core.test.ts
@@ -167,10 +167,14 @@ describe('executeOnePdfProof', () => {
     const consumer = new ProofQueueConsumer(vi.fn());
     let report: Awaited<ReturnType<typeof proof.run>> | undefined;
 
-    const consumePromise = consumer.consume(message, async () => {
-      report = await proof.run();
-      return report;
-    });
+    const consumePromise = consumer.consume(
+      message,
+      async () => true,
+      async () => {
+        report = await proof.run();
+        return report;
+      }
+    );
     await vi.advanceTimersByTimeAsync(BROWSER_CLEANUP_GRACE_MS);
     await expect(consumePromise).resolves.toEqual({ action: 'ack', reason: 'failed' });
 

--- a/workers/proof/deployment-config.test.ts
+++ b/workers/proof/deployment-config.test.ts
@@ -26,10 +26,11 @@ describe('proof deployment-safe defaults', () => {
     expect(wranglerConfig).toContain('"binding": "PROOF_QUEUE"');
     expect(wranglerConfig.match(/"queue": "faction-sheet-one-pdf-proof"/g)).toHaveLength(2);
     expect(wranglerConfig).toContain('"max_batch_size": 1');
-    expect(wranglerConfig).toContain('"max_retries": 2');
-    expect(wranglerConfig).toContain('"retry_delay": 60');
+    expect(wranglerConfig).toContain('"max_retries": 0');
     expect(wranglerConfig).toContain('"max_concurrency": 1');
-    expect(wranglerConfig).toContain('"cpu_ms": 300000');
+    expect(wranglerConfig).not.toContain('"retry_delay"');
+    expect(wranglerConfig).not.toContain('"limits"');
+    expect(wranglerConfig).not.toContain('"cpu_ms"');
     expect(wranglerConfig).not.toContain('durable_objects');
     expect(wranglerConfig).not.toContain('migrations');
     expect(wranglerConfig).not.toContain('PROOF_EXECUTOR');
@@ -85,29 +86,21 @@ describe('proof deployment-safe defaults', () => {
     expect(runbook).toContain('do not enable an independent\nCloudflare Git auto-deploy');
   });
 
-  test('locks fail-closed Cron cleanup ordering and positive-dispatch shutdown', () => {
+  test('forbids arming a frequent Cron or running deployed failure-mode captures', () => {
     const runbook = readFileSync(new URL('workers/proof/README.md', repositoryRoot), 'utf8');
-    const cleanupStart = runbook.indexOf('cleanup_proof_window()');
-    const cleanupEnd = runbook.indexOf('\n}\n\nset_and_verify_empty()', cleanupStart);
-    const cleanup = runbook.slice(cleanupStart, cleanupEnd);
-    const emptyStart = runbook.indexOf('set_and_verify_empty()');
-    const emptyEnd = runbook.indexOf('\n}', emptyStart);
-    const setEmpty = runbook.slice(emptyStart, emptyEnd);
-    const positiveDispatch = runbook.indexOf('FIRST** `result: "enqueued"`');
-    const disableAfterDispatch = runbook.indexOf('set_and_verify_empty', positiveDispatch);
-    const waitAfterDisable = runbook.indexOf('wait for one successful PDF', disableAfterDispatch);
 
-    expect(cleanupStart).toBeGreaterThan(-1);
-    expect(cleanup.indexOf('set_and_verify_empty')).toBeLessThan(
-      cleanup.indexOf('wrangler triggers deploy')
-    );
-    expect(setEmpty.indexOf('convex env set ASSET_PUBLISHING_PROOF_ELIGIBILITY')).toBeLessThan(
-      setEmpty.indexOf('verify_convex_empty')
-    );
-    expect(runbook).not.toContain('cleanup_proof_window || true');
-    expect(runbook).toContain('exit 97');
-    expect(positiveDispatch).toBeGreaterThan(-1);
-    expect(disableAfterDispatch).toBeGreaterThan(positiveDispatch);
-    expect(waitAfterDisable).toBeGreaterThan(disableAfterDispatch);
+    expect(runbook).toContain('Do not arm a frequent or positive Cron');
+    expect(runbook).toContain('Do not deploy a failure mode');
+    expect(runbook).not.toContain("--triggers '*/15 * * * *'");
+    expect(runbook).not.toContain("printf '%s' 'eligible'");
+  });
+
+  test('documents the temporary R2 one-shot marker and deletes both proof objects', () => {
+    const runbook = readFileSync(new URL('workers/proof/README.md', repositoryRoot), 'utf8');
+
+    expect(runbook).toContain('proof/default-limit-experiment.claim.json');
+    expect(runbook.match(/bunx wrangler r2 object delete/g)).toHaveLength(2);
+    expect(runbook).toContain('temporary proof state');
+    expect(runbook).toContain('Ticket 2 replaces it with the real Convex lease');
   });
 });

--- a/workers/proof/index.test.ts
+++ b/workers/proof/index.test.ts
@@ -117,3 +117,43 @@ describe('proof Worker producer boundaries', () => {
     expect(send).not.toHaveBeenCalled();
   });
 });
+
+describe('proof Worker Queue delivery boundary', () => {
+  test('acknowledges an unexpected extra message without requesting a Queue retry', async () => {
+    const { env } = environment();
+    const first = {
+      id: 'invalid-first',
+      attempts: 1,
+      body: { invalid: true },
+      ack: vi.fn(),
+      retry: vi.fn(),
+      timestamp: new Date(),
+    };
+    const extra = {
+      id: 'unexpected-extra',
+      attempts: 1,
+      body: { invalid: true },
+      ack: vi.fn(),
+      retry: vi.fn(),
+      timestamp: new Date(),
+    };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await proofWorker.queue(
+      {
+        queue: 'faction-sheet-one-pdf-proof',
+        messages: [first, extra],
+        ackAll: vi.fn(),
+        retryAll: vi.fn(),
+      },
+      env,
+      {} as ExecutionContext
+    );
+
+    expect(first.ack).toHaveBeenCalledOnce();
+    expect(first.retry).not.toHaveBeenCalled();
+    expect(extra.ack).toHaveBeenCalledOnce();
+    expect(extra.retry).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining('"reason":"exhausted"'));
+  });
+});

--- a/workers/proof/index.ts
+++ b/workers/proof/index.ts
@@ -7,6 +7,7 @@ import type {
 } from '@cloudflare/playwright';
 
 import { handleProofCaptureAsset } from './capture-route';
+import { acquireDefaultLimitExperimentClaim } from './claim';
 import { sendConvexProofCheckpoint } from './convex';
 import {
   type CapturedPdf,
@@ -377,10 +378,25 @@ export const proofWorker = {
   async queue(batch: MessageBatch<unknown>, env: Env): Promise<void> {
     const [message, ...unexpectedExtras] = batch.messages;
     for (const extra of unexpectedExtras) {
-      extra.retry({ delaySeconds: 60 });
+      extra.ack();
+      console.error(
+        JSON.stringify({
+          event: 'asset_publishing_proof_queue_delivery',
+          messageId: extra.id,
+          attempts: extra.attempts,
+          action: 'ack',
+          reason: 'exhausted',
+          error: 'Queue delivered more than the configured one-message batch',
+        })
+      );
     }
     if (!message) return;
-    await queueConsumer.consume(message, async () => await runOnePdfProof(env));
+    await queueConsumer.consume(
+      message,
+      async (wakeUp, delivery) =>
+        await acquireDefaultLimitExperimentClaim(env.PROOF_BUCKET, wakeUp, delivery),
+      async () => await runOnePdfProof(env)
+    );
   },
 } satisfies ExportedHandler<Env, unknown>;
 

--- a/workers/proof/queue.test.ts
+++ b/workers/proof/queue.test.ts
@@ -11,6 +11,7 @@ const wakeUp = createProofWakeUp(
 
 const successReport = { outcome: 'success' } as ProofReport;
 const failedReport = { outcome: 'failed' } as ProofReport;
+const acquireClaim = async () => true;
 
 function delivery(
   body: unknown = wakeUp,
@@ -30,7 +31,7 @@ describe('proof Queue consumer acknowledgment policy', () => {
     const message = delivery();
     const consumer = new ProofQueueConsumer(vi.fn());
 
-    await expect(consumer.consume(message, async () => report)).resolves.toEqual({
+    await expect(consumer.consume(message, acquireClaim, async () => report)).resolves.toEqual({
       action: 'ack',
       reason,
     });
@@ -43,12 +44,13 @@ describe('proof Queue consumer acknowledgment policy', () => {
     const message = delivery({ ...wakeUp, faction: { id: 'forbidden' } });
     const consumer = new ProofQueueConsumer(vi.fn());
 
-    await expect(consumer.consume(message, run)).resolves.toEqual({
+    await expect(consumer.consume(message, acquireClaim, run)).resolves.toEqual({
       action: 'ack',
       reason: 'invalid',
     });
     expect(run).not.toHaveBeenCalled();
     expect(message.ack).toHaveBeenCalledOnce();
+    expect(message.retry).not.toHaveBeenCalled();
   });
 
   test('acks a handled end-to-end capture timeout without automatic redelivery', async () => {
@@ -60,7 +62,9 @@ describe('proof Queue consumer acknowledgment policy', () => {
     } as ProofReport;
     const consumer = new ProofQueueConsumer(vi.fn());
 
-    await expect(consumer.consume(message, async () => timeoutReport)).resolves.toEqual({
+    await expect(
+      consumer.consume(message, acquireClaim, async () => timeoutReport)
+    ).resolves.toEqual({
       action: 'ack',
       reason: 'failed',
     });
@@ -71,15 +75,16 @@ describe('proof Queue consumer acknowledgment policy', () => {
   test('acks a repeated trigger id after the first handled delivery', async () => {
     const run = vi.fn(async () => successReport);
     const consumer = new ProofQueueConsumer(vi.fn());
-    await consumer.consume(delivery(), run);
+    await consumer.consume(delivery(), acquireClaim, run);
     const duplicate = delivery();
 
-    await expect(consumer.consume(duplicate, run)).resolves.toEqual({
+    await expect(consumer.consume(duplicate, acquireClaim, run)).resolves.toEqual({
       action: 'ack',
       reason: 'duplicate',
     });
     expect(run).toHaveBeenCalledOnce();
     expect(duplicate.ack).toHaveBeenCalledOnce();
+    expect(duplicate.retry).not.toHaveBeenCalled();
   });
 
   test('acks a concurrent attempt as busy without opening an overlapping browser', async () => {
@@ -91,38 +96,41 @@ describe('proof Queue consumer acknowledgment policy', () => {
         })
     );
     const consumer = new ProofQueueConsumer(vi.fn());
-    const firstPromise = consumer.consume(delivery(), run);
+    const firstPromise = consumer.consume(delivery(), acquireClaim, run);
     const concurrent = delivery(createProofWakeUp(Date.now(), crypto.randomUUID()));
 
-    await expect(consumer.consume(concurrent, run)).resolves.toEqual({
+    await expect(consumer.consume(concurrent, acquireClaim, run)).resolves.toEqual({
       action: 'ack',
       reason: 'busy',
     });
     expect(run).toHaveBeenCalledOnce();
     expect(concurrent.ack).toHaveBeenCalledOnce();
+    expect(concurrent.retry).not.toHaveBeenCalled();
     finishFirst?.(successReport);
     await firstPromise;
   });
 
-  test('retries unexpected orchestration failure with a bounded delay before exhaustion', async () => {
+  test('acks unexpected orchestration failure as exhausted without requesting redelivery', async () => {
     const run = async () => {
       throw new Error('Worker orchestration failed');
     };
-    const consumer = new ProofQueueConsumer(vi.fn());
-    const retryable = delivery(wakeUp, 2);
-    await expect(consumer.consume(retryable, run)).resolves.toEqual({
-      action: 'retry',
-      reason: 'unexpected',
-    });
-    expect(retryable.retry).toHaveBeenCalledExactlyOnceWith({ delaySeconds: 60 });
-    expect(retryable.ack).not.toHaveBeenCalled();
+    const log = vi.fn();
+    const consumer = new ProofQueueConsumer(log);
+    const message = delivery();
 
-    const exhausted = delivery(wakeUp, 3);
-    await expect(consumer.consume(exhausted, run)).resolves.toEqual({
+    await expect(consumer.consume(message, acquireClaim, run)).resolves.toEqual({
       action: 'ack',
       reason: 'exhausted',
     });
-    expect(exhausted.ack).toHaveBeenCalledOnce();
-    expect(exhausted.retry).not.toHaveBeenCalled();
+    expect(message.ack).toHaveBeenCalledOnce();
+    expect(message.retry).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'ack',
+        attempts: 1,
+        error: 'Worker orchestration failed',
+        reason: 'exhausted',
+      })
+    );
   });
 });

--- a/workers/proof/queue.ts
+++ b/workers/proof/queue.ts
@@ -2,8 +2,6 @@ import type { ProofReport } from './core';
 import { type ProofWakeUp, parseProofWakeUp } from './dispatch';
 
 const MAX_RECENT_TRIGGER_IDS = 32;
-const MAX_DELIVERY_ATTEMPTS = 3;
-const RETRY_DELAY_SECONDS = 60;
 
 export type ProofQueueDelivery = {
   id: string;
@@ -13,12 +11,15 @@ export type ProofQueueDelivery = {
   retry(options?: { delaySeconds?: number }): void;
 };
 
-export type ProofQueueDisposition =
-  | {
-      action: 'ack';
-      reason: 'completed' | 'failed' | 'invalid' | 'duplicate' | 'busy' | 'exhausted';
-    }
-  | { action: 'retry'; reason: 'unexpected' };
+export type ProofQueueDisposition = {
+  action: 'ack';
+  reason: 'completed' | 'failed' | 'invalid' | 'duplicate' | 'busy' | 'exhausted';
+};
+
+export type ProofOneShotClaim = (
+  wakeUp: ProofWakeUp,
+  message: ProofQueueDelivery
+) => Promise<boolean>;
 
 export class ProofQueueConsumer {
   private running = false;
@@ -31,6 +32,7 @@ export class ProofQueueConsumer {
 
   async consume(
     message: ProofQueueDelivery,
+    acquireClaim: ProofOneShotClaim,
     runProof: (wakeUp: ProofWakeUp) => Promise<ProofReport>
   ): Promise<ProofQueueDisposition> {
     let wakeUp: ProofWakeUp;
@@ -56,6 +58,13 @@ export class ProofQueueConsumer {
 
     this.running = true;
     try {
+      const acquired = await acquireClaim(wakeUp, message);
+      if (!acquired) {
+        this.remember(wakeUp.triggerId);
+        message.ack();
+        this.logDelivery(message, 'ack', 'duplicate', wakeUp);
+        return { action: 'ack', reason: 'duplicate' };
+      }
       const report = await runProof(wakeUp);
       this.remember(wakeUp.triggerId);
       message.ack();
@@ -63,14 +72,9 @@ export class ProofQueueConsumer {
       this.logDelivery(message, 'ack', reason, wakeUp, undefined, report);
       return { action: 'ack', reason };
     } catch (error) {
-      if (message.attempts >= MAX_DELIVERY_ATTEMPTS) {
-        message.ack();
-        this.logDelivery(message, 'ack', 'exhausted', wakeUp, error);
-        return { action: 'ack', reason: 'exhausted' };
-      }
-      message.retry({ delaySeconds: RETRY_DELAY_SECONDS });
-      this.logDelivery(message, 'retry', 'unexpected', wakeUp, error);
-      return { action: 'retry', reason: 'unexpected' };
+      message.ack();
+      this.logDelivery(message, 'ack', 'exhausted', wakeUp, error);
+      return { action: 'ack', reason: 'exhausted' };
     } finally {
       this.running = false;
     }
@@ -87,7 +91,7 @@ export class ProofQueueConsumer {
 
   private logDelivery(
     message: ProofQueueDelivery,
-    action: 'ack' | 'retry',
+    action: 'ack',
     reason: ProofQueueDisposition['reason'],
     wakeUp?: ProofWakeUp,
     error?: unknown,

--- a/workers/proof/wrangler.jsonc
+++ b/workers/proof/wrangler.jsonc
@@ -6,9 +6,6 @@
   "compatibility_flags": ["nodejs_compat"],
   "workers_dev": true,
   "upload_source_maps": true,
-  "limits": {
-    "cpu_ms": 300000
-  },
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1,
@@ -44,8 +41,7 @@
         "queue": "faction-sheet-one-pdf-proof",
         "max_batch_size": 1,
         "max_batch_timeout": 1,
-        "max_retries": 2,
-        "retry_delay": 60,
+        "max_retries": 0,
         "max_concurrency": 1
       }
     ]


### PR DESCRIPTION
## What changed

- remove the unsupported custom Queue CPU limit for one final Workers Free experiment
- configure one-message batches, one consumer, and zero provider retries
- add a private, conditional R2 one-shot claim before any Convex or Browser work
- keep the annual Cron inert and reduce deployed evidence to exactly one authenticated manual wake-up
- document fail-closed GO/NO-GO criteria and complete proof-resource cleanup

## Why

Cloudflare rejected the reviewed `limits.cpu_ms` setting on Workers Free before any Browser work ran. This follow-up measures the account's actual default Queue-consumer allowance once. Because Queues are at-least-once, the R2 claim marker ensures a rare duplicate delivery cannot start a second Browser attempt.

## Validation

- `bun run proof:typecheck`
- `bun run proof:test` — 91 tests
- targeted Biome check
- `bun run proof:dry-run`
- `bun run typecheck`
- `git diff --check`
- cold Traycer review: SAFE for the controlled one-message deployment

No Cloudflare or Convex resource is created by this PR itself. The existing GitHub Actions production workflow remains the deployment gate before the manual Cloudflare proof.