### PR TITLE
Prevent faction-sheet publisher contract drift

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -35,6 +35,36 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Quiesce publisher for contract-safe deployment
+        id: publisher_quiesce
+        run: |
+          config="$(bunx convex data asset_type_configs --prod --limit 2 --format json)"
+          previous_status="$(jq -er '
+            if length == 1 and .[0].asset_type == "faction_sheet"
+            then .[0].status
+            else error("Expected exactly one faction-sheet publisher config")
+            end
+          ' <<<"$config")"
+          case "$previous_status" in
+            active)
+              result="$(bunx convex run --prod assetPublisherOperator:pause '{}')"
+              printf '%s\n' "$result"
+              jq -e '.status == "paused"' <<<"$result"
+              echo "reactivate=true" >> "$GITHUB_OUTPUT"
+              ;;
+            paused|disabled)
+              printf 'Publisher already safe for deployment: %s\n' "$previous_status"
+              echo "reactivate=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              printf 'Unsupported publisher status: %s\n' "$previous_status" >&2
+              exit 1
+              ;;
+          esac
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          CONVEX_DEPLOYMENT: ${{ secrets.CONVEX_DEPLOYMENT }}
+
       - name: Deploy Convex
         run: bun run convex:deploy
         env:
@@ -90,6 +120,19 @@ jobs:
 
       - name: Smoke scheduled Worker release
         run: bun run ./scripts/publisher-deployment-contract.ts smoke
+
+      - name: Reactivate publisher after release smoke
+        if: steps.publisher_quiesce.outputs.reactivate == 'true'
+        run: |
+          renderer_version="$(jq -r '.vars.SUPPORTED_RENDERER_VERSION' workers/publisher/wrangler.jsonc)"
+          args="$(jq -cn --arg renderer "$renderer_version" '{rendererVersion: $renderer}')"
+          result="$(bunx convex run --prod assetPublisherOperator:activate "$args")"
+          printf '%s\n' "$result"
+          jq -e --arg renderer "$renderer_version" \
+            '.status == "active" and .rendererVersion == $renderer' <<<"$result"
+        env:
+          CONVEX_DEPLOY_KEY: ${{ secrets.CONVEX_DEPLOY_KEY }}
+          CONVEX_DEPLOYMENT: ${{ secrets.CONVEX_DEPLOYMENT }}
 
       - name: Set canonical Convex site URL
         run: bunx convex env set SITE_URL https://dune.zone --prod

--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -88,6 +88,10 @@ jobs:
         run: bun run publisher:dry-run
         env:
           VITE_CONVEX_URL: https://example.convex.cloud
+      - name: Install Chromium for publisher contract regression
+        run: npx playwright install --with-deps chromium
+      - name: Exercise production snapshot envelope in Chromium
+        run: bun run workers/publisher/capture-contract-regression.ts
       - name: Check Worker startup
         run: bun run publisher:startup
 

