### PR TITLE
Reconcile observed Browser Run usage safely

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as faq from "../faq.js";
 import type * as groups from "../groups.js";
 import type * as http from "../http.js";
 import type * as lib_assetPublisherHttp from "../lib/assetPublisherHttp.js";
+import type * as lib_assetPublisherLimits from "../lib/assetPublisherLimits.js";
 import type * as lib_assetPublisherSchemas from "../lib/assetPublisherSchemas.js";
 import type * as lib_assetPublishingProof from "../lib/assetPublishingProof.js";
 import type * as lib_factionSheetPublicationGuard from "../lib/factionSheetPublicationGuard.js";
@@ -53,6 +54,7 @@ declare const fullApi: ApiFromModules<{
   groups: typeof groups;
   http: typeof http;
   "lib/assetPublisherHttp": typeof lib_assetPublisherHttp;
+  "lib/assetPublisherLimits": typeof lib_assetPublisherLimits;
   "lib/assetPublisherSchemas": typeof lib_assetPublisherSchemas;
   "lib/assetPublishingProof": typeof lib_assetPublishingProof;
   "lib/factionSheetPublicationGuard": typeof lib_factionSheetPublicationGuard;

--- a/convex/assetPublisher.test.ts
+++ b/convex/assetPublisher.test.ts
@@ -618,6 +618,23 @@ describe('daily Browser reservation accounting', () => {
   test('quota fails closed and the next UTC day clears a lost reservation', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
+    const { t: exactAllowance } = await seed();
+    await exactAllowance.run(async (ctx) => {
+      const state = await ctx.db
+        .query('asset_publisher_state')
+        .withIndex('by_key', (q) => q.eq('key', 'singleton'))
+        .unique();
+      if (!state) throw new Error('missing state');
+      await ctx.db.patch(state._id, { daily_browser_ms: 120_000 });
+    });
+    await expect(
+      exactAllowance.mutation(internal.assetPublisher.acquireBatch, { batchToken: BATCH_ONE })
+    ).resolves.toMatchObject({
+      status: 'acquired',
+      dailyBrowserMs: 600_000,
+      browserReservationMs: 480_000,
+    });
+
     const { t: quota } = await seed();
     await quota.run(async (ctx) => {
       const state = await ctx.db

--- a/convex/assetPublisher.ts
+++ b/convex/assetPublisher.ts
@@ -4,6 +4,7 @@ import SHA256 from 'crypto-js/sha256';
 import { FactionInputSchema } from '../src/game/schema/faction';
 import type { Doc, Id } from './_generated/dataModel';
 import { internalMutation, internalQuery, query } from './_generated/server';
+import { BROWSER_RESERVATION_MS, FREE_BROWSER_ALLOWANCE_MS } from './lib/assetPublisherLimits';
 import {
   completionMetadataSchema,
   exactClaimSchema,
@@ -20,9 +21,9 @@ import type { MutationCtx, QueryCtx } from './types';
 export const ASSET_TYPE = 'faction_sheet' as const;
 export const BATCH_LEASE_MS = 12 * 60 * 1_000;
 export const MIN_UPLOAD_LEASE_MARGIN_MS = 2 * 60 * 1_000;
-export const FREE_BROWSER_ALLOWANCE_MS = 10 * 60 * 1_000;
-export const BROWSER_RESERVATION_MS = 8 * 60 * 1_000;
 export const MAX_BROWSER_SETTLEMENT_MS = 15 * 60 * 1_000;
+export { BROWSER_RESERVATION_MS, FREE_BROWSER_ALLOWANCE_MS };
+
 const MAX_RETRY_DELAY_MS = 6 * 60 * 60 * 1_000;
 const BASE_RETRY_DELAY_MS = 60 * 1_000;
 

--- a/convex/assetPublisherOperator.test.ts
+++ b/convex/assetPublisherOperator.test.ts
@@ -14,6 +14,15 @@ const activationArgs = {
   targetPrerequisite: 'faction_sheet_targets_verify_v1' as const,
   storagePrerequisite: 'faction_sheet_publication_admissions_v1' as const,
 };
+const RECONCILIATION_RESERVATION_TOKEN = 'prior-canary-reservation';
+const reconciliationArgs = {
+  expectedUtcDate: '2026-07-16',
+  expectedDailyBrowserMs: 484_275,
+  expectedBrowserReservationBatchToken: RECONCILIATION_RESERVATION_TOKEN,
+  expectedBrowserReservationUtcDate: '2026-07-16',
+  expectedBrowserReservedMs: 480_000,
+  replacementDailyBrowserMs: 120_000,
+};
 
 afterEach(() => vi.useRealTimers());
 
@@ -33,6 +42,66 @@ async function recordSuccessfulPrerequisite(t: ReturnType<typeof convexTest>) {
         updated_at: new Date(NOW).toISOString(),
       });
     }
+  });
+}
+
+async function seedBrowserUsageReconciliation(t: ReturnType<typeof convexTest>) {
+  return await t.run(async (ctx) => {
+    const ownerId = await ctx.db.insert('users', { name: 'Browser reconciliation owner' });
+    const factionId = await ctx.db.insert('factions', {
+      owner_id: ownerId,
+      data: {},
+      slug: 'browser-reconciliation-canary',
+      created_at: new Date(NOW).toISOString(),
+      updated_at: new Date(NOW).toISOString(),
+      is_deleted: false,
+      group_id: null,
+    });
+    const configId = await ctx.db.insert('asset_type_configs', {
+      asset_type: 'faction_sheet',
+      status: 'paused',
+      active_renderer_version: 'faction-sheet-v1',
+      updated_at: NOW - 10_000,
+    });
+    const stateId = await ctx.db.insert('asset_publisher_state', {
+      key: 'singleton',
+      status: 'paused',
+      cooldown_until: NOW - 20_000,
+      daily_browser_utc_date: reconciliationArgs.expectedUtcDate,
+      daily_browser_ms: reconciliationArgs.expectedDailyBrowserMs,
+      browser_reservation_batch_token: RECONCILIATION_RESERVATION_TOKEN,
+      browser_reservation_utc_date: reconciliationArgs.expectedBrowserReservationUtcDate,
+      browser_reserved_ms: reconciliationArgs.expectedBrowserReservedMs,
+      last_browser_settlement_batch_token: 'historical-settlement-token',
+      last_browser_settlement_ms: 4_275,
+      last_browser_release_batch_token: 'historical-release-token',
+      last_browser_release_mode: 'after_settlement',
+      next_lane: 'rollout',
+    });
+    const targetId = await ctx.db.insert('asset_targets', {
+      faction_id: factionId,
+      asset_type: 'faction_sheet',
+      desired_generation: 2,
+      desired_renderer_version: 'faction-sheet-v1',
+      published_generation: 1,
+      published_renderer_version: 'faction-sheet-v1',
+      published_cache_token: 'v1.existing-canary-token.existing-canary-signature',
+      published_r2_etag: 'existing-etag',
+      published_bytes: 100_180,
+      published_at: NOW - 30_000,
+      first_publication_admitted: true,
+      status: 'pending',
+      next_eligible_at: 0,
+      attempt_count: 3,
+      last_error: 'retained retry diagnostic',
+      last_completed_batch_token: 'completed-batch-token',
+      last_completed_claim_token: 'completed-claim-token',
+    });
+    const counterId = await ctx.db.insert('counters', {
+      key: 'asset_publisher:faction_sheet:first_publications',
+      value: 1,
+    });
+    return { configId, counterId, factionId, stateId, targetId };
   });
 }
 
@@ -403,6 +472,208 @@ describe('asset publisher operator controls', () => {
         )
       ).resolves.toMatchObject({ desired_generation: testCase.desiredGeneration ?? 1 });
     }
+  });
+
+  test('reconciles exact current Browser evidence without collateral state changes', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+    const seeded = await seedBrowserUsageReconciliation(t);
+    const before = await t.run(async (ctx) => ({
+      config: await ctx.db.get('asset_type_configs', seeded.configId),
+      counter: await ctx.db.get('counters', seeded.counterId),
+      state: await ctx.db.get('asset_publisher_state', seeded.stateId),
+      target: await ctx.db.get('asset_targets', seeded.targetId),
+    }));
+
+    await expect(
+      t.mutation(internal.assetPublisherOperator.reconcileCurrentBrowserUsage, reconciliationArgs)
+    ).resolves.toEqual({
+      status: 'reconciled',
+      utcDate: '2026-07-16',
+      previousDailyBrowserMs: 484_275,
+      dailyBrowserMs: 120_000,
+      clearedReservationBatchToken: RECONCILIATION_RESERVATION_TOKEN,
+    });
+
+    const after = await t.run(async (ctx) => ({
+      config: await ctx.db.get('asset_type_configs', seeded.configId),
+      counter: await ctx.db.get('counters', seeded.counterId),
+      state: await ctx.db.get('asset_publisher_state', seeded.stateId),
+      target: await ctx.db.get('asset_targets', seeded.targetId),
+    }));
+    expect(after.config).toEqual(before.config);
+    expect(after.counter).toEqual(before.counter);
+    expect(after.target).toEqual(before.target);
+    expect(after.state).toMatchObject({
+      daily_browser_utc_date: '2026-07-16',
+      daily_browser_ms: 120_000,
+      cooldown_until: before.state?.cooldown_until,
+      last_browser_settlement_batch_token: before.state?.last_browser_settlement_batch_token,
+      last_browser_settlement_ms: before.state?.last_browser_settlement_ms,
+      last_browser_release_batch_token: before.state?.last_browser_release_batch_token,
+      last_browser_release_mode: before.state?.last_browser_release_mode,
+      next_lane: before.state?.next_lane,
+    });
+    expect(after.state?.browser_reservation_batch_token).toBeUndefined();
+    expect(after.state?.browser_reservation_utc_date).toBeUndefined();
+    expect(after.state?.browser_reserved_ms).toBeUndefined();
+
+    await expect(
+      t.mutation(internal.assetPublisherOperator.reconcileCurrentBrowserUsage, reconciliationArgs)
+    ).rejects.toThrow('state does not match expected accounting');
+  });
+
+  test.each([
+    ['stale accounted value', { expectedDailyBrowserMs: 484_274 }],
+    [
+      'stale UTC date',
+      {
+        expectedUtcDate: '2026-07-15',
+        expectedBrowserReservationUtcDate: '2026-07-15',
+      },
+    ],
+  ])('rejects %s without clearing the reservation', async (_name, override) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+    const seeded = await seedBrowserUsageReconciliation(t);
+    const before = await t.run(
+      async (ctx) => await ctx.db.get('asset_publisher_state', seeded.stateId)
+    );
+
+    await expect(
+      t.mutation(internal.assetPublisherOperator.reconcileCurrentBrowserUsage, {
+        ...reconciliationArgs,
+        ...override,
+      })
+    ).rejects.toThrow();
+    await expect(
+      t.run(async (ctx) => await ctx.db.get('asset_publisher_state', seeded.stateId))
+    ).resolves.toEqual(before);
+  });
+
+  test.each([
+    ['daily total', { daily_browser_ms: 484_274 }],
+    ['reservation token', { browser_reservation_batch_token: 'different-reservation-token' }],
+    ['reservation date', { browser_reservation_utc_date: '2026-07-15' }],
+    ['reserved amount', { browser_reserved_ms: 479_999 }],
+  ])('rejects drift in the stored %s', async (_name, statePatch) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+    const seeded = await seedBrowserUsageReconciliation(t);
+    await t.run(async (ctx) => await ctx.db.patch(seeded.stateId, statePatch));
+    const before = await t.run(
+      async (ctx) => await ctx.db.get('asset_publisher_state', seeded.stateId)
+    );
+
+    await expect(
+      t.mutation(internal.assetPublisherOperator.reconcileCurrentBrowserUsage, reconciliationArgs)
+    ).rejects.toThrow('state does not match expected accounting');
+    await expect(
+      t.run(async (ctx) => await ctx.db.get('asset_publisher_state', seeded.stateId))
+    ).resolves.toEqual(before);
+  });
+
+  test.each([
+    ['config', 'active', 'paused'],
+    ['publisher singleton', 'paused', 'active'],
+  ] as const)('requires paused %s control', async (_name, configStatus, stateStatus) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+    const seeded = await seedBrowserUsageReconciliation(t);
+    await t.run(async (ctx) => {
+      await ctx.db.patch(seeded.configId, { status: configStatus });
+      await ctx.db.patch(seeded.stateId, { status: stateStatus });
+    });
+
+    await expect(
+      t.mutation(internal.assetPublisherOperator.reconcileCurrentBrowserUsage, reconciliationArgs)
+    ).rejects.toThrow('requires paused publisher controls');
+  });
+
+  test.each([
+    'batch',
+    'target claim',
+    'snapshot',
+  ] as const)('rejects active %s ownership without changing accounting', async (ownership) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+    const seeded = await seedBrowserUsageReconciliation(t);
+    await t.run(async (ctx) => {
+      if (ownership === 'batch') {
+        await ctx.db.patch(seeded.stateId, {
+          batch_token: 'new-owned-batch-token',
+          batch_lease_expires_at: NOW + 60_000,
+        });
+      } else if (ownership === 'target claim') {
+        await ctx.db.patch(seeded.targetId, {
+          status: 'leased',
+          batch_token: 'new-owned-batch-token',
+          claim_token: 'new-owned-claim-token',
+          claimed_generation: 2,
+          claimed_renderer_version: 'faction-sheet-v1',
+          lease_expires_at: NOW + 60_000,
+          claim_payload_hash: 'owned-payload-hash',
+        });
+      } else {
+        await ctx.db.insert('asset_claim_snapshots', {
+          target_id: seeded.targetId,
+          faction_id: seeded.factionId,
+          asset_type: 'faction_sheet',
+          batch_token: 'new-owned-batch-token',
+          claim_token: 'new-owned-claim-token',
+          generation: 2,
+          renderer_version: 'faction-sheet-v1',
+          lease_expires_at: NOW + 60_000,
+          payload_hash: 'owned-payload-hash',
+          payload: {},
+        });
+      }
+    });
+    const before = await t.run(
+      async (ctx) => await ctx.db.get('asset_publisher_state', seeded.stateId)
+    );
+
+    await expect(
+      t.mutation(internal.assetPublisherOperator.reconcileCurrentBrowserUsage, reconciliationArgs)
+    ).rejects.toThrow(
+      ownership === 'batch'
+        ? 'requires no owned publisher batch'
+        : 'requires no owned claims or snapshots'
+    );
+    await expect(
+      t.run(async (ctx) => await ctx.db.get('asset_publisher_state', seeded.stateId))
+    ).resolves.toEqual(before);
+  });
+
+  test.each([
+    ['equal value', 484_275],
+    ['increased value', 500_000],
+    ['negative value', -1],
+    ['over allowance', 600_001],
+    ['fractional value', 120_000.5],
+  ])('rejects invalid replacement: %s', async (_name, replacementDailyBrowserMs) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+    const seeded = await seedBrowserUsageReconciliation(t);
+    const before = await t.run(
+      async (ctx) => await ctx.db.get('asset_publisher_state', seeded.stateId)
+    );
+
+    await expect(
+      t.mutation(internal.assetPublisherOperator.reconcileCurrentBrowserUsage, {
+        ...reconciliationArgs,
+        replacementDailyBrowserMs,
+      })
+    ).rejects.toThrow('Invalid Browser usage reconciliation values');
+    await expect(
+      t.run(async (ctx) => await ctx.db.get('asset_publisher_state', seeded.stateId))
+    ).resolves.toEqual(before);
   });
 
   test.each([

--- a/convex/assetPublisherOperator.ts
+++ b/convex/assetPublisherOperator.ts
@@ -2,6 +2,8 @@ import { v } from 'convex/values';
 
 import type { Doc } from './_generated/dataModel';
 import { internalMutation } from './_generated/server';
+import { BROWSER_RESERVATION_MS, FREE_BROWSER_ALLOWANCE_MS } from './lib/assetPublisherLimits';
+import { publisherTokenSchema } from './lib/assetPublisherSchemas';
 import {
   assertFirstPublicationCounterReady,
   exactPublisherStateOrNull,
@@ -194,6 +196,90 @@ export const requeueCurrentFactionSheetCanary = internalMutation({
       desiredGeneration,
       rendererVersion: config.active_renderer_version,
       nextEligibleAt: CANARY_PRIORITY_NEXT_ELIGIBLE_AT,
+    };
+  },
+});
+
+function currentUtcDate() {
+  return new Date(Date.now()).toISOString().slice(0, 10);
+}
+
+/**
+ * One-shot reconciliation for a provider-observed Browser total after an
+ * ambiguous close retained a conservative reservation. The exact comparison
+ * fields make the cleared reservation a compare-and-swap, not a generic quota
+ * adjustment.
+ */
+export const reconcileCurrentBrowserUsage = internalMutation({
+  args: {
+    expectedUtcDate: v.string(),
+    expectedDailyBrowserMs: v.number(),
+    expectedBrowserReservationBatchToken: v.string(),
+    expectedBrowserReservationUtcDate: v.string(),
+    expectedBrowserReservedMs: v.number(),
+    replacementDailyBrowserMs: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const today = currentUtcDate();
+    if (args.expectedUtcDate !== today || args.expectedBrowserReservationUtcDate !== today) {
+      throw new Error('Browser usage reconciliation requires the current UTC accounting date');
+    }
+    if (
+      !publisherTokenSchema.safeParse(args.expectedBrowserReservationBatchToken).success ||
+      !Number.isSafeInteger(args.expectedDailyBrowserMs) ||
+      args.expectedDailyBrowserMs < 0 ||
+      args.expectedBrowserReservedMs !== BROWSER_RESERVATION_MS ||
+      !Number.isSafeInteger(args.replacementDailyBrowserMs) ||
+      args.replacementDailyBrowserMs < 0 ||
+      args.replacementDailyBrowserMs > FREE_BROWSER_ALLOWANCE_MS ||
+      args.replacementDailyBrowserMs >= args.expectedDailyBrowserMs
+    ) {
+      throw new Error('Invalid Browser usage reconciliation values');
+    }
+
+    const [config, state] = await Promise.all([
+      exactConfigOrNull(ctx),
+      exactPublisherStateOrNull(ctx),
+    ]);
+    if (config?.status !== 'paused' || state?.status !== 'paused') {
+      throw new Error('Browser usage reconciliation requires paused publisher controls');
+    }
+    if (state.batch_token !== undefined || state.batch_lease_expires_at !== undefined) {
+      throw new Error('Browser usage reconciliation requires no owned publisher batch');
+    }
+
+    const [ownedTarget, ownedSnapshot] = await Promise.all([
+      ctx.db
+        .query('asset_targets')
+        .withIndex('by_batch_token', (q) => q.gte('batch_token', ''))
+        .first(),
+      ctx.db.query('asset_claim_snapshots').withIndex('by_batch_token').first(),
+    ]);
+    if (ownedTarget || ownedSnapshot) {
+      throw new Error('Browser usage reconciliation requires no owned claims or snapshots');
+    }
+    if (
+      state.daily_browser_utc_date !== args.expectedUtcDate ||
+      state.daily_browser_ms !== args.expectedDailyBrowserMs ||
+      state.browser_reservation_batch_token !== args.expectedBrowserReservationBatchToken ||
+      state.browser_reservation_utc_date !== args.expectedBrowserReservationUtcDate ||
+      state.browser_reserved_ms !== args.expectedBrowserReservedMs
+    ) {
+      throw new Error('Browser usage reconciliation state does not match expected accounting');
+    }
+
+    await ctx.db.patch(state._id, {
+      daily_browser_ms: args.replacementDailyBrowserMs,
+      browser_reservation_batch_token: undefined,
+      browser_reservation_utc_date: undefined,
+      browser_reserved_ms: undefined,
+    });
+    return {
+      status: 'reconciled' as const,
+      utcDate: args.expectedUtcDate,
+      previousDailyBrowserMs: args.expectedDailyBrowserMs,
+      dailyBrowserMs: args.replacementDailyBrowserMs,
+      clearedReservationBatchToken: args.expectedBrowserReservationBatchToken,
     };
   },
 });

--- a/convex/lib/assetPublisherLimits.ts
+++ b/convex/lib/assetPublisherLimits.ts
@@ -1,0 +1,2 @@
+export const FREE_BROWSER_ALLOWANCE_MS = 10 * 60 * 1_000;
+export const BROWSER_RESERVATION_MS = 8 * 60 * 1_000;


### PR DESCRIPTION
## What changed

- adds a narrow internal Convex maintenance mutation that compare-and-swaps the exact stale Browser reservation
- requires paused controls and no owned batch, claims, or snapshots
- replaces the conservative 484,275 ms total with provider-observed evidence and clears only the stale reservation fields
- shares the unchanged 480-second reservation and 600-second allowance constants with the normal acquisition path

## Why

Cloudflare reports just under two minutes of actual Browser Run use today, while an ambiguous close left a conservative 480-second reservation fenced in Convex. Rounding observed use up to 120,000 ms leaves room for exactly one existing 480,000 ms canary reservation without weakening the normal safety policy.

## Verification

- focused Convex publisher/operator tests: 65 passed
- full suite: 508 passed
- TypeScript, Convex skip guard, targeted/full Biome, codegen, and diff checks passed
- production remains paused with no Cron, active Browser session, Queue backlog, claim, or snapshot

No production mutation is performed by this PR itself.