### PR TITLE
Connect faction saves to asset publishing

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as http from "../http.js";
 import type * as lib_assetPublisherHttp from "../lib/assetPublisherHttp.js";
 import type * as lib_assetPublisherSchemas from "../lib/assetPublisherSchemas.js";
 import type * as lib_assetPublishingProof from "../lib/assetPublishingProof.js";
+import type * as lib_factionSheetTargets from "../lib/factionSheetTargets.js";
 import type * as lib_faqRulesetList from "../lib/faqRulesetList.js";
 import type * as lib_ids from "../lib/ids.js";
 import type * as lib_memberGroups from "../lib/memberGroups.js";
@@ -49,6 +50,7 @@ declare const fullApi: ApiFromModules<{
   "lib/assetPublisherHttp": typeof lib_assetPublisherHttp;
   "lib/assetPublisherSchemas": typeof lib_assetPublisherSchemas;
   "lib/assetPublishingProof": typeof lib_assetPublishingProof;
+  "lib/factionSheetTargets": typeof lib_factionSheetTargets;
   "lib/faqRulesetList": typeof lib_faqRulesetList;
   "lib/ids": typeof lib_ids;
   "lib/memberGroups": typeof lib_memberGroups;

--- a/convex/factions.assetPublishing.test.ts
+++ b/convex/factions.assetPublishing.test.ts
@@ -1,0 +1,454 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import migrationsTest from '@convex-dev/migrations/test';
+import { convexTest } from 'convex-test';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { proofFaction } from '../src/app/capture/proofFaction';
+import { api, internal } from './_generated/api';
+import type { Id } from './_generated/dataModel';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+const NOW = Date.parse('2026-07-16T12:00:00.000Z');
+const BATCH = 'batch-token-0000000000000001';
+const CLAIM = 'claim-token-0000000000000001';
+
+afterEach(() => vi.useRealTimers());
+
+async function authenticatedTest() {
+  const t = convexTest(schema, modules);
+  const userId = await t.run(
+    async (ctx) => await ctx.db.insert('users', { name: 'Faction publisher test user' })
+  );
+  return {
+    t,
+    userId,
+    asUser: t.withIdentity({ subject: userId }),
+  };
+}
+
+async function createFaction(
+  asUser: Awaited<ReturnType<typeof authenticatedTest>>['asUser'],
+  name = proofFaction.name
+) {
+  return await asUser.mutation(api.factions.create, {
+    data: { ...proofFaction, name },
+    group_id: null,
+  });
+}
+
+async function targetFor(
+  t: Awaited<ReturnType<typeof authenticatedTest>>['t'],
+  factionId: Id<'factions'>
+) {
+  return await t.run(
+    async (ctx) =>
+      await ctx.db
+        .query('asset_targets')
+        .withIndex('by_faction_id_and_asset_type', (q) =>
+          q.eq('faction_id', factionId).eq('asset_type', 'faction_sheet')
+        )
+        .unique()
+  );
+}
+
+describe('faction save target reconciliation', () => {
+  test('a save before config seeding creates disabled config and durable pending work', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t, asUser } = await authenticatedTest();
+
+    const faction = await createFaction(asUser);
+    const state = await t.run(async (ctx) => ({
+      config: await ctx.db
+        .query('asset_type_configs')
+        .withIndex('by_asset_type', (q) => q.eq('asset_type', 'faction_sheet'))
+        .unique(),
+      target: await ctx.db
+        .query('asset_targets')
+        .withIndex('by_faction_id_and_asset_type', (q) =>
+          q.eq('faction_id', faction._id).eq('asset_type', 'faction_sheet')
+        )
+        .unique(),
+      publisherState: await ctx.db.query('asset_publisher_state').take(1),
+    }));
+
+    expect(state.config).toMatchObject({
+      asset_type: 'faction_sheet',
+      status: 'disabled',
+      active_renderer_version: 'faction-sheet-v1',
+    });
+    expect(state.target).toMatchObject({
+      faction_id: faction._id,
+      asset_type: 'faction_sheet',
+      desired_generation: 1,
+      desired_renderer_version: 'faction-sheet-v1',
+      status: 'pending',
+      next_eligible_at: NOW,
+      attempt_count: 0,
+    });
+    expect(state.publisherState).toEqual([]);
+    await expect(
+      t.query(internal.assetPublisher.hasEligibleWork, { cutoff: NOW })
+    ).resolves.toEqual({ eligibility: 'empty' });
+    await expect(
+      t.query(api.assetPublisher.getPublicMetadata, {
+        factionId: faction._id,
+        assetType: 'faction_sheet',
+      })
+    ).resolves.toEqual({
+      factionId: faction._id,
+      assetType: 'faction_sheet',
+      status: 'pending',
+      publication: null,
+    });
+  });
+
+  test('rapid saves advance one target monotonically and use the latest configured renderer', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t, asUser } = await authenticatedTest();
+    await t.run(async (ctx) => {
+      await ctx.db.insert('asset_type_configs', {
+        asset_type: 'faction_sheet',
+        status: 'disabled',
+        active_renderer_version: 'faction-sheet-v2',
+        updated_at: NOW,
+      });
+    });
+    const faction = await createFaction(asUser);
+
+    await asUser.mutation(api.factions.update, {
+      id: faction._id,
+      data: { ...proofFaction, name: 'Atreides Revised' },
+    });
+    await asUser.mutation(api.factions.update, {
+      id: faction._id,
+      data: { ...proofFaction, name: 'Atreides Final' },
+    });
+
+    const targets = await t.run(
+      async (ctx) =>
+        await ctx.db
+          .query('asset_targets')
+          .withIndex('by_faction_id_and_asset_type', (q) =>
+            q.eq('faction_id', faction._id).eq('asset_type', 'faction_sheet')
+          )
+          .take(2)
+    );
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({
+      desired_generation: 3,
+      desired_renderer_version: 'faction-sheet-v2',
+      status: 'pending',
+    });
+  });
+
+  test('a save during a claim preserves the exact claim snapshot and makes that claim stale', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t, asUser } = await authenticatedTest();
+    await t.run(async (ctx) => {
+      await ctx.db.insert('asset_type_configs', {
+        asset_type: 'faction_sheet',
+        status: 'active',
+        active_renderer_version: 'faction-sheet-v1',
+        updated_at: NOW,
+      });
+      await ctx.db.insert('asset_publisher_state', {
+        key: 'singleton',
+        status: 'active',
+        cooldown_until: 0,
+        daily_browser_utc_date: '2026-07-16',
+        daily_browser_ms: 0,
+        next_lane: 'foreground',
+      });
+    });
+    const faction = await createFaction(asUser);
+    await t.mutation(internal.assetPublisher.acquireBatch, { batchToken: BATCH });
+    const claim = await t.mutation(internal.assetPublisher.claimOne, {
+      batchToken: BATCH,
+      claimToken: CLAIM,
+    });
+    if (claim.status !== 'claimed') throw new Error(`Expected claim, got ${claim.status}`);
+    const before = await t.run(async (ctx) => ({
+      target: await ctx.db.get('asset_targets', claim.targetId),
+      snapshot: await ctx.db
+        .query('asset_claim_snapshots')
+        .withIndex('by_target_id', (q) => q.eq('target_id', claim.targetId))
+        .unique(),
+    }));
+
+    await asUser.mutation(api.factions.update, {
+      id: faction._id,
+      data: { ...proofFaction, name: 'Atreides After Claim' },
+    });
+
+    const after = await t.run(async (ctx) => ({
+      target: await ctx.db.get('asset_targets', claim.targetId),
+      snapshot: await ctx.db
+        .query('asset_claim_snapshots')
+        .withIndex('by_target_id', (q) => q.eq('target_id', claim.targetId))
+        .unique(),
+      faction: await ctx.db.get('factions', faction._id),
+    }));
+    expect(after.target).toMatchObject({
+      status: 'leased',
+      desired_generation: 2,
+      claimed_generation: 1,
+      batch_token: BATCH,
+      claim_token: CLAIM,
+    });
+    expect(after.target?.next_eligible_at).toBe(before.target?.next_eligible_at);
+    expect(after.snapshot).toEqual(before.snapshot);
+    expect((after.snapshot?.payload as { faction: { name: string } }).faction.name).toBe(
+      proofFaction.name
+    );
+    expect((after.faction?.data as { name: string }).name).toBe('Atreides After Claim');
+    await expect(
+      t.query(internal.assetPublisher.revalidateClaim, {
+        targetId: claim.targetId,
+        batchToken: claim.batchToken,
+        claimToken: claim.claimToken,
+        generation: claim.generation,
+        rendererVersion: claim.rendererVersion,
+      })
+    ).resolves.toEqual({ status: 'stale' });
+  });
+
+  test('setGroup does not dirty the faction-sheet target', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t, userId, asUser } = await authenticatedTest();
+    const faction = await createFaction(asUser);
+    const groupId = await t.run(async (ctx) => {
+      const id = await ctx.db.insert('groups', {
+        name: 'Publisher group',
+        slug: 'publisher-group',
+        created_at: new Date(NOW).toISOString(),
+        created_by: userId,
+      });
+      await ctx.db.insert('group_members', {
+        group_id: id,
+        user_id: userId,
+        status: 'active',
+        requested_at: new Date(NOW).toISOString(),
+        approved_at: new Date(NOW).toISOString(),
+        approved_by: userId,
+      });
+      return id;
+    });
+    const before = await targetFor(t, faction._id);
+
+    await asUser.mutation(api.factions.setGroup, { id: faction._id, group_id: groupId });
+
+    expect(await targetFor(t, faction._id)).toEqual(before);
+  });
+
+  test('soft deletion preserves the target and its publication', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t, asUser } = await authenticatedTest();
+    const faction = await createFaction(asUser);
+    const target = await targetFor(t, faction._id);
+    if (!target) throw new Error('Missing target');
+    await t.run(async (ctx) => {
+      await ctx.db.patch(target._id, {
+        status: 'current',
+        published_generation: 1,
+        published_renderer_version: 'faction-sheet-v1',
+        published_cache_token: 'published-token',
+        published_r2_etag: 'published-etag',
+        published_bytes: 1234,
+        published_at: NOW,
+      });
+    });
+    const before = await targetFor(t, faction._id);
+
+    await asUser.mutation(api.factions.softDelete, { id: faction._id });
+
+    expect(await targetFor(t, faction._id)).toEqual(before);
+  });
+
+  test('duplicate target drift aborts both the faction update and target reconciliation', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t, asUser } = await authenticatedTest();
+    const faction = await createFaction(asUser);
+    await t.run(async (ctx) => {
+      await ctx.db.insert('asset_targets', {
+        faction_id: faction._id,
+        asset_type: 'faction_sheet',
+        desired_generation: 99,
+        desired_renderer_version: 'drifted-renderer',
+        status: 'pending',
+        next_eligible_at: NOW,
+        attempt_count: 0,
+      });
+    });
+
+    await expect(
+      asUser.mutation(api.factions.update, {
+        id: faction._id,
+        data: { ...proofFaction, name: 'Must Roll Back' },
+      })
+    ).rejects.toThrow('duplicate faction-sheet targets');
+    const after = await t.run(async (ctx) => ({
+      faction: await ctx.db.get('factions', faction._id),
+      targets: await ctx.db
+        .query('asset_targets')
+        .withIndex('by_faction_id_and_asset_type', (q) =>
+          q.eq('faction_id', faction._id).eq('asset_type', 'faction_sheet')
+        )
+        .take(3),
+    }));
+    expect((after.faction?.data as { name: string }).name).toBe(proofFaction.name);
+    expect(after.targets.map((target) => target.desired_generation).sort()).toEqual([1, 99]);
+  });
+
+  test('authoritative validation failure creates no faction, config, or target', async () => {
+    const { t, asUser } = await authenticatedTest();
+
+    await expect(
+      asUser.mutation(api.factions.create, {
+        data: { ...proofFaction, name: 42 },
+        group_id: null,
+      })
+    ).rejects.toThrow('Invalid faction data at name');
+    await expect(
+      t.run(async (ctx) => ({
+        factions: await ctx.db.query('factions').take(1),
+        configs: await ctx.db.query('asset_type_configs').take(1),
+        targets: await ctx.db.query('asset_targets').take(1),
+      }))
+    ).resolves.toEqual({ factions: [], configs: [], targets: [] });
+  });
+});
+
+describe('faction-sheet target migrations', () => {
+  test('backfill is active-only, bounded, idempotent, and followed by zero-defect verification', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+    migrationsTest.register(t);
+    const factions = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert('users', { name: 'Migration owner' });
+      const insertFaction = async (name: string, isDeleted: boolean) =>
+        await ctx.db.insert('factions', {
+          owner_id: userId,
+          data: { ...proofFaction, name },
+          slug: name.toLowerCase().replaceAll(' ', '-'),
+          created_at: new Date(NOW).toISOString(),
+          updated_at: new Date(NOW).toISOString(),
+          is_deleted: isDeleted,
+          group_id: null,
+        });
+      return {
+        activeOne: await insertFaction('Active One', false),
+        activeTwo: await insertFaction('Active Two', false),
+        deleted: await insertFaction('Deleted One', true),
+      };
+    });
+
+    const ids = ['faction_sheet_targets_backfill_v1', 'faction_sheet_targets_verify_v1'];
+    await t.mutation(api.migrations.runRequired, { ids });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const first = await t.run(async (ctx) => ({
+      configs: await ctx.db.query('asset_type_configs').take(2),
+      activeOne: await ctx.db
+        .query('asset_targets')
+        .withIndex('by_faction_id_and_asset_type', (q) =>
+          q.eq('faction_id', factions.activeOne).eq('asset_type', 'faction_sheet')
+        )
+        .take(2),
+      activeTwo: await ctx.db
+        .query('asset_targets')
+        .withIndex('by_faction_id_and_asset_type', (q) =>
+          q.eq('faction_id', factions.activeTwo).eq('asset_type', 'faction_sheet')
+        )
+        .take(2),
+      deleted: await ctx.db
+        .query('asset_targets')
+        .withIndex('by_faction_id_and_asset_type', (q) =>
+          q.eq('faction_id', factions.deleted).eq('asset_type', 'faction_sheet')
+        )
+        .take(2),
+    }));
+    expect(first.configs).toHaveLength(1);
+    expect(first.configs[0]).toMatchObject({ status: 'disabled' });
+    expect(first.activeOne).toHaveLength(1);
+    expect(first.activeTwo).toHaveLength(1);
+    expect(first.deleted).toHaveLength(0);
+    await expect(
+      t.query(api.migrations.verifyMigration, { id: 'faction_sheet_targets_verify_v1' })
+    ).resolves.toMatchObject({
+      complete: true,
+      pending: 0,
+      missing: 0,
+      duplicates: 0,
+    });
+    await expect(
+      t.query(api.migrations.assertReadyForNarrow, { required: ids })
+    ).resolves.toMatchObject({ ok: true, required: ids });
+
+    await t.mutation(api.migrations.runRequired, { ids });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const finalTargets = await t.run(async (ctx) => await ctx.db.query('asset_targets').take(4));
+    expect(finalTargets).toHaveLength(2);
+    expect(finalTargets.every((target) => target.desired_generation === 1)).toBe(true);
+  });
+
+  test('the verification migration fails closed on duplicate targets', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+    migrationsTest.register(t);
+    await t.run(async (ctx) => {
+      const userId = await ctx.db.insert('users', { name: 'Verification owner' });
+      const factionId = await ctx.db.insert('factions', {
+        owner_id: userId,
+        data: proofFaction,
+        slug: 'verification-faction',
+        created_at: new Date(NOW).toISOString(),
+        updated_at: new Date(NOW).toISOString(),
+        is_deleted: false,
+        group_id: null,
+      });
+      await ctx.db.insert('asset_type_configs', {
+        asset_type: 'faction_sheet',
+        status: 'disabled',
+        active_renderer_version: 'faction-sheet-v1',
+        updated_at: NOW,
+      });
+      for (const generation of [1, 2]) {
+        await ctx.db.insert('asset_targets', {
+          faction_id: factionId,
+          asset_type: 'faction_sheet',
+          desired_generation: generation,
+          desired_renderer_version: 'faction-sheet-v1',
+          status: 'pending',
+          next_eligible_at: NOW,
+          attempt_count: 0,
+        });
+      }
+    });
+
+    await t.mutation(api.migrations.runRequired, {
+      ids: ['faction_sheet_targets_verify_v1'],
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    await expect(
+      t.query(api.migrations.verifyMigration, { id: 'faction_sheet_targets_verify_v1' })
+    ).resolves.toMatchObject({
+      complete: false,
+      state: 'failed',
+      missing: null,
+      duplicates: null,
+      error: expect.stringContaining('duplicate targets'),
+    });
+  });
+});

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -4,6 +4,7 @@ import { v } from 'convex/values';
 import { FactionInputSchema } from '../src/game/schema/faction';
 import type { Doc, Id } from './_generated/dataModel';
 import { mutation, query } from './_generated/server';
