### PR TITLE
Accept production render capabilities in the publisher

### DIFF
--- a/workers/publisher/capture-route.test.ts
+++ b/workers/publisher/capture-route.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { type CaptureEnv, captureCapabilityHeader, handleCaptureRoute } from './capture-route';
 
-const capability = 'render-capability-token-000000001';
+const capability = `${'e'.repeat(400)}.${'s'.repeat(43)}`;
 
 function env(
   assetFetch = vi.fn(async (_request: Request) => new Response('<html>capture</html>'))

--- a/workers/publisher/capture-route.ts
+++ b/workers/publisher/capture-route.ts
@@ -3,12 +3,11 @@ import {
   serializePublisherLogEvent,
 } from '../../src/app/capture/publisher-diagnostics';
 import { readBoundedJson, runWithDeadline } from './http';
+import { isRenderCapability } from './render-capability';
 
 const CAPABILITY_HEADER = 'X-Asset-Render-Capability';
 const CAPABILITY_COOKIE = '__Host-asset_render_capability';
 const DEADLINE_COOKIE = '__Host-asset_render_deadline';
-const MIN_CAPABILITY_BYTES = 16;
-const MAX_CAPABILITY_BYTES = 8_192;
 const MAX_SNAPSHOT_BYTES = 1_000_000;
 const SNAPSHOT_DEADLINE_MS = 30_000;
 
@@ -30,9 +29,7 @@ function capability(request: Request): string | undefined {
     .find((part) => part.startsWith(`${CAPABILITY_COOKIE}=`))
     ?.slice(CAPABILITY_COOKIE.length + 1);
   const value = header ?? cookie;
-  if (!value) return undefined;
-  const length = new TextEncoder().encode(value).byteLength;
-  return length >= MIN_CAPABILITY_BYTES && length <= MAX_CAPABILITY_BYTES ? value : undefined;
+  return isRenderCapability(value) ? value : undefined;
 }
 
 function cookie(request: Request, name: string): string | undefined {

--- a/workers/publisher/convex.test.ts
+++ b/workers/publisher/convex.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'vitest';
+
+import { createRenderCapability } from '../../convex/lib/assetPublisherHttp';
+import { parseClaim } from './convex';
+import { MAX_RENDER_CAPABILITY_BYTES } from './render-capability';
+
+const batchToken = 'b'.repeat(32);
+const claimToken = 'c'.repeat(32);
+
+type ClaimOverrides = {
+  batchToken?: string;
+  claimToken?: string;
+  renderCapability?: string;
+  replay?: boolean;
+};
+
+async function claimedResponse(overrides: ClaimOverrides = {}) {
+  const responseBatchToken = overrides.batchToken ?? batchToken;
+  const responseClaimToken = overrides.claimToken ?? claimToken;
+  const renderCapability =
+    overrides.renderCapability ??
+    (await createRenderCapability(
+      {
+        version: 1,
+        factionId: 'j57d9kz4ktbkpa12nb7j7s7w8h7ygb8p',
+        assetType: 'faction_sheet',
+        payloadHash: 'a'.repeat(64),
+        generation: 1,
+        rendererVersion: 'faction-sheet-v1',
+        batchToken: responseBatchToken,
+        claimToken: responseClaimToken,
+        expiresAt: 2_000_000_000_000,
+      },
+      'render-secret'
+    ));
+  return {
+    ok: true,
+    status: 'claimed',
+    replay: overrides.replay ?? false,
+    targetId: 'k17d9kz4ktbkpa12nb7j7s7w8h7ygb8p',
+    factionId: 'j57d9kz4ktbkpa12nb7j7s7w8h7ygb8p',
+    assetType: 'faction_sheet',
+    batchToken: responseBatchToken,
+    claimToken: responseClaimToken,
+    generation: 1,
+    rendererVersion: 'faction-sheet-v1',
+    leaseExpiresAt: 2_000_000_000_000,
+    payloadHash: 'a'.repeat(64),
+    renderCapability,
+    renderCapabilityExpiresAt: 2_000_000_000_000,
+  };
+}
+
+describe('Convex claimed target parsing', () => {
+  test.each([
+    false,
+    true,
+  ])('accepts a production-shape signed render capability when replay is %s', async (replay) => {
+    const response = await claimedResponse({ replay });
+    expect(response.renderCapability.length).toBeGreaterThan(256);
+    expect(response.renderCapability.length).toBeLessThanOrEqual(MAX_RENDER_CAPABILITY_BYTES);
+    expect(parseClaim(response)).toEqual({
+      status: 'claimed',
+      replay,
+      targetId: response.targetId,
+      factionId: response.factionId,
+      assetType: 'faction_sheet',
+      batchToken,
+      claimToken,
+      generation: 1,
+      rendererVersion: 'faction-sheet-v1',
+      leaseExpiresAt: response.leaseExpiresAt,
+      payloadHash: response.payloadHash,
+      renderCapability: response.renderCapability,
+      renderCapabilityExpiresAt: response.renderCapabilityExpiresAt,
+    });
+  });
+
+  test('retains the generic 16 through 256 character batch and claim token bounds', async () => {
+    expect(parseClaim(await claimedResponse({ batchToken: 'b'.repeat(16) })).status).toBe(
+      'claimed'
+    );
+    expect(parseClaim(await claimedResponse({ claimToken: 'c'.repeat(16) })).status).toBe(
+      'claimed'
+    );
+    expect(parseClaim(await claimedResponse({ batchToken: 'b'.repeat(256) })).status).toBe(
+      'claimed'
+    );
+    expect(parseClaim(await claimedResponse({ claimToken: 'c'.repeat(256) })).status).toBe(
+      'claimed'
+    );
+    const response = await claimedResponse();
+    expect(() => parseClaim({ ...response, batchToken: 'b'.repeat(15) })).toThrow(
+      'Convex claimed target response is invalid'
+    );
+    expect(() => parseClaim({ ...response, claimToken: 'c'.repeat(15) })).toThrow(
+      'Convex claimed target response is invalid'
+    );
+    expect(() => parseClaim({ ...response, batchToken: 'b'.repeat(257) })).toThrow(
+      'Convex claimed target response is invalid'
+    );
+    expect(() => parseClaim({ ...response, claimToken: 'c'.repeat(257) })).toThrow(
+      'Convex claimed target response is invalid'
+    );
+  });
+
+  test('rejects malformed, truncated, oversized, and extra-segment capabilities', async () => {
+    const response = await claimedResponse();
+    const valid = response.renderCapability;
+    const [payload, signature] = valid.split('.');
+    const malformed = `${payload}.${signature.slice(0, -1)}*`;
+    const truncated = valid.slice(0, -1);
+    const oversized = `${'a'.repeat(MAX_RENDER_CAPABILITY_BYTES - 43)}.${'s'.repeat(43)}`;
+    const extraSegment = `${valid}.extra`;
+
+    for (const renderCapability of [malformed, truncated, oversized, extraSegment]) {
+      expect(() => parseClaim({ ...response, renderCapability })).toThrow(
+        'Convex claimed target response is invalid'
+      );
+    }
+  });
+});

--- a/workers/publisher/convex.ts
+++ b/workers/publisher/convex.ts
@@ -1,6 +1,7 @@
 import { publisherErrorMessage } from '../../src/app/capture/publisher-diagnostics';
 import type { PublisherWakeUp } from './dispatch';
 import { postJson } from './http';
+import { isRenderCapability } from './render-capability';
 
 export type AcquireResult =
   | { status: 'empty'; reason: 'disabled' | 'no_eligible_work' | 'browser_quota' }
@@ -133,7 +134,7 @@ export function parseClaim(value: unknown): ClaimResult {
     !finite(body.leaseExpiresAt) ||
     typeof body.payloadHash !== 'string' ||
     !/^[0-9a-f]{64}$/.test(body.payloadHash) ||
-    !token(body.renderCapability) ||
+    !isRenderCapability(body.renderCapability) ||
     !finite(body.renderCapabilityExpiresAt)
   ) {
     throw new Error('Convex claimed target response is invalid');

--- a/workers/publisher/render-capability.ts
+++ b/workers/publisher/render-capability.ts
@@ -1,0 +1,25 @@
+const BASE64URL_SEGMENT = /^[A-Za-z0-9_-]+$/;
+const HMAC_SHA256_BASE64URL_CHARACTERS = 43;
+
+export const MAX_RENDER_CAPABILITY_BYTES = 8_192;
+
+/**
+ * Checks the bounded wire grammar produced by Convex's createRenderCapability.
+ * Cryptographic authority and payload semantics remain the Convex render route's job.
+ */
+export function isRenderCapability(value: unknown): value is string {
+  // Accepted segments are ASCII-only, so string length is also the encoded byte length.
+  if (typeof value !== 'string' || value.length > MAX_RENDER_CAPABILITY_BYTES) return false;
+
+  const separator = value.indexOf('.');
+  if (separator <= 0 || value.indexOf('.', separator + 1) !== -1) return false;
+
+  const payload = value.slice(0, separator);
+  const signature = value.slice(separator + 1);
+  return (
+    payload.length % 4 !== 1 &&
+    signature.length === HMAC_SHA256_BASE64URL_CHARACTERS &&
+    BASE64URL_SEGMENT.test(payload) &&
+    BASE64URL_SEGMENT.test(signature)
+  );
+}


### PR DESCRIPTION
## What changed

- give signed render capabilities a dedicated bounded two-segment base64url grammar
- preserve the existing 16-256 character batch and claim token limits
- reuse the same capability validator for claim parsing and capture routes
- add real Convex-signed initial/replay coverage plus malformed, truncated, oversized, and extra-segment rejection

## Why

The first controlled production canary produced a valid roughly 500-character signed render capability, but the Worker incorrectly applied the generic 256-character publisher-token limit. It rejected both the claim response and its idempotent replay, so Convex safely fenced the uncertain claim before capture or R2.

## Validation

- focused claim/capture: 18/18
- publisher: 307/307
- full suite: 477/477
- proof: 92/92
- root, publisher, and proof TypeScript
- production asset build and Wrangler dry-run/startup
- Convex guard, Biome, and diff check

No Cloudflare or Convex production state is changed by this PR.