### PR TITLE
Add published faction PDF links

### DIFF
--- a/convex/assetPublishingStatus.test.ts
+++ b/convex/assetPublishingStatus.test.ts
@@ -61,8 +61,8 @@ describe('public asset publishing status projection', () => {
     const factionId = await seedFaction(t);
     const projection = await publicStatus(t, factionId);
 
-    expect(projection).toEqual({ status: null });
-    expect(Object.keys(projection)).toEqual(['status']);
+    expect(projection).toEqual({ status: null, publicationHref: null });
+    expect(Object.keys(projection).sort()).toEqual(['publicationHref', 'status']);
   });
 
   test.each([
@@ -75,8 +75,8 @@ describe('public asset publishing status projection', () => {
     await insertTarget(t, factionId, targetStatus);
 
     const projection = await publicStatus(t, factionId);
-    expect(projection).toEqual({ status: expected });
-    expect(Object.keys(projection)).toEqual(['status']);
+    expect(projection).toEqual({ status: expected, publicationHref: null });
+    expect(Object.keys(projection).sort()).toEqual(['publicationHref', 'status']);
   });
 
   test('reports current only when generation and renderer match exactly', async () => {
@@ -94,11 +94,12 @@ describe('public asset publishing status projection', () => {
       });
     });
 
-    expect(await publicStatus(t, factionId)).toEqual({ status: 'current' });
+    const publicationHref = `/published/factions/${encodeURIComponent(factionId)}/sheet.pdf?v=private-cache-token`;
+    expect(await publicStatus(t, factionId)).toEqual({ status: 'current', publicationHref });
     await t.run(async (ctx) => {
       await ctx.db.patch(targetId, { desired_generation: 3 });
     });
-    expect(await publicStatus(t, factionId)).toEqual({ status: 'waiting' });
+    expect(await publicStatus(t, factionId)).toEqual({ status: 'waiting', publicationHref });
   });
 
   test('keeps disabled control state internal while saved work remains visibly waiting', async () => {
@@ -123,7 +124,25 @@ describe('public asset publishing status projection', () => {
     });
 
     const projection = await publicStatus(t, factionId);
-    expect(projection).toEqual({ status: 'waiting' });
-    expect(Object.keys(projection)).toEqual(['status']);
+    expect(projection).toEqual({ status: 'waiting', publicationHref: null });
+    expect(Object.keys(projection).sort()).toEqual(['publicationHref', 'status']);
+  });
+
+  test('does not link an incomplete publication', async () => {
+    const t = convexTest(schema, modules);
+    const factionId = await seedFaction(t);
+    const targetId = await insertTarget(t, factionId, 'pending');
+    await t.run(async (ctx) => {
+      await ctx.db.patch(targetId, {
+        published_generation: 1,
+        published_renderer_version: 'faction-sheet-v1',
+        published_cache_token: 'incomplete-cache-token',
+      });
+    });
+
+    expect(await publicStatus(t, factionId)).toEqual({
+      status: 'waiting',
+      publicationHref: null,
+    });
   });
 });

--- a/convex/assetPublishingStatus.ts
+++ b/convex/assetPublishingStatus.ts
@@ -8,37 +8,54 @@ export type PublicAssetPublishingStatus = 'waiting' | 'publishing' | 'delayed' |
 
 export type PublicAssetPublishingStatusProjection = {
   status: PublicAssetPublishingStatus | null;
+  publicationHref: string | null;
 };
 
 type ProjectableTarget = Pick<
   Doc<'asset_targets'>,
+  | 'faction_id'
   | 'status'
   | 'desired_generation'
   | 'desired_renderer_version'
   | 'published_generation'
   | 'published_renderer_version'
