### PR TITLE
Refresh production renderer manifest

### DIFF
--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,8 +4,8 @@ export const rendererManifest = {
   schemaVersion: 1,
   rendererVersion: 'faction-sheet-v1',
   rendererId:
-    'faction-sheet/sha256:c8c802f6b35aaff3239a1b16c55b7c02d35f1d08102cd64c5e7acbf332447ea5',
-  digest: 'c8c802f6b35aaff3239a1b16c55b7c02d35f1d08102cd64c5e7acbf332447ea5',
+    'faction-sheet/sha256:8675058cb7378bcaa87017da6866ca12f15e6697bd4eb2a0eb38f81c11bf9f72',
+  digest: '8675058cb7378bcaa87017da6866ca12f15e6697bd4eb2a0eb38f81c11bf9f72',
   contract: {
     rendererVersion: 'faction-sheet-v1',
     viewport: {


### PR DESCRIPTION
The Phase B release build correctly recomputed the renderer manifest with the protected production regional Convex origin and failed the source-drift guard because the committed digest came from a non-production build origin. This commits the exact production-build digest.\n\nVerification:\n- two consecutive builds with the production regional Convex origin produce `8675058c…f9f72`\n- the second build leaves the checkout clean\n- unified release contains 1,008 assets and the expected 1,015 renderer-manifest entries\n\nCloudflare was not redeployed by the failed run; it remains on the previous known-good version.