### PR TITLE
Add disabled-first renderer rollout control plane

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -11,6 +11,7 @@
 import type * as assetPublisher from "../assetPublisher.js";
 import type * as assetPublisherOperator from "../assetPublisherOperator.js";
 import type * as assetPublishingStatus from "../assetPublishingStatus.js";
+import type * as assetRollouts from "../assetRollouts.js";
 import type * as auth from "../auth.js";
 import type * as e2e from "../e2e.js";
 import type * as factions from "../factions.js";
@@ -47,6 +48,7 @@ declare const fullApi: ApiFromModules<{
   assetPublisher: typeof assetPublisher;
   assetPublisherOperator: typeof assetPublisherOperator;
   assetPublishingStatus: typeof assetPublishingStatus;
+  assetRollouts: typeof assetRollouts;
   auth: typeof auth;
   e2e: typeof e2e;
   factions: typeof factions;

--- a/convex/assetPublisher.ts
+++ b/convex/assetPublisher.ts
@@ -4,6 +4,14 @@ import SHA256 from 'crypto-js/sha256';
 import { FactionInputSchema } from '../src/game/schema/faction';
 import type { Doc, Id } from './_generated/dataModel';
 import { internalMutation, internalQuery, query } from './_generated/server';
+import {
+  completeRolloutItem,
+  failRolloutItem,
+  firstEligibleRolloutTarget,
+  markRolloutClaimed,
+  recoverExpiredRolloutClaim,
+  releaseRolloutItem,
+} from './assetRollouts';
 import { BROWSER_RESERVATION_MS, FREE_BROWSER_ALLOWANCE_MS } from './lib/assetPublisherLimits';
 import {
   completionMetadataSchema,
@@ -51,51 +59,44 @@ async function assetTypeConfig(ctx: PublisherReadCtx) {
     .unique();
 }
 
-async function firstEligibleTarget(ctx: PublisherReadCtx, cutoff: number, admittedOnly: boolean) {
-  const pending = admittedOnly
+async function firstEligibleForegroundTargetForLane(
+  ctx: PublisherReadCtx,
+  cutoff: number,
+  admittedOnly: boolean,
+  workLane: 'foreground' | undefined
+) {
+  for (const status of ['pending', 'cooldown'] as const) {
+    const rows = admittedOnly
+      ? await ctx.db
+          .query('asset_targets')
+          .withIndex('by_type_lane_admitted_status_eligible', (q) =>
+            q
+              .eq('asset_type', ASSET_TYPE)
+              .eq('work_lane', workLane)
+              .eq('first_publication_admitted', true)
+              .eq('status', status)
+              .lte('next_eligible_at', cutoff)
+          )
+          .take(1)
+      : await ctx.db
+          .query('asset_targets')
+          .withIndex('by_type_lane_status_eligible', (q) =>
+            q
+              .eq('asset_type', ASSET_TYPE)
+              .eq('work_lane', workLane)
+              .eq('status', status)
+              .lte('next_eligible_at', cutoff)
+          )
+          .take(1);
+    if (rows[0]) return rows[0];
+  }
+  const rows = admittedOnly
     ? await ctx.db
         .query('asset_targets')
-        .withIndex('by_asset_type_and_admitted_and_status_and_next_eligible_at', (q) =>
+        .withIndex('by_type_lane_admitted_status_lease', (q) =>
           q
             .eq('asset_type', ASSET_TYPE)
-            .eq('first_publication_admitted', true)
-            .eq('status', 'pending')
-            .lte('next_eligible_at', cutoff)
-        )
-        .take(1)
-    : await ctx.db
-        .query('asset_targets')
-        .withIndex('by_asset_type_and_status_and_next_eligible_at', (q) =>
-          q.eq('asset_type', ASSET_TYPE).eq('status', 'pending').lte('next_eligible_at', cutoff)
-        )
-        .take(1);
-  if (pending[0]) return pending[0];
-
-  const cooldown = admittedOnly
-    ? await ctx.db
-        .query('asset_targets')
-        .withIndex('by_asset_type_and_admitted_and_status_and_next_eligible_at', (q) =>
-          q
-            .eq('asset_type', ASSET_TYPE)
-            .eq('first_publication_admitted', true)
-            .eq('status', 'cooldown')
-            .lte('next_eligible_at', cutoff)
-        )
-        .take(1)
-    : await ctx.db
-        .query('asset_targets')
-        .withIndex('by_asset_type_and_status_and_next_eligible_at', (q) =>
-          q.eq('asset_type', ASSET_TYPE).eq('status', 'cooldown').lte('next_eligible_at', cutoff)
-        )
-        .take(1);
-  if (cooldown[0]) return cooldown[0];
-
-  const expiredLease = admittedOnly
-    ? await ctx.db
-        .query('asset_targets')
-        .withIndex('by_asset_type_and_admitted_and_status_and_lease_expires_at', (q) =>
-          q
-            .eq('asset_type', ASSET_TYPE)
+            .eq('work_lane', workLane)
             .eq('first_publication_admitted', true)
             .eq('status', 'leased')
             .lte('lease_expires_at', cutoff)
@@ -103,11 +104,25 @@ async function firstEligibleTarget(ctx: PublisherReadCtx, cutoff: number, admitt
         .take(1)
     : await ctx.db
         .query('asset_targets')
-        .withIndex('by_asset_type_and_status_and_lease_expires_at', (q) =>
-          q.eq('asset_type', ASSET_TYPE).eq('status', 'leased').lte('lease_expires_at', cutoff)
+        .withIndex('by_type_lane_status_lease', (q) =>
+          q
+            .eq('asset_type', ASSET_TYPE)
+            .eq('work_lane', workLane)
+            .eq('status', 'leased')
+            .lte('lease_expires_at', cutoff)
         )
         .take(1);
-  return expiredLease[0] ?? null;
+  return rows[0] ?? null;
+}
+
+async function firstEligibleTarget(ctx: PublisherReadCtx, cutoff: number, admittedOnly: boolean) {
+  // At the production maximum of one, ordinary saves always win. Existing rows with no lane field
+  // remain foreground without a backfill; new and newly-saved rows use the explicit lane value.
+  for (const lane of [undefined, 'foreground'] as const) {
+    const foreground = await firstEligibleForegroundTargetForLane(ctx, cutoff, admittedOnly, lane);
+    if (foreground) return foreground;
+  }
+  return await firstEligibleRolloutTarget(ctx, cutoff);
 }
 
 async function hasEligibleWorkAt(ctx: PublisherReadCtx, cutoff: number, now: number) {
@@ -518,36 +533,40 @@ export const claimOne = internalMutation({
         leaseExpiresAt: existingTarget.lease_expires_at,
         payload: snapshot.payload,
         payloadHash: existingTarget.claim_payload_hash,
+        workLane:
+          existingTarget.work_lane === 'rollout' ? ('rollout' as const) : ('foreground' as const),
       };
     }
 
-    const expired = await ctx.db
-      .query('asset_targets')
-      .withIndex('by_asset_type_and_status_and_lease_expires_at', (q) =>
-        q.eq('asset_type', ASSET_TYPE).eq('status', 'leased').lte('lease_expires_at', now)
-      )
-      .take(1);
-    if (expired[0]) {
-      const expiredSnapshot = await claimSnapshot(ctx, expired[0]._id);
-      if (
-        expiredSnapshot &&
-        expiredSnapshot.batch_token === expired[0].batch_token &&
-        expiredSnapshot.claim_token === expired[0].claim_token
-      ) {
-        await ctx.db.delete(expiredSnapshot._id);
-      }
-      await ctx.db.patch(expired[0]._id, {
-        ...clearClaim(),
-        status: 'pending',
-        next_eligible_at: now,
-      });
-    }
-
-    const target = await firstEligibleTarget(
+    let target = await firstEligibleTarget(
       ctx,
       now,
       counter.value >= MAX_FIRST_PUBLISHED_FACTION_SHEETS
     );
+    if (target?.status === 'leased') {
+      const expiredSnapshot = await claimSnapshot(ctx, target._id);
+      if (
+        expiredSnapshot &&
+        expiredSnapshot.batch_token === target.batch_token &&
+        expiredSnapshot.claim_token === target.claim_token
+      ) {
+        await ctx.db.delete(expiredSnapshot._id);
+      }
+      const detached = await recoverExpiredRolloutClaim(ctx, target, now);
+      if (!detached) {
+        await ctx.db.patch(target._id, {
+          ...clearClaim(),
+          status: 'pending',
+          next_eligible_at: now,
+        });
+      }
+      target = await firstEligibleTarget(
+        ctx,
+        now,
+        counter.value >= MAX_FIRST_PUBLISHED_FACTION_SHEETS
+      );
+    }
+
     if (!target || target.status === 'leased') return { status: 'empty' as const };
     const faction = await ctx.db.get('factions', target.faction_id);
     if (!faction) throw new Error('Publisher target faction is missing');
@@ -569,6 +588,7 @@ export const claimOne = internalMutation({
       payload_hash: payloadHash,
       payload,
     });
+    await markRolloutClaimed(ctx, target, now);
     await ctx.db.patch(target._id, {
       status: 'leased',
       next_eligible_at: leaseExpiresAt,
@@ -595,6 +615,7 @@ export const claimOne = internalMutation({
       leaseExpiresAt,
       payload,
       payloadHash,
+      workLane: target.work_lane === 'rollout' ? ('rollout' as const) : ('foreground' as const),
     };
   },
 });
@@ -715,7 +736,9 @@ export const completeClaim = internalMutation({
     }
 
     const publishedAt = now;
+    const rolloutClaim = target.work_lane === 'rollout' && target.rollout_item_id !== undefined;
     await deleteSnapshotIfExact(ctx, args);
+    await completeRolloutItem(ctx, target, now);
     await ctx.db.patch(target._id, {
       ...clearClaim(),
       status: 'current',
@@ -728,8 +751,11 @@ export const completeClaim = internalMutation({
       published_at: publishedAt,
       last_completed_batch_token: args.batchToken,
       last_completed_claim_token: args.claimToken,
+      work_lane: 'foreground',
+      rollout_id: undefined,
+      rollout_item_id: undefined,
     });
-    await releaseBatchIfOwned(ctx, args.batchToken);
+    if (!rolloutClaim) await releaseBatchIfOwned(ctx, args.batchToken);
     return {
       status: 'completed' as const,
       replay: false,
@@ -772,14 +798,24 @@ export const failClaim = internalMutation({
     }
 
     const nextEligibleAt = now + retryDelayMs(target.attempt_count);
+    const rolloutClaim = target.work_lane === 'rollout' && target.rollout_item_id !== undefined;
     await deleteSnapshotIfExact(ctx, args);
-    await ctx.db.patch(target._id, {
-      ...clearClaim(),
-      status: 'cooldown',
-      next_eligible_at: nextEligibleAt,
-      last_error: failure.data.error,
-    });
-    await releaseBatchIfOwned(ctx, args.batchToken);
+    const rolloutOutcome = await failRolloutItem(
+      ctx,
+      target,
+      failure.data.error,
+      nextEligibleAt,
+      now
+    );
+    if (rolloutOutcome !== 'detached') {
+      await ctx.db.patch(target._id, {
+        ...clearClaim(),
+        status: 'cooldown',
+        next_eligible_at: nextEligibleAt,
+        last_error: failure.data.error,
+      });
+    }
+    if (!rolloutClaim) await releaseBatchIfOwned(ctx, args.batchToken);
     return { status: 'failed' as const, nextEligibleAt };
   },
 });
@@ -800,13 +836,17 @@ export const releaseClaim = internalMutation({
     ) {
       return { status: 'stale' as const };
     }
+    const rolloutClaim = target.work_lane === 'rollout' && target.rollout_item_id !== undefined;
     await deleteSnapshotIfExact(ctx, args);
-    await ctx.db.patch(target._id, {
-      ...clearClaim(),
-      status: 'pending',
-      next_eligible_at: now,
-    });
-    await releaseBatchIfOwned(ctx, args.batchToken);
+    const rolloutOutcome = await releaseRolloutItem(ctx, target, now);
+    if (rolloutOutcome !== 'detached') {
+      await ctx.db.patch(target._id, {
+        ...clearClaim(),
+        status: 'pending',
+        next_eligible_at: now,
+      });
+    }
+    if (!rolloutClaim) await releaseBatchIfOwned(ctx, args.batchToken);
     return { status: 'released' as const };
   },
 });

--- a/convex/assetRollouts.test.ts
+++ b/convex/assetRollouts.test.ts
@@ -1,0 +1,573 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import { convexTest } from 'convex-test';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { proofFaction } from '../src/app/capture/proofFaction';
+import { api, internal } from './_generated/api';
+import type { Id } from './_generated/dataModel';
+import { ROLLOUT_DISCOVERY_PAGE_SIZE } from './assetRollouts';
+import { FACTION_SHEET_PUBLICATION_COUNTER_KEY } from './lib/factionSheetPublicationGuard';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+const NOW = Date.parse('2026-07-17T10:00:00.000Z');
+const BATCHES = [1, 2, 3, 4].map(
+  (value) => `rollout-batch-token-${String(value).padStart(16, '0')}`
+);
+const CLAIMS = [1, 2, 3, 4].map(
+  (value) => `rollout-claim-token-${String(value).padStart(16, '0')}`
+);
+
+afterEach(() => vi.useRealTimers());
+
+type Seeded = {
+  t: ReturnType<typeof convexTest>;
+  userIds: Id<'users'>[];
+  factionIds: Id<'factions'>[];
+  targetIds: Id<'asset_targets'>[];
+};
+
+async function seedCurrentTargets(
+  count: number,
+  rendererVersion = 'faction-sheet-v0'
+): Promise<Seeded> {
+  const t = convexTest(schema, modules);
+  await t.run(async (ctx) => {
+    await ctx.db.insert('asset_type_configs', {
+      asset_type: 'faction_sheet',
+      status: 'active',
+      active_renderer_version: 'faction-sheet-v1',
+      updated_at: NOW,
+    });
+    await ctx.db.insert('asset_publisher_state', {
+      key: 'singleton',
+      status: 'active',
+      cooldown_until: 0,
+      daily_browser_utc_date: '2026-07-17',
+      daily_browser_ms: 0,
+      next_lane: 'foreground',
+    });
+    await ctx.db.insert('counters', {
+      key: FACTION_SHEET_PUBLICATION_COUNTER_KEY,
+      value: count,
+    });
+  });
+
+  const userIds: Id<'users'>[] = [];
+  const factionIds: Id<'factions'>[] = [];
+  const targetIds: Id<'asset_targets'>[] = [];
+  for (let offset = 0; offset < count; offset += 100) {
+    const batchSize = Math.min(100, count - offset);
+    const inserted = await t.run(async (ctx) => {
+      const batchUsers: Id<'users'>[] = [];
+      const batchFactions: Id<'factions'>[] = [];
+      const batchTargets: Id<'asset_targets'>[] = [];
+      for (let index = 0; index < batchSize; index += 1) {
+        const sequence = offset + index;
+        const userId = await ctx.db.insert('users', { name: `Rollout owner ${sequence}` });
+        const factionId = await ctx.db.insert('factions', {
+          owner_id: userId,
+          data: { ...proofFaction, name: `Rollout faction ${sequence}` },
+          slug: `rollout-faction-${sequence}`,
+          created_at: new Date(NOW).toISOString(),
+          updated_at: new Date(NOW).toISOString(),
+          is_deleted: false,
+          group_id: null,
+        });
+        const targetId = await ctx.db.insert('asset_targets', {
+          faction_id: factionId,
+          asset_type: 'faction_sheet',
+          desired_generation: 1,
+          desired_renderer_version: rendererVersion,
+          published_generation: 1,
+          published_renderer_version: rendererVersion,
+          published_cache_token: `existing-${sequence}`,
+          published_r2_etag: `etag-${sequence}`,
+          published_bytes: 1_000 + sequence,
+          published_at: NOW,
+          first_publication_admitted: true,
+          status: 'current',
+          next_eligible_at: NOW,
+          attempt_count: 0,
+        });
+        batchUsers.push(userId);
+        batchFactions.push(factionId);
+        batchTargets.push(targetId);
+      }
+      return { batchUsers, batchFactions, batchTargets };
+    });
+    userIds.push(...inserted.batchUsers);
+    factionIds.push(...inserted.batchFactions);
+    targetIds.push(...inserted.batchTargets);
+  }
+  return { t, userIds, factionIds, targetIds };
+}
+
+async function createPaused(t: Seeded['t']) {
+  return await t.mutation(internal.assetRollouts.createPaused, {
+    targetRendererVersion: 'faction-sheet-v1',
+  });
+}
+
+async function resumeAndDrainDiscovery(t: Seeded['t'], rolloutId: Id<'asset_rollouts'>) {
+  await t.mutation(internal.assetRollouts.resume, { rolloutId });
+  await t.finishAllScheduledFunctions(vi.runAllTimers);
+  const progress = await t.query(internal.assetRollouts.progress, { rolloutId });
+  if (!progress.rollout) throw new Error('Expected rollout progress');
+  return progress.rollout;
+}
+
+async function acquireAndClaimRollout(t: Seeded['t'], sequence = 0) {
+  const acquisition = await t.mutation(internal.assetPublisher.acquireBatch, {
+    batchToken: BATCHES[sequence],
+  });
+  expect(acquisition.status).toBe('acquired');
+  const claim = await t.mutation(internal.assetPublisher.claimOne, {
+    batchToken: BATCHES[sequence],
+    claimToken: CLAIMS[sequence],
+  });
+  if (claim.status !== 'claimed') throw new Error(`Expected claim, received ${claim.status}`);
+  expect(claim.workLane).toBe('rollout');
+  return claim;
+}
+
+function exact(claim: Awaited<ReturnType<typeof acquireAndClaimRollout>>) {
+  return {
+    targetId: claim.targetId,
+    batchToken: claim.batchToken,
+    claimToken: claim.claimToken,
+    generation: claim.generation,
+    rendererVersion: claim.rendererVersion,
+  };
+}
+
+async function settleAndRelease(t: Seeded['t'], batchToken: string) {
+  await t.mutation(internal.assetPublisher.settleBrowserReservation, {
+    batchToken,
+    measuredBrowserMs: 0,
+  });
+  await t.mutation(internal.assetPublisher.releaseBatch, {
+    batchToken,
+    mode: 'after_settlement',
+  });
+}
+
+describe('renderer rollout control plane', () => {
+  test('create-paused is fail-closed, idempotent, and transactionally unique', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t } = await seedCurrentTargets(1);
+
+    await expect(
+      t.mutation(internal.assetRollouts.createPaused, {
+        targetRendererVersion: 'operator-invented-renderer',
+      })
+    ).rejects.toThrow(/not supported/);
+    const [first, replay] = await Promise.all([createPaused(t), createPaused(t)]);
+    expect(replay.rolloutId).toBe(first.rolloutId);
+    expect(first.status).toBe('paused');
+    await expect(
+      t.run(async (ctx) => await ctx.db.query('asset_rollouts').take(3))
+    ).resolves.toHaveLength(1);
+  });
+
+  test.each([
+    25, 2_000,
+  ])('discovers %i targets in exact bounded pages with one sequential continuation per nonfinal page', async (count) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t } = await seedCurrentTargets(count);
+    const created = await createPaused(t);
+    const progress = await resumeAndDrainDiscovery(t, created.rolloutId);
+    const pages = Math.ceil(count / ROLLOUT_DISCOVERY_PAGE_SIZE);
+
+    expect(progress).toMatchObject({
+      status: 'running',
+      discoveryPages: pages,
+      discoveryContinuations: pages - 1,
+      counters: {
+        discovered: count,
+        pending: count,
+        leased: 0,
+        succeeded: 0,
+        superseded: 0,
+        cancelled: 0,
+        terminalErrors: 0,
+      },
+    });
+    const rows = await t.run(async (ctx) => ({
+      items: await ctx.db.query('asset_rollout_items').take(count + 1),
+      targets: await ctx.db.query('asset_targets').take(count + 1),
+    }));
+    expect(rows.items).toHaveLength(count);
+    expect(
+      rows.targets.filter((target) => target.work_lane === 'rollout' && target.status === 'pending')
+    ).toHaveLength(count);
+  }, 30_000);
+
+  test('pause/resume/cancel are idempotent and cancellation preserves published authority', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t, targetIds } = await seedCurrentTargets(25);
+    const created = await createPaused(t);
+    await t.mutation(internal.assetRollouts.resume, { rolloutId: created.rolloutId });
+    const paused = await t.mutation(internal.assetRollouts.pause, {
+      rolloutId: created.rolloutId,
+    });
+    expect(paused.status).toBe('paused');
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(
+      (await t.query(internal.assetRollouts.progress, { rolloutId: created.rolloutId })).rollout
+        ?.counters.discovered
+    ).toBe(0);
+
+    await resumeAndDrainDiscovery(t, created.rolloutId);
+    await Promise.all([
+      t.mutation(internal.assetRollouts.cancel, { rolloutId: created.rolloutId }),
+      t.mutation(internal.assetRollouts.cancel, { rolloutId: created.rolloutId }),
+    ]);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const progress = await t.query(internal.assetRollouts.progress, {
+      rolloutId: created.rolloutId,
+    });
+    expect(progress.rollout).toMatchObject({
+      status: 'cancelled',
+      counters: { pending: 0, leased: 0, cancelled: 25 },
+    });
+    const target = await t.run(async (ctx) => await ctx.db.get('asset_targets', targetIds[0]));
+    expect(target).toMatchObject({
+      desired_generation: 1,
+      desired_renderer_version: 'faction-sheet-v0',
+      published_generation: 1,
+      published_renderer_version: 'faction-sheet-v0',
+      status: 'current',
+      work_lane: 'foreground',
+    });
+    expect(target?.rollout_id).toBeUndefined();
+  });
+
+  test('a save during discovery is enrolled once as superseded and remains foreground', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t, userIds, factionIds, targetIds } = await seedCurrentTargets(1);
+    const created = await createPaused(t);
+    await t.mutation(internal.assetRollouts.resume, { rolloutId: created.rolloutId });
+
+    vi.setSystemTime(NOW + 1);
+    await t.withIdentity({ subject: userIds[0] }).mutation(api.factions.update, {
+      id: factionIds[0],
+      data: { ...proofFaction, name: 'Saved during rollout discovery' },
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const state = await t.run(async (ctx) => ({
+      target: await ctx.db.get('asset_targets', targetIds[0]),
+      items: await ctx.db.query('asset_rollout_items').take(2),
+    }));
+    expect(state.items).toHaveLength(1);
+    expect(state.items[0]).toMatchObject({ state: 'superseded' });
+    expect(state.target).toMatchObject({
+      desired_generation: 2,
+      desired_renderer_version: 'faction-sheet-v1',
+      status: 'pending',
+      work_lane: 'foreground',
+    });
+  });
+
+  test('a save during a rollout claim supersedes only that item and the stale claim cannot win', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t, userIds, factionIds, targetIds } = await seedCurrentTargets(1);
+    const created = await createPaused(t);
+    await resumeAndDrainDiscovery(t, created.rolloutId);
+    const claim = await acquireAndClaimRollout(t);
+
+    vi.setSystemTime(NOW + 1);
+    await t.withIdentity({ subject: userIds[0] }).mutation(api.factions.update, {
+      id: factionIds[0],
+      data: { ...proofFaction, name: 'Saved during rollout claim' },
+    });
+    await expect(
+      t.mutation(internal.assetPublisher.completeClaim, {
+        ...exact(claim),
+        r2Etag: 'stale-rollout-etag',
+        bytes: 1234,
+        cacheToken: `v1.${'a'.repeat(22)}.${'b'.repeat(43)}`,
+      })
+    ).resolves.toEqual({ status: 'stale' });
+
+    const state = await t.run(async (ctx) => ({
+      target: await ctx.db.get('asset_targets', targetIds[0]),
+      items: await ctx.db.query('asset_rollout_items').take(2),
+    }));
+    expect(state.items[0]?.state).toBe('superseded');
+    expect(state.target).toMatchObject({
+      desired_generation: 2,
+      desired_renderer_version: 'faction-sheet-v1',
+      status: 'pending',
+      work_lane: 'foreground',
+    });
+    expect(state.target?.published_renderer_version).toBe('faction-sheet-v0');
+  });
+
+  test('cancel waits for a leased item and bounded continuation reclaims it after exact expiry', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t, targetIds } = await seedCurrentTargets(1);
+    const created = await createPaused(t);
+    await resumeAndDrainDiscovery(t, created.rolloutId);
+    await acquireAndClaimRollout(t);
+
+    await t.mutation(internal.assetRollouts.cancel, { rolloutId: created.rolloutId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    const progress = await t.query(internal.assetRollouts.progress, {
+      rolloutId: created.rolloutId,
+    });
+    expect(progress.rollout).toMatchObject({
+      status: 'cancelled',
+      counters: { pending: 0, leased: 0, cancelled: 1 },
+    });
+    const target = await t.run(async (ctx) => await ctx.db.get('asset_targets', targetIds[0]));
+    expect(target).toMatchObject({
+      status: 'current',
+      desired_renderer_version: 'faction-sheet-v0',
+      work_lane: 'foreground',
+    });
+    expect(target?.claim_token).toBeUndefined();
+  });
+
+  test('rollout failures retain the batch until final release and end as completed_with_errors', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t } = await seedCurrentTargets(1);
+    const created = await createPaused(t);
+    await resumeAndDrainDiscovery(t, created.rolloutId);
+
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const claim = await acquireAndClaimRollout(t, attempt);
+      const failed = await t.mutation(internal.assetPublisher.failClaim, {
+        ...exact(claim),
+        error: `bounded rollout failure ${attempt}`,
+      });
+      expect(failed.status).toBe('failed');
+      const owned = await t.run(
+        async (ctx) => (await ctx.db.query('asset_publisher_state').take(2))[0]
+      );
+      expect(owned?.batch_token).toBe(BATCHES[attempt]);
+      await settleAndRelease(t, BATCHES[attempt]);
+      if (attempt < 2 && 'nextEligibleAt' in failed && failed.nextEligibleAt !== undefined) {
+        vi.setSystemTime(failed.nextEligibleAt);
+      }
+    }
+
+    const progress = await t.query(internal.assetRollouts.progress, {
+      rolloutId: created.rolloutId,
+    });
+    expect(progress.rollout).toMatchObject({
+      status: 'completed_with_errors',
+      counters: { pending: 0, leased: 0, terminalErrors: 1 },
+    });
+    expect(progress.activeRolloutId).toBeNull();
+  });
+
+  test('a successful item checkpoint retains rollout batch ownership until exact final release', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t } = await seedCurrentTargets(1);
+    const created = await createPaused(t);
+    await resumeAndDrainDiscovery(t, created.rolloutId);
+    const claim = await acquireAndClaimRollout(t);
+
+    await expect(
+      t.mutation(internal.assetPublisher.completeClaim, {
+        ...exact(claim),
+        r2Etag: 'rollout-success-etag',
+        bytes: 1_234,
+        cacheToken: `v1.${'c'.repeat(22)}.${'d'.repeat(43)}`,
+      })
+    ).resolves.toMatchObject({ status: 'completed' });
+    const owned = await t.run(
+      async (ctx) => (await ctx.db.query('asset_publisher_state').take(2))[0]
+    );
+    expect(owned?.batch_token).toBe(BATCHES[0]);
+    await settleAndRelease(t, BATCHES[0]);
+    await expect(
+      t.query(internal.assetRollouts.progress, { rolloutId: created.rolloutId })
+    ).resolves.toMatchObject({
+      activeRolloutId: null,
+      rollout: {
+        status: 'completed',
+        counters: { pending: 0, leased: 0, succeeded: 1, terminalErrors: 0 },
+      },
+    });
+  });
+
+  test('terminal rollout rollback is a new paused rollout with immutable linkage', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t } = await seedCurrentTargets(1);
+    const created = await createPaused(t);
+    await resumeAndDrainDiscovery(t, created.rolloutId);
+    await t.mutation(internal.assetRollouts.cancel, { rolloutId: created.rolloutId });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const rollback = await t.mutation(internal.assetRollouts.createRollback, {
+      rollbackOfRolloutId: created.rolloutId,
+      targetRendererVersion: 'faction-sheet-v1',
+    });
+    const replay = await t.mutation(internal.assetRollouts.createRollback, {
+      rollbackOfRolloutId: created.rolloutId,
+      targetRendererVersion: 'faction-sheet-v1',
+    });
+    expect(rollback).toMatchObject({
+      status: 'paused',
+      rollbackOfRolloutId: created.rolloutId,
+    });
+    expect(replay.rolloutId).toBe(rollback.rolloutId);
+  });
+
+  test('ordinary pending saves retain claim priority over an active rollout at max one', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t } = await seedCurrentTargets(2);
+    const created = await createPaused(t);
+    await resumeAndDrainDiscovery(t, created.rolloutId);
+    await t.run(async (ctx) => {
+      const userId = await ctx.db.insert('users', { name: 'Foreground owner' });
+      const factionId = await ctx.db.insert('factions', {
+        owner_id: userId,
+        data: { ...proofFaction, name: 'Foreground priority' },
+        slug: 'foreground-priority',
+        created_at: new Date(NOW).toISOString(),
+        updated_at: new Date(NOW).toISOString(),
+        is_deleted: false,
+        group_id: null,
+      });
+      await ctx.db.insert('asset_targets', {
+        faction_id: factionId,
+        asset_type: 'faction_sheet',
+        desired_generation: 1,
+        desired_renderer_version: 'faction-sheet-v1',
+        first_publication_admitted: true,
+        status: 'pending',
+        next_eligible_at: NOW,
+        attempt_count: 0,
+        work_lane: 'foreground',
+        foreground_updated_at: NOW,
+      });
+      const counter = (await ctx.db.query('counters').take(10)).find(
+        (row) => row.key === FACTION_SHEET_PUBLICATION_COUNTER_KEY
+      );
+      if (counter) await ctx.db.patch(counter._id, { value: counter.value + 1 });
+    });
+
+    const acquisition = await t.mutation(internal.assetPublisher.acquireBatch, {
+      batchToken: BATCHES[0],
+    });
+    expect(acquisition.status).toBe('acquired');
+    const claim = await t.mutation(internal.assetPublisher.claimOne, {
+      batchToken: BATCHES[0],
+      claimToken: CLAIMS[0],
+    });
+    expect(claim).toMatchObject({ status: 'claimed', workLane: 'foreground' });
+  });
+
+  test('production-shape rows with all rollout optionals absent remain valid and foreground', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const { t } = await seedCurrentTargets(1, 'faction-sheet-v1');
+    const created = await createPaused(t);
+    const progress = await resumeAndDrainDiscovery(t, created.rolloutId);
+    expect(progress).toMatchObject({
+      status: 'completed',
+      counters: { discovered: 1, succeeded: 1, pending: 0, leased: 0 },
+    });
+  });
+
+  test('the operator HTTP boundary is secret-scoped, strict, and returns only bounded projection', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const keys = [
+      'ASSET_PUBLISHER_ACTIVATION_SECRET',
+      'ASSET_PUBLISHER_POLL_SECRET',
+      'ASSET_PUBLISHER_EXECUTOR_SECRET',
+      'ASSET_PUBLISHER_RENDER_CAPABILITY_SECRET',
+      'ASSET_PUBLISHER_CACHE_TOKEN_SECRET',
+    ] as const;
+    const prior = Object.fromEntries(keys.map((key) => [key, process.env[key]]));
+    process.env.ASSET_PUBLISHER_ACTIVATION_SECRET = 'rollout-activation-secret';
+    process.env.ASSET_PUBLISHER_POLL_SECRET = 'rollout-poll-secret';
+    process.env.ASSET_PUBLISHER_EXECUTOR_SECRET = 'rollout-executor-secret';
+    process.env.ASSET_PUBLISHER_RENDER_CAPABILITY_SECRET = 'rollout-render-secret';
+    process.env.ASSET_PUBLISHER_CACHE_TOKEN_SECRET = 'rollout-cache-secret';
+    try {
+      const { t } = await seedCurrentTargets(1);
+      const post = async (body: unknown, secret = 'rollout-activation-secret') =>
+        await t.fetch('/asset-publishing/rollouts', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${secret}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        });
+
+      expect(
+        (
+          await post(
+            {
+              schemaVersion: 1,
+              operation: 'create_paused',
+              targetRendererVersion: 'faction-sheet-v1',
+            },
+            'rollout-poll-secret'
+          )
+        ).status
+      ).toBe(404);
+      expect(
+        (
+          await post({
+            schemaVersion: 1,
+            operation: 'create_paused',
+            targetRendererVersion: 'operator-invented-renderer',
+          })
+        ).status
+      ).toBe(400);
+      expect(
+        (
+          await post({
+            schemaVersion: 1,
+            operation: 'create_paused',
+            targetRendererVersion: 'faction-sheet-v1',
+            dispatch: 'internal.anything',
+          })
+        ).status
+      ).toBe(400);
+
+      const created = await post({
+        schemaVersion: 1,
+        operation: 'create_paused',
+        targetRendererVersion: 'faction-sheet-v1',
+      });
+      expect(created.status).toBe(200);
+      const createdBody = (await created.json()) as { rollout: { rolloutId: string } };
+      const progress = await post({
+        schemaVersion: 1,
+        operation: 'progress',
+        rolloutId: createdBody.rollout.rolloutId,
+      });
+      expect(progress.status).toBe(200);
+      const serialized = JSON.stringify(await progress.json());
+      expect(serialized).toContain('remainingItems');
+      expect(serialized).not.toMatch(/claimToken|batchToken|payload|last_error|lastError/);
+    } finally {
+      for (const key of keys) {
+        const value = prior[key];
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+});

