### PR TITLE
Add exact publisher canary requeue

### DIFF
--- a/convex/assetPublisherOperator.test.ts
+++ b/convex/assetPublisherOperator.test.ts
@@ -204,6 +204,207 @@ describe('asset publisher operator controls', () => {
     expect(await t.run(async (ctx) => await ctx.db.get('asset_targets', targetId))).toEqual(before);
   });
 
+  test('requeues exactly one current canary first while preserving its publication', async () => {
+    const t = convexTest(schema, modules);
+    const seeded = await t.run(async (ctx) => {
+      const ownerId = await ctx.db.insert('users', { name: 'Canary owner' });
+      const olderFactionId = await ctx.db.insert('factions', {
+        owner_id: ownerId,
+        data: {},
+        slug: 'older-pending-faction',
+        created_at: new Date(NOW).toISOString(),
+        updated_at: new Date(NOW).toISOString(),
+        is_deleted: false,
+        group_id: null,
+      });
+      const factionId = await ctx.db.insert('factions', {
+        owner_id: ownerId,
+        data: {},
+        slug: 'current-canary',
+        created_at: new Date(NOW).toISOString(),
+        updated_at: new Date(NOW).toISOString(),
+        is_deleted: false,
+        group_id: null,
+      });
+      await ctx.db.insert('asset_type_configs', {
+        asset_type: 'faction_sheet',
+        status: 'paused',
+        active_renderer_version: 'faction-sheet-v1',
+        updated_at: NOW,
+      });
+      await ctx.db.insert('asset_publisher_state', {
+        key: 'singleton',
+        status: 'paused',
+        cooldown_until: 0,
+        daily_browser_utc_date: '2026-07-16',
+        daily_browser_ms: 480_000,
+        browser_reservation_batch_token: 'prior-canary-reservation',
+        browser_reservation_utc_date: '2026-07-16',
+        browser_reserved_ms: 480_000,
+        next_lane: 'foreground',
+      });
+      const olderTargetId = await ctx.db.insert('asset_targets', {
+        faction_id: olderFactionId,
+        asset_type: 'faction_sheet',
+        desired_generation: 1,
+        desired_renderer_version: 'faction-sheet-v1',
+        first_publication_admitted: false,
+        status: 'pending',
+        next_eligible_at: NOW - 60_000,
+        attempt_count: 0,
+      });
+      const targetId = await ctx.db.insert('asset_targets', {
+        faction_id: factionId,
+        asset_type: 'faction_sheet',
+        desired_generation: 1,
+        desired_renderer_version: 'faction-sheet-v1',
+        published_generation: 1,
+        published_renderer_version: 'faction-sheet-v1',
+        published_cache_token: 'v1.existing-canary-token.existing-canary-signature',
+        published_r2_etag: 'existing-etag',
+        published_bytes: 100_180,
+        published_at: NOW - 1_000,
+        first_publication_admitted: true,
+        status: 'current',
+        next_eligible_at: NOW - 1_000,
+        attempt_count: 1,
+        last_error: 'old diagnostic',
+        last_completed_batch_token: 'completed-batch-token',
+        last_completed_claim_token: 'completed-claim-token',
+      });
+      return { factionId, olderTargetId, targetId };
+    });
+    const before = await t.run(async (ctx) => await ctx.db.get('asset_targets', seeded.targetId));
+
+    await expect(
+      t.mutation(internal.assetPublisherOperator.requeueCurrentFactionSheetCanary, {
+        factionId: seeded.factionId,
+      })
+    ).resolves.toMatchObject({
+      status: 'requeued',
+      targetId: seeded.targetId,
+      previousGeneration: 1,
+      desiredGeneration: 2,
+      rendererVersion: 'faction-sheet-v1',
+      nextEligibleAt: 0,
+    });
+
+    const after = await t.run(async (ctx) => await ctx.db.get('asset_targets', seeded.targetId));
+    expect(after).toMatchObject({
+      desired_generation: 2,
+      desired_renderer_version: 'faction-sheet-v1',
+      status: 'pending',
+      next_eligible_at: 0,
+      attempt_count: 1,
+      published_generation: 1,
+      published_renderer_version: 'faction-sheet-v1',
+      published_cache_token: before?.published_cache_token,
+      published_r2_etag: before?.published_r2_etag,
+      published_bytes: before?.published_bytes,
+      published_at: before?.published_at,
+      first_publication_admitted: true,
+      last_completed_batch_token: before?.last_completed_batch_token,
+      last_completed_claim_token: before?.last_completed_claim_token,
+    });
+    expect(after?.last_error).toBeUndefined();
+    await expect(
+      t.run(async (ctx) =>
+        ctx.db
+          .query('asset_targets')
+          .withIndex('by_asset_type_and_status_and_next_eligible_at', (q) =>
+            q.eq('asset_type', 'faction_sheet').eq('status', 'pending')
+          )
+          .take(2)
+      )
+    ).resolves.toMatchObject([{ _id: seeded.targetId }, { _id: seeded.olderTargetId }]);
+    await expect(
+      t.mutation(internal.assetPublisherOperator.requeueCurrentFactionSheetCanary, {
+        factionId: seeded.factionId,
+      })
+    ).rejects.toThrow('requires one current target');
+  });
+
+  test('canary requeue fails closed on control, ownership, and publication drift', async () => {
+    const cases: Array<{
+      name: string;
+      configStatus?: 'active';
+      stateStatus?: 'active';
+      targetStatus?: 'pending';
+      admitted?: false;
+      desiredGeneration?: 2;
+      batchToken?: string;
+    }> = [
+      { name: 'active controls', configStatus: 'active', stateStatus: 'active' },
+      { name: 'non-current target', targetStatus: 'pending' },
+      { name: 'unadmitted publication', admitted: false },
+      { name: 'generation drift', desiredGeneration: 2 },
+      { name: 'owned batch', batchToken: 'owned-batch-token' },
+    ];
+
+    for (const testCase of cases) {
+      const t = convexTest(schema, modules);
+      const factionId = await t.run(async (ctx) => {
+        const ownerId = await ctx.db.insert('users', { name: testCase.name });
+        const id = await ctx.db.insert('factions', {
+          owner_id: ownerId,
+          data: {},
+          slug: testCase.name.replaceAll(' ', '-'),
+          created_at: new Date(NOW).toISOString(),
+          updated_at: new Date(NOW).toISOString(),
+          is_deleted: false,
+          group_id: null,
+        });
+        await ctx.db.insert('asset_type_configs', {
+          asset_type: 'faction_sheet',
+          status: testCase.configStatus ?? 'paused',
+          active_renderer_version: 'faction-sheet-v1',
+          updated_at: NOW,
+        });
+        await ctx.db.insert('asset_publisher_state', {
+          key: 'singleton',
+          status: testCase.stateStatus ?? 'paused',
+          batch_token: testCase.batchToken,
+          batch_lease_expires_at: testCase.batchToken ? NOW + 60_000 : undefined,
+          cooldown_until: 0,
+          daily_browser_utc_date: '2026-07-16',
+          daily_browser_ms: 0,
+          next_lane: 'foreground',
+        });
+        await ctx.db.insert('asset_targets', {
+          faction_id: id,
+          asset_type: 'faction_sheet',
+          desired_generation: testCase.desiredGeneration ?? 1,
+          desired_renderer_version: 'faction-sheet-v1',
+          published_generation: 1,
+          published_renderer_version: 'faction-sheet-v1',
+          published_cache_token: 'retained-token',
+          published_r2_etag: 'retained-etag',
+          published_bytes: 100,
+          published_at: NOW,
+          first_publication_admitted: testCase.admitted ?? true,
+          status: testCase.targetStatus ?? 'current',
+          next_eligible_at: NOW,
+          attempt_count: 1,
+        });
+        return id;
+      });
+
+      await expect(
+        t.mutation(internal.assetPublisherOperator.requeueCurrentFactionSheetCanary, { factionId })
+      ).rejects.toThrow();
+      await expect(
+        t.run(async (ctx) =>
+          ctx.db
+            .query('asset_targets')
+            .withIndex('by_faction_id_and_asset_type', (q) =>
+              q.eq('faction_id', factionId).eq('asset_type', 'faction_sheet')
+            )
+            .unique()
+        )
+      ).resolves.toMatchObject({ desired_generation: testCase.desiredGeneration ?? 1 });
+    }
+  });
+
   test.each([
     'singleton',
     'config',

--- a/convex/assetPublisherOperator.ts
+++ b/convex/assetPublisherOperator.ts
@@ -106,6 +106,98 @@ export const disable = internalMutation({
   handler: async (ctx) => await setStatus(ctx, 'disabled'),
 });
 
+const CANARY_PRIORITY_NEXT_ELIGIBLE_AT = 0;
+
+/**
+ * One-shot maintenance operation for replacing a known current canary after a
+ * renderer correction. It is intentionally internal-only and may run only
+ * while both publisher controls are paused and no batch owns the singleton.
+ */
+export const requeueCurrentFactionSheetCanary = internalMutation({
+  args: { factionId: v.id('factions') },
+  handler: async (ctx, args) => {
+    const [config, state] = await Promise.all([
+      exactConfigOrNull(ctx),
+      exactPublisherStateOrNull(ctx),
+    ]);
+    if (config?.status !== 'paused' || state?.status !== 'paused') {
+      throw new Error('Canary requeue requires paused publisher controls');
+    }
+    if (state.batch_token !== undefined) {
+      throw new Error('Canary requeue requires no owned publisher batch');
+    }
+
+    const targets = await ctx.db
+      .query('asset_targets')
+      .withIndex('by_faction_id_and_asset_type', (q) =>
+        q.eq('faction_id', args.factionId).eq('asset_type', FACTION_SHEET_ASSET_TYPE)
+      )
+      .take(2);
+    if (targets.length === 0) {
+      throw new Error('Canary requeue target is missing');
+    }
+    if (targets.length > 1) {
+      throw new Error('Canary requeue target is duplicated');
+    }
+    const target = targets[0];
+    if (target?.status !== 'current') {
+      throw new Error('Canary requeue requires one current target');
+    }
+
+    const snapshots = await ctx.db
+      .query('asset_claim_snapshots')
+      .withIndex('by_target_id', (q) => q.eq('target_id', target._id))
+      .take(2);
+    if (snapshots.length !== 0) {
+      throw new Error('Canary requeue target has an unexpected claim snapshot');
+    }
+
+    const publicationIsComplete =
+      target.first_publication_admitted === true &&
+      Number.isSafeInteger(target.published_generation) &&
+      (target.published_generation ?? 0) > 0 &&
+      typeof target.published_renderer_version === 'string' &&
+      target.published_renderer_version.length > 0 &&
+      typeof target.published_cache_token === 'string' &&
+      target.published_cache_token.length > 0 &&
+      typeof target.published_r2_etag === 'string' &&
+      target.published_r2_etag.length > 0 &&
+      Number.isSafeInteger(target.published_bytes) &&
+      (target.published_bytes ?? 0) > 0 &&
+      Number.isFinite(target.published_at);
+    if (!publicationIsComplete) {
+      throw new Error('Canary requeue requires a complete admitted publication');
+    }
+    if (
+      !Number.isSafeInteger(target.desired_generation) ||
+      target.desired_generation < 1 ||
+      target.desired_generation >= Number.MAX_SAFE_INTEGER ||
+      target.desired_generation !== target.published_generation ||
+      target.desired_renderer_version !== target.published_renderer_version
+    ) {
+      throw new Error('Canary requeue target is not exactly current');
+    }
+
+    const desiredGeneration = target.desired_generation + 1;
+    await ctx.db.patch(target._id, {
+      desired_generation: desiredGeneration,
+      desired_renderer_version: config.active_renderer_version,
+      status: 'pending',
+      next_eligible_at: CANARY_PRIORITY_NEXT_ELIGIBLE_AT,
+      last_error: undefined,
+    });
+    return {
+      status: 'requeued' as const,
+      targetId: target._id,
+      factionId: target.faction_id,
+      previousGeneration: target.desired_generation,
+      desiredGeneration,
+      rendererVersion: config.active_renderer_version,
+      nextEligibleAt: CANARY_PRIORITY_NEXT_ELIGIBLE_AT,
+    };
+  },
+});
+
 async function assertExactPrerequisite(
   ctx: MutationCtx,
   prerequisite:


### PR DESCRIPTION
## What changed

- add an internal-only Convex maintenance mutation that requeues one exact current faction-sheet canary while publishing is paused
- preserve the stable publication, admission slot, cache token, R2 metadata, attempt count, and completion tokens
- assign priority timestamp 0 so the canary is selected before existing pending targets
- add focused preservation, ordering, replay, and fail-closed tests

## Why

The corrected Browser-close path needs one apples-to-apples production canary. The previous canary is already current, so without this bounded maintenance action the next Queue message would claim one of the older pending factions instead.

## Validation

- `bunx vitest run convex/assetPublisherOperator.test.ts` — 11 passed
- `bun run test` — 480 passed
- `bun run typecheck`
- targeted Biome
- Convex subscription guard
- `git diff --check`
- independent Traycer review: SAFE