--- a/convex/assetPublisher.test.ts
+++ b/convex/assetPublisher.test.ts
@@ -5,6 +5,7 @@ import { convexTest } from 'convex-test';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { proofFaction } from '../src/app/capture/proofFaction';
+import { publisherSnapshotSchema } from '../src/shared/asset-publishing/publisher-snapshot';
 import { internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import { ITEM_CLAIM_LEASE_MS, MAX_PUBLISHER_ITEMS } from './assetPublisher';
@@ -296,9 +297,15 @@ describe('item HTTP contracts', () => {
       headers: { Authorization: `Bearer ${item.claimToken}` },
     });
     expect(renderResponse.status).toBe(200);
-    await expect(renderResponse.json()).resolves.toMatchObject({
+    const renderSnapshot = publisherSnapshotSchema.parse(await renderResponse.json());
+    expect(renderSnapshot).toMatchObject({
       ok: true,
       targetId: item.targetId,
+      factionId: item.factionId,
+      assetType: item.assetType,
+      generation: item.generation,
+      rendererVersion: item.rendererVersion,
+      leaseExpiresAt: item.leaseExpiresAt,
       payload: { factionId: item.factionId },
     });
     const itemBody = {

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,5 +1,6 @@
 import { httpRouter } from 'convex/server';
 
+import { publisherSnapshotSchema } from '../src/shared/asset-publishing/publisher-snapshot';
 import { internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import { type ActionCtx, httpAction } from './_generated/server';
@@ -270,7 +271,9 @@ http.route({
     const authorization = request.headers.get('Authorization') ?? '';
     const claimToken = authorization.startsWith('Bearer ') ? authorization.slice(7) : '';
     const item = await ctx.runQuery(internal.assetPublisher.readItemForRender, { claimToken });
-    return item ? publisherJson({ ok: true, ...item }) : publisherJson({ error: 'Not found' }, 404);
+    return item
+      ? publisherJson(publisherSnapshotSchema.parse({ ok: true, ...item }))
+      : publisherJson({ error: 'Not found' }, 404);
   }),
 });
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,21 +20,21 @@ The checked-in publisher release is now the minimal item-only model:
 - there is no Queue binding, poll endpoint, batch/run entity, quota ledger, or item-count
   deployment knob.
 
-**Release prerequisite: the faction-sheet publisher config must remain paused or disabled while the
-widen release is deployed and verified.** In that state the first scheduled invocation must produce
-an empty `take-work` result and no Browser Run. If a live claim still exists from an earlier
-attempt, the expected empty result is `reason: "busy"` with its `leaseExpiresAt`; that is still a
-valid no-work outcome and must not open Browser.
+**The production workflow quiesces an active faction-sheet publisher before deploying Convex.** It
+only reactivates publishing after the matching Worker has deployed and passed its exact release
+smoke. If any intervening step fails, the workflow fails closed and deliberately leaves publishing
+paused for operator recovery instead of running mismatched producer and consumer contracts. A
+publisher that was already paused or disabled remains non-active and is not automatically enabled.
 
 Cloudflare Workers is the only frontend host. The checked-in Worker configuration attaches the
 exact Custom Domain `dune.zone`; Cloudflare manages its DNS record and TLS certificate. After the
 custom domain passes the release smoke, the workflow sets the production Convex Auth `SITE_URL` to
 `https://dune.zone`.
 
-The workflow does not call the operator activation boundary, mutate publisher data outside the
-normal scheduled executor, execute the later schema narrow, or delete the retired remote Queue.
-Activation, the twenty-item production canary, schema narrow, and remote Queue cleanup remain
-separate explicitly approved operations.
+The workflow mutates only the publisher's pause/activation control boundary around deployment. It
+does not mutate publisher items outside the normal scheduled executor, execute the later schema
+narrow, or delete the retired remote Queue. The first post-deploy scheduled invocation remains an
+operator-observed production canary.
 
 ## Build process
 
@@ -109,23 +109,31 @@ values.
 On every push to `main`:
 
 1. `bun install --frozen-lockfile`
-2. `bun run convex:deploy`
-3. `bun run migrations:deploy`
-4. Run fail-closed Worker preflight over the exact checked-in contract:
+2. Read the sole Convex publisher config. If active, pause it and remember to reactivate; if already
+   paused or disabled, preserve that operator intent and do not reactivate it.
+3. `bun run convex:deploy`
+4. `bun run migrations:deploy`
+5. Run fail-closed Worker preflight over the exact checked-in contract:
    exact `main` SHA and clean tracked source, required protected CI inputs, exact production
    `VITE_CONVEX_URL`, workers.dev origin, the exact `dune.zone` Custom Domain, one exact
    `*/5 * * * *` Cron, no Queue binding, one private R2 binding, exact renderer identity, 30-second
    CPU limit, fixed four-minute work window, 8,000,000-byte PDF cap, and the two required Worker
    secret names.
-5. Check generated Worker bindings and typecheck the Worker release.
-6. Build the SPA and capture bundle once with the protected `VITE_CONVEX_URL`, re-check assembled
+6. Check generated Worker bindings and typecheck the Worker release.
+7. Build the SPA and capture bundle once with the protected `VITE_CONVEX_URL`, re-check assembled
    asset limits, and reject generated-source drift.
-7. Dry-run the exact checked-in Worker release and then deploy it in strict mode with the full
+8. Dry-run the exact checked-in Worker release and then deploy it in strict mode with the full
    `GITHUB_SHA` as the Worker version tag.
-8. Smoke the exact checked-in workers.dev and `dune.zone` health URLs and require:
+9. Smoke the exact checked-in workers.dev and `dune.zone` health URLs and require:
    `ok: true`, `maxItems: 20`, schedule `*/5 * * * *`, exact renderer support/manifest agreement,
    `Cache-Control: no-store`, and the deployed Git SHA tag.
-9. Set the production Convex Auth `SITE_URL` to `https://dune.zone`.
+10. If the workflow paused an active publisher in step 2, reactivate it with the exact checked-in
+    renderer and require the returned status and renderer to match.
+11. Set the production Convex Auth `SITE_URL` to `https://dune.zone`.
+
+Steps 2-10 are intentionally asymmetric: any failure after the pause leaves publishing paused. Do
+not manually reactivate until the failed release has been diagnosed and the deployed producer and
+consumer are confirmed compatible.
 
 Wrangler receives only `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`. It does not receive
 Cron or route overrides, a secrets file, or activation flags. The checked-in Wrangler config is the
@@ -172,20 +180,22 @@ No separate manual migration command is required when the workflow succeeds.
 ```mermaid
 flowchart LR
     Git[Push main] --> GHA[GitHub Actions]
-    GHA --> ConvexDeploy[Deploy widen-compatible Convex state]
+    GHA --> Quiesce[Quiesce active publisher]
+    Quiesce --> ConvexDeploy[Deploy widen-compatible Convex state]
     ConvexDeploy --> Migrations[Run and verify required migrations]
     Migrations --> Preflight[Fail-closed Worker preflight]
     Preflight --> Build[Build one unified release]
     Build --> DryRun[Wrangler dry-run]
     DryRun --> WorkerDeploy[Strict Worker deploy tagged with Git SHA]
     WorkerDeploy --> Smoke[workers.dev + dune.zone release smoke]
-    Smoke --> SiteUrl[Set Convex SITE_URL to dune.zone]
+    Smoke --> Activate[Restore active state with exact renderer]
+    Activate --> SiteUrl[Set Convex SITE_URL to dune.zone]
 ```
 
 Wrangler manages the exact `dune.zone` Custom Domain from source control. The workflow changes only
-the public Convex Auth `SITE_URL`; it does not install or read publisher secrets, change OAuth
-provider credentials, call the operator activation endpoint, mutate publisher data directly, or
-send Queue work.
+the publisher control status and public Convex Auth `SITE_URL`; it does not install or read
+publisher secrets, change OAuth provider credentials, mutate publisher items directly, or send
+Queue work.
 
 ## First scheduled-release observation
 
@@ -194,18 +204,20 @@ shape. CI validates the source contract; live trigger readback remains an operat
 
 After the first merged scheduled release:
 
-1. Reconfirm through authorized read-only Convex state that the faction-sheet publisher config is
-   paused or disabled and that no unexpected live claims remain.
+1. Reconfirm through authorized read-only Convex state that the faction-sheet publisher config
+   returned to its pre-deploy operator intent. If active, require the exact deployed renderer; in
+   every state, require no unexpected live claims.
 2. Require the deploy smoke to report `maxItems: 20`, schedule `*/5 * * * *`, exact renderer
    identity, and the merged full Git SHA on workers.dev and `dune.zone`.
 3. Read the trigger in the Cloudflare dashboard and require exactly one `*/5 * * * *` schedule.
-4. Observe at least one `asset_publisher_cron` log with `result: "empty"`.
-   If Convex is paused or disabled, expect `reason: "disabled"`.
+4. Observe at least one `asset_publisher_cron` log. If no faction changed during deployment, expect
+   `result: "empty"` and `reason: "no_eligible_work"`.
+   If the workflow failed after pausing, expect `reason: "disabled"` until recovery.
    If a previous claim is still live, expect `reason: "busy"` with a future `leaseExpiresAt`.
    If publishing is active but there is nothing eligible, expect `reason: "no_eligible_work"`.
 5. Reconfirm that the empty observation produced no Browser session.
-6. Keep Convex paused until the separate operator activation is explicitly approved, then verify a
-   representative twenty-item invocation before any schema narrow or remote Queue cleanup.
+6. If work was eligible, require every assigned item to complete or have an attributable failure;
+   investigate any infrastructure failure before schema narrow or remote Queue cleanup.
 
 ## Convex breaking migrations
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "publisher:dry-run": "bun run publisher:assets && wrangler deploy --dry-run --config workers/publisher/wrangler.jsonc",
     "publisher:release:dry-run": "wrangler deploy --dry-run --config workers/publisher/wrangler.jsonc",
     "publisher:font-regression": "bun run publisher:assets && bun run workers/publisher/font-regression.ts",
+    "publisher:capture-contract-regression": "bun run publisher:assets && bun run workers/publisher/capture-contract-regression.ts",
     "publisher:startup": "wrangler check startup --cwd workers/publisher --config wrangler.jsonc --outfile /tmp/asset-publisher-startup.cpuprofile",
     "build-storybook": "storybook build",
     "local-capture": "storybook build && LOCAL=true bun run ./scripts/capture.ts",

--- a/src/app/capture/PublisherFactionSheetCapture.tsx
+++ b/src/app/capture/PublisherFactionSheetCapture.tsx
@@ -1,22 +1,13 @@
 import { useEffect, useState } from 'react';
-import { z } from 'zod';
 
 import { FactionSheetView } from '@app/components/factions/sheet/FactionSheetView';
-import { type FactionInput, FactionInputSchema } from '@game/schema/faction';
+import type { FactionInput } from '@game/schema/faction';
 
+import { publisherSnapshotSchema } from '../../shared/asset-publishing/publisher-snapshot';
 import { publisherErrorMessage, redactPublisherResource } from './publisher-diagnostics';
 import { assertRequiredPublisherFonts } from './publisher-fonts';
 
 const ASSET_SETTLE_TIMEOUT_MS = 15_000;
-const snapshotSchema = z.strictObject({
-  ok: z.literal(true),
-  payload: z.strictObject({
-    factionId: z.string().min(1),
-    slug: z.string(),
-    faction: FactionInputSchema,
-  }),
-  payloadHash: z.string().regex(/^[0-9a-f]{64}$/),
-});
 
 type CaptureState = 'loading' | 'ready' | 'error';
 
@@ -163,7 +154,7 @@ export function PublisherFactionSheetCapture() {
           signal: controller.signal,
         });
         if (!response.ok) throw new Error(`Claimed snapshot returned HTTP ${response.status}`);
-        const snapshot = snapshotSchema.parse(await response.json());
+        const snapshot = publisherSnapshotSchema.parse(await response.json());
         setFaction(snapshot.payload.faction);
         setPayloadHash(snapshot.payloadHash);
         setDetail(`Rendering exact claimed snapshot ${snapshot.payloadHash}`);

--- a/src/app/capture/publisher-diagnostics.ts
+++ b/src/app/capture/publisher-diagnostics.ts
@@ -35,6 +35,55 @@ export function publisherErrorMessage(error: unknown): string {
   return sanitizePublisherDiagnostic(error instanceof Error ? error.message : String(error));
 }
 
+export type PublisherErrorDetail = {
+  name: string;
+  message: string;
+  stack?: string;
+};
+
+const MAX_ERROR_DETAILS = 6;
+const MAX_ERROR_DETAIL_DEPTH = 6;
+const MAX_ERROR_MESSAGE_LENGTH = 1_024;
+const MAX_ERROR_STACK_LENGTH = 1_500;
+
+/**
+ * Flattens Error.cause and AggregateError.errors without allowing publisher secrets or an
+ * unbounded exception graph into telemetry.
+ */
+export function publisherErrorDetails(error: unknown): PublisherErrorDetail[] {
+  const details: PublisherErrorDetail[] = [];
+  const visited = new Set<unknown>();
+
+  function visit(value: unknown, depth: number): void {
+    if (
+      details.length >= MAX_ERROR_DETAILS ||
+      depth >= MAX_ERROR_DETAIL_DEPTH ||
+      visited.has(value)
+    ) {
+      return;
+    }
+    visited.add(value);
+
+    const current = value instanceof Error ? value : new Error(String(value));
+    const stack = current.stack
+      ? sanitizePublisherDiagnostic(current.stack).slice(0, MAX_ERROR_STACK_LENGTH)
+      : undefined;
+    details.push({
+      name: sanitizePublisherDiagnostic(current.name).slice(0, 128),
+      message: publisherErrorMessage(current).slice(0, MAX_ERROR_MESSAGE_LENGTH),
+      ...(stack ? { stack } : {}),
+    });
+
+    if (value instanceof AggregateError) {
+      for (const nested of value.errors) visit(nested, depth + 1);
+    }
+    if (value instanceof Error && value.cause !== undefined) visit(value.cause, depth + 1);
+  }
+
+  visit(error, 0);
+  return details;
+}
+
 export function serializePublisherLogEvent(event: Record<string, unknown>): string {
   return JSON.stringify(event, (_key, value: unknown) => {
     if (value instanceof Error) return publisherErrorMessage(value);

--- a/src/shared/asset-publishing/publisher-snapshot.ts
+++ b/src/shared/asset-publishing/publisher-snapshot.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+import { FactionInputSchema } from '../../game/schema/faction';
+
+/** Shared exact contract for the protected Convex producer and Browser capture consumer. */
+export const publisherSnapshotSchema = z
+  .strictObject({
+    ok: z.literal(true),
+    targetId: z.string().min(1),
+    factionId: z.string().min(1),
+    assetType: z.literal('faction_sheet'),
+    generation: z.number().int().positive(),
+    rendererVersion: z.string().trim().min(1).max(128),
+    leaseExpiresAt: z.number().int().positive(),
+    payload: z.strictObject({
+      factionId: z.string().min(1),
+      slug: z.string(),
+      faction: FactionInputSchema,
+    }),
+    payloadHash: z.string().regex(/^[0-9a-f]{64}$/),
+  })
+  .refine((snapshot) => snapshot.factionId === snapshot.payload.factionId, {
+    message: 'Snapshot faction identity does not match its payload',
+    path: ['payload', 'factionId'],
+  });
+
+export type PublisherSnapshot = z.infer<typeof publisherSnapshotSchema>;

--- a/workers/publisher/MEASUREMENT.md
+++ b/workers/publisher/MEASUREMENT.md
@@ -40,6 +40,7 @@ Failed invocation:
 
 - `result: "failed"`
 - bounded `error`
+- bounded, sanitized `errors` entries that flatten `AggregateError.errors` and `Error.cause`
 
 Every cron event also carries a fresh `invocationId` and the Cloudflare `scheduledTime`.
 

--- a/workers/publisher/README.md
+++ b/workers/publisher/README.md
@@ -45,16 +45,24 @@ bun run publisher:test
 bun run publisher:assets
 bun run publisher:assets:check
 bun run publisher:font-regression
+bun run publisher:capture-contract-regression
 bun run publisher:dry-run
 bun run publisher:startup
 ```
 
+`publisher:capture-contract-regression` serves the built capture bundle a complete production-shaped
+Convex item envelope in Chromium and requires the capture marker, payload hash, and two-page PDF
+contract to succeed. The protected Convex producer and capture client also parse the same shared
+strict schema, so adding or removing response fields cannot be accepted on only one side.
+
 The protected `main` workflow runs source/config preflight, generated-type check, typecheck, one
 production-URL asset build, assembled-asset verification, Wrangler dry-run, strict SHA-tagged
-deploy, and health smoke. It does not provision or delete Cloudflare resources, install or read
-secret values, mutate the Convex operator surface, or activate publishing.
+deploy, and health smoke. It pauses an active Convex publisher before the producer deploy and
+reactivates the exact checked-in renderer only after the Worker smoke succeeds. An already paused
+or disabled publisher retains that operator intent. The workflow does not provision or delete
+Cloudflare resources, install or read secret values, or mutate publisher items directly.
 
-**Convex publisher config must remain paused or disabled while the widen migrations and this Worker
-release are deployed and verified.** Observe an empty Cron without a Browser Run before a separately
-approved activation. After activation, verify a representative twenty-item invocation before any
-remote Queue cleanup.
+**A failed production release intentionally leaves the Convex publisher paused.** Diagnose the
+failed release and confirm producer/consumer compatibility before manually reactivating. After a
+successful release, observe the first scheduled invocation and investigate any infrastructure
+failure before remote Queue cleanup.

--- a/workers/publisher/browser.ts
+++ b/workers/publisher/browser.ts
@@ -201,64 +201,83 @@ export class PublisherBrowserSession {
   async capture(claimToken: string, timeoutMs: number): Promise<CapturedPdf> {
     const deadline = performance.now() + timeoutMs;
     const lifecycleDeadlineAt = Date.now() + timeoutMs;
-    this.context = await this.browser.newContext({
-      deviceScaleFactor: VIEWPORT_CONTRACT.deviceScaleFactor,
-      locale: 'en-US',
-      timezoneId: 'UTC',
-      viewport: { width: VIEWPORT_CONTRACT.width, height: VIEWPORT_CONTRACT.height },
-    });
-    await this.context.addCookies(
-      publisherCaptureCookies(this.captureBaseUrl, claimToken, lifecycleDeadlineAt)
-    );
-    const page = await this.context.newPage();
-    const diagnostics = registerCaptureDiagnostics(page);
-    const response = await page.goto(`${this.captureBaseUrl}/__asset-publisher/capture`, {
-      waitUntil: 'domcontentloaded',
-      timeout: remaining(deadline),
-    });
-    if (!response?.ok()) throw new Error(`Capture navigation returned HTTP ${response?.status()}`);
-    const marker = page.locator('#capture-status');
-    await marker.waitFor({ state: 'attached', timeout: remaining(deadline) });
-    await page.waitForFunction(
-      () => {
-        const browserGlobal = globalThis as typeof globalThis & {
-          document: {
-            querySelector(selector: string): { getAttribute(name: string): string | null } | null;
+    let stage = 'create_context';
+    try {
+      this.context = await this.browser.newContext({
+        deviceScaleFactor: VIEWPORT_CONTRACT.deviceScaleFactor,
+        locale: 'en-US',
+        timezoneId: 'UTC',
+        viewport: { width: VIEWPORT_CONTRACT.width, height: VIEWPORT_CONTRACT.height },
+      });
+      stage = 'install_claim_cookies';
+      await this.context.addCookies(
+        publisherCaptureCookies(this.captureBaseUrl, claimToken, lifecycleDeadlineAt)
+      );
+      stage = 'create_page';
+      const page = await this.context.newPage();
+      const diagnostics = registerCaptureDiagnostics(page);
+      stage = 'navigate';
+      const response = await page.goto(`${this.captureBaseUrl}/__asset-publisher/capture`, {
+        waitUntil: 'domcontentloaded',
+        timeout: remaining(deadline),
+      });
+      if (!response?.ok()) {
+        throw new Error(`Capture navigation returned HTTP ${response?.status()}`);
+      }
+      const marker = page.locator('#capture-status');
+      stage = 'wait_for_status_marker';
+      await marker.waitFor({ state: 'attached', timeout: remaining(deadline) });
+      stage = 'wait_for_ready_state';
+      await page.waitForFunction(
+        () => {
+          const browserGlobal = globalThis as typeof globalThis & {
+            document: {
+              querySelector(selector: string): { getAttribute(name: string): string | null } | null;
+            };
           };
-        };
-        return (
-          browserGlobal.document
-            .querySelector('#capture-status')
-            ?.getAttribute('data-capture-state') !== 'loading'
-        );
-      },
-      undefined,
-      { timeout: remaining(deadline) }
-    );
-    const state = await marker.getAttribute('data-capture-state');
-    if (state !== 'ready') {
-      throw new Error(`Capture route reported ${state}: ${await marker.textContent()}`);
+          return (
+            browserGlobal.document
+              .querySelector('#capture-status')
+              ?.getAttribute('data-capture-state') !== 'loading'
+          );
+        },
+        undefined,
+        { timeout: remaining(deadline) }
+      );
+      stage = 'read_capture_state';
+      const state = await marker.getAttribute('data-capture-state');
+      if (state !== 'ready') {
+        throw new Error(`Capture route reported ${state}: ${await marker.textContent()}`);
+      }
+      const payloadHash = await marker.getAttribute('data-payload-hash');
+      if (!payloadHash || !/^[0-9a-f]{64}$/.test(payloadHash)) {
+        throw new Error('Capture route did not expose the exact payload hash');
+      }
+      stage = 'validate_page_bounds';
+      await assertPageBounds(page, deadline);
+      stage = 'validate_pre_pdf_diagnostics';
+      assertCaptureDiagnostics(diagnostics);
+      stage = 'generate_pdf';
+      const bytes = await page.pdf({
+        displayHeaderFooter: PDF_CONTRACT.displayHeaderFooter,
+        margin: PDF_CONTRACT.marginMm,
+        preferCSSPageSize: PDF_CONTRACT.preferCssPageSize,
+        printBackground: PDF_CONTRACT.printBackground,
+      });
+      stage = 'inspect_pdf';
+      const inspection = await inspectPublisherPdf(bytes);
+      stage = 'validate_post_pdf_diagnostics';
+      assertCaptureDiagnostics(diagnostics);
+      return {
+        bytes,
+        payloadHash,
+        ...inspection,
+        ...diagnostics,
+      };
+    } catch (error) {
+      if (error instanceof TargetRenderError) throw error;
+      throw new Error(`Browser capture failed during ${stage}`, { cause: error });
     }
-    const payloadHash = await marker.getAttribute('data-payload-hash');
-    if (!payloadHash || !/^[0-9a-f]{64}$/.test(payloadHash)) {
-      throw new Error('Capture route did not expose the exact payload hash');
-    }
-    await assertPageBounds(page, deadline);
-    assertCaptureDiagnostics(diagnostics);
-    const bytes = await page.pdf({
-      displayHeaderFooter: PDF_CONTRACT.displayHeaderFooter,
-      margin: PDF_CONTRACT.marginMm,
-      preferCSSPageSize: PDF_CONTRACT.preferCssPageSize,
-      printBackground: PDF_CONTRACT.printBackground,
-    });
-    const inspection = await inspectPublisherPdf(bytes);
-    assertCaptureDiagnostics(diagnostics);
-    return {
-      bytes,
-      payloadHash,
-      ...inspection,
-      ...diagnostics,
-    };
   }
 
   async close(): Promise<void> {

--- a/workers/publisher/capture-contract-regression.ts
+++ b/workers/publisher/capture-contract-regression.ts
@@ -1,0 +1,111 @@
+import path from 'node:path';
+
+import { chromium } from 'playwright';
+
+import { proofFaction } from '../../src/app/capture/proofFaction';
+import { publisherSnapshotSchema } from '../../src/shared/asset-publishing/publisher-snapshot';
+import { inspectChromiumPdf } from '../proof/pdf';
+import { PUBLISHER_RENDERER_CONTRACT, PUBLISHER_RENDERER_VERSION } from './renderer-contract';
+
+const repositoryRoot = path.resolve(import.meta.dirname, '../..');
+const publisherDist = path.join(repositoryRoot, 'workers/publisher/dist');
+const payload = {
+  factionId: 'k17publisherContractFaction',
+  slug: 'publisher-contract-faction',
+  faction: proofFaction,
+};
+const payloadHash = new Bun.CryptoHasher('sha256').update(JSON.stringify(payload)).digest('hex');
+const snapshot = publisherSnapshotSchema.parse({
+  ok: true,
+  targetId: 'mh7publisherContractTarget',
+  factionId: payload.factionId,
+  assetType: 'faction_sheet',
+  generation: 1,
+  rendererVersion: PUBLISHER_RENDERER_VERSION,
+  leaseExpiresAt: Date.now() + 60_000,
+  payload,
+  payloadHash,
+});
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+const server = Bun.serve({
+  port: 0,
+  async fetch(request) {
+    const pathname = decodeURIComponent(new URL(request.url).pathname);
+    if (pathname === '/__asset-publisher/snapshot') {
+      return Response.json(snapshot, { headers: { 'Cache-Control': 'no-store' } });
+    }
+    const relative = pathname === '/' ? 'publisher-capture.html' : pathname.replace(/^\/+/, '');
+    if (relative.split('/').includes('..')) return new Response('Not found', { status: 404 });
+    const file = Bun.file(path.join(publisherDist, relative));
+    return (await file.exists()) ? new Response(file) : new Response('Not found', { status: 404 });
+  },
+});
+
+const browser = await chromium.launch({ headless: true });
+try {
+  const page = await browser.newPage({
+    viewport: PUBLISHER_RENDERER_CONTRACT.viewport,
+    locale: 'en-US',
+    timezoneId: 'UTC',
+  });
+  const errors: string[] = [];
+  page.on('console', (message) => {
+    if (message.type() === 'error') errors.push(`console: ${message.text()}`);
+  });
+  page.on('pageerror', (error) => errors.push(`page: ${error.message}`));
+  page.on('requestfailed', (request) => {
+    errors.push(`request: ${request.method()} ${new URL(request.url()).pathname}`);
+  });
+  page.on('response', (response) => {
+    if (response.status() >= 400) {
+      errors.push(`response: ${response.status()} ${new URL(response.url()).pathname}`);
+    }
+  });
+
+  await page.goto(`http://127.0.0.1:${server.port}/publisher-capture.html`, {
+    waitUntil: 'domcontentloaded',
+  });
+  const marker = page.locator('#capture-status');
+  await marker.waitFor({ state: 'attached' });
+  await page.waitForFunction(
+    () =>
+      document.querySelector('#capture-status')?.getAttribute('data-capture-state') !== 'loading'
+  );
+  const state = await marker.getAttribute('data-capture-state');
+  const detail = (await marker.textContent()) ?? '';
+  invariant(state === 'ready', `Production-shaped capture reported ${state}: ${detail}`);
+  invariant(
+    (await marker.getAttribute('data-payload-hash')) === payloadHash,
+    'Production-shaped capture did not expose the exact payload hash'
+  );
+  invariant(errors.length === 0, `Production-shaped capture emitted errors: ${errors.join(' | ')}`);
+
+  const pdf = await page.pdf({
+    displayHeaderFooter: PUBLISHER_RENDERER_CONTRACT.pdf.displayHeaderFooter,
+    margin: PUBLISHER_RENDERER_CONTRACT.pdf.marginMm,
+    preferCSSPageSize: PUBLISHER_RENDERER_CONTRACT.pdf.preferCssPageSize,
+    printBackground: PUBLISHER_RENDERER_CONTRACT.pdf.printBackground,
+  });
+  const inspection = await inspectChromiumPdf(pdf);
+  invariant(
+    inspection.pageCount === PUBLISHER_RENDERER_CONTRACT.pdf.pageCount,
+    `Production-shaped capture produced ${inspection.pageCount} pages`
+  );
+  invariant(
+    Math.abs(inspection.pageWidthMm - PUBLISHER_RENDERER_CONTRACT.pdf.pageWidthMm) <=
+      PUBLISHER_RENDERER_CONTRACT.pdf.pageSizeToleranceMm &&
+      Math.abs(inspection.pageHeightMm - PUBLISHER_RENDERER_CONTRACT.pdf.pageHeightMm) <=
+        PUBLISHER_RENDERER_CONTRACT.pdf.pageSizeToleranceMm,
+    `Production-shaped capture produced ${inspection.pageWidthMm.toFixed(2)} mm x ${inspection.pageHeightMm.toFixed(2)} mm pages`
+  );
+  console.log(
+    `Publisher production-envelope Chromium regression passed: ${inspection.pageCount} pages, ${pdf.byteLength} bytes`
+  );
+} finally {
+  await browser.close();
+  server.stop(true);
+}

--- a/workers/publisher/deployment-config.test.ts
+++ b/workers/publisher/deployment-config.test.ts
@@ -118,18 +118,36 @@ describe('scheduled production deployment shape', () => {
     expect(example.status).toBe(1);
   });
 
-  test('documents paused-or-disabled Convex and Queue-free empty-work observation', () => {
+  test('fails closed by pausing before deploy and activating only after Worker smoke', () => {
     const deploymentGuide = readFileSync(path.resolve(process.cwd(), 'docs/deployment.md'), 'utf8');
     const workerGuide = readFileSync(
       path.resolve(process.cwd(), 'workers/publisher/README.md'),
       'utf8'
     );
+    const deploymentWorkflow = readFileSync(
+      path.resolve(process.cwd(), '.github/workflows/deploy-main.yml'),
+      'utf8'
+    );
     for (const guide of [deploymentGuide, workerGuide]) {
-      expect(guide).toContain('paused or disabled');
+      expect(guide).toContain('leaves');
+      expect(guide).toContain('paused');
       expect(guide).toContain('*/5 * * * *');
     }
-    expect(deploymentGuide).toContain('empty `take-work` result');
-    expect(workerGuide).toContain('empty Cron without a Browser Run');
+    const statusReadIndex = deploymentWorkflow.indexOf('convex data asset_type_configs');
+    const pauseIndex = deploymentWorkflow.indexOf('assetPublisherOperator:pause');
+    const convexDeployIndex = deploymentWorkflow.indexOf('name: Deploy Convex');
+    const smokeIndex = deploymentWorkflow.indexOf('name: Smoke scheduled Worker release');
+    const activateIndex = deploymentWorkflow.indexOf('assetPublisherOperator:activate');
+    expect(statusReadIndex).toBeGreaterThan(-1);
+    expect(statusReadIndex).toBeLessThan(pauseIndex);
+    expect(pauseIndex).toBeGreaterThan(-1);
+    expect(pauseIndex).toBeLessThan(convexDeployIndex);
+    expect(smokeIndex).toBeLessThan(activateIndex);
+    expect(deploymentWorkflow).toContain('paused|disabled)');
+    expect(deploymentWorkflow).toContain('reactivate=false');
+    expect(deploymentWorkflow).toContain("steps.publisher_quiesce.outputs.reactivate == 'true'");
+    expect(deploymentWorkflow).toContain('.status == "paused"');
+    expect(deploymentWorkflow).toContain('.status == "active" and .rendererVersion == $renderer');
   });
 
   test('documents the item-claim migration pack and its paused/no-live-claims preconditions', () => {

--- a/workers/publisher/diagnostics.test.ts
+++ b/workers/publisher/diagnostics.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  publisherErrorDetails,
   publisherErrorMessage,
   redactPublisherResource,
   sanitizePublisherDiagnostic,
@@ -45,6 +46,21 @@ describe('publisher diagnostic redaction', () => {
       expect(message).not.toContain(secret);
       expect(log).not.toContain(secret);
     }
+  });
+
+  test('flattens sanitized AggregateError members and Error causes for telemetry', () => {
+    const root = new Error(`Failed to decode ${signedUrl}`);
+    const staged = new Error('Browser capture failed during validate_page_bounds', { cause: root });
+    const aggregate = new AggregateError([staged], 'Item-list publisher execution failed');
+
+    const details = publisherErrorDetails(aggregate);
+
+    expect(details.map((detail) => detail.message)).toEqual([
+      'Item-list publisher execution failed',
+      'Browser capture failed during validate_page_bounds',
+      'Failed to decode https://cdn.example.com/<redacted>',
+    ]);
+    for (const secret of secrets) expect(JSON.stringify(details)).not.toContain(secret);
   });
 
   test.each([

--- a/workers/publisher/index.ts
+++ b/workers/publisher/index.ts
@@ -1,4 +1,5 @@
 import {
+  publisherErrorDetails,
   publisherErrorMessage,
   serializePublisherLogEvent,
 } from '../../src/app/capture/publisher-diagnostics';
@@ -117,6 +118,7 @@ export const publisherWorker = {
         scheduledTime: controller.scheduledTime,
         result: 'failed',
         error: publisherErrorMessage(error),
+        errors: publisherErrorDetails(error),
       });
       throw error;
     }

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -5,8 +5,8 @@ export const rendererManifest = {
   rendererVersion: 'faction-sheet-v3',
   supportedRendererVersions: ['faction-sheet-v3'],
   rendererId:
-    'faction-sheet/sha256:a7cd5ee806a7831b9b3c7e58a996387f6fe6f53a4a91fd93955ba79f3aa3e74a',
-  digest: 'a7cd5ee806a7831b9b3c7e58a996387f6fe6f53a4a91fd93955ba79f3aa3e74a',
+    'faction-sheet/sha256:1bdb614f2018224dfce73a9c8793c93d4d824cb996a2c3517840e6232e3870d8',
+  digest: '1bdb614f2018224dfce73a9c8793c93d4d824cb996a2c3517840e6232e3870d8',
   contract: {
     rendererVersion: 'faction-sheet-v3',
     supportedRendererVersions: ['faction-sheet-v3'],

--- a/workers/publisher/snapshot-contract.test.ts
+++ b/workers/publisher/snapshot-contract.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest';
+
+import { publisherSnapshotSchema } from '../../src/shared/asset-publishing/publisher-snapshot';
+
+const faction = {
+  name: 'Test faction',
+  logo: '/vector/logo/atreides.svg',
+  colors: ['Green'],
+  background: {
+    image: '/image/texture/021.jpg',
+    colors: ['#4b4c0d', '#d9c979'],
+    opacity: 1,
+    strength: 0.55,
+  },
+  themeColor: '#4b4c0d',
+  hero: { name: 'Lady Jessica', image: '/image/leader/official/jessica.png' },
+  leaders: [],
+  decals: [],
+  troops: [],
+  rules: {
+    startText: 'Start text',
+    revivalText: 'Revival text',
+    spiceCount: 1,
+    advantages: [],
+    alliance: { text: 'Alliance text' },
+    fate: { title: 'Fate', text: 'Fate text' },
+  },
+};
+
+const productionEnvelope = {
+  ok: true,
+  targetId: 'k17assetTarget',
+  factionId: 'k17faction',
+  assetType: 'faction_sheet',
+  generation: 4,
+  rendererVersion: 'faction-sheet-v3',
+  leaseExpiresAt: Date.parse('2026-07-18T12:00:00.000Z'),
+  payload: {
+    factionId: 'k17faction',
+    slug: 'test-faction',
+    faction,
+  },
+  payloadHash: 'a'.repeat(64),
+} as const;
+
+describe('protected publisher snapshot contract', () => {
+  test('accepts the complete production item-render envelope', () => {
+    expect(publisherSnapshotSchema.parse(productionEnvelope)).toMatchObject({
+      targetId: productionEnvelope.targetId,
+      factionId: productionEnvelope.factionId,
+      generation: productionEnvelope.generation,
+      payload: { faction },
+    });
+  });
+
+  test('retains strict unknown-key and cross-field identity validation', () => {
+    expect(() =>
+      publisherSnapshotSchema.parse({ ...productionEnvelope, unexpected: true })
+    ).toThrow();
+    expect(() =>
+      publisherSnapshotSchema.parse({
+        ...productionEnvelope,
+        payload: { ...productionEnvelope.payload, factionId: 'different-faction' },
+      })
+    ).toThrow(/Snapshot faction identity/);
+  });
+});

--- a/workers/publisher/tsconfig.json
+++ b/workers/publisher/tsconfig.json
@@ -15,5 +15,5 @@
     "noUncheckedSideEffectImports": true
   },
   "include": ["./*.ts", "./worker-configuration.d.ts"],
-  "exclude": ["./font-regression.ts"]
+  "exclude": ["./capture-contract-regression.ts", "./font-regression.ts"]
 }


### PR DESCRIPTION
## Summary

- define one strict snapshot schema shared by the Convex render producer and Browser capture consumer
- exercise the real protected endpoint envelope and built capture page in Chromium, including exact two-page PDF validation
- add capture-stage and nested-cause telemetry so Browser failures retain their actionable trace
- quiesce an active publisher before production deployment and restore it only after the matching Worker passes smoke; preserve intentional paused/disabled states and fail closed on partial releases

## Incident prevented

The previous release expanded the Convex render envelope while the capture client retained a strict older schema. Existing tests mocked the old response and never ran the built capture client against the production-shaped envelope, so every Browser render failed before PDF generation.

## Verification

- `bunx @biomejs/biome check .`
- `bun run check:convex-skip`
- `bun run typecheck`
- `bun run test` (327 tests)
- `bun run publisher:test` (176 tests)
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:capture-contract-regression`
- `bun run publisher:assets:check`
- `bun run publisher:release:dry-run`
- `bun run publisher:startup`
- `bun run generate`
- `bun run build-storybook`

The Chromium contract regression produced a valid two-page PDF (1,872,754 bytes).
