### PR TITLE
Simplify publisher capture boundaries

### DIFF
--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -92,7 +92,7 @@ jobs:
         run: git diff --exit-code -- workers/publisher/renderer-manifest.generated.ts
       - name: Install Chromium for publisher contract regression
         run: npx playwright install --with-deps chromium
-      - name: Exercise production snapshot envelope in Chromium
+      - name: Exercise narrow snapshot contract in Chromium
         run: bun run workers/publisher/capture-contract-regression.ts
       - name: Check Worker startup
         run: bun run publisher:startup

--- a/convex/assetPublisher.test.ts
+++ b/convex/assetPublisher.test.ts
@@ -5,7 +5,7 @@ import { convexTest } from 'convex-test';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { proofFaction } from '../src/app/capture/proofFaction';
-import { publisherSnapshotSchema } from '../src/shared/asset-publishing/publisher-snapshot';
+import { parsePublisherCaptureSnapshot } from '../src/shared/asset-publishing/publisher-snapshot';
 import { internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import { ITEM_CLAIM_LEASE_MS, MAX_PUBLISHER_ITEMS } from './assetPublisher';
@@ -158,9 +158,7 @@ describe('exact item operations', () => {
     await expect(
       t.query(internal.assetPublisher.readItemForRender, { claimToken: item.claimToken })
     ).resolves.toMatchObject({
-      targetId: item.targetId,
-      generation: 1,
-      rendererVersion: 'faction-sheet-v1',
+      payload: { factionId: item.factionId },
       payloadHash: expect.stringMatching(/^[0-9a-f]{64}$/),
     });
     await expect(
@@ -297,16 +295,15 @@ describe('item HTTP contracts', () => {
       headers: { Authorization: `Bearer ${item.claimToken}` },
     });
     expect(renderResponse.status).toBe(200);
-    const renderSnapshot = publisherSnapshotSchema.parse(await renderResponse.json());
-    expect(renderSnapshot).toMatchObject({
+    const renderSnapshot = parsePublisherCaptureSnapshot(await renderResponse.json());
+    expect(renderSnapshot).toEqual({
       ok: true,
-      targetId: item.targetId,
-      factionId: item.factionId,
-      assetType: item.assetType,
-      generation: item.generation,
-      rendererVersion: item.rendererVersion,
-      leaseExpiresAt: item.leaseExpiresAt,
-      payload: { factionId: item.factionId },
+      payload: {
+        factionId: item.factionId,
+        slug: 'faction-0',
+        faction: { ...proofFaction, name: 'Faction 0' },
+      },
+      payloadHash: expect.stringMatching(/^[0-9a-f]{64}$/),
     });
     const itemBody = {
       schemaVersion: 1,

--- a/convex/assetPublisher.test.ts
+++ b/convex/assetPublisher.test.ts
@@ -5,7 +5,7 @@ import { convexTest } from 'convex-test';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { proofFaction } from '../src/app/capture/proofFaction';
-import { parsePublisherCaptureSnapshot } from '../src/shared/asset-publishing/publisher-snapshot';
+import { publisherCaptureSnapshotSchema } from '../src/shared/asset-publishing/publisher-snapshot';
 import { internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import { ITEM_CLAIM_LEASE_MS, MAX_PUBLISHER_ITEMS } from './assetPublisher';
@@ -295,7 +295,7 @@ describe('item HTTP contracts', () => {
       headers: { Authorization: `Bearer ${item.claimToken}` },
     });
     expect(renderResponse.status).toBe(200);
-    const renderSnapshot = parsePublisherCaptureSnapshot(await renderResponse.json());
+    const renderSnapshot = publisherCaptureSnapshotSchema.parse(await renderResponse.json());
     expect(renderSnapshot).toEqual({
       ok: true,
       payload: {

--- a/convex/assetPublisher.ts
+++ b/convex/assetPublisher.ts
@@ -272,12 +272,6 @@ export const readItemForRender = internalQuery({
     if (!faction || faction.is_deleted) return null;
     const payload = claimPayload(faction);
     return {
-      targetId: target._id,
-      factionId: target.faction_id,
-      assetType: target.asset_type,
-      generation: target.claimed_generation,
-      rendererVersion: target.claimed_renderer_version,
-      leaseExpiresAt: target.lease_expires_at,
       payload,
       payloadHash: SHA256(JSON.stringify(payload)).toString(),
     };

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,6 +1,6 @@
 import { httpRouter } from 'convex/server';
 
-import { publisherSnapshotSchema } from '../src/shared/asset-publishing/publisher-snapshot';
+import { makePublisherCaptureSnapshot } from '../src/shared/asset-publishing/publisher-snapshot';
 import { internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import { type ActionCtx, httpAction } from './_generated/server';
@@ -272,7 +272,7 @@ http.route({
     const claimToken = authorization.startsWith('Bearer ') ? authorization.slice(7) : '';
     const item = await ctx.runQuery(internal.assetPublisher.readItemForRender, { claimToken });
     return item
-      ? publisherJson(publisherSnapshotSchema.parse({ ok: true, ...item }))
+      ? publisherJson(makePublisherCaptureSnapshot(item))
       : publisherJson({ error: 'Not found' }, 404);
   }),
 });

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -1,6 +1,6 @@
 import { httpRouter } from 'convex/server';
 
-import { makePublisherCaptureSnapshot } from '../src/shared/asset-publishing/publisher-snapshot';
+import { publisherCaptureSnapshotSchema } from '../src/shared/asset-publishing/publisher-snapshot';
 import { internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import { type ActionCtx, httpAction } from './_generated/server';
@@ -272,7 +272,13 @@ http.route({
     const claimToken = authorization.startsWith('Bearer ') ? authorization.slice(7) : '';
     const item = await ctx.runQuery(internal.assetPublisher.readItemForRender, { claimToken });
     return item
-      ? publisherJson(makePublisherCaptureSnapshot(item))
+      ? publisherJson(
+          publisherCaptureSnapshotSchema.parse({
+            ok: true,
+            payload: item.payload,
+            payloadHash: item.payloadHash,
+          })
+        )
       : publisherJson({ error: 'Not found' }, 404);
   }),
 });

--- a/src/app/capture/PublisherFactionSheetCapture.tsx
+++ b/src/app/capture/PublisherFactionSheetCapture.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { FactionSheetView } from '@app/components/factions/sheet/FactionSheetView';
 import type { FactionInput } from '@game/schema/faction';
 
-import { publisherSnapshotSchema } from '../../shared/asset-publishing/publisher-snapshot';
+import { parsePublisherCaptureSnapshot } from '../../shared/asset-publishing/publisher-snapshot';
 import { publisherErrorMessage, redactPublisherResource } from './publisher-diagnostics';
 import { assertRequiredPublisherFonts } from './publisher-fonts';
 
@@ -154,7 +154,7 @@ export function PublisherFactionSheetCapture() {
           signal: controller.signal,
         });
         if (!response.ok) throw new Error(`Claimed snapshot returned HTTP ${response.status}`);
-        const snapshot = publisherSnapshotSchema.parse(await response.json());
+        const snapshot = parsePublisherCaptureSnapshot(await response.json());
         setFaction(snapshot.payload.faction);
         setPayloadHash(snapshot.payloadHash);
         setDetail(`Rendering exact claimed snapshot ${snapshot.payloadHash}`);

--- a/src/app/capture/PublisherFactionSheetCapture.tsx
+++ b/src/app/capture/PublisherFactionSheetCapture.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { FactionSheetView } from '@app/components/factions/sheet/FactionSheetView';
 import type { FactionInput } from '@game/schema/faction';
 
-import { parsePublisherCaptureSnapshot } from '../../shared/asset-publishing/publisher-snapshot';
+import { publisherCaptureSnapshotSchema } from '../../shared/asset-publishing/publisher-snapshot';
 import { publisherErrorMessage, redactPublisherResource } from './publisher-diagnostics';
 import { assertRequiredPublisherFonts } from './publisher-fonts';
 
@@ -154,7 +154,7 @@ export function PublisherFactionSheetCapture() {
           signal: controller.signal,
         });
         if (!response.ok) throw new Error(`Claimed snapshot returned HTTP ${response.status}`);
-        const snapshot = parsePublisherCaptureSnapshot(await response.json());
+        const snapshot = publisherCaptureSnapshotSchema.parse(await response.json());
         setFaction(snapshot.payload.faction);
         setPayloadHash(snapshot.payloadHash);
         setDetail(`Rendering exact claimed snapshot ${snapshot.payloadHash}`);

--- a/src/app/capture/proofFaction.ts
+++ b/src/app/capture/proofFaction.ts
@@ -1,5 +1,4 @@
-import type { Faction } from '@db/factions';
-import { FactionInputSchema } from '@game/schema/faction';
+import { type FactionInput, FactionInputSchema } from '../../game/schema/faction';
 
 const proofFactionInput = {
   name: 'Atreides',
@@ -71,7 +70,7 @@ const proofFactionInput = {
       text: 'Play your fate card before Ship and Move to obtain the Carryall Tech Token.',
     },
   },
-} satisfies Faction;
+} satisfies FactionInput;
 
 /** Stable, representative payload used only by the one-PDF Cloudflare proof. */
-export const proofFaction: Faction = FactionInputSchema.parse(proofFactionInput);
+export const proofFaction: FactionInput = FactionInputSchema.parse(proofFactionInput);

--- a/src/app/capture/publisher-diagnostics.ts
+++ b/src/app/capture/publisher-diagnostics.ts
@@ -41,10 +41,9 @@ export type PublisherErrorDetail = {
   stack?: string;
 };
 
-const MAX_ERROR_DETAILS = 6;
-const MAX_ERROR_DETAIL_DEPTH = 6;
-const MAX_ERROR_MESSAGE_LENGTH = 1_024;
-const MAX_ERROR_STACK_LENGTH = 1_500;
+const MAX_ERROR_DETAILS = 4;
+const MAX_ERROR_MESSAGE_LENGTH = 512;
+const MAX_ERROR_STACK_LENGTH = 900;
 
 /**
  * Flattens Error.cause and AggregateError.errors without allowing publisher secrets or an
@@ -54,12 +53,8 @@ export function publisherErrorDetails(error: unknown): PublisherErrorDetail[] {
   const details: PublisherErrorDetail[] = [];
   const visited = new Set<unknown>();
 
-  function visit(value: unknown, depth: number): void {
-    if (
-      details.length >= MAX_ERROR_DETAILS ||
-      depth >= MAX_ERROR_DETAIL_DEPTH ||
-      visited.has(value)
-    ) {
+  function visit(value: unknown): void {
+    if (details.length >= MAX_ERROR_DETAILS || visited.has(value)) {
       return;
     }
     visited.add(value);
@@ -75,13 +70,22 @@ export function publisherErrorDetails(error: unknown): PublisherErrorDetail[] {
     });
 
     if (value instanceof AggregateError) {
-      for (const nested of value.errors) visit(nested, depth + 1);
+      for (const nested of value.errors) visit(nested);
     }
-    if (value instanceof Error && value.cause !== undefined) visit(value.cause, depth + 1);
+    if (value instanceof Error && value.cause !== undefined) visit(value.cause);
   }
 
-  visit(error, 0);
+  visit(error);
   return details;
+}
+
+/** Preserves the existing dashboard fields while building the sanitized error graph once. */
+export function publisherFailureFields(error: unknown) {
+  const errors = publisherErrorDetails(error);
+  return {
+    error: errors[0]?.message ?? publisherErrorMessage(error),
+    errors,
+  };
 }
 
 export function serializePublisherLogEvent(event: Record<string, unknown>): string {

--- a/src/shared/asset-publishing/publisher-snapshot.ts
+++ b/src/shared/asset-publishing/publisher-snapshot.ts
@@ -1,27 +1,33 @@
 import { z } from 'zod';
 
-import { FactionInputSchema } from '../../game/schema/faction';
+import { FactionInputSchema, FactionRowSlugSchema } from '../../game/schema/faction';
 
 /** Shared exact contract for the protected Convex producer and Browser capture consumer. */
-export const publisherSnapshotSchema = z
-  .strictObject({
-    ok: z.literal(true),
-    targetId: z.string().min(1),
+const publisherCaptureSnapshotSchema = z.strictObject({
+  ok: z.literal(true),
+  payload: z.strictObject({
     factionId: z.string().min(1),
-    assetType: z.literal('faction_sheet'),
-    generation: z.number().int().positive(),
-    rendererVersion: z.string().trim().min(1).max(128),
-    leaseExpiresAt: z.number().int().positive(),
-    payload: z.strictObject({
-      factionId: z.string().min(1),
-      slug: z.string(),
-      faction: FactionInputSchema,
-    }),
-    payloadHash: z.string().regex(/^[0-9a-f]{64}$/),
-  })
-  .refine((snapshot) => snapshot.factionId === snapshot.payload.factionId, {
-    message: 'Snapshot faction identity does not match its payload',
-    path: ['payload', 'factionId'],
-  });
+    slug: FactionRowSlugSchema,
+    faction: FactionInputSchema,
+  }),
+  payloadHash: z.string().regex(/^[0-9a-f]{64}$/),
+});
 
-export type PublisherSnapshot = z.infer<typeof publisherSnapshotSchema>;
+type PublisherCaptureSnapshotSource = {
+  payload: unknown;
+  payloadHash: unknown;
+};
+
+/** Explicitly projects the narrow browser DTO so operational item fields cannot leak into it. */
+export function makePublisherCaptureSnapshot(source: PublisherCaptureSnapshotSource) {
+  return publisherCaptureSnapshotSchema.parse({
+    ok: true,
+    payload: source.payload,
+    payloadHash: source.payloadHash,
+  });
+}
+
+/** Strictly parses the untrusted snapshot response inside Browser capture. */
+export function parsePublisherCaptureSnapshot(value: unknown) {
+  return publisherCaptureSnapshotSchema.parse(value);
+}

--- a/src/shared/asset-publishing/publisher-snapshot.ts
+++ b/src/shared/asset-publishing/publisher-snapshot.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { FactionInputSchema, FactionRowSlugSchema } from '../../game/schema/faction';
 
 /** Shared exact contract for the protected Convex producer and Browser capture consumer. */
-const publisherCaptureSnapshotSchema = z.strictObject({
+export const publisherCaptureSnapshotSchema = z.strictObject({
   ok: z.literal(true),
   payload: z.strictObject({
     factionId: z.string().min(1),
@@ -25,9 +25,4 @@ export function makePublisherCaptureSnapshot(source: PublisherCaptureSnapshotSou
     payload: source.payload,
     payloadHash: source.payloadHash,
   });
-}
-
-/** Strictly parses the untrusted snapshot response inside Browser capture. */
-export function parsePublisherCaptureSnapshot(value: unknown) {
-  return publisherCaptureSnapshotSchema.parse(value);
 }

--- a/src/shared/asset-publishing/publisher-snapshot.ts
+++ b/src/shared/asset-publishing/publisher-snapshot.ts
@@ -12,17 +12,3 @@ export const publisherCaptureSnapshotSchema = z.strictObject({
   }),
   payloadHash: z.string().regex(/^[0-9a-f]{64}$/),
 });
-
-type PublisherCaptureSnapshotSource = {
-  payload: unknown;
-  payloadHash: unknown;
-};
-
-/** Explicitly projects the narrow browser DTO so operational item fields cannot leak into it. */
-export function makePublisherCaptureSnapshot(source: PublisherCaptureSnapshotSource) {
-  return publisherCaptureSnapshotSchema.parse({
-    ok: true,
-    payload: source.payload,
-    payloadHash: source.payloadHash,
-  });
-}

--- a/workers/publisher/MEASUREMENT.md
+++ b/workers/publisher/MEASUREMENT.md
@@ -40,7 +40,8 @@ Failed invocation:
 
 - `result: "failed"`
 - bounded `error`
-- bounded, sanitized `errors` entries that flatten `AggregateError.errors` and `Error.cause`
+- bounded, sanitized `errors` entries that flatten `AggregateError.errors` and `Error.cause` while
+  fitting the complete failure event within its 8 KiB telemetry budget
 
 Every cron event also carries a fresh `invocationId` and the Cloudflare `scheduledTime`.
 

--- a/workers/publisher/README.md
+++ b/workers/publisher/README.md
@@ -50,10 +50,11 @@ bun run publisher:dry-run
 bun run publisher:startup
 ```
 
-`publisher:capture-contract-regression` serves the built capture bundle a complete production-shaped
-Convex item envelope in Chromium and requires the capture marker, payload hash, and two-page PDF
-contract to succeed. The protected Convex producer and capture client also parse the same shared
-strict schema, so adding or removing response fields cannot be accepted on only one side.
+`publisher:capture-contract-regression` serves the built capture bundle the exact narrow Browser DTO
+in Chromium and requires the capture marker, payload hash, and two-page PDF contract to succeed.
+Convex explicitly projects only the claimed payload and hash, then producer and capture client both
+validate that shared strict contract. Operational item metadata cannot leak into or couple the
+Browser response to executor internals.
 
 The PR publisher-release job builds on Linux with the exact production Convex URL and rejects any
 change to `renderer-manifest.generated.ts`. Treat that CI-produced manifest as authoritative; a

--- a/workers/publisher/browser.test.ts
+++ b/workers/publisher/browser.test.ts
@@ -43,10 +43,31 @@ describe('production capture output validation', () => {
       request: () => ({ method: () => 'GET' }),
     } as never);
 
-    expect(diagnostics.pageErrors).toEqual(['post-ready exception']);
-    expect(diagnostics.requestFailures[0]).toMatch(/connection reset/);
-    expect(diagnostics.httpErrors[0]).toMatch(/HTTP 404/);
-    expect(() => assertCaptureDiagnostics(diagnostics)).toThrow(/page errors/);
+    expect(diagnostics.issues).toEqual([
+      'page: post-ready exception',
+      expect.stringMatching(/^request: .*connection reset/),
+      expect.stringMatching(/^http: .*HTTP 404/),
+    ]);
+    expect(() => assertCaptureDiagnostics(diagnostics)).toThrow(/Capture issues/);
+  });
+
+  test('bounds noisy capture diagnostics while retaining dropped issue volume', () => {
+    const listeners = new Map<string, (...args: never[]) => void>();
+    const page = {
+      on: vi.fn((name: string, listener: (...args: never[]) => void) => {
+        listeners.set(name, listener);
+      }),
+    } as unknown as Page;
+    const diagnostics = registerCaptureDiagnostics(page);
+
+    for (let index = 0; index < 20; index += 1) {
+      listeners.get('pageerror')?.(new Error(`issue ${index} ${'x'.repeat(1_000)}`) as never);
+    }
+
+    expect(diagnostics.issues).toHaveLength(12);
+    expect(diagnostics.issues.every((issue) => issue.length <= 512)).toBe(true);
+    expect(diagnostics.dropped).toBe(8);
+    expect(() => assertCaptureDiagnostics(diagnostics)).toThrow(/8 additional issues dropped/);
   });
 
   test('diagnostics never retain signed artwork URL credentials, paths, queries, or fragments', () => {

--- a/workers/publisher/browser.ts
+++ b/workers/publisher/browser.ts
@@ -21,21 +21,14 @@ const { pdf: PDF_CONTRACT, viewport: VIEWPORT_CONTRACT } = PUBLISHER_RENDERER_CO
 export type CapturedPdf = {
   bytes: Uint8Array;
   payloadHash: string;
-  pageCount: number;
-  pageWidthMm: number;
-  pageHeightMm: number;
-  consoleErrors: string[];
-  requestFailures: string[];
-  pageErrors: string[];
-  httpErrors: string[];
 };
 
 export class TargetRenderError extends Error {}
 
-export type CaptureDiagnostics = Pick<
-  CapturedPdf,
-  'consoleErrors' | 'requestFailures' | 'pageErrors' | 'httpErrors'
->;
+export type CaptureDiagnostics = { issues: string[]; dropped: number };
+
+const MAX_CAPTURE_ISSUES = 12;
+const MAX_CAPTURE_ISSUE_LENGTH = 512;
 
 export function assertCapturedPdfOutput(inspection: {
   pageCount: number;
@@ -57,18 +50,9 @@ export function assertCapturedPdfOutput(inspection: {
 }
 
 export function assertCaptureDiagnostics(diagnostics: CaptureDiagnostics): void {
-  if (diagnostics.consoleErrors.length) {
-    throw new Error(`Capture console errors: ${diagnostics.consoleErrors.join(' | ')}`);
-  }
-  if (diagnostics.pageErrors.length) {
-    throw new Error(`Capture page errors: ${diagnostics.pageErrors.join(' | ')}`);
-  }
-  if (diagnostics.requestFailures.length) {
-    throw new Error(`Capture request failures: ${diagnostics.requestFailures.join(' | ')}`);
-  }
-  if (diagnostics.httpErrors.length) {
-    throw new Error(`Capture HTTP errors: ${diagnostics.httpErrors.join(' | ')}`);
-  }
+  if (!diagnostics.issues.length) return;
+  const dropped = diagnostics.dropped ? ` | ${diagnostics.dropped} additional issues dropped` : '';
+  throw new Error(`Capture issues: ${diagnostics.issues.join(' | ')}${dropped}`);
 }
 
 function remaining(deadline: number): number {
@@ -94,21 +78,23 @@ function responseFailureLabel(response: PlaywrightResponse): string {
 }
 
 export function registerCaptureDiagnostics(page: Page): CaptureDiagnostics {
-  const diagnostics: CaptureDiagnostics = {
-    consoleErrors: [],
-    requestFailures: [],
-    pageErrors: [],
-    httpErrors: [],
+  const diagnostics: CaptureDiagnostics = { issues: [], dropped: 0 };
+  const add = (kind: string, value: string) => {
+    if (diagnostics.issues.length >= MAX_CAPTURE_ISSUES) {
+      diagnostics.dropped += 1;
+      return;
+    }
+    diagnostics.issues.push(
+      `${kind}: ${sanitizePublisherDiagnostic(value)}`.slice(0, MAX_CAPTURE_ISSUE_LENGTH)
+    );
   };
   page.on('console', (message: ConsoleMessage) => {
-    if (message.type() === 'error') {
-      diagnostics.consoleErrors.push(sanitizePublisherDiagnostic(message.text()));
-    }
+    if (message.type() === 'error') add('console', message.text());
   });
-  page.on('requestfailed', (request) => diagnostics.requestFailures.push(failureLabel(request)));
-  page.on('pageerror', (error) => diagnostics.pageErrors.push(publisherErrorMessage(error)));
+  page.on('requestfailed', (request) => add('request', failureLabel(request)));
+  page.on('pageerror', (error) => add('page', publisherErrorMessage(error)));
   page.on('response', (response) => {
-    if (response.status() >= 400) diagnostics.httpErrors.push(responseFailureLabel(response));
+    if (response.status() >= 400) add('http', responseFailureLabel(response));
   });
   return diagnostics;
 }
@@ -187,8 +173,6 @@ async function assertPageBounds(page: Page, deadline: number): Promise<void> {
 }
 
 export class PublisherBrowserSession {
-  private context?: BrowserContext;
-
   constructor(
     private readonly browser: Browser,
     private readonly captureBaseUrl: string
@@ -201,22 +185,20 @@ export class PublisherBrowserSession {
   async capture(claimToken: string, timeoutMs: number): Promise<CapturedPdf> {
     const deadline = performance.now() + timeoutMs;
     const lifecycleDeadlineAt = Date.now() + timeoutMs;
-    let stage = 'create_context';
+    let phase: 'setup' | 'load' | 'validate' | 'pdf' = 'setup';
     try {
-      this.context = await this.browser.newContext({
+      const context = await this.browser.newContext({
         deviceScaleFactor: VIEWPORT_CONTRACT.deviceScaleFactor,
         locale: 'en-US',
         timezoneId: 'UTC',
         viewport: { width: VIEWPORT_CONTRACT.width, height: VIEWPORT_CONTRACT.height },
       });
-      stage = 'install_claim_cookies';
-      await this.context.addCookies(
+      await context.addCookies(
         publisherCaptureCookies(this.captureBaseUrl, claimToken, lifecycleDeadlineAt)
       );
-      stage = 'create_page';
-      const page = await this.context.newPage();
+      const page = await context.newPage();
       const diagnostics = registerCaptureDiagnostics(page);
-      stage = 'navigate';
+      phase = 'load';
       const response = await page.goto(`${this.captureBaseUrl}/__asset-publisher/capture`, {
         waitUntil: 'domcontentloaded',
         timeout: remaining(deadline),
@@ -225,9 +207,7 @@ export class PublisherBrowserSession {
         throw new Error(`Capture navigation returned HTTP ${response?.status()}`);
       }
       const marker = page.locator('#capture-status');
-      stage = 'wait_for_status_marker';
       await marker.waitFor({ state: 'attached', timeout: remaining(deadline) });
-      stage = 'wait_for_ready_state';
       await page.waitForFunction(
         () => {
           const browserGlobal = globalThis as typeof globalThis & {
@@ -244,7 +224,6 @@ export class PublisherBrowserSession {
         undefined,
         { timeout: remaining(deadline) }
       );
-      stage = 'read_capture_state';
       const state = await marker.getAttribute('data-capture-state');
       if (state !== 'ready') {
         throw new Error(`Capture route reported ${state}: ${await marker.textContent()}`);
@@ -253,30 +232,22 @@ export class PublisherBrowserSession {
       if (!payloadHash || !/^[0-9a-f]{64}$/.test(payloadHash)) {
         throw new Error('Capture route did not expose the exact payload hash');
       }
-      stage = 'validate_page_bounds';
+      phase = 'validate';
       await assertPageBounds(page, deadline);
-      stage = 'validate_pre_pdf_diagnostics';
       assertCaptureDiagnostics(diagnostics);
-      stage = 'generate_pdf';
+      phase = 'pdf';
       const bytes = await page.pdf({
         displayHeaderFooter: PDF_CONTRACT.displayHeaderFooter,
         margin: PDF_CONTRACT.marginMm,
         preferCSSPageSize: PDF_CONTRACT.preferCssPageSize,
         printBackground: PDF_CONTRACT.printBackground,
       });
-      stage = 'inspect_pdf';
-      const inspection = await inspectPublisherPdf(bytes);
-      stage = 'validate_post_pdf_diagnostics';
+      await inspectPublisherPdf(bytes);
       assertCaptureDiagnostics(diagnostics);
-      return {
-        bytes,
-        payloadHash,
-        ...inspection,
-        ...diagnostics,
-      };
+      return { bytes, payloadHash };
     } catch (error) {
       if (error instanceof TargetRenderError) throw error;
-      throw new Error(`Browser capture failed during ${stage}`, { cause: error });
+      throw new Error(`Browser capture failed during ${phase}`, { cause: error });
     }
   }
 

--- a/workers/publisher/capture-contract-regression.ts
+++ b/workers/publisher/capture-contract-regression.ts
@@ -3,9 +3,8 @@ import path from 'node:path';
 import { chromium } from 'playwright';
 
 import { proofFaction } from '../../src/app/capture/proofFaction';
-import { publisherSnapshotSchema } from '../../src/shared/asset-publishing/publisher-snapshot';
 import { inspectChromiumPdf } from '../proof/pdf';
-import { PUBLISHER_RENDERER_CONTRACT, PUBLISHER_RENDERER_VERSION } from './renderer-contract';
+import { PUBLISHER_RENDERER_CONTRACT } from './renderer-contract';
 
 const repositoryRoot = path.resolve(import.meta.dirname, '../..');
 const publisherDist = path.join(repositoryRoot, 'workers/publisher/dist');
@@ -15,17 +14,11 @@ const payload = {
   faction: proofFaction,
 };
 const payloadHash = new Bun.CryptoHasher('sha256').update(JSON.stringify(payload)).digest('hex');
-const snapshot = publisherSnapshotSchema.parse({
+const snapshot = {
   ok: true,
-  targetId: 'mh7publisherContractTarget',
-  factionId: payload.factionId,
-  assetType: 'faction_sheet',
-  generation: 1,
-  rendererVersion: PUBLISHER_RENDERER_VERSION,
-  leaseExpiresAt: Date.now() + 60_000,
   payload,
   payloadHash,
-});
+};
 
 function invariant(condition: unknown, message: string): asserts condition {
   if (!condition) throw new Error(message);
@@ -103,7 +96,7 @@ try {
     `Production-shaped capture produced ${inspection.pageWidthMm.toFixed(2)} mm x ${inspection.pageHeightMm.toFixed(2)} mm pages`
   );
   console.log(
-    `Publisher production-envelope Chromium regression passed: ${inspection.pageCount} pages, ${pdf.byteLength} bytes`
+    `Publisher narrow-contract Chromium regression passed: ${inspection.pageCount} pages, ${pdf.byteLength} bytes`
   );
 } finally {
   await browser.close();

--- a/workers/publisher/diagnostics.test.ts
+++ b/workers/publisher/diagnostics.test.ts
@@ -50,14 +50,14 @@ describe('publisher diagnostic redaction', () => {
 
   test('flattens sanitized AggregateError members and Error causes for telemetry', () => {
     const root = new Error(`Failed to decode ${signedUrl}`);
-    const staged = new Error('Browser capture failed during validate_page_bounds', { cause: root });
+    const staged = new Error('Browser capture failed during validate', { cause: root });
     const aggregate = new AggregateError([staged], 'Item-list publisher execution failed');
 
     const details = publisherErrorDetails(aggregate);
 
     expect(details.map((detail) => detail.message)).toEqual([
       'Item-list publisher execution failed',
-      'Browser capture failed during validate_page_bounds',
+      'Browser capture failed during validate',
       'Failed to decode https://cdn.example.com/<redacted>',
     ]);
     for (const secret of secrets) expect(JSON.stringify(details)).not.toContain(secret);

--- a/workers/publisher/executor.test.ts
+++ b/workers/publisher/executor.test.ts
@@ -36,13 +36,6 @@ function capturedPdf(): CapturedPdf {
   return {
     bytes: new Uint8Array([1, 2, 3]),
     payloadHash: 'a'.repeat(64),
-    pageCount: 2,
-    pageWidthMm: 215.9,
-    pageHeightMm: 279.4,
-    consoleErrors: [],
-    requestFailures: [],
-    pageErrors: [],
-    httpErrors: [],
   };
 }
 

--- a/workers/publisher/index.test.ts
+++ b/workers/publisher/index.test.ts
@@ -159,13 +159,6 @@ describe('publisher Worker scheduled item-list flow', () => {
       capture: async () => ({
         bytes: new Uint8Array([1, 2, 3]),
         payloadHash: 'a'.repeat(64),
-        pageCount: 2,
-        pageWidthMm: 215.9,
-        pageHeightMm: 279.4,
-        consoleErrors: [],
-        requestFailures: [],
-        pageErrors: [],
-        httpErrors: [],
       }),
       close: async () => undefined,
       sessionId: () => 'browser-session-one',

--- a/workers/publisher/index.ts
+++ b/workers/publisher/index.ts
@@ -1,8 +1,4 @@
-import {
-  publisherErrorDetails,
-  publisherErrorMessage,
-  serializePublisherLogEvent,
-} from '../../src/app/capture/publisher-diagnostics';
+import { publisherFailureFields } from '../../src/app/capture/publisher-diagnostics';
 import { openPublisherBrowser } from './browser';
 import { handleCaptureRoute } from './capture-route';
 import { MAX_ASSIGNED_ITEMS, parsePublisherConfig } from './config';
@@ -13,11 +9,11 @@ import { rendererManifest } from './renderer-manifest.generated';
 import { boundedPublisherTelemetryEvent, publisherBuildIdentity } from './telemetry';
 
 function log(event: Record<string, unknown>): void {
-  console.log(serializePublisherLogEvent(boundedPublisherTelemetryEvent(event)));
+  console.log(JSON.stringify(boundedPublisherTelemetryEvent(event)));
 }
 
 function logError(event: Record<string, unknown>): void {
-  console.error(serializePublisherLogEvent(boundedPublisherTelemetryEvent(event)));
+  console.error(JSON.stringify(boundedPublisherTelemetryEvent(event)));
 }
 
 function client(env: Env, executorBaseUrl: string) {
@@ -117,8 +113,7 @@ export const publisherWorker = {
         invocationId,
         scheduledTime: controller.scheduledTime,
         result: 'failed',
-        error: publisherErrorMessage(error),
-        errors: publisherErrorDetails(error),
+        ...publisherFailureFields(error),
       });
       throw error;
     }

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -5,8 +5,8 @@ export const rendererManifest = {
   rendererVersion: 'faction-sheet-v3',
   supportedRendererVersions: ['faction-sheet-v3'],
   rendererId:
-    'faction-sheet/sha256:22bfe1c3525c1d3f7e9b3e4d8201f1cd95c4ab97beb594a9bd872febaf4b3176',
-  digest: '22bfe1c3525c1d3f7e9b3e4d8201f1cd95c4ab97beb594a9bd872febaf4b3176',
+    'faction-sheet/sha256:d5ae930ca309189f5cedf99f99a2022876edbb482bbc1c1795beb3f41d400155',
+  digest: 'd5ae930ca309189f5cedf99f99a2022876edbb482bbc1c1795beb3f41d400155',
   contract: {
     rendererVersion: 'faction-sheet-v3',
     supportedRendererVersions: ['faction-sheet-v3'],

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -5,8 +5,8 @@ export const rendererManifest = {
   rendererVersion: 'faction-sheet-v3',
   supportedRendererVersions: ['faction-sheet-v3'],
   rendererId:
-    'faction-sheet/sha256:7c84fbb69db232ccd5eb7bc280142c18cf7a04445b677aa48bbb118224b058df',
-  digest: '7c84fbb69db232ccd5eb7bc280142c18cf7a04445b677aa48bbb118224b058df',
+    'faction-sheet/sha256:22bfe1c3525c1d3f7e9b3e4d8201f1cd95c4ab97beb594a9bd872febaf4b3176',
+  digest: '22bfe1c3525c1d3f7e9b3e4d8201f1cd95c4ab97beb594a9bd872febaf4b3176',
   contract: {
     rendererVersion: 'faction-sheet-v3',
     supportedRendererVersions: ['faction-sheet-v3'],

--- a/workers/publisher/snapshot-contract.test.ts
+++ b/workers/publisher/snapshot-contract.test.ts
@@ -1,67 +1,28 @@
 import { describe, expect, test } from 'vitest';
 
-import { publisherSnapshotSchema } from '../../src/shared/asset-publishing/publisher-snapshot';
-
-const faction = {
-  name: 'Test faction',
-  logo: '/vector/logo/atreides.svg',
-  colors: ['Green'],
-  background: {
-    image: '/image/texture/021.jpg',
-    colors: ['#4b4c0d', '#d9c979'],
-    opacity: 1,
-    strength: 0.55,
-  },
-  themeColor: '#4b4c0d',
-  hero: { name: 'Lady Jessica', image: '/image/leader/official/jessica.png' },
-  leaders: [],
-  decals: [],
-  troops: [],
-  rules: {
-    startText: 'Start text',
-    revivalText: 'Revival text',
-    spiceCount: 1,
-    advantages: [],
-    alliance: { text: 'Alliance text' },
-    fate: { title: 'Fate', text: 'Fate text' },
-  },
-};
+import { proofFaction } from '../../src/app/capture/proofFaction';
+import { parsePublisherCaptureSnapshot } from '../../src/shared/asset-publishing/publisher-snapshot';
 
 const productionEnvelope = {
   ok: true,
-  targetId: 'k17assetTarget',
-  factionId: 'k17faction',
-  assetType: 'faction_sheet',
-  generation: 4,
-  rendererVersion: 'faction-sheet-v3',
-  leaseExpiresAt: Date.parse('2026-07-18T12:00:00.000Z'),
   payload: {
     factionId: 'k17faction',
     slug: 'test-faction',
-    faction,
+    faction: proofFaction,
   },
   payloadHash: 'a'.repeat(64),
 } as const;
 
 describe('protected publisher snapshot contract', () => {
-  test('accepts the complete production item-render envelope', () => {
-    expect(publisherSnapshotSchema.parse(productionEnvelope)).toMatchObject({
-      targetId: productionEnvelope.targetId,
-      factionId: productionEnvelope.factionId,
-      generation: productionEnvelope.generation,
-      payload: { faction },
-    });
-  });
-
-  test('retains strict unknown-key and cross-field identity validation', () => {
+  test('retains strict unknown-key and slug validation', () => {
     expect(() =>
-      publisherSnapshotSchema.parse({ ...productionEnvelope, unexpected: true })
+      parsePublisherCaptureSnapshot({ ...productionEnvelope, unexpected: true })
     ).toThrow();
     expect(() =>
-      publisherSnapshotSchema.parse({
+      parsePublisherCaptureSnapshot({
         ...productionEnvelope,
-        payload: { ...productionEnvelope.payload, factionId: 'different-faction' },
+        payload: { ...productionEnvelope.payload, slug: 'Not A URL Slug' },
       })
-    ).toThrow(/Snapshot faction identity/);
+    ).toThrow();
   });
 });

--- a/workers/publisher/snapshot-contract.test.ts
+++ b/workers/publisher/snapshot-contract.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { proofFaction } from '../../src/app/capture/proofFaction';
-import { parsePublisherCaptureSnapshot } from '../../src/shared/asset-publishing/publisher-snapshot';
+import { publisherCaptureSnapshotSchema } from '../../src/shared/asset-publishing/publisher-snapshot';
 
 const productionEnvelope = {
   ok: true,
@@ -16,10 +16,10 @@ const productionEnvelope = {
 describe('protected publisher snapshot contract', () => {
   test('retains strict unknown-key and slug validation', () => {
     expect(() =>
-      parsePublisherCaptureSnapshot({ ...productionEnvelope, unexpected: true })
+      publisherCaptureSnapshotSchema.parse({ ...productionEnvelope, unexpected: true })
     ).toThrow();
     expect(() =>
-      parsePublisherCaptureSnapshot({
+      publisherCaptureSnapshotSchema.parse({
         ...productionEnvelope,
         payload: { ...productionEnvelope.payload, slug: 'Not A URL Slug' },
       })

--- a/workers/publisher/telemetry.test.ts
+++ b/workers/publisher/telemetry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
+import { publisherFailureFields } from '../../src/app/capture/publisher-diagnostics';
 import { boundedPublisherTelemetryEvent, MAX_TELEMETRY_EVENT_BYTES } from './telemetry';
 
 describe('bounded publisher telemetry', () => {
@@ -34,5 +35,28 @@ describe('bounded publisher telemetry', () => {
       result: 'telemetry_truncated',
     });
     expect(serialized).not.toContain(secret);
+  });
+
+  test('retains a maximum-sized actionable error graph within the event budget', () => {
+    let error: Error = new Error(`leaf ${'x'.repeat(1_000)}`);
+    for (let index = 0; index < 3; index += 1) {
+      error = new Error(`cause ${index} ${'x'.repeat(1_000)}`, { cause: error });
+    }
+    for (let current: unknown = error; current instanceof Error; current = current.cause) {
+      current.stack = `Error: ${current.message}\n${'s'.repeat(2_000)}`;
+    }
+
+    const bounded = boundedPublisherTelemetryEvent({
+      event: 'asset_publisher_cron',
+      result: 'failed',
+      ...publisherFailureFields(error),
+    });
+    const serialized = JSON.stringify(bounded);
+
+    expect(new TextEncoder().encode(serialized).byteLength).toBeLessThanOrEqual(
+      MAX_TELEMETRY_EVENT_BYTES
+    );
+    expect(bounded.result).toBe('failed');
+    expect(serialized).toContain('leaf ');
   });
 });


### PR DESCRIPTION
## What changed

- replace the operational render envelope with a strict, narrow Browser DTO containing only the faction payload and its hash
- explicitly project the DTO in Convex and strictly parse it again in the capture client
- consolidate capture failures into four useful phases and one bounded, redacted diagnostics list
- construct sanitized failure telemetry once while preserving the existing Cloudflare dashboard fields
- remove validated PDF metadata and empty diagnostics from the successful capture result

## Why

The incident hardening correctly added claim fencing, strict validation, renderer identity checks, output validation, redaction, and deployment guards. Some of the supporting code duplicated operational fields across the Convex-to-Browser boundary and maintained more diagnostic shapes than callers needed. This refactor makes those boundaries smaller and easier to audit without removing any of the security properties introduced by the incident response.

## Security and operational impact

- claim tokens, generation/renderer/lease fencing, executor revalidation, and R2 publication checks are unchanged
- the Browser receives less information, and unknown response fields remain rejected
- diagnostics remain redacted and are now bounded by count, per-item length, error-graph size, and total telemetry bytes
- the real Chromium two-page PDF check and Linux renderer-manifest drift guard remain mandatory in CI

## Validation

- `bunx @biomejs/biome check .`
- `bun run publisher:typecheck`
- `bun run publisher:test` (178 tests)
- `bun run test` (329 tests)
- `bun run typecheck`
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:capture-contract-regression`
- `bun run publisher:assets:check`
- `bun run publisher:release:dry-run`
- `bun run publisher:startup`
- `bun run check:convex-skip`

