### PR TITLE
Temporarily accelerate the v3 rollout drain

### DIFF
--- a/convex/assetPublisher.test.ts
+++ b/convex/assetPublisher.test.ts
@@ -830,12 +830,12 @@ describe('daily Browser reservation accounting', () => {
     expect(first).toMatchObject({
       status: 'acquired',
       replay: false,
-      browserReservationMs: 240_000,
-      dailyBrowserMs: 240_000,
+      browserReservationMs: 20_000,
+      dailyBrowserMs: 20_000,
     });
     await expect(
       t.mutation(internal.assetPublisher.acquireBatch, { batchToken: BATCH_ONE })
-    ).resolves.toMatchObject({ status: 'acquired', replay: true, dailyBrowserMs: 240_000 });
+    ).resolves.toMatchObject({ status: 'acquired', replay: true, dailyBrowserMs: 20_000 });
     await expect(
       t.mutation(internal.assetPublisher.settleBrowserReservation, {
         batchToken: BATCH_ONE,
@@ -882,7 +882,7 @@ describe('daily Browser reservation accounting', () => {
     expect(state).toMatchObject({
       batch_token: BATCH_ONE,
       browser_reservation_batch_token: BATCH_ONE,
-      daily_browser_ms: 240_000,
+      daily_browser_ms: 20_000,
     });
   });
 
@@ -902,8 +902,8 @@ describe('daily Browser reservation accounting', () => {
       currentAccounting.mutation(internal.assetPublisher.acquireBatch, { batchToken: BATCH_ONE })
     ).resolves.toMatchObject({
       status: 'acquired',
-      dailyBrowserMs: 373_485,
-      browserReservationMs: 240_000,
+      dailyBrowserMs: 153_485,
+      browserReservationMs: 20_000,
     });
 
     const { t: exactAllowance } = await seed();
@@ -913,14 +913,14 @@ describe('daily Browser reservation accounting', () => {
         .withIndex('by_key', (q) => q.eq('key', 'singleton'))
         .unique();
       if (!state) throw new Error('missing state');
-      await ctx.db.patch(state._id, { daily_browser_ms: 360_000 });
+      await ctx.db.patch(state._id, { daily_browser_ms: 580_000 });
     });
     await expect(
       exactAllowance.mutation(internal.assetPublisher.acquireBatch, { batchToken: BATCH_ONE })
     ).resolves.toMatchObject({
       status: 'acquired',
       dailyBrowserMs: 600_000,
-      browserReservationMs: 240_000,
+      browserReservationMs: 20_000,
     });
 
     const { t: quota } = await seed();
@@ -930,7 +930,7 @@ describe('daily Browser reservation accounting', () => {
         .withIndex('by_key', (q) => q.eq('key', 'singleton'))
         .unique();
       if (!state) throw new Error('missing state');
-      await ctx.db.patch(state._id, { daily_browser_ms: 360_001 });
+      await ctx.db.patch(state._id, { daily_browser_ms: 580_001 });
     });
     await expect(
       quota.mutation(internal.assetPublisher.acquireBatch, { batchToken: BATCH_ONE })
@@ -947,7 +947,7 @@ describe('daily Browser reservation accounting', () => {
     ).resolves.toMatchObject({
       status: 'acquired',
       batchToken: BATCH_TWO,
-      dailyBrowserMs: 240_000,
+      dailyBrowserMs: 20_000,
     });
   });
 
@@ -972,7 +972,7 @@ describe('daily Browser reservation accounting', () => {
     expect(before?.batch_token).toBeUndefined();
     expect(before).toMatchObject({
       browser_reservation_batch_token: BATCH_ONE,
-      daily_browser_ms: 240_000,
+      daily_browser_ms: 20_000,
     });
     await expect(
       t.mutation(internal.assetPublisher.settleBrowserReservation, {
@@ -1041,7 +1041,7 @@ describe('daily Browser reservation accounting', () => {
       const { t } = await seed();
       await addSecondTarget(t);
       await t.mutation(internal.assetPublisher.acquireBatch, { batchToken: BATCH_ONE });
-      const current = NOW + 481_000;
+      const current = NOW + 581_000;
       vi.setSystemTime(current);
       const client = new ConvexPublisherClient({
         pollUrl: 'https://convex.test/asset-publishing/poll',
@@ -1054,7 +1054,7 @@ describe('daily Browser reservation accounting', () => {
           return await t.fetch(new URL(url).pathname, init);
         }) as typeof fetch,
       });
-      await expect(client.settleBrowser(BATCH_ONE, 481_000, NOW + 510_000)).resolves.toBe(
+      await expect(client.settleBrowser(BATCH_ONE, 581_000, NOW + 610_000)).resolves.toBe(
         'settled'
       );
       const state = await t.run(
@@ -1064,7 +1064,7 @@ describe('daily Browser reservation accounting', () => {
             .withIndex('by_key', (q) => q.eq('key', 'singleton'))
             .unique()
       );
-      expect(state?.daily_browser_ms).toBe(481_000);
+      expect(state?.daily_browser_ms).toBe(581_000);
       await t.mutation(internal.assetPublisher.releaseBatch, {
         batchToken: BATCH_ONE,
         mode: 'after_settlement',
@@ -1406,7 +1406,7 @@ describe('publisher HTTP authorization separation', () => {
         status: 'acquired',
         replay: true,
         batchToken: BATCH_ONE,
-        dailyBrowserMs: 240_000,
+        dailyBrowserMs: 20_000,
       });
       const differentAcquisition = (await (
         await post('/asset-publishing/executor/acquire', {

--- a/convex/lib/assetPublisherLimits.ts
+++ b/convex/lib/assetPublisherLimits.ts
@@ -1,2 +1,4 @@
 export const FREE_BROWSER_ALLOWANCE_MS = 10 * 60 * 1_000;
-export const BROWSER_RESERVATION_MS = 4 * 60 * 1_000;
+// Temporary rollout-drain admission estimate. Exact settlement still replaces this reservation
+// with measured Browser time, while the Worker lifecycle remains bounded independently at 240s.
+export const BROWSER_RESERVATION_MS = 20 * 1_000;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,8 +4,8 @@
 
 The ordered `main` workflow deploys the already-provisioned unified Cloudflare Worker after Convex
 and required migrations. The checked-in Worker release is persistently scheduled: both publisher
-flags are `true` and exactly one `*/15 * * * *` Cron is source controlled. The Convex control plane
-remains the durable execution authority.
+flags are `true` and exactly one temporary `* * * * *` rollout-drain Cron is source controlled. The
+Convex control plane remains the durable execution authority.
 
 **Release prerequisite: Convex publisher config and singleton must both be paused before this
 scheduled Worker release is merged or deployed.** Deploying the Worker and Cron against paused
@@ -108,8 +108,8 @@ On every push to `main`:
 3. `bun run migrations:deploy` (auto-run + await required Convex migrations)
 4. Fail-closed Worker preflight: exact `main` SHA and clean tracked source, required protected CI
    inputs, exact production `VITE_CONVEX_URL`, stable source-controlled Worker/Queue/R2 names,
-   `true/true` flags, one exact `*/15 * * * *` Cron, workers.dev origin, renderer identity, max items
-   `1`, and required secret names.
+   `true/true` flags, one exact `* * * * *` Cron, workers.dev origin, renderer identity, max items
+   `2`, and required secret names.
 5. Check generated Worker bindings, typecheck, build the SPA and capture bundle once with the
    protected `VITE_CONVEX_URL`, re-check the assembled asset limits, and reject generated source
    drift.
@@ -182,9 +182,9 @@ After the first merged scheduled release:
 1. Reconfirm through authorized read-only Convex state that the publisher config and singleton are
    both paused; confirm the Queue is empty and Browser Run has zero active sessions.
 2. Require the deploy smoke to report `publisherEnabled=true`, `cronDispatchEnabled=true`, max items
-   `1`, exact renderer identity, and the merged full Git SHA.
+   `2`, exact renderer identity, and the merged full Git SHA.
 3. Read the Worker trigger in the Cloudflare dashboard and require exactly one
-   `*/15 * * * *` schedule. Do not use the mutating `wrangler triggers deploy` command for readback.
+   `* * * * *` schedule. Do not use the mutating `wrangler triggers deploy` command for readback.
 4. Observe at least one `asset_publisher_cron` log with `result: "empty"`, then reconfirm no Queue
    message and no Browser session were created.
 5. Keep Convex paused until the separate operator activation is explicitly approved. The deployment

--- a/scripts/publisher-deployment-contract.test.ts
+++ b/scripts/publisher-deployment-contract.test.ts
@@ -68,7 +68,7 @@ describe('publisher CI deployment contract', () => {
     expect(() => validatePublisherDeployContract(cronConfig, ciEnvironment())).toThrow();
 
     const extraCronConfig = structuredClone(readPublisherConfig());
-    extraCronConfig.triggers = { crons: ['*/15 * * * *', '0 0 * * *'] };
+    extraCronConfig.triggers = { crons: ['* * * * *', '0 0 * * *'] };
     expect(() => validatePublisherDeployContract(extraCronConfig, ciEnvironment())).toThrow();
 
     const bucketConfig = structuredClone(readPublisherConfig());

--- a/scripts/publisher-deployment-contract.ts
+++ b/scripts/publisher-deployment-contract.ts
@@ -18,7 +18,7 @@ export { PUBLISHER_RENDERER_VERSION, PUBLISHER_SUPPORTED_RENDERER_VERSIONS };
 
 const CONFIG_PATH = path.resolve(process.cwd(), 'workers/publisher/wrangler.jsonc');
 const PUBLISHER_CONVEX_SITE_ORIGIN = 'https://exuberant-finch-263.eu-west-1.convex.site';
-const PUBLISHER_CRON = '*/15 * * * *';
+const PUBLISHER_CRON = '* * * * *';
 const REQUIRED_SECRETS = [
   'ASSET_PUBLISHER_CACHE_TOKEN_SECRET',
   'ASSET_PUBLISHER_POLL_SECRET',

--- a/workers/publisher/README.md
+++ b/workers/publisher/README.md
@@ -4,7 +4,7 @@ This is the production-shaped, sequential publisher surface. Its stable Cloudfla
 provisioned, and the persistent release configuration is ready for scheduled polling:
 
 - `PUBLISHER_ENABLED` and `CRON_DISPATCH_ENABLED` are `true`;
-- the Cron trigger list contains exactly one `*/15 * * * *` schedule;
+- the temporary rollout-drain trigger list contains exactly one `* * * * *` schedule;
 - the production Queue and dedicated private R2 bucket are named explicitly;
 - capture and Convex HTTP URLs use the intended workers.dev and regional Convex origins;
 - the primary semantic renderer and exact executable support set are `faction-sheet-v3`; Convex
@@ -24,10 +24,13 @@ provisioned, and the persistent release configuration is ready for scheduled pol
 
 The Queue payload is only `{ schemaVersion, scheduledCutoff, triggerId }`. Convex owns all batch,
 claim, retry, snapshot, publication, and Browser reservation state. R2 metadata is diagnostic only.
-The 240-second work deadline and fixed 240-second Browser reservation cannot be extended by phase
-settings. A separate 30-second
-post-lifecycle window may only settle definitely closed Browser usage; it is bounded well inside the
-15-minute Queue wall and cannot perform more Browser, R2, or publication work.
+The 240-second work deadline remains the absolute execution bound. During the bounded v3 rollout
+drain, admission temporarily reserves 20 seconds per batch and exact settlement replaces it with
+measured Browser time. This estimate may overrun, but it cannot extend the Worker lifecycle or the
+Cloudflare Free daily Browser limit. Restore the normal 240-second reservation and `*/15` Cron as
+soon as the rollout reaches a terminal state or any real Browser/quota failure appears. A separate
+30-second post-lifecycle window may only settle definitely closed Browser usage; it is bounded well
+inside the 15-minute Queue wall and cannot perform more Browser, R2, or publication work.
 
 The capture shell, HTML, and isolated bundle revalidate the host-only render capability against the
 exact Convex snapshot endpoint before serving. Capture diagnostics retain at most an artwork
@@ -110,7 +113,7 @@ environment variable; the API token is a protected secret. The exact Queue and R
 **Release prerequisite: Convex publisher config and singleton must both be paused before this
 scheduled Worker release is merged or deployed.** The stable private bucket and Queue must be
 reverified, the disabled-first publication-admission migration/counter must pass, and the three
-Worker secrets must be installed. Deploy `true/true` plus the exact 15-minute Cron against paused
+Worker secrets must be installed. Deploy `true/true` plus the exact checked-in Cron against paused
 Convex, observe at least one empty Cron with no Queue message or Browser Run, and only then consider
 the separately approved Convex operator activation. Normal `main` deploys after that activation keep
 this same scheduled source configuration; they never re-run or reverse the activation transition.

--- a/workers/publisher/deployment-config.test.ts
+++ b/workers/publisher/deployment-config.test.ts
@@ -12,8 +12,8 @@ const packageConfig = JSON.parse(
 ) as { scripts: Record<string, string> };
 
 describe('scheduled production deployment shape', () => {
-  test('keeps exactly one 15-minute Cron and active Worker flags in source control', () => {
-    expect(config.triggers).toEqual({ crons: ['*/15 * * * *'] });
+  test('keeps exactly one temporary one-minute rollout Cron and active Worker flags', () => {
+    expect(config.triggers).toEqual({ crons: ['* * * * *'] });
     expect(config.vars).toMatchObject({
       PUBLISHER_ENABLED: 'true',
       CRON_DISPATCH_ENABLED: 'true',

--- a/workers/publisher/index.test.ts
+++ b/workers/publisher/index.test.ts
@@ -193,7 +193,7 @@ describe('publisher Worker structured-log security boundary', () => {
     const now = Date.now();
 
     await publisherWorker.scheduled(
-      { scheduledTime: now, cron: '*/15 * * * *', noRetry: vi.fn() },
+      { scheduledTime: now, cron: '* * * * *', noRetry: vi.fn() },
       publisherEnv()
     );
 

--- a/workers/publisher/wrangler.jsonc
+++ b/workers/publisher/wrangler.jsonc
@@ -47,7 +47,7 @@
       }
     ]
   },
-  "triggers": { "crons": ["*/15 * * * *"] },
+  "triggers": { "crons": ["* * * * *"] },
   "secrets": {
     "required": [
       "ASSET_PUBLISHER_CACHE_TOKEN_SECRET",


### PR DESCRIPTION
## What changed

- temporarily reduce Convex Browser admission reservation from 240 seconds to 20 seconds
- temporarily poll every minute instead of every 15 minutes
- retain the 240-second execution deadline, max-two sequential batch, Queue concurrency one, exact measured settlement, and all ownership/storage guards
- document the mandatory terminal/failure restoration to the normal reservation and Cron

## Why

The v3 A4 rollout is healthy but blocked by a conservative reservation rather than the Cloudflare daily Browser limit. This bounded mode lets the remaining rollout make progress today.

## Verification

- focused 96/96
- full 556/556
- repository and publisher typechecks
- targeted Biome and diff check
- Wrangler types check
- production-URL 1,009-asset build/check
- Wrangler deploy dry-run and startup analysis