--- a/convex/assetRollouts.ts
+++ b/convex/assetRollouts.ts
@@ -1,0 +1,793 @@
+import { v } from 'convex/values';
+
+import { internal } from './_generated/api';
+import type { Doc, Id } from './_generated/dataModel';
+import { internalMutation, internalQuery } from './_generated/server';
+import {
+  FACTION_SHEET_ASSET_TYPE,
+  INITIAL_FACTION_SHEET_RENDERER_VERSION,
+} from './lib/assetPublisherConstants';
+import { BROWSER_RESERVATION_MS, FREE_BROWSER_ALLOWANCE_MS } from './lib/assetPublisherLimits';
+import type { MutationCtx, QueryCtx } from './types';
+
+export const ROLLOUT_DISCOVERY_PAGE_SIZE = 50;
+export const ROLLOUT_CLEANUP_PAGE_SIZE = 50;
+export const MAX_ROLLOUT_ATTEMPTS = 3;
+export const EFFECTIVE_PUBLISHER_MAX_ITEMS = 1;
+
+type RolloutStatus = Doc<'asset_rollouts'>['status'];
+type RolloutItemState = Doc<'asset_rollout_items'>['state'];
+type ReadCtx = Pick<QueryCtx, 'db'>;
+
+const NONTERMINAL_STATUSES = [
+  'discovering',
+  'running',
+  'paused',
+  'cancelling',
+] as const satisfies readonly RolloutStatus[];
+
+function isNonterminal(status: RolloutStatus): boolean {
+  return NONTERMINAL_STATUSES.includes(status as (typeof NONTERMINAL_STATUSES)[number]);
+}
+
+function supportedRenderer(version: string): boolean {
+  // A candidate is executable only after the embedded Worker compatibility contract is widened.
+  // Operator input alone must never manufacture renderer support.
+  return version === INITIAL_FACTION_SHEET_RENDERER_VERSION;
+}
+
+async function exactConfig(ctx: ReadCtx) {
+  const rows = await ctx.db
+    .query('asset_type_configs')
+    .withIndex('by_asset_type', (q) => q.eq('asset_type', FACTION_SHEET_ASSET_TYPE))
+    .take(2);
+  if (rows.length !== 1) {
+    throw new Error(`Expected exactly one faction-sheet config, found ${rows.length}`);
+  }
+  return rows[0];
+}
+
+async function exactRolloutItem(
+  ctx: ReadCtx,
+  rolloutId: Id<'asset_rollouts'>,
+  targetId: Id<'asset_targets'>
+) {
+  const rows = await ctx.db
+    .query('asset_rollout_items')
+    .withIndex('by_rollout_id_and_target_id', (q) =>
+      q.eq('rollout_id', rolloutId).eq('target_id', targetId)
+    )
+    .take(2);
+  if (rows.length > 1) throw new Error('Duplicate rollout membership');
+  return rows[0] ?? null;
+}
+
+function counterPatch(
+  rollout: Doc<'asset_rollouts'>,
+  from: RolloutItemState | null,
+  to: RolloutItemState
+) {
+  const patch: Record<string, number> = { updated_at: Date.now() };
+  if (from) patch[from === 'terminal_error' ? 'terminal_errors' : from] = -1;
+  patch[to === 'terminal_error' ? 'terminal_errors' : to] =
+    (patch[to === 'terminal_error' ? 'terminal_errors' : to] ?? 0) + 1;
+
+  const result: Record<string, number> = { updated_at: patch.updated_at };
+  for (const [field, delta] of Object.entries(patch)) {
+    if (field === 'updated_at') continue;
+    const current = rollout[field as keyof Doc<'asset_rollouts'>];
+    if (typeof current !== 'number' || current + delta < 0) {
+      throw new Error(`Invalid rollout counter transition for ${field}`);
+    }
+    result[field] = current + delta;
+  }
+  return result;
+}
+
+async function clearActiveRolloutPointer(ctx: MutationCtx, rollout: Doc<'asset_rollouts'>) {
+  const config = await exactConfig(ctx);
+  if (config.active_rollout_id === rollout._id) {
+    await ctx.db.patch(config._id, { active_rollout_id: undefined, updated_at: Date.now() });
+  }
+}
+
+async function maybeFinalizeRollout(ctx: MutationCtx, rolloutId: Id<'asset_rollouts'>) {
+  const rollout = await ctx.db.get('asset_rollouts', rolloutId);
+  if (rollout?.pending !== 0 || rollout.leased !== 0) return rollout;
+
+  let terminalStatus: 'cancelled' | 'completed' | 'completed_with_errors' | null = null;
+  if (rollout.status === 'cancelling') {
+    terminalStatus = 'cancelled';
+  } else if (rollout.status === 'running' && rollout.discovery_sealed_at !== undefined) {
+    terminalStatus = rollout.terminal_errors === 0 ? 'completed' : 'completed_with_errors';
+  }
+  if (!terminalStatus) return rollout;
+
+  const updated = { ...rollout, status: terminalStatus, updated_at: Date.now() };
+  await ctx.db.patch(rollout._id, {
+    status: terminalStatus,
+    updated_at: updated.updated_at,
+  });
+  await clearActiveRolloutPointer(ctx, updated);
+  return updated;
+}
+
+async function assertNoOtherNonterminalRollout(ctx: MutationCtx) {
+  const config = await exactConfig(ctx);
+  if (config.active_rollout_id) {
+    const active = await ctx.db.get('asset_rollouts', config.active_rollout_id);
+    if (active && isNonterminal(active.status)) {
+      throw new Error('A nonterminal faction-sheet rollout already exists');
+    }
+    await ctx.db.patch(config._id, { active_rollout_id: undefined, updated_at: Date.now() });
+  }
+
+  for (const status of NONTERMINAL_STATUSES) {
+    const existing = await ctx.db
+      .query('asset_rollouts')
+      .withIndex('by_asset_type_and_status', (q) =>
+        q.eq('asset_type', FACTION_SHEET_ASSET_TYPE).eq('status', status)
+      )
+      .take(1);
+    if (existing[0]) {
+      throw new Error('A nonterminal rollout exists without the config ownership pointer');
+    }
+  }
+  return config;
+}
+
+async function insertPausedRollout(
+  ctx: MutationCtx,
+  targetRendererVersion: string,
+  rollbackOfRolloutId?: Id<'asset_rollouts'>
+) {
+  if (!supportedRenderer(targetRendererVersion)) {
+    throw new Error('Renderer is not supported by the embedded Worker compatibility contract');
+  }
+  const config = await assertNoOtherNonterminalRollout(ctx);
+  const now = Date.now();
+  const rolloutId = await ctx.db.insert('asset_rollouts', {
+    asset_type: FACTION_SHEET_ASSET_TYPE,
+    target_renderer_version: targetRendererVersion,
+    ...(rollbackOfRolloutId ? { rollback_of_rollout_id: rollbackOfRolloutId } : {}),
+    status: 'paused',
+    cutoff_creation_time: now,
+    discovery_pages: 0,
+    discovery_continuations: 0,
+    discovered: 0,
+    pending: 0,
+    leased: 0,
+    succeeded: 0,
+    superseded: 0,
+    cancelled: 0,
+    terminal_errors: 0,
+    created_at: now,
+    updated_at: now,
+  });
+  const inserted = await ctx.db.get('asset_rollouts', rolloutId);
+  if (!inserted) throw new Error('Failed to read created rollout');
+  // Use Convex's ordered database creation clock, not a wall-clock millisecond. This keeps the
+  // cutoff exact even when many targets and the rollout are inserted inside one millisecond.
+  await ctx.db.patch(rolloutId, { cutoff_creation_time: inserted._creationTime });
+  await ctx.db.patch(config._id, { active_rollout_id: rolloutId, updated_at: now });
+  return await ctx.db.get('asset_rollouts', rolloutId);
+}
+
+export const normalizeRolloutId = internalQuery({
+  args: { rolloutId: v.string() },
+  handler: async (ctx, args) => ctx.db.normalizeId('asset_rollouts', args.rolloutId),
+});
+
+export const createPaused = internalMutation({
+  args: { targetRendererVersion: v.string() },
+  handler: async (ctx, args) => {
+    const config = await exactConfig(ctx);
+    if (config.active_rollout_id) {
+      const existing = await ctx.db.get('asset_rollouts', config.active_rollout_id);
+      if (
+        existing?.status === 'paused' &&
+        existing.target_renderer_version === args.targetRendererVersion &&
+        existing.rollback_of_rollout_id === undefined &&
+        existing.discovered === 0
+      ) {
+        return projectRollout(existing);
+      }
+    }
+    const rollout = await insertPausedRollout(ctx, args.targetRendererVersion);
+    if (!rollout) throw new Error('Failed to create rollout');
+    return projectRollout(rollout);
+  },
+});
+
+export const createRollback = internalMutation({
+  args: {
+    rollbackOfRolloutId: v.id('asset_rollouts'),
+    targetRendererVersion: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const prior = await ctx.db.get('asset_rollouts', args.rollbackOfRolloutId);
+    if (!prior || isNonterminal(prior.status)) {
+      throw new Error('Rollback source must be a terminal rollout');
+    }
+    const config = await exactConfig(ctx);
+    if (config.active_rollout_id) {
+      const existing = await ctx.db.get('asset_rollouts', config.active_rollout_id);
+      if (
+        existing?.status === 'paused' &&
+        existing.target_renderer_version === args.targetRendererVersion &&
+        existing.rollback_of_rollout_id === args.rollbackOfRolloutId &&
+        existing.discovered === 0
+      ) {
+        return projectRollout(existing);
+      }
+    }
+    const rollout = await insertPausedRollout(
+      ctx,
+      args.targetRendererVersion,
+      args.rollbackOfRolloutId
+    );
+    if (!rollout) throw new Error('Failed to create rollback rollout');
+    return projectRollout(rollout);
+  },
+});
+
+export const resume = internalMutation({
+  args: { rolloutId: v.id('asset_rollouts') },
+  handler: async (ctx, args) => {
+    const rollout = await ctx.db.get('asset_rollouts', args.rolloutId);
+    if (!rollout) throw new Error('Rollout not found');
+    if (!isNonterminal(rollout.status) || rollout.status === 'cancelling') {
+      return projectRollout(rollout);
+    }
+    if (rollout.status === 'discovering' || rollout.status === 'running') {
+      return projectRollout(rollout);
+    }
+    const status = rollout.discovery_sealed_at === undefined ? 'discovering' : 'running';
+    const updatedAt = Date.now();
+    await ctx.db.patch(rollout._id, { status, updated_at: updatedAt });
+    if (status === 'discovering') {
+      await ctx.scheduler.runAfter(0, internal.assetRollouts.discoverPage, {
+        rolloutId: rollout._id,
+      });
+    } else {
+      await maybeFinalizeRollout(ctx, rollout._id);
+    }
+    const updated = await ctx.db.get('asset_rollouts', rollout._id);
+    if (!updated) throw new Error('Rollout disappeared');
+    return projectRollout(updated);
+  },
+});
+
+export const pause = internalMutation({
+  args: { rolloutId: v.id('asset_rollouts') },
+  handler: async (ctx, args) => {
+    const rollout = await ctx.db.get('asset_rollouts', args.rolloutId);
+    if (!rollout) throw new Error('Rollout not found');
+    if (rollout.status !== 'discovering' && rollout.status !== 'running') {
+      return projectRollout(rollout);
+    }
+    const updatedAt = Date.now();
+    await ctx.db.patch(rollout._id, { status: 'paused', updated_at: updatedAt });
+    return projectRollout({ ...rollout, status: 'paused', updated_at: updatedAt });
+  },
+});
+
+export const cancel = internalMutation({
+  args: { rolloutId: v.id('asset_rollouts') },
+  handler: async (ctx, args) => {
+    const rollout = await ctx.db.get('asset_rollouts', args.rolloutId);
+    if (!rollout) throw new Error('Rollout not found');
+    if (!isNonterminal(rollout.status)) return projectRollout(rollout);
+    if (rollout.status !== 'cancelling') {
+      const updatedAt = Date.now();
+      await ctx.db.patch(rollout._id, {
+        status: 'cancelling',
+        discovery_cursor: undefined,
+        discovery_sealed_at: rollout.discovery_sealed_at ?? updatedAt,
+        updated_at: updatedAt,
+      });
+    }
+    await ctx.scheduler.runAfter(0, internal.assetRollouts.cancelPage, {
+      rolloutId: rollout._id,
+    });
+    const updated = await ctx.db.get('asset_rollouts', rollout._id);
+    if (!updated) throw new Error('Rollout disappeared');
+    return projectRollout(updated);
+  },
+});
+
+function exactCurrentPublication(target: Doc<'asset_targets'>): boolean {
+  return (
+    target.status === 'current' &&
+    target.published_generation !== undefined &&
+    target.published_renderer_version !== undefined &&
+    target.desired_generation === target.published_generation &&
+    target.desired_renderer_version === target.published_renderer_version
+  );
+}
+
+export const discoverPage = internalMutation({
+  args: { rolloutId: v.id('asset_rollouts') },
+  handler: async (ctx, args) => {
+    const rollout = await ctx.db.get('asset_rollouts', args.rolloutId);
+    if (rollout?.status !== 'discovering') return { status: 'stopped' as const };
+
+    const page = await ctx.db
+      .query('asset_targets')
+      .withIndex('by_asset_type', (q) =>
+        q
+          .eq('asset_type', FACTION_SHEET_ASSET_TYPE)
+          .lte('_creationTime', rollout.cutoff_creation_time)
+      )
+      .paginate({
+        numItems: ROLLOUT_DISCOVERY_PAGE_SIZE,
+        cursor: rollout.discovery_cursor ?? null,
+      });
+
+    const counts = {
+      discovered: rollout.discovered,
+      pending: rollout.pending,
+      succeeded: rollout.succeeded,
+      superseded: rollout.superseded,
+    };
+    for (const target of page.page) {
+      const existing = await exactRolloutItem(ctx, rollout._id, target._id);
+      if (existing) continue;
+      const faction = await ctx.db.get('factions', target.faction_id);
+      if (!faction || faction.is_deleted) continue;
+
+      const now = Date.now();
+      let state: 'pending' | 'succeeded' | 'superseded';
+      if (
+        exactCurrentPublication(target) &&
+        target.published_renderer_version === rollout.target_renderer_version
+      ) {
+        state = 'succeeded';
+      } else if (
+        !exactCurrentPublication(target) ||
+        target.status === 'leased' ||
+        (target.foreground_updated_at ?? 0) > rollout.cutoff_creation_time ||
+        target.desired_renderer_version === rollout.target_renderer_version
+      ) {
+        state = 'superseded';
+      } else {
+        state = 'pending';
+      }
+
+      const itemId = await ctx.db.insert('asset_rollout_items', {
+        rollout_id: rollout._id,
+        target_id: target._id,
+        enrolled_generation: target.desired_generation,
+        enrolled_renderer_version: rollout.target_renderer_version,
+        ...(target.published_renderer_version
+          ? { previous_renderer_version: target.published_renderer_version }
+          : {}),
+        state,
+        retry_count: 0,
+        next_eligible_at: now,
+        created_at: now,
+        updated_at: now,
+      });
+      counts.discovered += 1;
+      counts[state] += 1;
+      if (state === 'pending') {
+        await ctx.db.patch(target._id, {
+          desired_renderer_version: rollout.target_renderer_version,
+          status: 'pending',
+          next_eligible_at: now,
+          last_error: undefined,
+          work_lane: 'rollout',
+          rollout_id: rollout._id,
+          rollout_item_id: itemId,
+        });
+      }
+    }
+
+    const now = Date.now();
+    await ctx.db.patch(rollout._id, {
+      ...counts,
+      discovery_pages: rollout.discovery_pages + 1,
+      discovery_continuations: rollout.discovery_continuations + (page.isDone ? 0 : 1),
+      discovery_cursor: page.isDone ? undefined : page.continueCursor,
+      ...(page.isDone ? { discovery_sealed_at: now, status: 'running' as const } : {}),
+      updated_at: now,
+    });
+    if (!page.isDone) {
+      await ctx.scheduler.runAfter(0, internal.assetRollouts.discoverPage, {
+        rolloutId: rollout._id,
+      });
+    } else {
+      await maybeFinalizeRollout(ctx, rollout._id);
+    }
+    return {
+      status: page.isDone ? ('sealed' as const) : ('continued' as const),
+      pageSize: page.page.length,
+      discovered: counts.discovered,
+    };
+  },
+});
+
+function restoreTargetAfterRollout(
+  target: Doc<'asset_targets'>,
+  item: Doc<'asset_rollout_items'>,
+  now: number
+) {
+  const restoredRenderer =
+    item.previous_renderer_version ??
+    target.published_renderer_version ??
+    target.desired_renderer_version;
+  const isCurrent =
+    target.published_generation === target.desired_generation &&
+    target.published_renderer_version === restoredRenderer;
+  return {
+    desired_renderer_version: restoredRenderer,
+    status: isCurrent ? ('current' as const) : ('pending' as const),
+    next_eligible_at: now,
+    last_error: undefined,
+    work_lane: 'foreground' as const,
+    rollout_id: undefined,
+    rollout_item_id: undefined,
+    batch_token: undefined,
+    claim_token: undefined,
+    claimed_generation: undefined,
+    claimed_renderer_version: undefined,
+    lease_expires_at: undefined,
+    claim_payload_hash: undefined,
+  };
+}
+
+async function cancelOneItem(
+  ctx: MutationCtx,
+  rollout: Doc<'asset_rollouts'>,
+  item: Doc<'asset_rollout_items'>
+) {
+  if (item.state !== 'pending') return rollout;
+  const target = await ctx.db.get('asset_targets', item.target_id);
+  const now = Date.now();
+  if (
+    target?.rollout_id === rollout._id &&
+    target.rollout_item_id === item._id &&
+    target.status !== 'leased'
+  ) {
+    await ctx.db.patch(target._id, restoreTargetAfterRollout(target, item, now));
+  }
+  await ctx.db.patch(item._id, { state: 'cancelled', updated_at: now, last_error: undefined });
+  const updated = { ...rollout, ...counterPatch(rollout, 'pending', 'cancelled') };
+  await ctx.db.patch(rollout._id, counterPatch(rollout, 'pending', 'cancelled'));
+  return updated;
+}
+
+export const cancelPage = internalMutation({
+  args: { rolloutId: v.id('asset_rollouts') },
+  handler: async (ctx, args) => {
+    let rollout = await ctx.db.get('asset_rollouts', args.rolloutId);
+    if (rollout?.status !== 'cancelling') return { status: 'stopped' as const };
+    const rolloutId = rollout._id;
+    const now = Date.now();
+    const expiredTargets = await ctx.db
+      .query('asset_targets')
+      .withIndex('by_type_lane_status_lease', (q) =>
+        q
+          .eq('asset_type', FACTION_SHEET_ASSET_TYPE)
+          .eq('work_lane', 'rollout')
+          .eq('status', 'leased')
+          .lte('lease_expires_at', now)
+      )
+      .take(ROLLOUT_CLEANUP_PAGE_SIZE);
+    for (const target of expiredTargets) {
+      if (target.rollout_id !== rolloutId) continue;
+      const snapshot = await ctx.db
+        .query('asset_claim_snapshots')
+        .withIndex('by_target_id', (q) => q.eq('target_id', target._id))
+        .unique();
+      if (
+        snapshot &&
+        snapshot.batch_token === target.batch_token &&
+        snapshot.claim_token === target.claim_token
+      ) {
+        await ctx.db.delete(snapshot._id);
+      }
+      await recoverExpiredRolloutClaim(ctx, target, now);
+    }
+    rollout = (await ctx.db.get('asset_rollouts', rolloutId)) ?? rollout;
+    const remainingCapacity = ROLLOUT_CLEANUP_PAGE_SIZE - expiredTargets.length;
+    const items =
+      remainingCapacity === 0
+        ? []
+        : await ctx.db
+            .query('asset_rollout_items')
+            .withIndex('by_rollout_id_and_state_and_next_eligible_at', (q) =>
+              q.eq('rollout_id', rolloutId).eq('state', 'pending')
+            )
+            .take(remainingCapacity);
+    for (const item of items) rollout = await cancelOneItem(ctx, rollout, item);
+
+    if (items.length + expiredTargets.length === ROLLOUT_CLEANUP_PAGE_SIZE) {
+      await ctx.scheduler.runAfter(0, internal.assetRollouts.cancelPage, {
+        rolloutId: rollout._id,
+      });
+    } else {
+      const finalized = await maybeFinalizeRollout(ctx, rollout._id);
+      if (finalized?.status === 'cancelling' && finalized.leased > 0) {
+        const earliestLease = await ctx.db
+          .query('asset_targets')
+          .withIndex('by_type_lane_status_lease', (q) =>
+            q
+              .eq('asset_type', FACTION_SHEET_ASSET_TYPE)
+              .eq('work_lane', 'rollout')
+              .eq('status', 'leased')
+          )
+          .first();
+        if (!earliestLease?.lease_expires_at) {
+          throw new Error('Cancelling rollout has leased count without an owned target');
+        }
+        await ctx.scheduler.runAfter(
+          Math.max(0, earliestLease.lease_expires_at - Date.now() + 1),
+          internal.assetRollouts.cancelPage,
+          { rolloutId: rollout._id }
+        );
+      }
+    }
+    return {
+      status: 'processed' as const,
+      pendingCount: items.length,
+      expiredLeaseCount: expiredTargets.length,
+    };
+  },
+});
+
+export async function firstEligibleRolloutTarget(ctx: ReadCtx, now: number) {
+  const config = await exactConfig(ctx);
+  if (!config.active_rollout_id) return null;
+  const rollout = await ctx.db.get('asset_rollouts', config.active_rollout_id);
+  if (rollout?.status !== 'running') return null;
+  for (const status of ['pending', 'cooldown'] as const) {
+    const targets = await ctx.db
+      .query('asset_targets')
+      .withIndex('by_type_lane_status_eligible', (q) =>
+        q
+          .eq('asset_type', FACTION_SHEET_ASSET_TYPE)
+          .eq('work_lane', 'rollout')
+          .eq('status', status)
+          .lte('next_eligible_at', now)
+      )
+      .take(10);
+    for (const target of targets) {
+      if (target.rollout_id !== rollout._id || !target.rollout_item_id) continue;
+      const item = await ctx.db.get('asset_rollout_items', target.rollout_item_id);
+      if (item?.state === 'pending' && item.rollout_id === rollout._id) return target;
+    }
+  }
+  const expired = await ctx.db
+    .query('asset_targets')
+    .withIndex('by_type_lane_status_lease', (q) =>
+      q
+        .eq('asset_type', FACTION_SHEET_ASSET_TYPE)
+        .eq('work_lane', 'rollout')
+        .eq('status', 'leased')
+        .lte('lease_expires_at', now)
+    )
+    .take(1);
+  return expired[0] ?? null;
+}
+
+export async function markRolloutClaimed(
+  ctx: MutationCtx,
+  target: Doc<'asset_targets'>,
+  now: number
+) {
+  if (!target.rollout_id || !target.rollout_item_id) return;
+  const [rollout, item] = await Promise.all([
+    ctx.db.get('asset_rollouts', target.rollout_id),
+    ctx.db.get('asset_rollout_items', target.rollout_item_id),
+  ]);
+  if (
+    rollout?.status !== 'running' ||
+    !item ||
+    item.rollout_id !== rollout._id ||
+    item.target_id !== target._id ||
+    item.state !== 'pending'
+  ) {
+    throw new Error('Rollout claim ownership is inconsistent');
+  }
+  await ctx.db.patch(item._id, { state: 'leased', updated_at: now });
+  await ctx.db.patch(rollout._id, counterPatch(rollout, 'pending', 'leased'));
+}
+
+export async function recoverExpiredRolloutClaim(
+  ctx: MutationCtx,
+  target: Doc<'asset_targets'>,
+  now: number
+) {
+  if (!target.rollout_id || !target.rollout_item_id) return false;
+  const [rollout, item] = await Promise.all([
+    ctx.db.get('asset_rollouts', target.rollout_id),
+    ctx.db.get('asset_rollout_items', target.rollout_item_id),
+  ]);
+  if (!rollout || !item || item.state !== 'leased') return false;
+  if (rollout.status === 'cancelling') {
+    await ctx.db.patch(target._id, restoreTargetAfterRollout(target, item, now));
+    await ctx.db.patch(item._id, { state: 'cancelled', updated_at: now });
+    await ctx.db.patch(rollout._id, counterPatch(rollout, 'leased', 'cancelled'));
+    await maybeFinalizeRollout(ctx, rollout._id);
+    return true;
+  }
+  await ctx.db.patch(item._id, { state: 'pending', next_eligible_at: now, updated_at: now });
+  await ctx.db.patch(rollout._id, counterPatch(rollout, 'leased', 'pending'));
+  return false;
+}
+
+export async function supersedeRolloutForSave(
+  ctx: MutationCtx,
+  target: Doc<'asset_targets'>,
+  now: number
+) {
+  if (!target.rollout_id || !target.rollout_item_id) return;
+  const [rollout, item] = await Promise.all([
+    ctx.db.get('asset_rollouts', target.rollout_id),
+    ctx.db.get('asset_rollout_items', target.rollout_item_id),
+  ]);
+  if (
+    !rollout ||
+    !item ||
+    item.rollout_id !== rollout._id ||
+    item.target_id !== target._id ||
+    (item.state !== 'pending' && item.state !== 'leased')
+  ) {
+    throw new Error('Save found inconsistent rollout ownership');
+  }
+  await ctx.db.patch(item._id, { state: 'superseded', updated_at: now, last_error: undefined });
+  await ctx.db.patch(rollout._id, counterPatch(rollout, item.state, 'superseded'));
+  await maybeFinalizeRollout(ctx, rollout._id);
+}
+
+export async function completeRolloutItem(
+  ctx: MutationCtx,
+  target: Doc<'asset_targets'>,
+  now: number
+) {
+  if (!target.rollout_id || !target.rollout_item_id) return;
+  const [rollout, item] = await Promise.all([
+    ctx.db.get('asset_rollouts', target.rollout_id),
+    ctx.db.get('asset_rollout_items', target.rollout_item_id),
+  ]);
+  if (!rollout || !item || item.state !== 'leased') {
+    throw new Error('Rollout completion ownership is inconsistent');
+  }
+  await ctx.db.patch(item._id, { state: 'succeeded', updated_at: now, last_error: undefined });
+  await ctx.db.patch(rollout._id, counterPatch(rollout, 'leased', 'succeeded'));
+  await maybeFinalizeRollout(ctx, rollout._id);
+}
+
+export async function failRolloutItem(
+  ctx: MutationCtx,
+  target: Doc<'asset_targets'>,
+  error: string,
+  nextEligibleAt: number,
+  now: number
+): Promise<'not_rollout' | 'retry' | 'detached'> {
+  if (!target.rollout_id || !target.rollout_item_id) return 'not_rollout';
+  const [rollout, item] = await Promise.all([
+    ctx.db.get('asset_rollouts', target.rollout_id),
+    ctx.db.get('asset_rollout_items', target.rollout_item_id),
+  ]);
+  if (!rollout || !item || item.state !== 'leased') {
+    throw new Error('Rollout failure ownership is inconsistent');
+  }
+  if (rollout.status === 'cancelling') {
+    await ctx.db.patch(target._id, restoreTargetAfterRollout(target, item, now));
+    await ctx.db.patch(item._id, { state: 'cancelled', updated_at: now, last_error: undefined });
+    await ctx.db.patch(rollout._id, counterPatch(rollout, 'leased', 'cancelled'));
+    await maybeFinalizeRollout(ctx, rollout._id);
+    return 'detached';
+  }
+  const retryCount = item.retry_count + 1;
+  if (retryCount >= MAX_ROLLOUT_ATTEMPTS) {
+    await ctx.db.patch(target._id, restoreTargetAfterRollout(target, item, now));
+    await ctx.db.patch(item._id, {
+      state: 'terminal_error',
+      retry_count: retryCount,
+      last_error: error,
+      updated_at: now,
+    });
+    await ctx.db.patch(rollout._id, counterPatch(rollout, 'leased', 'terminal_error'));
+    await maybeFinalizeRollout(ctx, rollout._id);
+    return 'detached';
+  }
+  await ctx.db.patch(item._id, {
+    state: 'pending',
+    retry_count: retryCount,
+    next_eligible_at: nextEligibleAt,
+    last_error: error,
+    updated_at: now,
+  });
+  await ctx.db.patch(rollout._id, counterPatch(rollout, 'leased', 'pending'));
+  return 'retry';
+}
+
+export async function releaseRolloutItem(
+  ctx: MutationCtx,
+  target: Doc<'asset_targets'>,
+  now: number
+): Promise<'not_rollout' | 'retry' | 'detached'> {
+  if (!target.rollout_id || !target.rollout_item_id) return 'not_rollout';
+  const [rollout, item] = await Promise.all([
+    ctx.db.get('asset_rollouts', target.rollout_id),
+    ctx.db.get('asset_rollout_items', target.rollout_item_id),
+  ]);
+  if (!rollout || !item || item.state !== 'leased') {
+    throw new Error('Rollout release ownership is inconsistent');
+  }
+  if (rollout.status === 'cancelling') {
+    await ctx.db.patch(target._id, restoreTargetAfterRollout(target, item, now));
+    await ctx.db.patch(item._id, { state: 'cancelled', updated_at: now });
+    await ctx.db.patch(rollout._id, counterPatch(rollout, 'leased', 'cancelled'));
+    await maybeFinalizeRollout(ctx, rollout._id);
+    return 'detached';
+  }
+  await ctx.db.patch(item._id, { state: 'pending', next_eligible_at: now, updated_at: now });
+  await ctx.db.patch(rollout._id, counterPatch(rollout, 'leased', 'pending'));
+  return 'retry';
+}
+
+function projectRollout(rollout: Doc<'asset_rollouts'>) {
+  return {
+    rolloutId: rollout._id,
+    assetType: rollout.asset_type,
+    targetRendererVersion: rollout.target_renderer_version,
+    rollbackOfRolloutId: rollout.rollback_of_rollout_id ?? null,
+    status: rollout.status,
+    cutoffCreationTime: rollout.cutoff_creation_time,
+    discoverySealedAt: rollout.discovery_sealed_at ?? null,
+    discoveryPages: rollout.discovery_pages,
+    discoveryContinuations: rollout.discovery_continuations,
+    counters: {
+      discovered: rollout.discovered,
+      pending: rollout.pending,
+      leased: rollout.leased,
+      succeeded: rollout.succeeded,
+      superseded: rollout.superseded,
+      cancelled: rollout.cancelled,
+      terminalErrors: rollout.terminal_errors,
+    },
+    remainingItems: rollout.pending + rollout.leased,
+    createdAt: rollout.created_at,
+    updatedAt: rollout.updated_at,
+  };
+}
+
+export const progress = internalQuery({
+  args: { rolloutId: v.optional(v.id('asset_rollouts')) },
+  handler: async (ctx, args) => {
+    const config = await exactConfig(ctx);
+    const state = await ctx.db
+      .query('asset_publisher_state')
+      .withIndex('by_key', (q) => q.eq('key', 'singleton'))
+      .unique();
+    const rolloutId = args.rolloutId ?? config.active_rollout_id;
+    const rollout = rolloutId ? await ctx.db.get('asset_rollouts', rolloutId) : null;
+    return {
+      activeRolloutId: config.active_rollout_id ?? null,
+      configStatus: config.status,
+      activeRendererVersion: config.active_renderer_version,
+      effectiveMaxItems: EFFECTIVE_PUBLISHER_MAX_ITEMS,
+      rollout: rollout ? projectRollout(rollout) : null,
+      quota: state
+        ? {
+            utcDate: state.daily_browser_utc_date,
+            dailyAccountedMs: state.daily_browser_ms,
+            outstandingReservationMs: state.browser_reserved_ms ?? 0,
+            fixedReservationMs: BROWSER_RESERVATION_MS,
+            providerAllowanceMs: FREE_BROWSER_ALLOWANCE_MS,
+          }
+        : null,
+      etaInputs: rollout
+        ? {
+            remainingItems: rollout.pending + rollout.leased,
+            observedBrowserMsPerItem: null,
+            dispatchIntervalMinutes: 15,
+          }
+        : null,
+    };
+  },
+});

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -22,6 +22,7 @@ import {
   operatorRequestSchema,
   pollRequestSchema,
   releaseBatchRequestSchema,
+  rolloutOperatorRequestSchema,
   settleBrowserRequestSchema,
 } from './lib/assetPublisherSchemas';
 import {
@@ -140,6 +141,81 @@ http.route({
             targetPrerequisite: FACTION_SHEET_TARGET_ACTIVATION_PREREQUISITE,
             storagePrerequisite: FACTION_SHEET_STORAGE_ACTIVATION_PREREQUISITE,
           })),
