### PR TITLE
Regenerate Convex rollout API bindings

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,7 @@ import type * as factions from "../factions.js";
 import type * as faq from "../faq.js";
 import type * as groups from "../groups.js";
 import type * as http from "../http.js";
+import type * as lib_assetPublisherConstants from "../lib/assetPublisherConstants.js";
 import type * as lib_assetPublisherHttp from "../lib/assetPublisherHttp.js";
 import type * as lib_assetPublisherLimits from "../lib/assetPublisherLimits.js";
 import type * as lib_assetPublisherSchemas from "../lib/assetPublisherSchemas.js";
@@ -55,6 +56,7 @@ declare const fullApi: ApiFromModules<{
   faq: typeof faq;
   groups: typeof groups;
   http: typeof http;
+  "lib/assetPublisherConstants": typeof lib_assetPublisherConstants;
   "lib/assetPublisherHttp": typeof lib_assetPublisherHttp;
   "lib/assetPublisherLimits": typeof lib_assetPublisherLimits;
   "lib/assetPublisherSchemas": typeof lib_assetPublisherSchemas;


### PR DESCRIPTION
The Phase B production deploy correctly regenerated the missing `lib/assetPublisherConstants` module entry, which made the checkout dirty and caused the exact Worker preflight to fail closed. This commits the two machine-generated API binding lines.\n\nVerification:\n- connected Convex codegen is stable on a clean checkout\n- repository TypeScript passes\n- diff check passes\n\nThe prior run deployed Convex and verified migrations, but did not redeploy Cloudflare; this follow-up lets the ordered release continue.