### PR TITLE
Pin production size-two renderer manifest

### DIFF
--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,8 +4,8 @@ export const rendererManifest = {
   schemaVersion: 1,
   rendererVersion: 'faction-sheet-v1',
   rendererId:
-    'faction-sheet/sha256:ee0f7f694a6de57b25741a030d29f7855eee70cfae10bdc57899f44c3580acf3',
-  digest: 'ee0f7f694a6de57b25741a030d29f7855eee70cfae10bdc57899f44c3580acf3',
+    'faction-sheet/sha256:1b30eadf195867a3711af0f65fe92e404c574be5f406db98bca6da4b06365e97',
+  digest: '1b30eadf195867a3711af0f65fe92e404c574be5f406db98bca6da4b06365e97',
   contract: {
     rendererVersion: 'faction-sheet-v1',
     viewport: {


### PR DESCRIPTION
## What changed
Regenerates the checked-in publisher renderer manifest using the exact production `VITE_CONVEX_URL`.

## Why
The first PR #45 production workflow failed safely at the merged-source drift guard after recomputing the production renderer digest. Convex deployed, but Cloudflare and Netlify deployment steps did not run.

## Validation
- two consecutive production-URL publisher builds produce `1b30eadf...65e97`
- 1,008-asset assembly check
- deployment/config contract tests: 24/24
- publisher TypeScript
- diff hygiene

Production Convex controls remain paused.