### PR TITLE
Pin PDF actions renderer manifest

### DIFF
--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -5,8 +5,8 @@ export const rendererManifest = {
   rendererVersion: 'faction-sheet-v2',
   supportedRendererVersions: ['faction-sheet-v1', 'faction-sheet-v2'],
   rendererId:
-    'faction-sheet/sha256:d773253212512200a4f0bf6907954fc9f881f264f593b789638aba6e1c124993',
-  digest: 'd773253212512200a4f0bf6907954fc9f881f264f593b789638aba6e1c124993',
+    'faction-sheet/sha256:fcd66d60dc8f20b6beaa399a6b766acc36840998157a5e9f6ac959c1b55aa39b',
+  digest: 'fcd66d60dc8f20b6beaa399a6b766acc36840998157a5e9f6ac959c1b55aa39b',
   contract: {
     rendererVersion: 'faction-sheet-v2',
     supportedRendererVersions: ['faction-sheet-v1', 'faction-sheet-v2'],


### PR DESCRIPTION
The unified Worker asset tree changed when the faction PDF actions landed. Regenerate and pin the deterministic renderer manifest digest so the production exact-source guard can proceed.

- Generated digest: `fcd66d60dc8f20b6beaa399a6b766acc36840998157a5e9f6ac959c1b55aa39b`
- Entry count: 1,017
- Two consecutive production-URL assemblies produced no source drift.
- No runtime contract, Convex state, or renderer geometry change.