### PR TITLE
Allow exact current Browser reservation reconciliation

### DIFF
--- a/convex/assetPublisherOperator.test.ts
+++ b/convex/assetPublisherOperator.test.ts
@@ -23,6 +23,11 @@ const reconciliationArgs = {
   expectedBrowserReservedMs: 480_000,
   replacementDailyBrowserMs: 120_000,
 };
+const currentReservationReconciliationArgs = {
+  ...reconciliationArgs,
+  expectedDailyBrowserMs: 272_498,
+  expectedBrowserReservedMs: 240_000,
+};
 
 afterEach(() => vi.useRealTimers());
 
@@ -45,7 +50,10 @@ async function recordSuccessfulPrerequisite(t: ReturnType<typeof convexTest>) {
   });
 }
 
-async function seedBrowserUsageReconciliation(t: ReturnType<typeof convexTest>) {
+async function seedBrowserUsageReconciliation(
+  t: ReturnType<typeof convexTest>,
+  args = reconciliationArgs
+) {
   return await t.run(async (ctx) => {
     const ownerId = await ctx.db.insert('users', { name: 'Browser reconciliation owner' });
     const factionId = await ctx.db.insert('factions', {
@@ -67,11 +75,11 @@ async function seedBrowserUsageReconciliation(t: ReturnType<typeof convexTest>) 
       key: 'singleton',
       status: 'paused',
       cooldown_until: NOW - 20_000,
-      daily_browser_utc_date: reconciliationArgs.expectedUtcDate,
-      daily_browser_ms: reconciliationArgs.expectedDailyBrowserMs,
+      daily_browser_utc_date: args.expectedUtcDate,
+      daily_browser_ms: args.expectedDailyBrowserMs,
       browser_reservation_batch_token: RECONCILIATION_RESERVATION_TOKEN,
-      browser_reservation_utc_date: reconciliationArgs.expectedBrowserReservationUtcDate,
-      browser_reserved_ms: reconciliationArgs.expectedBrowserReservedMs,
+      browser_reservation_utc_date: args.expectedBrowserReservationUtcDate,
+      browser_reserved_ms: args.expectedBrowserReservedMs,
       last_browser_settlement_batch_token: 'historical-settlement-token',
       last_browser_settlement_ms: 4_275,
       last_browser_release_batch_token: 'historical-release-token',
@@ -522,6 +530,48 @@ describe('asset publisher operator controls', () => {
     await expect(
       t.mutation(internal.assetPublisherOperator.reconcileCurrentBrowserUsage, reconciliationArgs)
     ).rejects.toThrow('state does not match expected accounting');
+  });
+
+  test('reconciles the exact currently deployed 240-second reservation', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+    const seeded = await seedBrowserUsageReconciliation(t, currentReservationReconciliationArgs);
+
+    await expect(
+      t.mutation(
+        internal.assetPublisherOperator.reconcileCurrentBrowserUsage,
+        currentReservationReconciliationArgs
+      )
+    ).resolves.toEqual({
+      status: 'reconciled',
+      utcDate: '2026-07-16',
+      previousDailyBrowserMs: 272_498,
+      dailyBrowserMs: 120_000,
+      clearedReservationBatchToken: RECONCILIATION_RESERVATION_TOKEN,
+    });
+
+    const state = await t.run(
+      async (ctx) => await ctx.db.get('asset_publisher_state', seeded.stateId)
+    );
+    expect(state?.daily_browser_ms).toBe(120_000);
+    expect(state?.browser_reservation_batch_token).toBeUndefined();
+    expect(state?.browser_reservation_utc_date).toBeUndefined();
+    expect(state?.browser_reserved_ms).toBeUndefined();
+  });
+
+  test('rejects an operator-supplied reservation outside the historical and current contracts', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+    await seedBrowserUsageReconciliation(t);
+
+    await expect(
+      t.mutation(internal.assetPublisherOperator.reconcileCurrentBrowserUsage, {
+        ...reconciliationArgs,
+        expectedBrowserReservedMs: 120_000,
+      })
+    ).rejects.toThrow('Invalid Browser usage reconciliation values');
   });
 
   test.each([

--- a/convex/assetPublisherOperator.ts
+++ b/convex/assetPublisherOperator.ts
@@ -21,9 +21,17 @@ import type { MutationCtx } from './types';
 const rendererValidator = v.literal(INITIAL_FACTION_SHEET_RENDERER_VERSION);
 const targetPrerequisiteValidator = v.literal(FACTION_SHEET_TARGET_ACTIVATION_PREREQUISITE);
 const storagePrerequisiteValidator = v.literal(FACTION_SHEET_STORAGE_ACTIVATION_PREREQUISITE);
-// This one-shot maintenance contract reconciles the exact stale reservation created by the
-// 2026-07-16 canary. It is historical evidence, not the reservation for new acquisitions.
-const BROWSER_USAGE_RECONCILIATION_RESERVATION_MS = 8 * 60 * 1_000;
+// Freeze both evidence-backed compare-and-swap amounts. These maintenance values must not follow a
+// later change to the normal acquisition reservation policy.
+const HISTORICAL_BROWSER_USAGE_RECONCILIATION_RESERVATION_MS = 8 * 60 * 1_000;
+const DEPLOYED_BROWSER_USAGE_RECONCILIATION_RESERVATION_MS = 4 * 60 * 1_000;
+
+function isReconciliableBrowserReservation(value: number): boolean {
+  return (
+    value === HISTORICAL_BROWSER_USAGE_RECONCILIATION_RESERVATION_MS ||
+    value === DEPLOYED_BROWSER_USAGE_RECONCILIATION_RESERVATION_MS
+  );
+}
 
 async function exactConfigOrNull(ctx: MutationCtx) {
   const configs = await ctx.db
@@ -231,7 +239,7 @@ export const reconcileCurrentBrowserUsage = internalMutation({
       !publisherTokenSchema.safeParse(args.expectedBrowserReservationBatchToken).success ||
       !Number.isSafeInteger(args.expectedDailyBrowserMs) ||
       args.expectedDailyBrowserMs < 0 ||
-      args.expectedBrowserReservedMs !== BROWSER_USAGE_RECONCILIATION_RESERVATION_MS ||
+      !isReconciliableBrowserReservation(args.expectedBrowserReservedMs) ||
       !Number.isSafeInteger(args.replacementDailyBrowserMs) ||
       args.replacementDailyBrowserMs < 0 ||
       args.replacementDailyBrowserMs > FREE_BROWSER_ALLOWANCE_MS ||


### PR DESCRIPTION
Production has one exact current-day 240,000-ms Browser reservation retained after an ordinary timeout. No batch, claim, snapshot, rollout ownership, or active Browser session remains. The existing maintenance mutation only recognized the historical 480,000-ms canary reservation.\n\nThis change keeps a frozen two-value maintenance allowlist for exactly 480,000 and 240,000 ms. It does not follow future normal reservation-policy changes. Every existing current-date, exact-state, pause, no-owner, lower-replacement, and allowance guard remains.\n\nVerification:\n- independent review: SAFE\n- focused publisher/operator: 67/67\n- full suite: 528/528\n- repository TypeScript\n- Convex skip guard\n- targeted Biome and diff checks