### PR TITLE
Add read-only Cloudflare drift guard

### DIFF
--- a/.github/workflows/cloudflare-live-drift.yml
+++ b/.github/workflows/cloudflare-live-drift.yml
@@ -2,7 +2,8 @@ name: Cloudflare live drift
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
   workflow_dispatch:
 
 permissions:
@@ -14,18 +15,17 @@ concurrency:
 
 jobs:
   audit:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Checkout trusted base revision
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Reject live Cloudflare drift
         run: bun run cloudflare:drift-check

--- a/.github/workflows/cloudflare-live-drift.yml
+++ b/.github/workflows/cloudflare-live-drift.yml
@@ -1,0 +1,34 @@
+name: Cloudflare live drift
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-live-drift-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout trusted base revision
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2.2.0
+
+      - name: Reject live Cloudflare drift
+        run: bun run cloudflare:drift-check
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_READ_API_TOKEN }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -143,6 +143,31 @@ The protected `CLOUDFLARE_API_TOKEN` must stay scoped to the one Cloudflare acco
 permission set needed to update the existing Worker and bindings. Do not grant or exercise resource
 provisioning, secret-management, billing, domain, or unrelated-resource access.
 
+## Pull-request Cloudflare drift guard
+
+`.github/workflows/cloudflare-live-drift.yml` compares production Cloudflare state with the trusted
+`main` contract on every pull request. It uses `pull_request_target`, checks out only the base SHA,
+and never checks out or executes pull-request-authored code. Keep that boundary intact: changing the
+workflow to execute the head revision would expose a repository secret to untrusted code.
+
+Configure a repository secret named `CLOUDFLARE_READ_API_TOKEN` with only these account-level read
+permissions:
+
+- Workers Scripts Read;
+- Queues Read; and
+- Workers R2 Storage Read.
+
+Do not reuse `CLOUDFLARE_API_TOKEN`; that deployment credential has write authority. The drift
+script issues only authenticated `GET` requests and checks the exact Worker bindings, secret names,
+Cron schedule, repository-owned Queue inventory, and private R2 bucket/domain state declared in
+`infra/cloudflare-live-contract.json` and `workers/publisher/wrangler.jsonc`.
+
+After the workflow has run once on `main`, make `Cloudflare live drift / audit` a required status
+check for the `main` branch. The repository currently has no branch protection, so adding the
+workflow alone does not block merging. The workflow is loaded from the default branch for security,
+which also means the pull request that first introduces it is a bootstrap change: the check begins
+on subsequent pull requests after this workflow is merged.
+
 ## Netlify one-time setup
 
 Production traffic should come only from GitHub Actions (`netlify deploy --prod` with a fresh

--- a/infra/cloudflare-live-contract.json
+++ b/infra/cloudflare-live-contract.json
@@ -1,0 +1,28 @@
+{
+  "schemaVersion": 1,
+  "publisherWorker": "faction-sheet-asset-publisher",
+  "ownedQueuePrefix": "faction-sheet-",
+  "queues": [
+    {
+      "name": "faction-sheet-asset-publisher",
+      "producers": 0,
+      "consumers": 0
+    }
+  ],
+  "buckets": [
+    {
+      "name": "tanstack-start-faction-sheet-assets",
+      "location": "weur",
+      "storageClass": "Standard",
+      "managedPublic": false,
+      "customDomains": []
+    },
+    {
+      "name": "tanstack-start-asset-publisher-proof",
+      "location": "weur",
+      "storageClass": "Standard",
+      "managedPublic": false,
+      "customDomains": []
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit",
     "check:convex-skip": "node scripts/assert-no-convex-skip-in-domain-db.mjs",
+    "cloudflare:drift-check": "bun run ./scripts/cloudflare-live-drift.ts",
     "generate": "bun run ./scripts/generate.ts",
     "migrations:dev-strict": "bun run ./scripts/migration-guards.ts dev-strict 300000 2000",
     "migrations:run-local-required": "bun run migrations:dev-strict",

--- a/scripts/cloudflare-live-drift.test.ts
+++ b/scripts/cloudflare-live-drift.test.ts
@@ -129,6 +129,13 @@ describe('Cloudflare live drift check', () => {
       'utf8'
     );
     expect(workflow).toContain('pull_request_target:');
+    expect(workflow).toContain('branches: [main]');
+    expect(workflow).toContain('types: [opened, synchronize, reopened, ready_for_review, edited]');
+    expect(workflow).not.toContain("github.event.pull_request.base.ref == 'main'");
+    expect(workflow).toContain('actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5');
+    expect(workflow).toContain(
+      'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0'
+    );
     expect(workflow).toContain(`ref: $${'{'}{ github.event.pull_request.base.sha || github.sha }}`);
     expect(workflow).toContain('persist-credentials: false');
     expect(workflow).toContain(

--- a/scripts/cloudflare-live-drift.test.ts
+++ b/scripts/cloudflare-live-drift.test.ts
@@ -1,0 +1,203 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+import { checkCloudflareLiveDrift } from './cloudflare-live-drift';
+
+const ACCOUNT_ID = '0123456789abcdef0123456789abcdef';
+const WORKER = 'faction-sheet-asset-publisher';
+
+function envelope(result: unknown, resultInfo?: unknown, status = 200): Response {
+  return Response.json(
+    {
+      success: status >= 200 && status < 300,
+      result,
+      ...(resultInfo ? { result_info: resultInfo } : {}),
+      errors: status >= 400 ? [{ message: 'request denied' }] : [],
+    },
+    { status }
+  );
+}
+
+function liveBindings() {
+  return [
+    { name: 'ASSET_BUCKET', type: 'r2_bucket', bucket_name: 'tanstack-start-faction-sheet-assets' },
+    { name: 'BROWSER', type: 'browser' },
+    { name: 'ASSETS', type: 'assets' },
+    { name: 'CF_VERSION_METADATA', type: 'version_metadata' },
+    { name: 'ASSET_PUBLISHER_CACHE_TOKEN_SECRET', type: 'secret_text' },
+    { name: 'ASSET_PUBLISHER_EXECUTOR_SECRET', type: 'secret_text' },
+    {
+      name: 'CAPTURE_BASE_URL',
+      type: 'plain_text',
+      text: 'https://faction-sheet-asset-publisher.ndelangen.workers.dev',
+    },
+    {
+      name: 'CONVEX_EXECUTOR_BASE_URL',
+      type: 'plain_text',
+      text: 'https://exuberant-finch-263.eu-west-1.convex.site/asset-publishing/executor',
+    },
+    {
+      name: 'CONVEX_RENDER_URL',
+      type: 'plain_text',
+      text: 'https://exuberant-finch-263.eu-west-1.convex.site/asset-publishing/render',
+    },
+    { name: 'SUPPORTED_RENDERER_VERSION', type: 'plain_text', text: 'faction-sheet-v3' },
+    { name: 'WORK_WINDOW_MS', type: 'plain_text', text: '240000' },
+    { name: 'BROWSER_CAPTURE_TIMEOUT_MS', type: 'plain_text', text: '45000' },
+    { name: 'BROWSER_CLEANUP_GRACE_MS', type: 'plain_text', text: '15000' },
+    { name: 'PDF_MAX_BYTES', type: 'plain_text', text: '8000000' },
+  ];
+}
+
+function liveFetcher(
+  options: {
+    extraSecret?: boolean;
+    queueConsumers?: number;
+    cron?: string;
+    publisherBucketPublic?: boolean;
+    denied?: boolean;
+  } = {}
+) {
+  const requests: Array<{ url: URL; method: string; authorization: string | null }> = [];
+  const fetcher = async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(typeof input === 'string' || input instanceof URL ? input : input.url);
+    requests.push({
+      url,
+      method: init?.method ?? 'GET',
+      authorization: new Headers(init?.headers).get('Authorization'),
+    });
+    if (options.denied) return envelope(null, undefined, 403);
+    if (url.pathname.endsWith(`/workers/scripts/${WORKER}/settings`)) {
+      return envelope({
+        bindings: liveBindings(),
+        compatibility_date: '2026-07-17',
+        compatibility_flags: ['nodejs_compat'],
+        limits: { cpu_ms: 30000 },
+      });
+    }
+    if (url.pathname.endsWith(`/workers/scripts/${WORKER}/secrets`)) {
+      return envelope([
+        { name: 'ASSET_PUBLISHER_CACHE_TOKEN_SECRET', type: 'secret_text' },
+        { name: 'ASSET_PUBLISHER_EXECUTOR_SECRET', type: 'secret_text' },
+        ...(options.extraSecret
+          ? [{ name: 'ASSET_PUBLISHER_POLL_SECRET', type: 'secret_text' }]
+          : []),
+      ]);
+    }
+    if (url.pathname.endsWith(`/workers/scripts/${WORKER}/schedules`)) {
+      return envelope({ schedules: [{ cron: options.cron ?? '*/5 * * * *' }] });
+    }
+    if (url.pathname.endsWith('/queues')) {
+      return envelope(
+        [
+          {
+            queue_name: 'faction-sheet-asset-publisher',
+            producers_total_count: 0,
+            consumers_total_count: options.queueConsumers ?? 0,
+          },
+        ],
+        { total_pages: 1 }
+      );
+    }
+    const bucketMatch = /\/r2\/buckets\/([^/]+)(.*)$/.exec(url.pathname);
+    if (bucketMatch) {
+      const bucket = decodeURIComponent(bucketMatch[1] ?? '');
+      const suffix = bucketMatch[2];
+      if (suffix === '/domains/managed') {
+        return envelope({
+          enabled:
+            bucket === 'tanstack-start-faction-sheet-assets' &&
+            options.publisherBucketPublic === true,
+        });
+      }
+      if (suffix === '/domains/custom') return envelope({ domains: [] });
+      if (suffix === '') {
+        return envelope({ name: bucket, location: 'weur', storage_class: 'Standard' });
+      }
+    }
+    throw new Error(`Unexpected test request: ${url.pathname}`);
+  };
+  return { fetcher, requests };
+}
+
+describe('Cloudflare live drift check', () => {
+  test('keeps the PR workflow on trusted base code with a dedicated read credential', () => {
+    const workflow = readFileSync(
+      path.resolve(process.cwd(), '.github/workflows/cloudflare-live-drift.yml'),
+      'utf8'
+    );
+    expect(workflow).toContain('pull_request_target:');
+    expect(workflow).toContain(`ref: $${'{'}{ github.event.pull_request.base.sha || github.sha }}`);
+    expect(workflow).toContain('persist-credentials: false');
+    expect(workflow).toContain(
+      `CLOUDFLARE_API_TOKEN: $${'{'}{ secrets.CLOUDFLARE_READ_API_TOKEN }}`
+    );
+    expect(workflow).not.toContain('github.event.pull_request.head.sha');
+    expect(workflow).not.toContain('secrets.CLOUDFLARE_API_TOKEN');
+  });
+
+  test('uses only authenticated GETs and accepts the reviewed live contract', async () => {
+    const live = liveFetcher();
+    await expect(
+      checkCloudflareLiveDrift({
+        accountId: ACCOUNT_ID,
+        apiToken: 'read-only-token',
+        fetcher: live.fetcher,
+      })
+    ).resolves.toEqual({
+      worker: WORKER,
+      bindingCount: 12,
+      secretCount: 2,
+      cronCount: 1,
+      queueCount: 1,
+      bucketCount: 2,
+    });
+    expect(live.requests).toHaveLength(10);
+    expect(new Set(live.requests.map((request) => request.method))).toEqual(new Set(['GET']));
+    expect(
+      live.requests.every((request) => request.authorization === 'Bearer read-only-token')
+    ).toBe(true);
+  });
+
+  test('reports extra secrets and restored Queue consumers together', async () => {
+    const live = liveFetcher({ extraSecret: true, queueConsumers: 1 });
+    await expect(
+      checkCloudflareLiveDrift({
+        accountId: ACCOUNT_ID,
+        apiToken: 'read-only-token',
+        fetcher: live.fetcher,
+      })
+    ).rejects.toThrow(
+      /Worker secrets drift: unexpected ASSET_PUBLISHER_POLL_SECRET[\s\S]*expected 0 producers\/0 consumers, found 0\/1/
+    );
+  });
+
+  test('reports Cron and public-bucket drift together', async () => {
+    const live = liveFetcher({ cron: '*/15 * * * *', publisherBucketPublic: true });
+    await expect(
+      checkCloudflareLiveDrift({
+        accountId: ACCOUNT_ID,
+        apiToken: 'read-only-token',
+        fetcher: live.fetcher,
+      })
+    ).rejects.toThrow(/Worker Cron drift[\s\S]*r2\.dev drift/);
+  });
+
+  test('fails closed on an API error without exposing the token', async () => {
+    const live = liveFetcher({ denied: true });
+    let message = '';
+    try {
+      await checkCloudflareLiveDrift({
+        accountId: ACCOUNT_ID,
+        apiToken: 'highly-sensitive-token',
+        fetcher: live.fetcher,
+      });
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    }
+    expect(message).toContain('HTTP 403');
+    expect(message).not.toContain('highly-sensitive-token');
+  });
+});

--- a/scripts/cloudflare-live-drift.ts
+++ b/scripts/cloudflare-live-drift.ts
@@ -1,0 +1,383 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+type JsonRecord = Record<string, unknown>;
+type Fetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+type QueueContract = {
+  name: string;
+  producers: number;
+  consumers: number;
+};
+
+type BucketContract = {
+  name: string;
+  location: string;
+  storageClass: string;
+  managedPublic: boolean;
+  customDomains: string[];
+};
+
+type LiveContract = {
+  schemaVersion: 1;
+  publisherWorker: string;
+  ownedQueuePrefix: string;
+  queues: QueueContract[];
+  buckets: BucketContract[];
+};
+
+export type CloudflareDriftDependencies = {
+  accountId: string;
+  apiToken: string;
+  fetcher?: Fetcher;
+  root?: string;
+};
+
+export type CloudflareDriftReport = {
+  worker: string;
+  bindingCount: number;
+  secretCount: number;
+  cronCount: number;
+  queueCount: number;
+  bucketCount: number;
+};
+
+function record(value: unknown, label: string): JsonRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`Cloudflare ${label} response is invalid`);
+  }
+  return value as JsonRecord;
+}
+
+function array(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value)) throw new Error(`Cloudflare ${label} response is invalid`);
+  return value;
+}
+
+function string(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Cloudflare ${label} response is invalid`);
+  }
+  return value;
+}
+
+function integer(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`Cloudflare ${label} response is invalid`);
+  }
+  return value;
+}
+
+function loadJson(file: string): JsonRecord {
+  return record(JSON.parse(readFileSync(file, 'utf8')), file);
+}
+
+function loadContract(root: string): LiveContract {
+  const value = loadJson(path.join(root, 'infra/cloudflare-live-contract.json'));
+  if (value.schemaVersion !== 1) throw new Error('Cloudflare live contract version is invalid');
+  const queues = array(value.queues, 'live contract queues').map((entry) => {
+    const queue = record(entry, 'live contract queue');
+    return {
+      name: string(queue.name, 'live contract queue name'),
+      producers: integer(queue.producers, 'live contract queue producers'),
+      consumers: integer(queue.consumers, 'live contract queue consumers'),
+    };
+  });
+  const buckets = array(value.buckets, 'live contract buckets').map((entry) => {
+    const bucket = record(entry, 'live contract bucket');
+    if (typeof bucket.managedPublic !== 'boolean') {
+      throw new Error('Cloudflare live contract bucket access is invalid');
+    }
+    return {
+      name: string(bucket.name, 'live contract bucket name'),
+      location: string(bucket.location, 'live contract bucket location').toLowerCase(),
+      storageClass: string(bucket.storageClass, 'live contract bucket storage class'),
+      managedPublic: bucket.managedPublic,
+      customDomains: array(bucket.customDomains, 'live contract custom domains').map((domain) =>
+        string(domain, 'live contract custom domain')
+      ),
+    };
+  });
+  return {
+    schemaVersion: 1,
+    publisherWorker: string(value.publisherWorker, 'live contract Worker'),
+    ownedQueuePrefix: string(value.ownedQueuePrefix, 'live contract Queue prefix'),
+    queues,
+    buckets,
+  };
+}
+
+class CloudflareReadClient {
+  private readonly baseUrl: string;
+
+  constructor(
+    accountId: string,
+    private readonly apiToken: string,
+    private readonly fetcher: Fetcher
+  ) {
+    this.baseUrl = `https://api.cloudflare.com/client/v4/accounts/${accountId}`;
+  }
+
+  async get(pathname: string): Promise<{ result: unknown; resultInfo?: JsonRecord }> {
+    const response = await this.fetcher(`${this.baseUrl}${pathname}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${this.apiToken}`,
+      },
+    });
+    let body: JsonRecord;
+    try {
+      body = record(await response.json(), 'API');
+    } catch {
+      throw new Error(`Cloudflare GET ${pathname} returned an invalid response`);
+    }
+    if (!response.ok || body.success !== true) {
+      const errors = Array.isArray(body.errors)
+        ? body.errors
+            .map((entry) =>
+              entry && typeof entry === 'object' ? (entry as JsonRecord).message : null
+            )
+            .filter((message): message is string => typeof message === 'string')
+            .join('; ')
+        : '';
+      throw new Error(
+        `Cloudflare GET ${pathname} failed with HTTP ${response.status}${errors ? `: ${errors}` : ''}`
+      );
+    }
+    return {
+      result: body.result,
+      ...(body.result_info && typeof body.result_info === 'object'
+        ? { resultInfo: body.result_info as JsonRecord }
+        : {}),
+    };
+  }
+}
+
+function expectedBindings(wrangler: JsonRecord): string[] {
+  const bindings: string[] = [];
+  const vars = record(wrangler.vars, 'Wrangler vars');
+  for (const [name, value] of Object.entries(vars)) {
+    bindings.push(`${name}|plain_text|${string(value, `Wrangler var ${name}`)}`);
+  }
+  const assets = record(wrangler.assets, 'Wrangler assets');
+  bindings.push(`${string(assets.binding, 'Wrangler assets binding')}|assets|`);
+  const browser = record(wrangler.browser, 'Wrangler browser');
+  bindings.push(`${string(browser.binding, 'Wrangler browser binding')}|browser|`);
+  const versionMetadata = record(wrangler.version_metadata, 'Wrangler version metadata');
+  bindings.push(
+    `${string(versionMetadata.binding, 'Wrangler version metadata binding')}|version_metadata|`
+  );
+  for (const entry of array(wrangler.r2_buckets, 'Wrangler R2 bindings')) {
+    const binding = record(entry, 'Wrangler R2 binding');
+    bindings.push(
+      `${string(binding.binding, 'Wrangler R2 binding name')}|r2_bucket|${string(
+        binding.bucket_name,
+        'Wrangler R2 bucket name'
+      )}`
+    );
+  }
+  return bindings.sort();
+}
+
+function liveBinding(value: unknown): string | null {
+  const binding = record(value, 'Worker binding');
+  const name = string(binding.name, 'Worker binding name');
+  const type = string(binding.type, `Worker binding ${name} type`);
+  if (type === 'secret_text' || type === 'secret_key') return null;
+  if (type === 'plain_text') return `${name}|${type}|${string(binding.text, `Worker var ${name}`)}`;
+  if (type === 'r2_bucket') {
+    return `${name}|${type}|${string(binding.bucket_name, `Worker R2 binding ${name}`)}`;
+  }
+  return `${name}|${type}|`;
+}
+
+function difference(expected: string[], actual: string[]): string {
+  const missing = expected.filter((value) => !actual.includes(value));
+  const extra = actual.filter((value) => !expected.includes(value));
+  return [
+    ...(missing.length ? [`missing ${missing.join(', ')}`] : []),
+    ...(extra.length ? [`unexpected ${extra.join(', ')}`] : []),
+  ].join('; ');
+}
+
+function compareExactSet(failures: string[], label: string, expected: string[], actual: string[]) {
+  const detail = difference([...expected].sort(), [...actual].sort());
+  if (detail) failures.push(`${label}: ${detail}`);
+}
+
+async function allQueues(client: CloudflareReadClient): Promise<JsonRecord[]> {
+  const queues: JsonRecord[] = [];
+  let page = 1;
+  let totalPages = 1;
+  do {
+    const response = await client.get(`/queues?page=${page}&per_page=100`);
+    queues.push(...array(response.result, 'Queues').map((value) => record(value, 'Queue')));
+    const reportedPages = response.resultInfo?.total_pages;
+    totalPages = typeof reportedPages === 'number' ? reportedPages : 1;
+    page += 1;
+  } while (page <= totalPages);
+  return queues;
+}
+
+export async function checkCloudflareLiveDrift(
+  dependencies: CloudflareDriftDependencies
+): Promise<CloudflareDriftReport> {
+  if (!/^[0-9a-f]{32}$/.test(dependencies.accountId)) {
+    throw new Error('CLOUDFLARE_ACCOUNT_ID must be a 32-character lowercase account ID');
+  }
+  if (!dependencies.apiToken.trim()) {
+    throw new Error('CLOUDFLARE_API_TOKEN must be a separately scoped read-only token');
+  }
+  const root = dependencies.root ?? process.cwd();
+  const contract = loadContract(root);
+  const wrangler = loadJson(path.join(root, 'workers/publisher/wrangler.jsonc'));
+  if (wrangler.name !== contract.publisherWorker) {
+    throw new Error('Publisher Worker name differs between Wrangler and the live contract');
+  }
+  const client = new CloudflareReadClient(
+    dependencies.accountId,
+    dependencies.apiToken,
+    dependencies.fetcher ?? fetch
+  );
+  const failures: string[] = [];
+
+  const encodedWorker = encodeURIComponent(contract.publisherWorker);
+  const [settingsResponse, secretsResponse, schedulesResponse, queues] = await Promise.all([
+    client.get(`/workers/scripts/${encodedWorker}/settings`),
+    client.get(`/workers/scripts/${encodedWorker}/secrets`),
+    client.get(`/workers/scripts/${encodedWorker}/schedules`),
+    allQueues(client),
+  ]);
+
+  const settings = record(settingsResponse.result, 'Worker settings');
+  const bindings = array(settings.bindings, 'Worker bindings')
+    .map(liveBinding)
+    .filter((binding): binding is string => binding !== null)
+    .sort();
+  compareExactSet(failures, 'Worker bindings drift', expectedBindings(wrangler), bindings);
+
+  if (settings.compatibility_date !== wrangler.compatibility_date) {
+    failures.push(
+      `Worker compatibility date drift: expected ${String(wrangler.compatibility_date)}, found ${String(
+        settings.compatibility_date
+      )}`
+    );
+  }
+  compareExactSet(
+    failures,
+    'Worker compatibility flags drift',
+    array(wrangler.compatibility_flags, 'Wrangler compatibility flags').map((value) =>
+      string(value, 'Wrangler compatibility flag')
+    ),
+    array(settings.compatibility_flags, 'Worker compatibility flags').map((value) =>
+      string(value, 'Worker compatibility flag')
+    )
+  );
+  const expectedLimits = record(wrangler.limits, 'Wrangler limits');
+  const actualLimits = record(settings.limits, 'Worker limits');
+  if (actualLimits.cpu_ms !== expectedLimits.cpu_ms) {
+    failures.push(
+      `Worker CPU limit drift: expected ${String(expectedLimits.cpu_ms)}, found ${String(actualLimits.cpu_ms)}`
+    );
+  }
+
+  const expectedSecrets = array(
+    record(wrangler.secrets, 'Wrangler secrets').required,
+    'Wrangler required secrets'
+  ).map((value) => string(value, 'Wrangler required secret'));
+  const liveSecrets = array(secretsResponse.result, 'Worker secrets').map((value) =>
+    string(record(value, 'Worker secret').name, 'Worker secret name')
+  );
+  compareExactSet(failures, 'Worker secrets drift', expectedSecrets, liveSecrets);
+
+  const schedules = record(schedulesResponse.result, 'Worker schedules');
+  const liveCrons = array(schedules.schedules, 'Worker schedules').map((value) =>
+    string(record(value, 'Worker schedule').cron, 'Worker schedule cron')
+  );
+  const expectedCrons = array(
+    record(wrangler.triggers, 'Wrangler triggers').crons,
+    'Wrangler Cron triggers'
+  ).map((value) => string(value, 'Wrangler Cron trigger'));
+  compareExactSet(failures, 'Worker Cron drift', expectedCrons, liveCrons);
+
+  const ownedQueues = queues.filter((queue) =>
+    string(queue.queue_name, 'Queue name').startsWith(contract.ownedQueuePrefix)
+  );
+  compareExactSet(
+    failures,
+    'Owned Queue inventory drift',
+    contract.queues.map((queue) => queue.name),
+    ownedQueues.map((queue) => string(queue.queue_name, 'Queue name'))
+  );
+  for (const expected of contract.queues) {
+    const live = ownedQueues.find((queue) => queue.queue_name === expected.name);
+    if (!live) continue;
+    const producers = integer(live.producers_total_count, `${expected.name} producers`);
+    const consumers = integer(live.consumers_total_count, `${expected.name} consumers`);
+    if (producers !== expected.producers || consumers !== expected.consumers) {
+      failures.push(
+        `Queue ${expected.name} drift: expected ${expected.producers} producers/${expected.consumers} consumers, found ${producers}/${consumers}`
+      );
+    }
+  }
+
+  for (const expected of contract.buckets) {
+    const bucketName = encodeURIComponent(expected.name);
+    const [bucketResponse, managedResponse, customResponse] = await Promise.all([
+      client.get(`/r2/buckets/${bucketName}`),
+      client.get(`/r2/buckets/${bucketName}/domains/managed`),
+      client.get(`/r2/buckets/${bucketName}/domains/custom`),
+    ]);
+    const bucket = record(bucketResponse.result, `R2 bucket ${expected.name}`);
+    if (
+      String(bucket.name) !== expected.name ||
+      String(bucket.location).toLowerCase() !== expected.location ||
+      bucket.storage_class !== expected.storageClass
+    ) {
+      failures.push(
+        `R2 bucket ${expected.name} drift: expected ${expected.location}/${expected.storageClass}, found ${String(
+          bucket.location
+        ).toLowerCase()}/${String(bucket.storage_class)}`
+      );
+    }
+    const managed = record(managedResponse.result, `R2 managed domain ${expected.name}`);
+    if (managed.enabled !== expected.managedPublic) {
+      failures.push(
+        `R2 bucket ${expected.name} r2.dev drift: expected enabled=${expected.managedPublic}, found ${String(
+          managed.enabled
+        )}`
+      );
+    }
+    const custom = record(customResponse.result, `R2 custom domains ${expected.name}`);
+    const domains = array(custom.domains, `R2 custom domains ${expected.name}`).map((value) =>
+      string(record(value, 'R2 custom domain').domain, 'R2 custom domain name')
+    );
+    compareExactSet(
+      failures,
+      `R2 bucket ${expected.name} custom-domain drift`,
+      expected.customDomains,
+      domains
+    );
+  }
+
+  if (failures.length > 0) {
+    throw new Error(`Cloudflare live infrastructure drift detected:\n- ${failures.join('\n- ')}`);
+  }
+  return {
+    worker: contract.publisherWorker,
+    bindingCount: bindings.length,
+    secretCount: liveSecrets.length,
+    cronCount: liveCrons.length,
+    queueCount: ownedQueues.length,
+    bucketCount: contract.buckets.length,
+  };
+}
+
+if (import.meta.main) {
+  const report = await checkCloudflareLiveDrift({
+    accountId: process.env.CLOUDFLARE_ACCOUNT_ID ?? '',
+    apiToken: process.env.CLOUDFLARE_API_TOKEN ?? '',
+  });
+  console.log(JSON.stringify({ ok: true, ...report }));
+}