+import { parseFactionInput, reconcileFactionSheetTargetForSave } from './lib/factionSheetTargets';
 import { isActiveGroupMember, requireAuthUserId } from './lib/policy';
 import { profileSummary } from './lib/profileSummary';
 import { nowIso, slugify } from './lib/utils';
@@ -30,17 +31,6 @@ async function groupsForFactionAndMemberships(
     }
   }
   return groups;
-}
-
-function normalizeFactionData(input: unknown) {
-  const parsed = FactionInputSchema.safeParse(input);
-  if (!parsed.success) {
-    const firstIssue = parsed.error.issues[0];
-    const issuePath = firstIssue?.path.join('.') ?? 'data';
-    const issueMessage = firstIssue?.message ?? 'Invalid faction data';
-    throw new Error(`Invalid faction data at ${issuePath}: ${issueMessage}`);
-  }
-  return parsed.data;
 }
 
 /** Faction detail page bundle (view, edit, and sheet preview). */
@@ -213,7 +203,7 @@ export const create = mutation({
       if (!canUseGroup) throw new Error('Not authorized for group');
     }
 
-    const data = normalizeFactionData(args.data);
+    const data = parseFactionInput(args.data);
     const slug = slugify(data.name);
     const existing = await ctx.db
       .query('factions')
@@ -233,6 +223,7 @@ export const create = mutation({
       updated_at: now,
       is_deleted: false,
     });
+    await reconcileFactionSheetTargetForSave(ctx, _id);
     const row = await ctx.db.get(_id);
     if (!row) throw new Error('Failed to create faction');
     return row;
@@ -253,7 +244,7 @@ export const update = mutation({
       row.group_id == null ? false : await isActiveGroupMember(ctx, row.group_id, userId);
     if (!isOwner && !isGroupEditor) throw new Error('Not authorized');
 
-    const data = normalizeFactionData(args.data);
+    const data = parseFactionInput(args.data);
     const slug = slugify(data.name);
     const slugOwner = await ctx.db
       .query('factions')
@@ -268,6 +259,7 @@ export const update = mutation({
       slug,
       updated_at: nowIso(),
     });
+    await reconcileFactionSheetTargetForSave(ctx, args.id);
     const updated = await ctx.db.get(args.id);
     if (!updated) throw new Error('Failed to update faction');
     return updated;

--- a/convex/lib/factionSheetTargets.ts
+++ b/convex/lib/factionSheetTargets.ts
@@ -1,0 +1,139 @@
+import { FactionInputSchema } from '../../src/game/schema/faction';
+import type { Id } from '../_generated/dataModel';
+import type { MutationCtx } from '../types';
+
+export const FACTION_SHEET_ASSET_TYPE = 'faction_sheet' as const;
+export const INITIAL_FACTION_SHEET_RENDERER_VERSION = 'faction-sheet-v1';
+
+export function parseFactionInput(input: unknown) {
+  const parsed = FactionInputSchema.safeParse(input);
+  if (!parsed.success) {
+    const firstIssue = parsed.error.issues[0];
+    const issuePath = firstIssue?.path.join('.') ?? 'data';
+    const issueMessage = firstIssue?.message ?? 'Invalid faction data';
+    throw new Error(`Invalid faction data at ${issuePath}: ${issueMessage}`);
+  }
+  return parsed.data;
+}
+
+async function factionSheetConfigs(ctx: MutationCtx) {
+  return await ctx.db
+    .query('asset_type_configs')
+    .withIndex('by_asset_type', (q) => q.eq('asset_type', FACTION_SHEET_ASSET_TYPE))
+    .take(2);
+}
+
+/**
+ * Returns the singleton faction-sheet config, creating it disabled when absent.
+ * The indexed range read makes concurrent first writers conflict and retry rather
+ * than creating two rows. Existing configuration is never implicitly activated,
+ * paused, or disabled by a faction save.
+ */
+export async function ensureFactionSheetConfig(ctx: MutationCtx) {
+  const configs = await factionSheetConfigs(ctx);
+  if (configs.length > 1) {
+    throw new Error('Asset publisher invariant violated: duplicate faction-sheet configs');
+  }
+  if (configs[0]) return configs[0];
+
+  const now = Date.now();
+  const configId = await ctx.db.insert('asset_type_configs', {
+    asset_type: FACTION_SHEET_ASSET_TYPE,
+    status: 'disabled',
+    active_renderer_version: INITIAL_FACTION_SHEET_RENDERER_VERSION,
+    updated_at: now,
+  });
+  const config = await ctx.db.get('asset_type_configs', configId);
+  if (!config) throw new Error('Failed to seed disabled faction-sheet publisher config');
+  return config;
+}
+
+async function factionSheetTargets(ctx: MutationCtx, factionId: Id<'factions'>) {
+  return await ctx.db
+    .query('asset_targets')
+    .withIndex('by_faction_id_and_asset_type', (q) =>
+      q.eq('faction_id', factionId).eq('asset_type', FACTION_SHEET_ASSET_TYPE)
+    )
+    .take(2);
+}
+
+function exactlyOneTargetOrNull(
+  targets: Awaited<ReturnType<typeof factionSheetTargets>>,
+  factionId: Id<'factions'>
+) {
+  if (targets.length > 1) {
+    throw new Error(
+      `Asset publisher invariant violated: duplicate faction-sheet targets for ${factionId}`
+    );
+  }
+  return targets[0] ?? null;
+}
+
+/** Reconcile one successful render-relevant save into the same Convex transaction. */
+export async function reconcileFactionSheetTargetForSave(
+  ctx: MutationCtx,
+  factionId: Id<'factions'>
+) {
+  const config = await ensureFactionSheetConfig(ctx);
+  const target = exactlyOneTargetOrNull(await factionSheetTargets(ctx, factionId), factionId);
+  const now = Date.now();
+
+  if (!target) {
+    return await ctx.db.insert('asset_targets', {
+      faction_id: factionId,
+      asset_type: FACTION_SHEET_ASSET_TYPE,
+      desired_generation: 1,
+      desired_renderer_version: config.active_renderer_version,
+      status: 'pending',
+      next_eligible_at: now,
+      attempt_count: 0,
+    });
+  }
+
+  await ctx.db.patch(target._id, {
+    desired_generation: target.desired_generation + 1,
+    desired_renderer_version: config.active_renderer_version,
+    ...(target.status === 'leased'
+      ? {}
+      : {
+          status: 'pending' as const,
+          next_eligible_at: now,
+          last_error: undefined,
+        }),
+  });
+  return target._id;
+}
+
+/** Idempotently create the target required by the active-faction backfill. */
+export async function ensureFactionSheetTargetForBackfill(
+  ctx: MutationCtx,
+  factionId: Id<'factions'>
+) {
+  const config = await ensureFactionSheetConfig(ctx);
+  const target = exactlyOneTargetOrNull(await factionSheetTargets(ctx, factionId), factionId);
+  if (target) return target._id;
+
+  return await ctx.db.insert('asset_targets', {
+    faction_id: factionId,
+    asset_type: FACTION_SHEET_ASSET_TYPE,
+    desired_generation: 1,
+    desired_renderer_version: config.active_renderer_version,
+    status: 'pending',
+    next_eligible_at: Date.now(),
+    attempt_count: 0,
+  });
+}
+
+/** Verification pass postcondition for a single active faction. */
+export async function assertExactlyOneFactionSheetTarget(
+  ctx: MutationCtx,
+  factionId: Id<'factions'>
+) {
+  const targets = await factionSheetTargets(ctx, factionId);
+  if (targets.length === 0) {
+    throw new Error(`Faction-sheet target verification failed: missing target for ${factionId}`);
+  }
+  if (targets.length > 1) {
+    throw new Error(`Faction-sheet target verification failed: duplicate targets for ${factionId}`);
+  }
+}

--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -21,9 +21,24 @@
       "requires": []
     },
     {
+      "id": "faction_sheet_targets_backfill_v1",
+      "phase": "widen",
+      "requires": []
+    },
+    {
+      "id": "faction_sheet_targets_verify_v1",
+      "phase": "widen",
+      "requires": []
+    },
+    {
       "id": "profiles_backfill_guard",
       "phase": "narrow",
       "requires": ["profiles_from_users_v1"]
+    },
+    {
+      "id": "faction_sheet_targets_backfill_guard",
+      "phase": "narrow",
+      "requires": ["faction_sheet_targets_backfill_v1", "faction_sheet_targets_verify_v1"]
     },
     {
       "id": "groups_slug_narrow",

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -4,10 +4,18 @@ import { v } from 'convex/values';
 
 import { DEFAULT_FAQ_TAG } from '../src/app/faq/tags';
 import { components, internal } from './_generated/api';
-import type { DataModel, Id } from './_generated/dataModel';
+import type { Id } from './_generated/dataModel';
 import { internalMutation, mutation, query } from './_generated/server';
+import {
+  assertExactlyOneFactionSheetTarget,
+  ensureFactionSheetConfig,
+  ensureFactionSheetTargetForBackfill,
+  FACTION_SHEET_ASSET_TYPE,
+  parseFactionInput,
+} from './lib/factionSheetTargets';
 import { ensureProfileForUser, profileSourcesFromUserDoc } from './lib/profileBootstrap';
 import { nowIso, slugify } from './lib/utils';
+import schema from './schema';
 import type { MutationCtx, QueryCtx } from './types';
 
 type MigrationRef = FunctionReference<'mutation', 'internal'>;
@@ -18,14 +26,22 @@ const MIGRATION_IDS: Record<string, MigrationRef> = {
   faq_item_slug_v1: internal.migrations.faq_item_slug_v1,
   faq_item_tags_v1: internal.migrations.faq_item_tags_v1,
   profiles_from_users_v1: internal.migrations.profiles_from_users_v1,
+  faction_sheet_targets_backfill_v1: internal.migrations.faction_sheet_targets_backfill_v1,
+  faction_sheet_targets_verify_v1: internal.migrations.faction_sheet_targets_verify_v1,
 };
 
 type MigrationId = keyof typeof MIGRATION_IDS;
 
-const migrations = new Migrations<DataModel>(components.migrations, {
+const migrations = new Migrations(components.migrations, {
   internalMutation,
   migrationsLocationPrefix: 'migrations:',
+  schema,
 });
+
+const FACTION_SHEET_TARGET_MIGRATION_IDS = [
+  'faction_sheet_targets_backfill_v1',
+  'faction_sheet_targets_verify_v1',
+] as const;
 
 async function resolveUniqueGroupSlug(
   ctx: QueryCtx | MutationCtx,
@@ -167,6 +183,31 @@ export const profiles_from_users_v1 = migrations.define({
   },
 });
 
+/** Bounded, resumable, idempotent target creation for active factions only. */
+export const faction_sheet_targets_backfill_v1 = migrations.define({
+  table: 'factions',
+  customRange: (q) => q.withIndex('by_deleted', (index) => index.eq('is_deleted', false)),
+  batchSize: 25,
+  migrateOne: async (ctx, faction) => {
+    parseFactionInput(faction.data);
+    await ensureFactionSheetTargetForBackfill(ctx, faction._id);
+  },
+});
+
+/**
+ * A separate bounded pass makes successful migration status proof that every
+ * active faction had exactly one target after backfill completion.
+ */
+export const faction_sheet_targets_verify_v1 = migrations.define({
+  table: 'factions',
+  customRange: (q) => q.withIndex('by_deleted', (index) => index.eq('is_deleted', false)),
+  batchSize: 25,
+  migrateOne: async (ctx, faction) => {
+    parseFactionInput(faction.data);
+    await assertExactlyOneFactionSheetTarget(ctx, faction._id);
+  },
+});
+
 export const run = migrations.runner();
 
 export const runDeployMigrations = migrations.runner([
@@ -175,12 +216,37 @@ export const runDeployMigrations = migrations.runner([
   internal.migrations.faq_item_slug_v1,
   internal.migrations.faq_item_tags_v1,
   internal.migrations.profiles_from_users_v1,
+  internal.migrations.faction_sheet_targets_backfill_v1,
+  internal.migrations.faction_sheet_targets_verify_v1,
 ]);
 
 export const runRequired = mutation({
   args: { ids: v.array(v.string()) },
   handler: async (ctx, args) => {
     const refs = migrationRefsFor(args.ids);
+    const requestedFactionSheetIds = args.ids.filter((id) =>
+      FACTION_SHEET_TARGET_MIGRATION_IDS.includes(
+        id as (typeof FACTION_SHEET_TARGET_MIGRATION_IDS)[number]
+      )
+    );
+    if (requestedFactionSheetIds.length > 0) {
+      const statuses = await migrations.getStatus(ctx, {
+        migrations: migrationRefsFor(requestedFactionSheetIds),
+      });
+      const completed = new Set(
+        statuses
+          .filter((status) => status.isDone && status.state === 'success')
+          .map((status) => toMigrationId(status.name))
+      );
+      if (requestedFactionSheetIds.some((id) => !completed.has(id))) {
+        const config = await ensureFactionSheetConfig(ctx);
+        if (config.status !== 'disabled') {
+          throw new Error(
+            `Faction-sheet target migration requires disabled configuration; found ${config.status}`
+          );
+        }
+      }
+    }
     const state = await migrations.runSerially(ctx, refs);
     return { started: true, state };
   },
@@ -272,6 +338,12 @@ export const verifyMigration = query({
       processed: status.processed,
       latestEnd: status.latestEnd ?? null,
       error: status.error ?? null,
+      ...(args.id === 'faction_sheet_targets_verify_v1'
+        ? {
+            missing: complete ? 0 : null,
+            duplicates: complete ? 0 : null,
+          }
+        : {}),
     };
   },
 });
@@ -293,6 +365,17 @@ export const assertReadyForNarrow = query({
         ...missing.map((id) => `${id}(missing)`),
       ].join(', ');
       throw new Error(`Narrow blocked: required migrations are incomplete. ${detail}`);
+    }
+    if (args.required.includes('faction_sheet_targets_verify_v1')) {
+      const configs = await ctx.db
+        .query('asset_type_configs')
+        .withIndex('by_asset_type', (q) => q.eq('asset_type', FACTION_SHEET_ASSET_TYPE))
+        .take(2);
+      if (configs.length !== 1) {
+        throw new Error(
+          `Narrow blocked: expected exactly one faction-sheet config, found ${configs.length}`
+        );
+      }
     }
     return {
       ok: true,

--- a/docs/convex-migrations.md
+++ b/docs/convex-migrations.md
@@ -69,8 +69,15 @@ Current widen migrations include:
 
 - `groups_slug_v1`, `rulesets_slug_v1`, `faq_item_slug_v1` (slug backfills)
 - `profiles_from_users_v1` (ensures every auth `users` row has a `profiles` row)
+- `faction_sheet_targets_backfill_v1` (creates one pending target for each active faction)
+- `faction_sheet_targets_verify_v1` (bounded proof of zero missing or duplicate active-faction targets)
 
 The `profiles_backfill_guard` narrow-phase entry exists only so deploy polling treats `profiles_from_users_v1` as required alongside schema narrow prerequisites; it is not a schema change.
+
+The faction-sheet target guard requires both its backfill and verification pass. Before either pass
+starts for the first time, `migrations:runRequired` seeds the singleton faction-sheet config as
+disabled. Faction create/update mutations use the same disabled-safe, transactional ensure path, so
+the function-deploy window before required migrations run cannot fail saves or activate publishing.
 
 ## Automated production flow (fail-closed)
 


### PR DESCRIPTION
## Summary
- transactionally reconcile one disabled faction-sheet target from faction create/update
- safely preserve exact live claim snapshots while advancing desired generations
- add bounded idempotent active-faction backfill and exact-one verification migrations

## Safety boundary
- missing config self-seeds as disabled during a save
- existing config is never implicitly activated or overwritten
- `setGroup` and soft delete do not invalidate or delete publications
- no Cloudflare calls, publishing activation, rendering, or external side effects

## Production merge effect
Merging will run the required bounded production migrations through the existing deployment workflow. They create disabled targets for active factions and verify exactly one target per faction. Publishing remains disabled.

## Verification
- 132 tests
- TypeScript and Convex skip guard
- migration manifest/guard audit
- targeted non-writing Biome and diff checks
- cold Traycer review: SAFE, including concurrent save/backfill adversarial cases
