### PR TITLE
Fix publisher close and troop rendering

### DIFF
--- a/src/game/assets/faction/sheet/Sheet.tsx
+++ b/src/game/assets/faction/sheet/Sheet.tsx
@@ -17,13 +17,6 @@ function isPreviewSheet(props: SheetProps): props is PreviewSheet {
   return 'background' in props;
 }
 
-// Type guard to check if a troop is Preview type (has star/striped properties)
-function isPreviewTroop(
-  troop: AssetSheet['troops'][0] | PreviewSheet['troops'][0]
-): troop is PreviewSheet['troops'][0] {
-  return 'star' in troop || 'striped' in troop;
-}
-
 // Type guard to check if a leader is Preview type (is an object, not a string)
 function isPreviewLeader(
   leader: AssetSheet['leaders'][0] | PreviewSheet['leaders'][0]
@@ -141,40 +134,44 @@ export function FactionSheetPage2(props: SheetProps) {
                 <div className={styles.subtitle}>Troops</div>
                 <div className={styles.troops}>
                   {props.troops.map((t) => {
-                    if (isPreviewTroop(t) && isPreviewSheet(props)) {
+                    if (isPreviewSheet(props)) {
+                      const previewTroop = t as PreviewSheet['troops'][0];
                       return (
-                        <div key={`${t.image}-${t.name}`} className={styles.troop}>
+                        <div
+                          key={`${previewTroop.image}-${previewTroop.name}`}
+                          className={styles.troop}
+                        >
                           <div>
                             <TroopToken
                               background={props.background}
-                              image={t.image}
-                              star={t.star}
-                              striped={t.striped}
+                              image={previewTroop.image}
+                              star={previewTroop.star}
+                              striped={previewTroop.striped}
                             />
                           </div>
                           <section>
-                            <div className={styles.head}>{t.name}</div>
+                            <div className={styles.head}>{previewTroop.name}</div>
                             <div className={styles.text}>
-                              <MarkdownContent>{t.description}</MarkdownContent>
+                              <MarkdownContent>{previewTroop.description}</MarkdownContent>
                             </div>
                           </section>
 
-                          {t.back && (
+                          {previewTroop.back && (
                             <>
                               <img className={styles.icon} src="/vector/icon/flip.svg" alt="Flip" />
                               <div>to:</div>
                               <div>
                                 <TroopToken
                                   background={props.background}
-                                  image={t.back.image}
-                                  star={t.back.star}
-                                  striped={t.back.striped}
+                                  image={previewTroop.back.image}
+                                  star={previewTroop.back.star}
+                                  striped={previewTroop.back.striped}
                                 />
                               </div>
                               <section>
-                                <div className={styles.head}>{t.back.name}</div>
+                                <div className={styles.head}>{previewTroop.back.name}</div>
                                 <div className={styles.text}>
-                                  <MarkdownContent>{t.back.description}</MarkdownContent>
+                                  <MarkdownContent>{previewTroop.back.description}</MarkdownContent>
                                 </div>
                               </section>
                             </>

--- a/workers/proof/browser-regression.ts
+++ b/workers/proof/browser-regression.ts
@@ -300,6 +300,11 @@ async function checkProofPdf(
       );
     }
 
+    invariant(
+      (await page.locator('[aria-label="Troop Token"]').count()) > 0,
+      'Preview troops with omitted optional modifiers must render as bounded TroopToken components'
+    );
+
     const bytes = await page.pdf({
       displayHeaderFooter: false,
       margin: { top: 0, right: 0, bottom: 0, left: 0 },

--- a/workers/publisher/browser.test.ts
+++ b/workers/publisher/browser.test.ts
@@ -1,9 +1,10 @@
-import type { Page } from '@cloudflare/playwright';
+import type { Browser, Page } from '@cloudflare/playwright';
 import { describe, expect, test, vi } from 'vitest';
 
 import {
   assertCaptureDiagnostics,
   assertCapturedPdfOutput,
+  PublisherBrowserSession,
   publisherCaptureCookies,
   registerCaptureDiagnostics,
 } from './browser';
@@ -102,5 +103,15 @@ describe('production capture output validation', () => {
     });
     expect(capabilityCookie).not.toHaveProperty('domain');
     expect(capabilityCookie?.url).not.toContain(capability);
+  });
+
+  test('closes the provider Browser session exactly once', async () => {
+    const close = vi.fn(async () => {});
+    const browser = { close } as unknown as Browser;
+    const session = new PublisherBrowserSession(browser, 'https://publisher.example.com');
+
+    await session.close();
+
+    expect(close).toHaveBeenCalledOnce();
   });
 });

--- a/workers/publisher/browser.ts
+++ b/workers/publisher/browser.ts
@@ -247,12 +247,10 @@ export class PublisherBrowserSession {
   }
 
   async close(): Promise<void> {
-    const results = await Promise.allSettled([
-      this.context?.close() ?? Promise.resolve(),
-      this.browser.close(),
-    ]);
-    const rejected = results.find((result) => result.status === 'rejected');
-    if (rejected?.status === 'rejected') throw rejected.reason;
+    // Browser.close() owns the provider session lifecycle and closes all contexts. Closing the
+    // context concurrently races the CDP connection teardown and can turn a normal provider close
+    // into a rejected close promise even though the session has already ended.
+    await this.browser.close();
   }
 }
 

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,8 +4,8 @@ export const rendererManifest = {
   schemaVersion: 1,
   rendererVersion: 'faction-sheet-v1',
   rendererId:
-    'faction-sheet/sha256:7b238b0865715ff3c32f7fc20259db89d3633b2d05273cc9a969f6600091d813',
-  digest: '7b238b0865715ff3c32f7fc20259db89d3633b2d05273cc9a969f6600091d813',
+    'faction-sheet/sha256:c5813007a2b1855f20473517a8aaf77ecd121fa529a444745e99eb5f3b45044b',
+  digest: 'c5813007a2b1855f20473517a8aaf77ecd121fa529a444745e99eb5f3b45044b',
   contract: {
     rendererVersion: 'faction-sheet-v1',
     viewport: {


### PR DESCRIPTION
## What changed

- let the provider-owned `browser.close()` operation close Browser Run and its contexts without a concurrent context teardown race
- choose preview troop rendering from the authoritative preview-sheet shape, including when optional `star` and `striped` fields are omitted
- add close coverage and a real Chromium regression for an unmodified preview troop
- regenerate the immutable renderer digest

## Why

The second controlled production canary completed capture, R2, Convex, and public delivery, but the raced close promise rejected and the real PDF exposed a raw troop SVG overflowing page 2. Production was paused and returned to inert mode before this fix.

## Verification

- publisher: 308/308
- full Vitest: 478/478
- proof: 92/92
- root and publisher TypeScript
- real Chromium proof and Storybook PDF regression
- visual raster check of corrected page 2
- unified asset build and Wrangler dry run/types/startup
- targeted Biome and diff check

No production state, resource, Cron, Queue, schema, or secret behavior is changed by this PR.