### PR TITLE
Fix asset proof runbook commands

### DIFF
--- a/workers/proof/README.md
+++ b/workers/proof/README.md
@@ -120,7 +120,7 @@ require no schema or index change:
 
 ```bash
 test -z "${CONVEX_DEPLOY_KEY:-}" || { echo 'Refusing a deploy key' >&2; exit 1; }
-bunx convex deploy --dry-run --verbose
+bunx convex deploy --dry-run
 ```
 
 Do not deploy production Convex functions from this workstation. The reviewed change must merge to
@@ -215,9 +215,10 @@ The installed Wrangler CLI does not expose a direct Queue-message command:
 ```bash
 export PROOF_TRIGGER_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 export PROOF_CUTOFF="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
-export PROOF_MESSAGE="$(printf \
-  '{\"schemaVersion\":1,\"scheduledCutoff\":\"%s\",\"triggerId\":\"%s\"}' \
-  "$PROOF_CUTOFF" "$PROOF_TRIGGER_ID")"
+export PROOF_MESSAGE="$(jq -cn \
+  --arg scheduledCutoff "$PROOF_CUTOFF" \
+  --arg triggerId "$PROOF_TRIGGER_ID" \
+  '{schemaVersion:1, scheduledCutoff:$scheduledCutoff, triggerId:$triggerId}')"
 curl -fsS -X POST "$WORKER_URL/__proof/enqueue" \
   -H "Authorization: Bearer $PROOF_TRIGGER_TOKEN" \
   -H 'Content-Type: application/json' \
@@ -334,6 +335,8 @@ trigger), Queue, scoped Convex variables, claim marker, and proof PDF object. Re
 Standard R2 bucket, but verify it is empty and still has neither `r2.dev` access nor a custom domain.
 
 ```bash
+bunx wrangler queues consumer remove \
+  faction-sheet-one-pdf-proof faction-sheet-one-pdf-proof
 bunx wrangler delete --name faction-sheet-one-pdf-proof
 bunx wrangler queues delete faction-sheet-one-pdf-proof
 bunx convex env remove ASSET_PUBLISHING_PROOF_SECRET --prod

--- a/workers/proof/deployment-config.test.ts
+++ b/workers/proof/deployment-config.test.ts
@@ -79,7 +79,8 @@ describe('proof deployment-safe defaults', () => {
   test('keeps production Convex deployment in the ordered main-branch GitHub Action', () => {
     const runbook = readFileSync(new URL('workers/proof/README.md', repositoryRoot), 'utf8');
 
-    expect(runbook).toContain('bunx convex deploy --dry-run --verbose');
+    expect(runbook).toContain('bunx convex deploy --dry-run');
+    expect(runbook).not.toContain('convex deploy --dry-run --verbose');
     expect(runbook).not.toContain('bunx convex deploy --verbose --message');
     expect(runbook).toContain('Deploy production');
     expect(runbook).toContain('must merge to');
@@ -102,5 +103,18 @@ describe('proof deployment-safe defaults', () => {
     expect(runbook.match(/bunx wrangler r2 object delete/g)).toHaveLength(2);
     expect(runbook).toContain('temporary proof state');
     expect(runbook).toContain('Ticket 2 replaces it with the real Convex lease');
+  });
+
+  test('builds valid manual JSON and detaches the Queue consumer before deleting resources', () => {
+    const runbook = readFileSync(new URL('workers/proof/README.md', repositoryRoot), 'utf8');
+    const detach = runbook.indexOf('wrangler queues consumer remove');
+    const deleteWorker = runbook.indexOf('wrangler delete --name');
+    const deleteQueue = runbook.indexOf('wrangler queues delete');
+
+    expect(runbook).toContain('export PROOF_MESSAGE="$(jq -cn');
+    expect(runbook).not.toContain('\'{\\"schemaVersion\\":1');
+    expect(detach).toBeGreaterThan(-1);
+    expect(deleteWorker).toBeGreaterThan(detach);
+    expect(deleteQueue).toBeGreaterThan(deleteWorker);
   });
 });


### PR DESCRIPTION
## What changed

- build the manual Queue message with `jq` so the body is valid JSON
- remove `--verbose` from the production Convex dry-run to avoid printing deployment environment values
- detach the Queue consumer before deleting the Worker and Queue
- add regression assertions for all three operational contracts

## Why

The controlled Free-tier proof exposed each issue directly: the original shell quoting produced HTTP 400 before enqueue, verbose Convex output was unnecessarily sensitive, and Cloudflare refused Worker deletion while it remained a Queue consumer.

## Validation

- `bun run proof:typecheck`
- `bun run proof:test` — 92 tests
- `bunx biome check workers/proof/deployment-config.test.ts`
- `git diff --check`