### PR TITLE
Remove obsolete publisher compatibility layers

### DIFF
--- a/convex/assetRollouts.ts
+++ b/convex/assetRollouts.ts
@@ -13,9 +13,9 @@ import {
 } from './lib/assetPublisherConstants';
 import type { MutationCtx, QueryCtx } from './types';
 
-export const ROLLOUT_DISCOVERY_PAGE_SIZE = 50;
-export const ROLLOUT_CLEANUP_PAGE_SIZE = 50;
-export const MAX_ROLLOUT_ATTEMPTS = 3;
+const ROLLOUT_DISCOVERY_PAGE_SIZE = 50;
+const ROLLOUT_CLEANUP_PAGE_SIZE = 50;
+const MAX_ROLLOUT_ATTEMPTS = 3;
 
 const rendererValidator = v.union(
   v.literal(INITIAL_FACTION_SHEET_RENDERER_VERSION),
@@ -700,31 +700,6 @@ export async function failRolloutItem(
     last_error: error,
     updated_at: now,
   });
-  await ctx.db.patch(rollout._id, counterPatch(rollout, 'leased', 'pending'));
-  return 'retry';
-}
-
-export async function releaseRolloutItem(
-  ctx: MutationCtx,
-  target: Doc<'asset_targets'>,
-  now: number
-): Promise<'not_rollout' | 'retry' | 'detached'> {
-  if (!target.rollout_id || !target.rollout_item_id) return 'not_rollout';
-  const [rollout, item] = await Promise.all([
-    ctx.db.get('asset_rollouts', target.rollout_id),
-    ctx.db.get('asset_rollout_items', target.rollout_item_id),
-  ]);
-  if (!rollout || !item || item.state !== 'leased') {
-    throw new Error('Rollout release ownership is inconsistent');
-  }
-  if (rollout.status === 'cancelling') {
-    await ctx.db.patch(target._id, restoreTargetAfterRollout(target, item, now));
-    await ctx.db.patch(item._id, { state: 'cancelled', updated_at: now });
-    await ctx.db.patch(rollout._id, counterPatch(rollout, 'leased', 'cancelled'));
-    await maybeFinalizeRollout(ctx, rollout._id);
-    return 'detached';
-  }
-  await ctx.db.patch(item._id, { state: 'pending', next_eligible_at: now, updated_at: now });
   await ctx.db.patch(rollout._id, counterPatch(rollout, 'leased', 'pending'));
   return 'retry';
 }

