### PR TITLE
Keep production Worker deploy source-exact

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -35,9 +35,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Generate app artifacts
-        run: bun run generate
-
       - name: Deploy Convex
         run: bun run convex:deploy
         env:

--- a/workers/publisher/deployment-config.test.ts
+++ b/workers/publisher/deployment-config.test.ts
@@ -180,5 +180,6 @@ describe('disabled production deployment shape', () => {
     expect(workflow).not.toContain('--keep-vars');
     expect(workflow).not.toContain('--triggers');
     expect(workflow).not.toContain('--secrets-file');
+    expect(workflow).not.toContain('name: Generate app artifacts');
   });
 });


### PR DESCRIPTION
## What changed

- remove the deploy job’s legacy generation step
- enforce that production deploys consume the reviewed, committed generated artifacts
- add a regression assertion that generation is absent from the production job

## Root cause

`bun run generate` rewrites tracked generated files. The new exact-checkout preflight correctly rejected those workflow-created changes before Cloudflare deployment.

## Verification

- 21 focused deployment-contract tests
- publisher TypeScript
- targeted Biome
- workflow YAML parse
- git diff check