### PR DESCRIPTION
## Summary

- add a declarative live Cloudflare contract for the publisher Worker, repository-owned Queues, and private R2 buckets
- add a fail-closed audit that uses only authenticated GET requests and compares live bindings, secret names, Cron schedules, Queue references, and R2 access against trusted `main`
- run the audit from `pull_request_target` while checking out only the base SHA, so pull-request-authored code never receives the Cloudflare credential
- document the bootstrap and branch-protection requirements

## Verification

- `bun run test` — 35 files, 322 tests
- `bun run typecheck`
- targeted Biome check
- `git diff --check`
- production-shape read against Cloudflare completed all endpoints and reported only the known stale `ASSET_PUBLISHER_POLL_SECRET`

## Required rollout steps

This is a bootstrap workflow and will begin running on pull requests only after it is present on `main`.

1. Create repository secret `CLOUDFLARE_READ_API_TOKEN` with only Workers Scripts Read, Queues Read, and Workers R2 Storage Read.
2. Remove the stale `ASSET_PUBLISHER_POLL_SECRET`; otherwise the new check will correctly remain red.
3. After the workflow has run once, configure `Cloudflare live drift / audit` as a required status check for `main`. The repository currently has no branch protection, so the workflow alone cannot block merges.

No Cloudflare infrastructure or GitHub protection settings are changed by this PR.