--- a/workers/publisher/config.test.ts
+++ b/workers/publisher/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import { createCacheSigningSecret } from '../../convex/lib/assetPublisherHttp';
-import { MAX_ASSIGNED_ITEMS, parsePublisherConfig } from './config';
+import { parsePublisherConfig } from './config';
 import { rendererManifest } from './renderer-manifest.generated';
 
 function env(overrides: Record<string, string> = {}): Env {
@@ -27,13 +27,15 @@ describe('publisher lifecycle configuration', () => {
       workWindowMs: 240_000,
       browserCaptureTimeoutMs: 45_000,
       browserCleanupGraceMs: 15_000,
-      maxItems: MAX_ASSIGNED_ITEMS,
     });
     expect(
       config.browserCaptureTimeoutMs + config.browserCleanupGraceMs + 5_000
     ).toBeLessThanOrEqual(config.workWindowMs);
-    expect(config.supportedRendererVersion).toBe('faction-sheet-v3');
     expect(config.supportedRendererVersions).toEqual(['faction-sheet-v3']);
+  });
+
+  test('still validates the capture route upstream without projecting it into executor config', () => {
+    expect(() => parsePublisherConfig(env({ CONVEX_RENDER_URL: 'not-a-url' }))).toThrow();
   });
 
   test('rejects phase settings that exceed the four-minute work window', () => {

--- a/workers/publisher/config.ts
+++ b/workers/publisher/config.ts
@@ -5,10 +5,7 @@ import { rendererManifest } from './renderer-manifest.generated';
 export type PublisherConfig = {
   captureBaseUrl: string;
   convexExecutorBaseUrl: string;
-  convexRenderUrl: string;
-  supportedRendererVersion: string;
-  supportedRendererVersions: readonly ['faction-sheet-v3'];
-  maxItems: number;
+  supportedRendererVersions: typeof rendererManifest.supportedRendererVersions;
   workWindowMs: number;
   browserCaptureTimeoutMs: number;
   browserCleanupGraceMs: number;
@@ -25,10 +22,6 @@ function integer(name: string, value: string, minimum: number, maximum: number):
     throw new Error(`${name} must be between ${minimum} and ${maximum}`);
   }
   return parsed;
-}
-
-export function configuredMaxItems(): number {
-  return MAX_PUBLISHER_ITEMS;
 }
 
 export function supportsRendererVersion(
@@ -79,16 +72,14 @@ export function parsePublisherConfig(env: Env): PublisherConfig {
       'Browser capture, cleanup, and completion margins must fit the absolute executor lifecycle deadline'
     );
   }
+  absoluteHttpsUrl('CONVEX_RENDER_URL', env.CONVEX_RENDER_URL);
   return {
     captureBaseUrl: absoluteHttpsUrl('CAPTURE_BASE_URL', env.CAPTURE_BASE_URL),
     convexExecutorBaseUrl: absoluteHttpsUrl(
       'CONVEX_EXECUTOR_BASE_URL',
       env.CONVEX_EXECUTOR_BASE_URL
     ),
-    convexRenderUrl: absoluteHttpsUrl('CONVEX_RENDER_URL', env.CONVEX_RENDER_URL),
-    supportedRendererVersion: rendererManifest.rendererVersion,
     supportedRendererVersions: rendererManifest.supportedRendererVersions,
-    maxItems: configuredMaxItems(),
     workWindowMs,
     browserCaptureTimeoutMs,
     browserCleanupGraceMs,

--- a/workers/publisher/convex.ts
+++ b/workers/publisher/convex.ts
@@ -1,6 +1,6 @@
 import { publisherErrorMessage } from '../../src/app/capture/publisher-diagnostics';
 import { MAX_ASSIGNED_ITEMS } from './config';
-import { PublisherHttpError, postJson } from './http';
+import { postJson } from './http';
 
 export type ExactItemClaim = {
   targetId: string;
@@ -15,7 +15,6 @@ export type AssignedItem = ExactItemClaim & {
   leaseExpiresAt: number;
   workLane?: 'foreground' | 'rollout';
 };
-export type ClaimedTarget = AssignedItem;
 
 export type TakeWorkResult =
   | {
@@ -149,7 +148,7 @@ export function parseTakeWork(value: unknown): TakeWorkResult {
   };
 }
 
-export function parseRevalidateItem(value: unknown):
+function parseRevalidateItem(value: unknown):
   | { status: 'stale' }
   | {
       status: 'valid';
@@ -212,7 +211,7 @@ function parseFailItem(value: unknown): FailItemResult {
   throw new Error('Convex fail-item response is invalid');
 }
 
-export type PublicationMetadata = {
+type PublicationMetadata = {
   r2Etag: string;
   bytes: number;
   cacheToken: string;
@@ -236,7 +235,7 @@ export class ConvexPublisherClient {
     return parseTakeWork(await this.postExecutor('take-work', { schemaVersion: 1 }, deadlineAt));
   }
 
-  async revalidateItem(
+  async revalidate(
     claim: ExactItemClaim,
     deadlineAt?: number
   ): Promise<ReturnType<typeof parseRevalidateItem>> {
@@ -245,60 +244,22 @@ export class ConvexPublisherClient {
     );
   }
 
-  async revalidate(
-    claim: ExactItemClaim,
-    deadlineAt?: number
-  ): Promise<ReturnType<typeof parseRevalidateItem>> {
-    return await this.revalidateItem(claim, deadlineAt);
-  }
-
-  async completeItem(
-    claim: ExactItemClaim,
-    r2Etag: string,
-    bytes: number,
-    cacheToken: string,
-    deadlineAt?: number
-  ): Promise<CompleteItemResult> {
-    return parseCompleteItem(
-      await this.postExecutor(
-        'complete-item',
-        { schemaVersion: 1, ...claim, r2Etag, bytes, cacheToken },
-        deadlineAt
-      )
-    );
-  }
-
   async complete(
     claim: ExactItemClaim,
     publication: PublicationMetadata,
     deadlineAt?: number
   ): Promise<'completed' | 'stale'> {
-    const result = await this.completeItem(
-      claim,
-      publication.r2Etag,
-      publication.bytes,
-      publication.cacheToken,
-      deadlineAt
+    const result: CompleteItemResult = parseCompleteItem(
+      await this.postExecutor(
+        'complete-item',
+        { schemaVersion: 1, ...claim, ...publication },
+        deadlineAt
+      )
     );
     if (result.status === 'completed' && result.cacheToken !== publication.cacheToken) {
       throw new Error('Convex completed item with a different cache token');
     }
     return result.status;
-  }
-
-  async failItem(
-    claim: ExactItemClaim,
-    attribution: 'target' | 'infrastructure',
-    error: unknown,
-    deadlineAt?: number
-  ): Promise<FailItemResult> {
-    return parseFailItem(
-      await this.postExecutor(
-        'fail-item',
-        { schemaVersion: 1, ...claim, attribution, error: truncatedError(error) },
-        deadlineAt
-      )
-    );
   }
 
   async fail(
@@ -307,12 +268,14 @@ export class ConvexPublisherClient {
     error: unknown,
     deadlineAt?: number
   ): Promise<FailItemResult['status']> {
-    const result = await this.failItem(claim, attribution, error, deadlineAt);
+    const result = parseFailItem(
+      await this.postExecutor(
+        'fail-item',
+        { schemaVersion: 1, ...claim, attribution, error: truncatedError(error) },
+        deadlineAt
+      )
+    );
     return result.status;
-  }
-
-  isRetryable(error: unknown): boolean {
-    return error instanceof PublisherHttpError && error.transient;
   }
 
   private async postExecutor(

--- a/workers/publisher/executor.test.ts
+++ b/workers/publisher/executor.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, test, vi } from 'vitest';
 
 import { createCacheSigningSecret } from '../../convex/lib/assetPublisherHttp';
 import { type CapturedPdf, TargetRenderError } from './browser';
-import type { ClaimedTarget } from './convex';
+import type { AssignedItem } from './convex';
 import { executeItemList } from './executor';
 import type { AssetBucket } from './r2';
 
 const NOW = Date.parse('2026-07-17T12:00:00.000Z');
 const cacheSecret = createCacheSigningSecret();
 
-const item: ClaimedTarget = {
+const item: AssignedItem = {
   targetId: 'target-one',
   factionId: 'j57d9kz4ktbkpa12nb7j7s7w8h7ygb8p',
   assetType: 'faction_sheet',
@@ -22,10 +22,7 @@ const item: ClaimedTarget = {
 const config = {
   captureBaseUrl: 'https://publisher.example.com',
   convexExecutorBaseUrl: 'https://convex.example.com/asset-publishing/executor',
-  convexRenderUrl: 'https://convex.example.com/asset-publishing/render',
-  supportedRendererVersion: 'faction-sheet-v3',
   supportedRendererVersions: ['faction-sheet-v3'] as const,
-  maxItems: 20,
   workWindowMs: 240_000,
   browserCaptureTimeoutMs: 45_000,
   browserCleanupGraceMs: 15_000,

--- a/workers/publisher/executor.ts
+++ b/workers/publisher/executor.ts
@@ -2,7 +2,7 @@ import { createCacheToken } from '../../convex/lib/assetPublisherHttp';
 import { publisherErrorMessage } from '../../src/app/capture/publisher-diagnostics';
 import { type CapturedPdf, type PublisherBrowserSession, TargetRenderError } from './browser';
 import { MAX_ASSIGNED_ITEMS, type PublisherConfig, supportsRendererVersion } from './config';
-import type { ClaimedTarget, ConvexPublisherClient, ExactItemClaim } from './convex';
+import type { AssignedItem, ConvexPublisherClient, ExactItemClaim } from './convex';
 import { type AssetBucket, conditionallyPutFactionSheet } from './r2';
 
 type BrowserSession = Pick<PublisherBrowserSession, 'capture' | 'close' | 'sessionId'>;
@@ -39,7 +39,7 @@ type PendingCompletion = {
   initial: Promise<CompletionObservation>;
 };
 
-function exact(item: ClaimedTarget): ExactItemClaim {
+function exact(item: AssignedItem): ExactItemClaim {
   return {
     targetId: item.targetId,
     claimToken: item.claimToken,
@@ -86,7 +86,7 @@ function assertCapturedSize(captured: CapturedPdf, maximum: number): void {
 /** Processes one fixed Convex assignment in exactly one Browser session. */
 export async function executeItemList(
   config: PublisherConfig,
-  items: ClaimedTarget[],
+  items: AssignedItem[],
   dependencies: ItemListDependencies
 ): Promise<ItemListExecution> {
   if (items.length < 1 || items.length > MAX_ASSIGNED_ITEMS) {

--- a/workers/publisher/r2.test.ts
+++ b/workers/publisher/r2.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import type { ClaimedTarget } from './convex';
+import type { AssignedItem } from './convex';
 import {
   type AssetBucket,
   ConditionalWriteConflictError,
@@ -10,7 +10,7 @@ import {
 import { fakeR2Object } from './test-helpers';
 
 const NOW = Date.parse('2026-07-17T12:00:00.000Z');
-const claim: ClaimedTarget = {
+const claim: AssignedItem = {
   targetId: 'target-one',
   factionId: 'faction',
   assetType: 'faction_sheet',

--- a/workers/publisher/r2.ts
+++ b/workers/publisher/r2.ts
@@ -1,4 +1,4 @@
-import type { ClaimedTarget } from './convex';
+import type { AssignedItem } from './convex';
 
 export const PUBLISHER_CACHE_TOKEN_METADATA_KEY = 'publisherCacheToken';
 
@@ -36,7 +36,7 @@ function storedGeneration(object: R2Object): number | undefined {
 
 export async function conditionallyPutFactionSheet(
   bucket: AssetBucket,
-  claim: ClaimedTarget,
+  claim: AssignedItem,
   payloadHash: string,
   cacheToken: string,
   bytes: Uint8Array


### PR DESCRIPTION
## Summary

- collapse duplicate Worker-to-Convex client method layers while preserving request and response behavior
- remove unused publisher configuration projections and retain the existing render-URL validation
- remove the orphaned rollout release helper left behind by the item-only publisher refactor
- reduce type and export aliases that no longer have callers

## Why

The item-only publisher refactor removed the runtime paths that used these compatibility surfaces, but left the wrappers, projections, and one rollout helper behind. Removing them reduces legacy setup without changing the active publication flow.

## Behavior

Transport payloads, parser refinements, cache-token acknowledgement checks, renderer support checks, URL validation, executor behavior, and registered Convex functions are unchanged.

## Validation

- focused publisher/Convex regression suite: 7 files, 40 tests
- full repository suite: 36 files, 330 tests
- publisher TypeScript check
- repository TypeScript check
- Biome check on all changed files
- `git diff --check`

## Release gate

This phase is not complete at merge alone. After approval and merge, the ordered `main` production workflow must deploy Convex and the Cloudflare Worker successfully, pass the exact release smoke, and then receive post-deploy verification before phase 2 begins.