+  | 'published_cache_token'
+  | 'published_r2_etag'
+  | 'published_bytes'
+  | 'published_at'
 >;
 
 /**
  * The only target state allowed across the public application boundary.
- * Operational errors, attempts, claims, leases, payloads, and publication
- * metadata intentionally never enter this projection.
+ * Operational errors, attempts, claims, leases, payloads, and private
+ * publication metadata intentionally never enter this projection. A complete
+ * publication contributes only its cache-busted public href.
  */
 export function projectPublicAssetPublishingStatus(
   target: ProjectableTarget | null
 ): PublicAssetPublishingStatusProjection {
-  if (!target) return { status: null };
+  if (!target) return { status: null, publicationHref: null };
 
-  if (target.status === 'leased') return { status: 'publishing' };
-  if (target.status === 'cooldown') return { status: 'delayed' };
+  const publicationHref =
+    target.published_generation === undefined ||
+    target.published_renderer_version === undefined ||
+    target.published_cache_token === undefined ||
+    target.published_r2_etag === undefined ||
+    target.published_bytes === undefined ||
+    target.published_at === undefined
+      ? null
+      : `/published/factions/${encodeURIComponent(target.faction_id)}/sheet.pdf?v=${encodeURIComponent(target.published_cache_token)}`;
+
+  if (target.status === 'leased') return { status: 'publishing', publicationHref };
+  if (target.status === 'cooldown') return { status: 'delayed', publicationHref };
   if (
     target.status === 'current' &&
     target.desired_generation === target.published_generation &&
     target.desired_renderer_version === target.published_renderer_version
   ) {
-    return { status: 'current' };
+    return { status: 'current', publicationHref };
   }
-  return { status: 'waiting' };
+  return { status: 'waiting', publicationHref };
 }
 
 export async function factionSheetPublishingStatus(

--- a/src/app/components/generic/ui/UIButton.stories.tsx
+++ b/src/app/components/generic/ui/UIButton.stories.tsx
@@ -1,5 +1,5 @@
 import preview from '@sb/preview';
-import { Save, Trash2 } from 'lucide-react';
+import { Download, Save, Trash2 } from 'lucide-react';
 
 import { UIButton } from './UIButton';
 
@@ -49,5 +49,16 @@ export const IconOnlyCritical = meta.story({
     iconOnly: true,
     variant: 'critical',
     children: <Trash2 size={16} aria-hidden />,
+  },
+});
+
+export const NativeLink = meta.story({
+  args: {
+    'aria-label': 'Open published PDF',
+    href: '/example.pdf',
+    target: '_blank',
+    rel: 'noopener noreferrer',
+    variant: 'secondary',
+    children: <Download size={16} aria-hidden />,
   },
 });

--- a/src/app/components/generic/ui/UIButton.tsx
+++ b/src/app/components/generic/ui/UIButton.tsx
@@ -14,14 +14,24 @@ type UIButtonShared = {
   iconOnly?: boolean;
 };
 
-type UIButtonAsLink = UIButtonShared & LinkComponentProps;
+type UIButtonAsLink = UIButtonShared &
+  LinkComponentProps & {
+    href?: undefined;
+  };
+
+type UIButtonAsAnchor = UIButtonShared &
+  ComponentPropsWithoutRef<'a'> & {
+    href: string;
+    to?: undefined;
+  };
 
 export type UIButtonAsButton = UIButtonShared &
   ComponentPropsWithoutRef<'button'> & {
     to?: undefined;
+    href?: undefined;
   };
 
