### PR TITLE
Fit the accelerated Browser reservation margins

### DIFF
--- a/convex/assetPublisher.test.ts
+++ b/convex/assetPublisher.test.ts
@@ -830,12 +830,12 @@ describe('daily Browser reservation accounting', () => {
     expect(first).toMatchObject({
       status: 'acquired',
       replay: false,
-      browserReservationMs: 20_000,
-      dailyBrowserMs: 20_000,
+      browserReservationMs: 30_000,
+      dailyBrowserMs: 30_000,
     });
     await expect(
       t.mutation(internal.assetPublisher.acquireBatch, { batchToken: BATCH_ONE })
-    ).resolves.toMatchObject({ status: 'acquired', replay: true, dailyBrowserMs: 20_000 });
+    ).resolves.toMatchObject({ status: 'acquired', replay: true, dailyBrowserMs: 30_000 });
     await expect(
       t.mutation(internal.assetPublisher.settleBrowserReservation, {
         batchToken: BATCH_ONE,
@@ -882,7 +882,7 @@ describe('daily Browser reservation accounting', () => {
     expect(state).toMatchObject({
       batch_token: BATCH_ONE,
       browser_reservation_batch_token: BATCH_ONE,
-      daily_browser_ms: 20_000,
+      daily_browser_ms: 30_000,
     });
   });
 
@@ -902,8 +902,8 @@ describe('daily Browser reservation accounting', () => {
       currentAccounting.mutation(internal.assetPublisher.acquireBatch, { batchToken: BATCH_ONE })
     ).resolves.toMatchObject({
       status: 'acquired',
-      dailyBrowserMs: 153_485,
-      browserReservationMs: 20_000,
+      dailyBrowserMs: 163_485,
+      browserReservationMs: 30_000,
     });
 
     const { t: exactAllowance } = await seed();
@@ -913,14 +913,14 @@ describe('daily Browser reservation accounting', () => {
         .withIndex('by_key', (q) => q.eq('key', 'singleton'))
         .unique();
       if (!state) throw new Error('missing state');
-      await ctx.db.patch(state._id, { daily_browser_ms: 580_000 });
+      await ctx.db.patch(state._id, { daily_browser_ms: 570_000 });
     });
     await expect(
       exactAllowance.mutation(internal.assetPublisher.acquireBatch, { batchToken: BATCH_ONE })
     ).resolves.toMatchObject({
       status: 'acquired',
       dailyBrowserMs: 600_000,
-      browserReservationMs: 20_000,
+      browserReservationMs: 30_000,
     });
 
     const { t: quota } = await seed();
@@ -930,7 +930,7 @@ describe('daily Browser reservation accounting', () => {
         .withIndex('by_key', (q) => q.eq('key', 'singleton'))
         .unique();
       if (!state) throw new Error('missing state');
-      await ctx.db.patch(state._id, { daily_browser_ms: 580_001 });
+      await ctx.db.patch(state._id, { daily_browser_ms: 570_001 });
     });
     await expect(
       quota.mutation(internal.assetPublisher.acquireBatch, { batchToken: BATCH_ONE })
@@ -947,7 +947,7 @@ describe('daily Browser reservation accounting', () => {
     ).resolves.toMatchObject({
       status: 'acquired',
       batchToken: BATCH_TWO,
-      dailyBrowserMs: 20_000,
+      dailyBrowserMs: 30_000,
     });
   });
 
@@ -972,7 +972,7 @@ describe('daily Browser reservation accounting', () => {
     expect(before?.batch_token).toBeUndefined();
     expect(before).toMatchObject({
       browser_reservation_batch_token: BATCH_ONE,
-      daily_browser_ms: 20_000,
+      daily_browser_ms: 30_000,
     });
     await expect(
       t.mutation(internal.assetPublisher.settleBrowserReservation, {
@@ -1406,7 +1406,7 @@ describe('publisher HTTP authorization separation', () => {
         status: 'acquired',
         replay: true,
         batchToken: BATCH_ONE,
-        dailyBrowserMs: 20_000,
+        dailyBrowserMs: 30_000,
       });
       const differentAcquisition = (await (
         await post('/asset-publishing/executor/acquire', {

--- a/convex/assetRollouts.test.ts
+++ b/convex/assetRollouts.test.ts
@@ -577,7 +577,10 @@ describe('renderer rollout control plane', () => {
         operation: 'progress',
         rolloutId: createdBody.rollout.rolloutId,
       });
-      await expect(progress.clone().json()).resolves.toMatchObject({ effectiveMaxItems: 2 });
+      await expect(progress.clone().json()).resolves.toMatchObject({
+        effectiveMaxItems: 2,
+        etaInputs: { dispatchIntervalMinutes: 1 },
+      });
       expect(progress.status).toBe(200);
       const serialized = JSON.stringify(await progress.json());
       expect(serialized).toContain('remainingItems');

--- a/convex/assetRollouts.ts
+++ b/convex/assetRollouts.ts
@@ -792,7 +792,7 @@ export const progress = internalQuery({
         ? {
             remainingItems: rollout.pending + rollout.leased,
             observedBrowserMsPerItem: null,
-            dispatchIntervalMinutes: 15,
+            dispatchIntervalMinutes: 1,
           }
         : null,
     };

--- a/convex/lib/assetPublisherLimits.ts
+++ b/convex/lib/assetPublisherLimits.ts
@@ -1,4 +1,4 @@
 export const FREE_BROWSER_ALLOWANCE_MS = 10 * 60 * 1_000;
 // Temporary rollout-drain admission estimate. Exact settlement still replaces this reservation
 // with measured Browser time, while the Worker lifecycle remains bounded independently at 240s.
-export const BROWSER_RESERVATION_MS = 20 * 1_000;
+export const BROWSER_RESERVATION_MS = 30 * 1_000;

--- a/workers/publisher/README.md
+++ b/workers/publisher/README.md
@@ -25,7 +25,7 @@ provisioned, and the persistent release configuration is ready for scheduled pol
 The Queue payload is only `{ schemaVersion, scheduledCutoff, triggerId }`. Convex owns all batch,
 claim, retry, snapshot, publication, and Browser reservation state. R2 metadata is diagnostic only.
 The 240-second work deadline remains the absolute execution bound. During the bounded v3 rollout
-drain, admission temporarily reserves 20 seconds per batch and exact settlement replaces it with
+drain, admission temporarily reserves 30 seconds per batch and exact settlement replaces it with
 measured Browser time. This estimate may overrun, but it cannot extend the Worker lifecycle or the
 Cloudflare Free daily Browser limit. Restore the normal 240-second reservation and `*/15` Cron as
 soon as the rollout reaches a terminal state or any real Browser/quota failure appears. A separate

--- a/workers/publisher/executor.test.ts
+++ b/workers/publisher/executor.test.ts
@@ -471,6 +471,18 @@ describe('one-item owned batch execution', () => {
     expect(spies.openBrowser).not.toHaveBeenCalled();
   });
 
+  test('a 30-second reservation fits the production cleanup and settlement margins', async () => {
+    const { dependencies, spies } = setup();
+    const report = await executeOwnedBatch(
+      dependencies,
+      { ...config, browserCleanupGraceMs: 15_000 },
+      { ...acquisition, browserReservationMs: 30_000, dailyBrowserMs: 30_000 },
+      NOW
+    );
+    expect(report).toMatchObject({ status: 'completed', browserOpened: true });
+    expect(spies.openBrowser).toHaveBeenCalledOnce();
+  });
+
   test('a launch failure keeps the conservative reservation and opens no replacement', async () => {
     const { dependencies, spies } = setup();
     dependencies.openBrowser = async () => await Promise.reject(new Error('launch failed'));


### PR DESCRIPTION
## What changed

- raise the temporary admission reservation from 20 seconds to 30 seconds
- add an executor regression proving 30 seconds fits the production 15-second cleanup plus 5-second settlement margins
- report the temporary one-minute interval in rollout progress

## Production finding

The 20-second release failed closed before Browser launch because equality with the cleanup and settlement margins is invalid. Both unclaimed reservations were released under pause; no Browser opened, item was claimed, or R2 write occurred. Production is paused pending this correction.

## Verification

- focused 165/165
- full 557/557
- repository and publisher typechecks
- Wrangler generated types check
- targeted Biome and diff check