+        };
+      },
+    });
+  }),
+});
+
+http.route({
+  path: '/asset-publishing/rollouts',
+  method: 'POST',
+  handler: httpAction(async (ctx, request) => {
+    return await handleAuthenticatedJson(request, {
+      expectedSecret: activationBoundarySecret(),
+      schema: rolloutOperatorRequestSchema,
+      execute: async (body) => {
+        if (body.operation === 'create_paused') {
+          return {
+            ok: true,
+            schemaVersion: body.schemaVersion,
+            operation: body.operation,
+            rollout: await ctx.runMutation(internal.assetRollouts.createPaused, {
+              targetRendererVersion: body.targetRendererVersion,
+            }),
+          };
+        }
+        const rolloutId = body.rolloutId
+          ? await ctx.runQuery(internal.assetRollouts.normalizeRolloutId, {
+              rolloutId: body.rolloutId,
+            })
+          : null;
+        if (body.rolloutId && !rolloutId) {
+          throw new InvalidPublisherRequestError('Invalid rollout id');
+        }
+        if (body.operation === 'progress') {
+          return {
+            ok: true,
+            schemaVersion: body.schemaVersion,
+            operation: body.operation,
+            ...(await ctx.runQuery(internal.assetRollouts.progress, {
+              ...(rolloutId ? { rolloutId } : {}),
+            })),
+          };
+        }
+        if (!rolloutId) throw new InvalidPublisherRequestError('Rollout id is required');
+        if (body.operation === 'resume') {
+          return {
+            ok: true,
+            schemaVersion: body.schemaVersion,
+            operation: body.operation,
+            rollout: await ctx.runMutation(internal.assetRollouts.resume, { rolloutId }),
+          };
+        }
+        if (body.operation === 'pause') {
+          return {
+            ok: true,
+            schemaVersion: body.schemaVersion,
+            operation: body.operation,
+            rollout: await ctx.runMutation(internal.assetRollouts.pause, { rolloutId }),
+          };
+        }
+        if (body.operation === 'cancel') {
+          return {
+            ok: true,
+            schemaVersion: body.schemaVersion,
+            operation: body.operation,
+            rollout: await ctx.runMutation(internal.assetRollouts.cancel, { rolloutId }),
+          };
+        }
+        return {
+          ok: true,
+          schemaVersion: body.schemaVersion,
+          operation: body.operation,
+          rollout: await ctx.runMutation(internal.assetRollouts.createRollback, {
+            rollbackOfRolloutId: rolloutId,
+            targetRendererVersion: body.targetRendererVersion,
+          }),
         };
       },
     });

--- a/convex/lib/assetPublisherConstants.ts
+++ b/convex/lib/assetPublisherConstants.ts
@@ -1,0 +1,2 @@
+export const FACTION_SHEET_ASSET_TYPE = 'faction_sheet' as const;
+export const INITIAL_FACTION_SHEET_RENDERER_VERSION = 'faction-sheet-v1';

--- a/convex/lib/assetPublisherSchemas.ts
+++ b/convex/lib/assetPublisherSchemas.ts
@@ -36,6 +36,43 @@ export const operatorRequestSchema = z.discriminatedUnion('operation', [
   z.strictObject({ schemaVersion: z.literal(1), operation: z.literal('activate') }),
 ]);
 
+const rolloutIdSchema = z.string().trim().min(1).max(128);
+const supportedRolloutRendererSchema = z.literal('faction-sheet-v1');
+
+export const rolloutOperatorRequestSchema = z.discriminatedUnion('operation', [
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    operation: z.literal('create_paused'),
+    targetRendererVersion: supportedRolloutRendererSchema,
+  }),
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    operation: z.literal('resume'),
+    rolloutId: rolloutIdSchema,
+  }),
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    operation: z.literal('pause'),
+    rolloutId: rolloutIdSchema,
+  }),
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    operation: z.literal('cancel'),
+    rolloutId: rolloutIdSchema,
+  }),
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    operation: z.literal('rollback'),
+    rolloutId: rolloutIdSchema,
+    targetRendererVersion: supportedRolloutRendererSchema,
+  }),
+  z.strictObject({
+    schemaVersion: z.literal(1),
+    operation: z.literal('progress'),
+    rolloutId: rolloutIdSchema.optional(),
+  }),
+]);
+
 export const acquireRequestSchema = z.strictObject({
   schemaVersion: z.literal(1),
   batchToken: publisherTokenSchema,

--- a/convex/lib/factionSheetTargets.ts
+++ b/convex/lib/factionSheetTargets.ts
@@ -1,9 +1,13 @@
 import { FactionInputSchema } from '../../src/game/schema/faction';
 import type { Id } from '../_generated/dataModel';
+import { supersedeRolloutForSave } from '../assetRollouts';
 import type { MutationCtx } from '../types';
+import {
+  FACTION_SHEET_ASSET_TYPE,
+  INITIAL_FACTION_SHEET_RENDERER_VERSION,
+} from './assetPublisherConstants';
 
-export const FACTION_SHEET_ASSET_TYPE = 'faction_sheet' as const;
-export const INITIAL_FACTION_SHEET_RENDERER_VERSION = 'faction-sheet-v1';
+export { FACTION_SHEET_ASSET_TYPE, INITIAL_FACTION_SHEET_RENDERER_VERSION };
 
 export function parseFactionInput(input: unknown) {
   const parsed = FactionInputSchema.safeParse(input);
@@ -88,12 +92,19 @@ export async function reconcileFactionSheetTargetForSave(
       status: 'pending',
       next_eligible_at: now,
       attempt_count: 0,
+      work_lane: 'foreground',
+      foreground_updated_at: now,
     });
   }
 
+  await supersedeRolloutForSave(ctx, target, now);
   await ctx.db.patch(target._id, {
     desired_generation: target.desired_generation + 1,
     desired_renderer_version: config.active_renderer_version,
+    work_lane: 'foreground',
+    rollout_id: undefined,
+    rollout_item_id: undefined,
+    foreground_updated_at: now,
     ...(target.status === 'leased'
       ? {}
       : {
@@ -123,6 +134,8 @@ export async function ensureFactionSheetTargetForBackfill(
     status: 'pending',
     next_eligible_at: Date.now(),
     attempt_count: 0,
+    work_lane: 'foreground',
+    foreground_updated_at: Date.now(),
   });
 }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -95,6 +95,10 @@ export default defineSchema({
     claim_payload_hash: v.optional(v.string()),
     last_completed_batch_token: v.optional(v.string()),
     last_completed_claim_token: v.optional(v.string()),
+    work_lane: v.optional(v.union(v.literal('foreground'), v.literal('rollout'))),
+    rollout_id: v.optional(v.id('asset_rollouts')),
+    rollout_item_id: v.optional(v.id('asset_rollout_items')),
+    foreground_updated_at: v.optional(v.number()),
   })
     .index('by_faction_id_and_asset_type', ['faction_id', 'asset_type'])
     .index('by_asset_type_and_status_and_next_eligible_at', [
@@ -120,6 +124,28 @@ export default defineSchema({
       'lease_expires_at',
     ])
     .index('by_asset_type_and_published_generation', ['asset_type', 'published_generation'])
+    .index('by_asset_type', ['asset_type'])
+    .index('by_type_lane_status_eligible', [
+      'asset_type',
+      'work_lane',
+      'status',
+      'next_eligible_at',
+    ])
+    .index('by_type_lane_status_lease', ['asset_type', 'work_lane', 'status', 'lease_expires_at'])
+    .index('by_type_lane_admitted_status_eligible', [
+      'asset_type',
+      'work_lane',
+      'first_publication_admitted',
+      'status',
+      'next_eligible_at',
+    ])
+    .index('by_type_lane_admitted_status_lease', [
+      'asset_type',
+      'work_lane',
+      'first_publication_admitted',
+      'status',
+      'lease_expires_at',
+    ])
     .index('by_batch_token', ['batch_token']),
   asset_claim_snapshots: defineTable({
     target_id: v.id('asset_targets'),
@@ -139,6 +165,7 @@ export default defineSchema({
     asset_type: v.literal('faction_sheet'),
     status: v.union(v.literal('disabled'), v.literal('active'), v.literal('paused')),
     active_renderer_version: v.string(),
+    active_rollout_id: v.optional(v.id('asset_rollouts')),
     updated_at: v.number(),
   }).index('by_asset_type', ['asset_type']),
   asset_publisher_state: defineTable({
@@ -159,7 +186,65 @@ export default defineSchema({
       v.union(v.literal('no_browser'), v.literal('after_settlement'))
     ),
     next_lane: v.union(v.literal('foreground'), v.literal('rollout')),
+    lane_sequence_position: v.optional(v.number()),
   }).index('by_key', ['key']),
+  asset_rollouts: defineTable({
+    asset_type: v.literal('faction_sheet'),
+    target_renderer_version: v.string(),
+    rollback_of_rollout_id: v.optional(v.id('asset_rollouts')),
+    status: v.union(
+      v.literal('discovering'),
+      v.literal('running'),
+      v.literal('paused'),
+      v.literal('cancelling'),
+      v.literal('cancelled'),
+      v.literal('completed'),
+      v.literal('completed_with_errors')
+    ),
+    cutoff_creation_time: v.number(),
+    discovery_cursor: v.optional(v.string()),
+    discovery_sealed_at: v.optional(v.number()),
+    discovery_pages: v.number(),
+    discovery_continuations: v.number(),
+    discovered: v.number(),
+    pending: v.number(),
+    leased: v.number(),
+    succeeded: v.number(),
+    superseded: v.number(),
+    cancelled: v.number(),
+    terminal_errors: v.number(),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index('by_asset_type_and_status', ['asset_type', 'status'])
+    .index('by_status_and_updated_at', ['status', 'updated_at']),
+  asset_rollout_items: defineTable({
+    rollout_id: v.id('asset_rollouts'),
+    target_id: v.id('asset_targets'),
+    enrolled_generation: v.number(),
+    enrolled_renderer_version: v.string(),
+    previous_renderer_version: v.optional(v.string()),
+    state: v.union(
+      v.literal('pending'),
+      v.literal('leased'),
+      v.literal('succeeded'),
+      v.literal('superseded'),
+      v.literal('cancelled'),
+      v.literal('terminal_error')
+    ),
+    retry_count: v.number(),
+    next_eligible_at: v.number(),
+    last_error: v.optional(v.string()),
+    created_at: v.number(),
+    updated_at: v.number(),
+  })
+    .index('by_rollout_id_and_target_id', ['rollout_id', 'target_id'])
+    .index('by_rollout_id_and_state_and_next_eligible_at', [
+      'rollout_id',
+      'state',
+      'next_eligible_at',
+    ])
+    .index('by_target_id_and_rollout_id', ['target_id', 'rollout_id']),
   rulesets: defineTable({
     name: v.string(),
     slug: v.string(),

--- a/workers/publisher/MEASUREMENT.md
+++ b/workers/publisher/MEASUREMENT.md
@@ -70,15 +70,18 @@ promotion: it is not a size-two full batch and lacks memory, subrequest, lease, 
 reservation, failure-recovery, projected-slope, and production ownership/stable-write correctness
 measurements. Those correctness fields remain explicitly unknown; Ticket 1 did not prove them.
 
-## Ticket 7 work still blocked
+## Ticket 7 Phase C work still blocked
 
-Until Ticket 6 supplies the stable delivery-enabled baseline, do not add or activate:
+The additive Convex rollout ledger/state machine, strict operator projection, page-50 discovery,
+foreground supersession, and batch-retaining rollout checkpoints are implemented disabled-first.
+They do not create or resume a production rollout, raise either runtime cap, or change the fixed
+240,000-ms reservation/deadline. Until a separately measured scaling batch supplies the stable
+delivery-enabled baseline, do not add or activate:
 
-- an `asset_rollouts`/rollout-item schema or rollout state machine;
-- batch-retaining item checkpoints, an effective maximum above one, or multi-item claiming;
+- an effective maximum above one or multi-item claiming;
 - dynamic batch-sized quota admission, weighted foreground/rollout scheduling, or quota borrowing;
-- candidate renderer activation, rollout discovery/pause/resume/cancel/rollback, or rollout ETA;
-- a final Browser reservation, CPU/memory/subrequest slope, marginal reused-session cost, or any
+- candidate renderer activation or a broad production rollout;
+- a dynamic Browser reservation, CPU/memory/subrequest slope, marginal reused-session cost, or any
   claim that batch sizes two through five are safe.
 
 `evaluateBatchPromotion` is pure. It recommends only the next step in `1 -> 2 -> 3 -> 4 -> 5`,

--- a/workers/publisher/README.md
+++ b/workers/publisher/README.md
@@ -11,7 +11,8 @@ provisioned, and the persistent release configuration is ready for scheduled pol
   identifies the exact assembled release for telemetry and canary checks;
 - poll and executor secrets are distinct required bindings and are not checked in.
 - the Convex-only activation secret is distinct from every publisher boundary secret and is not
-  checked in; it authenticates only initialize, pause, disable, and guarded activate operations.
+  checked in; it authenticates only initialize, pause, disable, guarded activate, and the strict
+  rollout create/pause/resume/cancel/rollback/progress operation union.
 - the cache-token signing secret is a required binding shared out-of-band with Convex and is not
   checked in or provisioned by this ticket. It has the exact canonical shape `s1.<43 base64url
   characters>`: version `s1`, a dot, and the unpadded canonical base64url encoding of 32 bytes from
@@ -21,7 +22,8 @@ provisioned, and the persistent release configuration is ready for scheduled pol
 
 The Queue payload is only `{ schemaVersion, scheduledCutoff, triggerId }`. Convex owns all batch,
 claim, retry, snapshot, publication, and Browser reservation state. R2 metadata is diagnostic only.
-The 480-second work deadline cannot be extended by phase settings. A separate 30-second
+The 240-second work deadline and fixed 240-second Browser reservation cannot be extended by phase
+settings. A separate 30-second
 post-lifecycle window may only settle definitely closed Browser usage; it is bounded well inside the
 15-minute Queue wall and cannot perform more Browser, R2, or publication work.
 
@@ -55,8 +57,16 @@ no-custom-limit configuration and re-measure the production one-item path rather
 allowance from the generic documentation.
 
 See [MEASUREMENT.md](./MEASUREMENT.md) for the pre-measurement telemetry contract, the production
-metrics Ticket 6 must join from Cloudflare, and the Ticket 7 rollout/scaling work that remains
-blocked. Promotion reports are recommendation-only; `EXECUTOR_MAX_ITEMS` remains exactly `1`.
+metrics Ticket 6 must join from Cloudflare, and the Ticket 7 scaling work that remains blocked.
+Convex now contains a disabled-first rollout control plane with page-50 discovery and batch-retaining
+rollout checkpoints, but no rollout is created or resumed by deployment. Promotion reports are
+recommendation-only; `EXECUTOR_MAX_ITEMS` remains exactly `1`.
+
+The only executable semantic renderer remains the release's embedded `faction-sheet-v1` contract.
+The rollout operator schema and mutation both reject any other string. Supporting a future candidate
+requires an ordered compatibility release: widen the Worker to embed/authorize that semantic
+renderer, verify its exact release id and a PDF canary, then widen the strict Convex operator
+validator before activation or paused rollout creation. Operator input alone is never support proof.
 
 ## Local checks
 

--- a/workers/publisher/convex.test.ts
+++ b/workers/publisher/convex.test.ts
@@ -12,6 +12,7 @@ type ClaimOverrides = {
   claimToken?: string;
   renderCapability?: string;
   replay?: boolean;
+  workLane?: unknown;
 };
 
 async function claimedResponse(overrides: ClaimOverrides = {}) {
@@ -48,6 +49,7 @@ async function claimedResponse(overrides: ClaimOverrides = {}) {
     payloadHash: 'a'.repeat(64),
     renderCapability,
     renderCapabilityExpiresAt: 2_000_000_000_000,
+    ...(overrides.workLane !== undefined ? { workLane: overrides.workLane } : {}),
   };
 }
 
@@ -100,6 +102,16 @@ describe('Convex claimed target parsing', () => {
       'Convex claimed target response is invalid'
     );
     expect(() => parseClaim({ ...response, claimToken: 'c'.repeat(257) })).toThrow(
+      'Convex claimed target response is invalid'
+    );
+  });
+
+  test('accepts only the bounded foreground/rollout lane projection', async () => {
+    const rollout = await claimedResponse({ workLane: 'rollout' });
+    expect(parseClaim(rollout)).toMatchObject({ status: 'claimed', workLane: 'rollout' });
+    const foreground = await claimedResponse({ workLane: 'foreground' });
+    expect(parseClaim(foreground)).toMatchObject({ status: 'claimed', workLane: 'foreground' });
+    expect(() => parseClaim({ ...rollout, workLane: 'operator-selected-lane' })).toThrow(
       'Convex claimed target response is invalid'
     );
   });

--- a/workers/publisher/convex.ts
+++ b/workers/publisher/convex.ts
@@ -32,6 +32,7 @@ export type ClaimedTarget = ExactClaim & {
   payloadHash: string;
   renderCapability: string;
   renderCapabilityExpiresAt: number;
+  workLane?: 'foreground' | 'rollout';
 };
 
 export type ClaimResult = ClaimedTarget | { status: 'empty' | 'stale' | 'conflict' };
@@ -135,7 +136,8 @@ export function parseClaim(value: unknown): ClaimResult {
     typeof body.payloadHash !== 'string' ||
     !/^[0-9a-f]{64}$/.test(body.payloadHash) ||
     !isRenderCapability(body.renderCapability) ||
-    !finite(body.renderCapabilityExpiresAt)
+    !finite(body.renderCapabilityExpiresAt) ||
+    (body.workLane !== undefined && body.workLane !== 'foreground' && body.workLane !== 'rollout')
   ) {
     throw new Error('Convex claimed target response is invalid');
   }
@@ -153,6 +155,9 @@ export function parseClaim(value: unknown): ClaimResult {
     payloadHash: body.payloadHash,
     renderCapability: body.renderCapability,
     renderCapabilityExpiresAt: body.renderCapabilityExpiresAt,
+    ...(body.workLane === 'rollout' || body.workLane === 'foreground'
+      ? { workLane: body.workLane }
+      : {}),
   };
 }
 

--- a/workers/publisher/executor.test.ts
+++ b/workers/publisher/executor.test.ts
@@ -196,6 +196,24 @@ describe('one-item owned batch execution', () => {
     });
   });
 
+  test('a rollout checkpoint releases the retained batch only after Browser settlement', async () => {
+    const rolloutClaim = { ...claim, workLane: 'rollout' as const };
+    const { dependencies, spies } = setup({ claimResult: rolloutClaim });
+    const report = await executeOwnedBatch(dependencies, config, acquisition, NOW);
+    expect(report).toMatchObject({
+      status: 'completed',
+      browserSettled: true,
+      telemetry: { queue: { lane: 'rollout' } },
+    });
+    expect(spies.complete).toHaveBeenCalledBefore(spies.settleBrowser);
+    expect(spies.settleBrowser).toHaveBeenCalledBefore(spies.releaseBatch);
+    expect(spies.releaseBatch).toHaveBeenCalledWith(
+      acquisition.batchToken,
+      'after_settlement',
+      expect.any(Number)
+    );
+  });
+
   test('empty and duplicate/busy-fenced claims close without upload', async () => {
     for (const status of ['empty', 'stale', 'conflict'] as const) {
       const { dependencies, spies } = setup({ claimResult: { status } });

--- a/workers/publisher/executor.ts
+++ b/workers/publisher/executor.ts
@@ -84,7 +84,7 @@ export type OwnedBatchTelemetry = {
     messageId?: string;
     attempt?: number;
     name?: string;
-    lane: 'foreground';
+    lane: 'foreground' | 'rollout';
     triggerId?: string;
   };
   batchCorrelationHash: string | null;
@@ -712,7 +712,12 @@ export async function executeOwnedBatch(
         ),
       'unsupported_renderer'
     );
-  } else if (releaseUnclaimedBatch && browserSettled) {
+  }
+  if (
+    browserSettled &&
+    !uncertainClaim &&
+    (releaseUnclaimedBatch || claim?.workLane === 'rollout')
+  ) {
     await bestEffort(
       async () =>
         await telemetry.convex('releaseBatch', async () =>
@@ -722,7 +727,7 @@ export async function executeOwnedBatch(
             ownedOutcomeDeadlineAt
           )
         ),
-      'unclaimed_batch_release'
+      releaseUnclaimedBatch ? 'unclaimed_batch_release' : 'rollout_checkpointed_batch_release'
     );
   } else if (uncertainClaim) {
     // The Convex release mutation also rejects while any target or snapshot owns this batch.
@@ -771,7 +776,7 @@ export async function executeOwnedBatch(
             triggerId: telemetryContext.triggerId,
           }
         : {}),
-      lane: 'foreground',
+      lane: claim?.workLane ?? 'foreground',
     },
     batchCorrelationHash,
     configuredMaxItems: config.maxItems,

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,8 +4,8 @@ export const rendererManifest = {
   schemaVersion: 1,
   rendererVersion: 'faction-sheet-v1',
   rendererId:
-    'faction-sheet/sha256:8675058cb7378bcaa87017da6866ca12f15e6697bd4eb2a0eb38f81c11bf9f72',
-  digest: '8675058cb7378bcaa87017da6866ca12f15e6697bd4eb2a0eb38f81c11bf9f72',
+    'faction-sheet/sha256:c8c802f6b35aaff3239a1b16c55b7c02d35f1d08102cd64c5e7acbf332447ea5',
+  digest: 'c8c802f6b35aaff3239a1b16c55b7c02d35f1d08102cd64c5e7acbf332447ea5',
   contract: {
     rendererVersion: 'faction-sheet-v1',
     viewport: {

--- a/workers/publisher/telemetry.ts
+++ b/workers/publisher/telemetry.ts
@@ -214,7 +214,7 @@ function queueSchema(value: unknown): Record<string, unknown> {
     messageId: boundedText(source.messageId, 128),
     attempt: nonnegativeInteger(source.attempt),
     name: boundedText(source.name, 128),
-    lane: source.lane === 'foreground' ? 'foreground' : null,
+    lane: source.lane === 'foreground' || source.lane === 'rollout' ? source.lane : null,
     triggerId: boundedText(source.triggerId, 128),
   };
 }


### PR DESCRIPTION
## What changed

- Add disabled-first Convex renderer-rollout parent/item state with bounded indexes and exact counters.
- Add strict authenticated operator operations for create, resume, pause, cancel, rollback, and progress.
- Discover targets in immutable 50-row cursor pages with idempotent membership and sequential continuation.
- Integrate save supersession and rollout claim/checkpoint/retry fences while foreground work remains first.
- Keep the production executor and Queue hard-capped at one item.
- Reconcile rollout documentation and measurements with the deployed 240-second reservation/deadline.

## Why

This establishes the durable Convex control plane required for explicit, pausable renderer rollouts
before any real second renderer or multi-item canary is enabled. It keeps current publication
behavior unchanged and disabled-first.

## Safety

- No rollout is created or activated by deployment.
- Only the embedded semantic renderer `faction-sheet-v1` is accepted.
- Existing production rows remain valid through optional fields and greenfield tables.
- No migration/backfill, Cloudflare resource change, Queue-size change, or executor-cap increase.

## Verification

- Cold review: SAFE to push, merge, and deploy disabled-first.
- Full tests: 37 files / 526 tests.
- Focused rollout/publisher/save tests: 112 tests.
- Root, publisher, and proof TypeScript.
- Connected-development Convex codegen.
- Production migration narrow-check.
- Wrangler types, unified 1,008-asset build, asset checks, and deployment dry-run.
- Biome and diff checks.
- Deterministic 25-target and simulated 2,000-target discovery tests.