-export type UIButtonProps = UIButtonAsLink | UIButtonAsButton;
+export type UIButtonProps = UIButtonAsLink | UIButtonAsAnchor | UIButtonAsButton;
 
 export type UIButtonLinkProps = Omit<UIButtonAsLink, 'children'> & {
   children: ReactNode;
@@ -43,7 +53,9 @@ function uiButtonClassNames(variant: UIButtonVariant, iconOnly: boolean): string
 }
 
 /**
- * Shared button chrome: semantic variants, optional icon-only layout, and TanStack Router `Link` when `to` is set.
+ * Shared button chrome with semantic variants and optional icon-only layout.
+ * Uses a native anchor for `href`, a TanStack Router `Link` for `to`, and a
+ * button otherwise.
  */
 export function UIButton({
   variant = 'confirm',
@@ -53,6 +65,18 @@ export function UIButton({
   ...rest
 }: UIButtonProps) {
   const cn = clsx(uiButtonClassNames(variant, iconOnly), className);
+
+  if ('href' in rest && rest.href !== undefined) {
+    const { href, ...anchorProps } = rest as Omit<
+      UIButtonAsAnchor,
+      'variant' | 'className' | 'children' | 'iconOnly'
+    >;
+    return (
+      <a {...anchorProps} href={href} className={cn}>
+        {children}
+      </a>
+    );
+  }
 
   if ('to' in rest && rest.to !== undefined) {
     const { to, ...linkProps } = rest as Omit<

--- a/src/app/factions/db.ts
+++ b/src/app/factions/db.ts
@@ -119,7 +119,7 @@ export function useFaction(
     memberships: result.data?.memberships,
     groups: result.data?.groups,
     groupAccess: result.data?.groupAccess ?? null,
-    assetPublishing: result.data?.assetPublishing ?? { status: null },
+    assetPublishing: result.data?.assetPublishing ?? { status: null, publicationHref: null },
   };
 }
 

--- a/src/app/routes/_app/factions/$factionId/index.tsx
+++ b/src/app/routes/_app/factions/$factionId/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, Outlet, useMatches } from '@tanstack/react-router';
-import { ArrowLeft, Pencil, Printer, UserPlus } from 'lucide-react';
+import { ArrowLeft, Download, Eye, Pencil, UserPlus } from 'lucide-react';
 
 import { loadFaction, useFaction } from '@db/factions';
 import { useRequestGroupMembership } from '@db/members';
@@ -181,18 +181,33 @@ function FactionDetailMain({ factionId }: { factionId: string }) {
           </ButtonGroup>
         </Toolbar.Left>
         <Toolbar.Right>
-          <FormTooltip content="Printable faction sheet">
-            <UIButton
-              variant="confirm"
-              to="/preview/sheet/$factionSlug"
-              params={{ factionSlug: factionId }}
-              search={{ mode: 'db' }}
-              target="_blank"
-              aria-label="Printable faction sheet"
-            >
-              <Printer size={16} aria-hidden />
-            </UIButton>
-          </FormTooltip>
+          <ButtonGroup>
+            <FormTooltip content="Preview faction sheet">
+              <UIButton
+                variant="confirm"
+                to="/preview/sheet/$factionSlug"
+                params={{ factionSlug: factionId }}
+                search={{ mode: 'db' }}
+                target="_blank"
+                aria-label="Preview faction sheet"
+              >
+                <Eye size={16} aria-hidden />
+              </UIButton>
+            </FormTooltip>
+            {assetPublishing.publicationHref ? (
+              <FormTooltip content="Open published PDF">
+                <UIButton
+                  variant="secondary"
+                  href={assetPublishing.publicationHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Open published PDF"
+                >
+                  <Download size={16} aria-hidden />
+                </UIButton>
+              </FormTooltip>
+            ) : null}
+          </ButtonGroup>
         </Toolbar.Right>
       </Toolbar>
 
@@ -202,7 +217,7 @@ function FactionDetailMain({ factionId }: { factionId: string }) {
           params={{ factionSlug: factionId }}
           search={{ mode: 'db' }}
         >
-          Printable faction sheet
+          Preview faction sheet
         </Link>{' '}
         (opens without site chrome; use the browser print dialog for PDF)
       </p>
@@ -210,6 +225,15 @@ function FactionDetailMain({ factionId }: { factionId: string }) {
       <section>
         <h3>Public assets</h3>
         <p>{factionAssetPublishingCopy(assetPublishing.status)}</p>
+        <p>
+          {assetPublishing.publicationHref ? (
+            <a href={assetPublishing.publicationHref} target="_blank" rel="noopener noreferrer">
+              Open published faction sheet (PDF)
+            </a>
+          ) : (
+            'The published PDF has not been rendered yet.'
+          )}
+        </p>
       </section>
 
       <section>


### PR DESCRIPTION
## Summary

- derive a cache-busted public faction-sheet PDF URL from Convex only after all successful-publication metadata is present
- keep the green toolbar action as an unconditional browser preview and add a separate published-PDF action when available
- show a clear “not rendered yet” message when no complete publication exists
- extend `UIButton` with a native-anchor branch for direct asset URLs while preserving router-link and button behavior

## Why

The faction detail page previously treated browser preview/printing as the only PDF action. This separates the live DB-mode preview from the pre-rendered R2-backed PDF and makes publication availability understandable to users.

Convex remains the publication authority; the page does not probe R2 directly and receives only the public status plus derived URL.

## Scope

GitHub's `main...traycer/fix-foreground-selector-priority` comparison contains exactly the six Slice A files. The local A4/`faction-sheet-v3` work is uncommitted and is not part of this PR.

## Validation

- cold Traycer review: no actionable findings
- `bunx vitest run convex/assetPublishingStatus.test.ts src/app/factions/assetPublishingStatus.test.ts` — 9 tests passed
- `bun run typecheck`
- focused Biome and diff whitespace checks
- production app build
- Storybook build
