### PR TITLE
Verify production renderer manifest before merge

### DIFF
--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -87,7 +87,9 @@ jobs:
       - name: Build and dry-run unified Worker release
         run: bun run publisher:dry-run
         env:
-          VITE_CONVEX_URL: https://example.convex.cloud
+          VITE_CONVEX_URL: https://exuberant-finch-263.eu-west-1.convex.cloud
+      - name: Verify production renderer manifest is committed
+        run: git diff --exit-code -- workers/publisher/renderer-manifest.generated.ts
       - name: Install Chromium for publisher contract regression
         run: npx playwright install --with-deps chromium
       - name: Exercise production snapshot envelope in Chromium

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -61,6 +61,8 @@ VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publi
 ```
 
 CI uses `bun run publisher:release:dry-run` after the already-built assets have been verified.
+The pull-request publisher job builds the same production-URL release on Linux and rejects renderer
+manifest drift before merge, matching the production runner that enforces a clean source tree.
 
 ## Routing and ownership
 

--- a/workers/publisher/README.md
+++ b/workers/publisher/README.md
@@ -55,6 +55,11 @@ Convex item envelope in Chromium and requires the capture marker, payload hash, 
 contract to succeed. The protected Convex producer and capture client also parse the same shared
 strict schema, so adding or removing response fields cannot be accepted on only one side.
 
+The PR publisher-release job builds on Linux with the exact production Convex URL and rejects any
+change to `renderer-manifest.generated.ts`. Treat that CI-produced manifest as authoritative; a
+manifest generated on another operating system may differ because it covers assembled build
+artifacts as well as renderer source.
+
 The protected `main` workflow runs source/config preflight, generated-type check, typecheck, one
 production-URL asset build, assembled-asset verification, Wrangler dry-run, strict SHA-tagged
 deploy, and health smoke. It pauses an active Convex publisher before the producer deploy and

--- a/workers/publisher/deployment-config.test.ts
+++ b/workers/publisher/deployment-config.test.ts
@@ -107,6 +107,19 @@ describe('scheduled production deployment shape', () => {
     expect(packageConfig.scripts['publisher:dry-run']).toContain('bun run publisher:assets');
   });
 
+  test('checks the Linux production renderer manifest before merge', () => {
+    const verifyWorkflow = readFileSync(
+      path.resolve(process.cwd(), '.github/workflows/reusable-verify.yml'),
+      'utf8'
+    );
+    expect(verifyWorkflow).toContain(
+      'VITE_CONVEX_URL: https://exuberant-finch-263.eu-west-1.convex.cloud'
+    );
+    expect(verifyWorkflow).toContain(
+      'git diff --exit-code -- workers/publisher/renderer-manifest.generated.ts'
+    );
+  });
+
   test('ignores publisher secret files while retaining the tracked example', () => {
     const ignored = spawnSync('git', ['check-ignore', 'workers/publisher/.dev.vars.production'], {
       encoding: 'utf8',

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -5,8 +5,8 @@ export const rendererManifest = {
   rendererVersion: 'faction-sheet-v3',
   supportedRendererVersions: ['faction-sheet-v3'],
   rendererId:
-    'faction-sheet/sha256:1bdb614f2018224dfce73a9c8793c93d4d824cb996a2c3517840e6232e3870d8',
-  digest: '1bdb614f2018224dfce73a9c8793c93d4d824cb996a2c3517840e6232e3870d8',
+    'faction-sheet/sha256:7c84fbb69db232ccd5eb7bc280142c18cf7a04445b677aa48bbb118224b058df',
+  digest: '7c84fbb69db232ccd5eb7bc280142c18cf7a04445b677aa48bbb118224b058df',
   contract: {
     rendererVersion: 'faction-sheet-v3',
     supportedRendererVersions: ['faction-sheet-v3'],


### PR DESCRIPTION
## Summary

- commit the Linux production-build renderer digest emitted by deployment run 29645273951
- make PR CI build the publisher with the exact production Convex URL
- fail PR CI when that Linux build changes the committed renderer manifest
- document Linux CI as the authoritative manifest generator

## Why

PR #62 was green and merged, but its manifest had been generated on macOS. The production Linux build produced a different digest and the deploy's clean-source guard correctly stopped before Worker deployment, leaving publishing paused. This moves that exact validation into PR CI so the mismatch is caught before merge next time.

## Verification

- `bunx biome check .github/workflows/reusable-verify.yml workers/publisher/deployment-config.test.ts workers/publisher/renderer-manifest.generated.ts`
- `bun run publisher:test` (177 tests)
