### PR TITLE
Complete publisher item-claim schema narrow

### DIFF
--- a/convex/assetPublisher.test.ts
+++ b/convex/assetPublisher.test.ts
@@ -87,7 +87,7 @@ function exact(item: ClaimedItem) {
 }
 
 describe('item claim assignment', () => {
-  test('is disabled without an active config and assigns at most twenty without snapshots', async () => {
+  test('is disabled without an active config and assigns at most twenty items', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
     const disabled = await seed({ active: false, targets: 1 });
@@ -99,17 +99,16 @@ describe('item claim assignment', () => {
     const items = await takeAssigned(t);
     expect(items).toHaveLength(MAX_PUBLISHER_ITEMS);
     expect(new Set(items.map((item) => item.claimToken)).size).toBe(MAX_PUBLISHER_ITEMS);
-    const state = await t.run(async (ctx) => ({
-      leased: await ctx.db
-        .query('asset_targets')
-        .withIndex('by_asset_type_and_status_and_lease_expires_at', (q) =>
-          q.eq('asset_type', 'faction_sheet').eq('status', 'leased')
-        )
-        .take(25),
-      snapshots: await ctx.db.query('asset_claim_snapshots').take(1),
-    }));
-    expect(state.leased).toHaveLength(MAX_PUBLISHER_ITEMS);
-    expect(state.snapshots).toEqual([]);
+    const leased = await t.run(
+      async (ctx) =>
+        await ctx.db
+          .query('asset_targets')
+          .withIndex('by_asset_type_and_status_and_lease_expires_at', (q) =>
+            q.eq('asset_type', 'faction_sheet').eq('status', 'leased')
+          )
+          .take(25)
+    );
+    expect(leased).toHaveLength(MAX_PUBLISHER_ITEMS);
   });
 
   test('returns no work while any live item claim remains', async () => {

--- a/convex/assetPublisher.ts
+++ b/convex/assetPublisher.ts
@@ -59,12 +59,10 @@ function claimPayload(faction: Doc<'factions'>) {
 
 function clearItemClaim() {
   return {
-    batch_token: undefined,
     claim_token: undefined,
     claimed_generation: undefined,
     claimed_renderer_version: undefined,
     lease_expires_at: undefined,
-    claim_payload_hash: undefined,
   };
 }
 
@@ -103,30 +101,23 @@ function parseExactItem(args: {
 }
 
 function earlierTarget(left: Doc<'asset_targets'>, right: Doc<'asset_targets'>) {
-  const leftEligible = left.next_eligible_at ?? 0;
-  const rightEligible = right.next_eligible_at ?? 0;
-  if (leftEligible !== rightEligible) return leftEligible - rightEligible;
   if (left._creationTime !== right._creationTime) return left._creationTime - right._creationTime;
   return left._id < right._id ? -1 : left._id > right._id ? 1 : 0;
 }
 
-async function eligibleForegroundTargets(ctx: PublisherReadCtx, now: number) {
+async function eligibleForegroundTargets(ctx: PublisherReadCtx) {
   const laneRows = await Promise.all(
     ([undefined, 'foreground'] as const).map(
       async (workLane) =>
         await ctx.db
           .query('asset_targets')
-          .withIndex('by_type_lane_status_eligible', (q) =>
+          .withIndex('by_asset_type_and_work_lane_and_status', (q) =>
             q.eq('asset_type', ASSET_TYPE).eq('work_lane', workLane).eq('status', 'pending')
           )
           .take(MAX_PUBLISHER_ITEMS)
     )
   );
-  return laneRows
-    .flat()
-    .filter((target) => target.next_eligible_at === undefined || target.next_eligible_at <= now)
-    .sort(earlierTarget)
-    .slice(0, MAX_PUBLISHER_ITEMS);
+  return laneRows.flat().sort(earlierTarget).slice(0, MAX_PUBLISHER_ITEMS);
 }
 
 async function expiredClaims(ctx: PublisherReadCtx, now: number) {
@@ -149,7 +140,6 @@ async function recoverExpiredClaims(ctx: MutationCtx, now: number) {
       await ctx.db.patch(target._id, {
         ...clearItemClaim(),
         status: 'pending',
-        next_eligible_at: undefined,
       });
     }
   }
@@ -174,15 +164,10 @@ async function assignClaim(
   await markRolloutClaimed(ctx, target, now);
   await ctx.db.patch(target._id, {
     status: 'leased',
-    next_eligible_at: undefined,
-    attempt_count: undefined,
-    first_publication_admitted: undefined,
-    batch_token: undefined,
     claim_token: claimToken,
     claimed_generation: target.desired_generation,
     claimed_renderer_version: target.desired_renderer_version,
     lease_expires_at: leaseExpiresAt,
-    claim_payload_hash: undefined,
   });
   return {
     targetId: target._id,
@@ -222,7 +207,7 @@ export const takeWork = internalMutation({
 
     const leaseExpiresAt = now + ITEM_CLAIM_LEASE_MS;
     const items = [];
-    const foreground = await eligibleForegroundTargets(ctx, now);
+    const foreground = await eligibleForegroundTargets(ctx);
     for (const target of foreground) {
       if (items.length >= args.claimTokens.length) break;
       items.push(
@@ -350,9 +335,6 @@ export const completeItem = internalMutation({
     await ctx.db.patch(target._id, {
       ...clearItemClaim(),
       status: 'current',
-      next_eligible_at: undefined,
-      attempt_count: undefined,
-      first_publication_admitted: undefined,
       consecutive_render_failures: 0,
       last_error: undefined,
       published_generation: args.generation,
@@ -361,7 +343,6 @@ export const completeItem = internalMutation({
       published_r2_etag: args.r2Etag,
       published_bytes: args.bytes,
       published_at: now,
-      last_completed_batch_token: undefined,
       last_completed_claim_token: args.claimToken,
       work_lane: 'foreground',
       rollout_id: undefined,
@@ -407,7 +388,7 @@ export const failItem = internalMutation({
       };
     }
 
-    const consecutiveFailures = (target.consecutive_render_failures ?? 0) + 1;
+    const consecutiveFailures = target.consecutive_render_failures + 1;
     const blocked = consecutiveFailures >= MAX_CONSECUTIVE_RENDER_FAILURES;
     const rolloutOutcome = await failRolloutItem(
       ctx,
@@ -427,7 +408,6 @@ export const failItem = internalMutation({
       await ctx.db.patch(target._id, {
         ...clearItemClaim(),
         status: blocked ? 'blocked' : 'pending',
-        next_eligible_at: undefined,
         consecutive_render_failures: consecutiveFailures,
         last_error: failure.data.error,
       });

--- a/convex/assetPublisherOperator.test.ts
+++ b/convex/assetPublisherOperator.test.ts
@@ -5,17 +5,14 @@ import { convexTest } from 'convex-test';
 import { describe, expect, test } from 'vitest';
 
 import { internal } from './_generated/api';
-import {
-  FACTION_SHEET_TARGET_ACTIVATION_PREREQUISITE,
-  ITEM_CLAIM_MIGRATION_IDS,
-} from './lib/assetPublisherConstants';
+import { FACTION_SHEET_TARGET_ACTIVATION_PREREQUISITE } from './lib/assetPublisherConstants';
 import schema from './schema';
 
 const modules = import.meta.glob('./**/*.ts');
 const NOW = Date.parse('2026-07-17T12:00:00.000Z');
 
 describe('asset publisher config authority', () => {
-  test('initialize, pause, and disable only mutate the asset type config', async () => {
+  test('initialize, pause, and disable mutate the asset type config', async () => {
     const t = convexTest(schema, modules);
     await expect(
       t.mutation(internal.assetPublisherOperator.initializeDisabled, {})
@@ -28,14 +25,9 @@ describe('asset publisher config authority', () => {
       status: 'disabled',
       changed: true,
     });
-    const legacy = await t.run(async (ctx) => ({
-      states: await ctx.db.query('asset_publisher_state').take(1),
-      counters: await ctx.db.query('counters').take(1),
-    }));
-    expect(legacy).toEqual({ states: [], counters: [] });
   });
 
-  test('activation fails closed until every target and item-claim migration is complete', async () => {
+  test('activation fails closed until target migration is complete', async () => {
     const t = convexTest(schema, modules);
     await t.mutation(internal.assetPublisherOperator.initializeDisabled, {});
     await expect(
@@ -45,20 +37,15 @@ describe('asset publisher config authority', () => {
     ).rejects.toThrow('activation prerequisite');
 
     await t.run(async (ctx) => {
-      for (const migrationId of [
-        FACTION_SHEET_TARGET_ACTIVATION_PREREQUISITE,
-        ...ITEM_CLAIM_MIGRATION_IDS,
-      ]) {
-        await ctx.db.insert('migration_runs', {
-          migration_id: migrationId,
-          state: 'success',
-          is_done: true,
-          processed: 1,
-          latest_start: NOW - 1,
-          latest_end: NOW,
-          updated_at: new Date(NOW).toISOString(),
-        });
-      }
+      await ctx.db.insert('migration_runs', {
+        migration_id: FACTION_SHEET_TARGET_ACTIVATION_PREREQUISITE,
+        state: 'success',
+        is_done: true,
+        processed: 1,
+        latest_start: NOW - 1,
+        latest_end: NOW,
+        updated_at: new Date(NOW).toISOString(),
+      });
     });
     await expect(
       t.mutation(internal.assetPublisherOperator.activate, {

--- a/convex/assetPublisherOperator.ts
+++ b/convex/assetPublisherOperator.ts
@@ -7,7 +7,6 @@ import {
   FACTION_SHEET_ASSET_TYPE,
   FACTION_SHEET_TARGET_ACTIVATION_PREREQUISITE,
   INITIAL_FACTION_SHEET_RENDERER_VERSION,
-  ITEM_CLAIM_MIGRATION_IDS,
   PREVIOUS_FACTION_SHEET_RENDERER_VERSION,
 } from './lib/assetPublisherConstants';
 import type { MutationCtx } from './types';
@@ -98,12 +97,7 @@ async function assertExactPrerequisite(ctx: MutationCtx, prerequisite: string) {
 export const activate = internalMutation({
   args: { rendererVersion: rendererValidator },
   handler: async (ctx, args) => {
-    for (const prerequisite of [
-      FACTION_SHEET_TARGET_ACTIVATION_PREREQUISITE,
-      ...ITEM_CLAIM_MIGRATION_IDS,
-    ]) {
-      await assertExactPrerequisite(ctx, prerequisite);
-    }
+    await assertExactPrerequisite(ctx, FACTION_SHEET_TARGET_ACTIVATION_PREREQUISITE);
     const config = await ensureConfig(ctx);
     const changed =
       config.status !== 'active' || config.active_renderer_version !== args.rendererVersion;

--- a/convex/assetPublishingStatus.test.ts
+++ b/convex/assetPublishingStatus.test.ts
@@ -28,7 +28,7 @@ async function seedFaction(t: ReturnType<typeof convexTest>) {
 async function insertTarget(
   t: ReturnType<typeof convexTest>,
   factionId: Id<'factions'>,
-  status: 'pending' | 'leased' | 'blocked' | 'cooldown' | 'current'
+  status: 'pending' | 'leased' | 'blocked' | 'current'
 ) {
   return await t.run(
     async (ctx) =>
@@ -38,15 +38,12 @@ async function insertTarget(
         desired_generation: 2,
         desired_renderer_version: 'faction-sheet-v1',
         status,
-        next_eligible_at: 123,
-        attempt_count: 7,
+        consecutive_render_failures: 0,
         last_error: 'private operational error',
-        batch_token: 'private-batch-token',
         claim_token: 'private-claim-token',
         claimed_generation: 2,
         claimed_renderer_version: 'faction-sheet-v1',
         lease_expires_at: 456,
-        claim_payload_hash: 'private-payload-hash',
       })
   );
 }
@@ -69,7 +66,6 @@ describe('public asset publishing status projection', () => {
     ['pending', 'waiting'],
     ['leased', 'publishing'],
     ['blocked', 'delayed'],
-    ['cooldown', 'delayed'],
   ] as const)('maps %s to %s without operational leakage', async (targetStatus, expected) => {
     const t = convexTest(schema, modules);
     const factionId = await seedFaction(t);

--- a/convex/assetPublishingStatus.ts
+++ b/convex/assetPublishingStatus.ts
@@ -47,7 +47,7 @@ export function projectPublicAssetPublishingStatus(
       : `/published/factions/${encodeURIComponent(target.faction_id)}/sheet.pdf?v=${encodeURIComponent(target.published_cache_token)}`;
 
   if (target.status === 'leased') return { status: 'publishing', publicationHref };
-  if (target.status === 'cooldown' || target.status === 'blocked') {
+  if (target.status === 'blocked') {
     return { status: 'delayed', publicationHref };
   }
   if (

--- a/convex/assetRollouts.test.ts
+++ b/convex/assetRollouts.test.ts
@@ -184,6 +184,5 @@ describe('rollout compatibility with independent item claims', () => {
       status: 'current',
       consecutive_render_failures: 3,
     });
-    expect(targets[0]?.next_eligible_at).toBeUndefined();
   });
 });

--- a/convex/assetRollouts.ts
+++ b/convex/assetRollouts.ts
@@ -380,7 +380,6 @@ export const discoverPage = internalMutation({
         await ctx.db.patch(target._id, {
           desired_renderer_version: rollout.target_renderer_version,
           status: 'pending',
-          next_eligible_at: undefined,
           last_error: undefined,
           work_lane: 'rollout',
           rollout_id: rollout._id,
@@ -428,17 +427,14 @@ function restoreTargetAfterRollout(
   return {
     desired_renderer_version: restoredRenderer,
     status: isCurrent ? ('current' as const) : ('pending' as const),
-    next_eligible_at: undefined,
     last_error: undefined,
     work_lane: 'foreground' as const,
     rollout_id: undefined,
     rollout_item_id: undefined,
-    batch_token: undefined,
     claim_token: undefined,
     claimed_generation: undefined,
     claimed_renderer_version: undefined,
     lease_expires_at: undefined,
-    claim_payload_hash: undefined,
   };
 }
 
@@ -538,7 +534,7 @@ export async function firstEligibleRolloutTarget(ctx: ReadCtx, now: number) {
   if (rollout?.status !== 'running') return null;
   const targets = await ctx.db
     .query('asset_targets')
-    .withIndex('by_type_lane_status_eligible', (q) =>
+    .withIndex('by_asset_type_and_work_lane_and_status', (q) =>
       q
         .eq('asset_type', FACTION_SHEET_ASSET_TYPE)
         .eq('work_lane', 'rollout')

--- a/convex/factions.assetPublishing.test.ts
+++ b/convex/factions.assetPublishing.test.ts
@@ -1,14 +1,12 @@
 /// <reference types="vite/client" />
 // @vitest-environment edge-runtime
 
-import migrationsTest from '@convex-dev/migrations/test';
 import { convexTest } from 'convex-test';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { assetPublishingFaction } from '../src/game/fixtures/assetPublishingFaction';
 import { api, internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
-import { ITEM_CLAIM_MIGRATION_IDS } from './lib/assetPublisherConstants';
 import schema from './schema';
 
 const modules = import.meta.glob('./**/*.ts');
@@ -50,7 +48,7 @@ async function targetFor(
 }
 
 describe('faction render-generation invariants', () => {
-  test('create seeds one disabled config and a new-shape pending target', async () => {
+  test('create seeds one disabled config and a pending target', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
     const { t, asUser } = await authenticatedTest();
@@ -68,7 +66,6 @@ describe('faction render-generation invariants', () => {
             .unique()
         )?._id as Id<'asset_targets'>
       ),
-      publisherState: await ctx.db.query('asset_publisher_state').take(1),
     }));
     expect(state.config).toHaveLength(1);
     expect(state.config[0]).toMatchObject({ status: 'disabled' });
@@ -77,10 +74,6 @@ describe('faction render-generation invariants', () => {
       status: 'pending',
       consecutive_render_failures: 0,
     });
-    expect(state.target?.attempt_count).toBeUndefined();
-    expect(state.target?.next_eligible_at).toBeUndefined();
-    expect(state.target?.first_publication_admitted).toBeUndefined();
-    expect(state.publisherState).toEqual([]);
   });
 
   test('every faction data save advances generation, unblocks, and resets only target failures', async () => {
@@ -177,147 +170,5 @@ describe('faction render-generation invariants', () => {
     });
     await asUser.mutation(api.factions.setGroup, { id: faction._id, group_id: groupId });
     expect(await targetFor(t, faction._id)).toEqual(before);
-  });
-});
-
-describe('item-claim widen migrations', () => {
-  test('converts legacy targets and deletes snapshots, singleton, and admission counter idempotently', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-    const t = convexTest(schema, modules);
-    migrationsTest.register(t);
-    await t.run(async (ctx) => {
-      const userId = await ctx.db.insert('users', { name: 'Migration owner' });
-      await ctx.db.insert('asset_type_configs', {
-        asset_type: 'faction_sheet',
-        status: 'paused',
-        active_renderer_version: 'faction-sheet-v1',
-        updated_at: NOW,
-      });
-      const factionId = await ctx.db.insert('factions', {
-        owner_id: userId,
-        data: assetPublishingFaction,
-        slug: 'legacy-faction',
-        created_at: new Date(NOW).toISOString(),
-        updated_at: new Date(NOW).toISOString(),
-        is_deleted: false,
-        group_id: null,
-      });
-      const targetId = await ctx.db.insert('asset_targets', {
-        faction_id: factionId,
-        asset_type: 'faction_sheet',
-        desired_generation: 1,
-        desired_renderer_version: 'faction-sheet-v1',
-        first_publication_admitted: true,
-        status: 'cooldown',
-        next_eligible_at: NOW + 60_000,
-        attempt_count: 7,
-        batch_token: 'legacy-batch-token-0001',
-        claim_payload_hash: 'a'.repeat(64),
-      });
-      await ctx.db.insert('asset_claim_snapshots', {
-        target_id: targetId,
-        faction_id: factionId,
-        asset_type: 'faction_sheet',
-        batch_token: 'legacy-batch-token-0001',
-        claim_token: 'legacy-claim-token-0001',
-        generation: 1,
-        renderer_version: 'faction-sheet-v1',
-        lease_expires_at: NOW - 1,
-        payload_hash: 'a'.repeat(64),
-        payload: { legacy: true },
-      });
-      await ctx.db.insert('asset_publisher_state', {
-        key: 'singleton',
-        status: 'paused',
-        cooldown_until: NOW,
-        daily_browser_utc_date: '2026-07-17',
-        daily_browser_ms: 123,
-        next_lane: 'foreground',
-      });
-      await ctx.db.insert('counters', {
-        key: 'asset_publisher:faction_sheet:first_publications',
-        value: 1,
-      });
-    });
-
-    const ids = [...ITEM_CLAIM_MIGRATION_IDS];
-    await t.mutation(api.migrations.runRequired, { ids });
-    await t.finishAllScheduledFunctions(vi.runAllTimers);
-    await expect(
-      t.query(api.migrations.assertReadyForNarrow, { required: ids })
-    ).resolves.toMatchObject({ ok: true, required: ids });
-    const migrated = await t.run(async (ctx) => ({
-      targets: await ctx.db.query('asset_targets').take(2),
-      snapshots: await ctx.db.query('asset_claim_snapshots').take(1),
-      state: await ctx.db.query('asset_publisher_state').take(1),
-      counter: await ctx.db
-        .query('counters')
-        .withIndex('by_key', (q) => q.eq('key', 'asset_publisher:faction_sheet:first_publications'))
-        .unique(),
-    }));
-    expect(migrated.targets[0]).toMatchObject({
-      status: 'pending',
-      consecutive_render_failures: 0,
-    });
-    expect(migrated.targets[0]?.attempt_count).toBeUndefined();
-    expect(migrated.targets[0]?.next_eligible_at).toBeUndefined();
-    expect(migrated.targets[0]?.first_publication_admitted).toBeUndefined();
-    expect(migrated.snapshots).toEqual([]);
-    expect(migrated.state).toEqual([]);
-    expect(migrated.counter).toBeNull();
-
-    await t.mutation(api.migrations.runRequired, { ids });
-    await t.finishAllScheduledFunctions(vi.runAllTimers);
-    await expect(
-      t.run(async (ctx) => await ctx.db.query('asset_targets').take(2))
-    ).resolves.toHaveLength(1);
-  });
-
-  test('fails closed while an unexpired claim exists', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-    const t = convexTest(schema, modules);
-    migrationsTest.register(t);
-    await t.run(async (ctx) => {
-      const userId = await ctx.db.insert('users', { name: 'Live claim owner' });
-      await ctx.db.insert('asset_type_configs', {
-        asset_type: 'faction_sheet',
-        status: 'paused',
-        active_renderer_version: 'faction-sheet-v1',
-        updated_at: NOW,
-      });
-      const factionId = await ctx.db.insert('factions', {
-        owner_id: userId,
-        data: assetPublishingFaction,
-        slug: 'live-claim',
-        created_at: new Date(NOW).toISOString(),
-        updated_at: new Date(NOW).toISOString(),
-        is_deleted: false,
-        group_id: null,
-      });
-      await ctx.db.insert('asset_targets', {
-        faction_id: factionId,
-        asset_type: 'faction_sheet',
-        desired_generation: 1,
-        desired_renderer_version: 'faction-sheet-v1',
-        status: 'leased',
-        next_eligible_at: NOW + 60_000,
-        attempt_count: 1,
-        claim_token: 'live-claim-token-00000001',
-        claimed_generation: 1,
-        claimed_renderer_version: 'faction-sheet-v1',
-        lease_expires_at: NOW + 60_000,
-      });
-    });
-    await t.mutation(api.migrations.runRequired, { ids: ['asset_targets_item_claims_v1'] });
-    await t.finishAllScheduledFunctions(vi.runAllTimers);
-    await expect(
-      t.query(api.migrations.verifyMigration, { id: 'asset_targets_item_claims_v1' })
-    ).resolves.toMatchObject({
-      complete: false,
-      state: 'failed',
-      error: expect.stringContaining('requires no live claims'),
-    });
   });
 });

--- a/convex/lib/assetPublisherConstants.ts
+++ b/convex/lib/assetPublisherConstants.ts
@@ -16,10 +16,3 @@ export const ITEM_CLAIM_LEASE_MS = 8 * 60 * 1_000;
 export const MAX_CONSECUTIVE_RENDER_FAILURES = 10;
 export const FACTION_SHEET_TARGET_ACTIVATION_PREREQUISITE =
   'faction_sheet_targets_verify_v1' as const;
-export const ITEM_CLAIM_MIGRATION_IDS = [
-  'asset_targets_item_claims_v1',
-  'asset_claim_snapshots_retire_v1',
-  'asset_publisher_state_retire_v1',
-  'asset_publisher_admission_counter_retire_v1',
-  'asset_targets_item_claims_verify_v1',
-] as const;

--- a/convex/lib/factionSheetTargets.ts
+++ b/convex/lib/factionSheetTargets.ts
@@ -113,9 +113,6 @@ export async function reconcileFactionSheetTargetForSave(
     foreground_updated_at: now,
     consecutive_render_failures: 0,
     last_error: undefined,
-    next_eligible_at: undefined,
-    attempt_count: undefined,
-    first_publication_admitted: undefined,
     ...(target.status === 'leased'
       ? {}
       : {

--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -30,15 +30,6 @@
       "phase": "widen",
       "requires": []
     },
-    { "id": "asset_targets_item_claims_v1", "phase": "widen", "requires": [] },
-    { "id": "asset_claim_snapshots_retire_v1", "phase": "widen", "requires": [] },
-    { "id": "asset_publisher_state_retire_v1", "phase": "widen", "requires": [] },
-    {
-      "id": "asset_publisher_admission_counter_retire_v1",
-      "phase": "widen",
-      "requires": []
-    },
-    { "id": "asset_targets_item_claims_verify_v1", "phase": "widen", "requires": [] },
     {
       "id": "profiles_backfill_guard",
       "phase": "narrow",
@@ -48,17 +39,6 @@
       "id": "faction_sheet_targets_backfill_guard",
       "phase": "narrow",
       "requires": ["faction_sheet_targets_backfill_v1", "faction_sheet_targets_verify_v1"]
-    },
-    {
-      "id": "asset_publisher_item_claims_narrow",
-      "phase": "narrow",
-      "requires": [
-        "asset_targets_item_claims_v1",
-        "asset_claim_snapshots_retire_v1",
-        "asset_publisher_state_retire_v1",
-        "asset_publisher_admission_counter_retire_v1",
-        "asset_targets_item_claims_verify_v1"
-      ]
     },
     {
       "id": "groups_slug_narrow",

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -6,11 +6,6 @@ import { DEFAULT_FAQ_TAG } from '../src/app/faq/tags';
 import { components, internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import { internalMutation, mutation, query } from './_generated/server';
-import { recoverExpiredRolloutClaim } from './assetRollouts';
-import {
-  ITEM_CLAIM_MIGRATION_IDS,
-  MAX_CONSECUTIVE_RENDER_FAILURES,
-} from './lib/assetPublisherConstants';
 import {
   assertExactlyOneFactionSheetTarget,
   ensureFactionSheetConfig,
@@ -33,12 +28,6 @@ const MIGRATION_IDS: Record<string, MigrationRef> = {
   profiles_from_users_v1: internal.migrations.profiles_from_users_v1,
   faction_sheet_targets_backfill_v1: internal.migrations.faction_sheet_targets_backfill_v1,
   faction_sheet_targets_verify_v1: internal.migrations.faction_sheet_targets_verify_v1,
-  asset_targets_item_claims_v1: internal.migrations.asset_targets_item_claims_v1,
-  asset_claim_snapshots_retire_v1: internal.migrations.asset_claim_snapshots_retire_v1,
-  asset_publisher_state_retire_v1: internal.migrations.asset_publisher_state_retire_v1,
-  asset_publisher_admission_counter_retire_v1:
-    internal.migrations.asset_publisher_admission_counter_retire_v1,
-  asset_targets_item_claims_verify_v1: internal.migrations.asset_targets_item_claims_verify_v1,
 };
 
 type MigrationId = keyof typeof MIGRATION_IDS;
@@ -52,7 +41,6 @@ const migrations = new Migrations(components.migrations, {
 const FACTION_SHEET_TARGET_MIGRATION_IDS = [
   'faction_sheet_targets_backfill_v1',
   'faction_sheet_targets_verify_v1',
-  ...ITEM_CLAIM_MIGRATION_IDS,
 ] as const;
 
 async function resolveUniqueGroupSlug(
@@ -220,117 +208,6 @@ export const faction_sheet_targets_verify_v1 = migrations.define({
   },
 });
 
-async function assertItemClaimMigrationInactive(ctx: MutationCtx) {
-  const config = await ensureFactionSheetConfig(ctx);
-  if (config.status === 'active') {
-    throw new Error('Item-claim migration requires paused or disabled configuration');
-  }
-}
-
-/** Converts legacy target coordination into the item-claim widen shape. */
-export const asset_targets_item_claims_v1 = migrations.define({
-  table: 'asset_targets',
-  batchSize: 25,
-  migrateOne: async (ctx, target) => {
-    await assertItemClaimMigrationInactive(ctx);
-    let status = target.status;
-    if (status === 'leased') {
-      if ((target.lease_expires_at ?? Number.POSITIVE_INFINITY) > Date.now()) {
-        throw new Error('Item-claim migration requires no live claims');
-      }
-      const detached = await recoverExpiredRolloutClaim(ctx, target, Date.now());
-      const recovered = await ctx.db.get('asset_targets', target._id);
-      status = detached ? (recovered?.status ?? 'pending') : 'pending';
-    } else if (status === 'cooldown') {
-      status = 'pending';
-    }
-    const existingFailures = target.consecutive_render_failures;
-    const consecutiveRenderFailures =
-      status === 'blocked'
-        ? Math.max(
-            existingFailures ?? MAX_CONSECUTIVE_RENDER_FAILURES,
-            MAX_CONSECUTIVE_RENDER_FAILURES
-          )
-        : (existingFailures ?? 0);
-    return {
-      status,
-      consecutive_render_failures: consecutiveRenderFailures,
-      first_publication_admitted: undefined,
-      next_eligible_at: undefined,
-      attempt_count: undefined,
-      batch_token: undefined,
-      claim_token: undefined,
-      claimed_generation: undefined,
-      claimed_renderer_version: undefined,
-      lease_expires_at: undefined,
-      claim_payload_hash: undefined,
-      last_completed_batch_token: undefined,
-      last_completed_claim_token: undefined,
-    };
-  },
-});
-
-/** Deletes copied payloads after all legacy ownership has been fenced off. */
-export const asset_claim_snapshots_retire_v1 = migrations.define({
-  table: 'asset_claim_snapshots',
-  batchSize: 25,
-  migrateOne: async (ctx, snapshot) => {
-    await assertItemClaimMigrationInactive(ctx);
-    await ctx.db.delete(snapshot._id);
-  },
-});
-
-/** Deletes the retired global batch/cooldown/quota singleton. */
-export const asset_publisher_state_retire_v1 = migrations.define({
-  table: 'asset_publisher_state',
-  batchSize: 5,
-  migrateOne: async (ctx, state) => {
-    await assertItemClaimMigrationInactive(ctx);
-    await ctx.db.delete(state._id);
-  },
-});
-
-/** Deletes only the retired first-publication admission counter. */
-export const asset_publisher_admission_counter_retire_v1 = migrations.define({
-  table: 'counters',
-  batchSize: 25,
-  migrateOne: async (ctx, counter) => {
-    await assertItemClaimMigrationInactive(ctx);
-    if (counter.key === 'asset_publisher:faction_sheet:first_publications') {
-      await ctx.db.delete(counter._id);
-    }
-  },
-});
-
-/** Per-target proof that the legacy coordination shape has been fully cleared. */
-export const asset_targets_item_claims_verify_v1 = migrations.define({
-  table: 'asset_targets',
-  batchSize: 25,
-  migrateOne: async (ctx, target) => {
-    await assertItemClaimMigrationInactive(ctx);
-    const failureCount = target.consecutive_render_failures;
-    if (
-      target.status === 'cooldown' ||
-      target.status === 'leased' ||
-      !Number.isSafeInteger(failureCount) ||
-      (failureCount ?? -1) < 0 ||
-      (target.status === 'blocked' && (failureCount ?? 0) < MAX_CONSECUTIVE_RENDER_FAILURES) ||
-      target.first_publication_admitted !== undefined ||
-      target.next_eligible_at !== undefined ||
-      target.attempt_count !== undefined ||
-      target.batch_token !== undefined ||
-      target.claim_token !== undefined ||
-      target.claimed_generation !== undefined ||
-      target.claimed_renderer_version !== undefined ||
-      target.lease_expires_at !== undefined ||
-      target.claim_payload_hash !== undefined ||
-      target.last_completed_batch_token !== undefined
-    ) {
-      throw new Error(`Item-claim target verification failed for ${target._id}`);
-    }
-  },
-});
-
 export const run = migrations.runner();
 
 export const runDeployMigrations = migrations.runner([
@@ -341,11 +218,6 @@ export const runDeployMigrations = migrations.runner([
   internal.migrations.profiles_from_users_v1,
   internal.migrations.faction_sheet_targets_backfill_v1,
   internal.migrations.faction_sheet_targets_verify_v1,
-  internal.migrations.asset_targets_item_claims_v1,
-  internal.migrations.asset_claim_snapshots_retire_v1,
-  internal.migrations.asset_publisher_state_retire_v1,
-  internal.migrations.asset_publisher_admission_counter_retire_v1,
-  internal.migrations.asset_targets_item_claims_verify_v1,
 ]);
 
 export const runRequired = mutation({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -77,26 +77,18 @@ export default defineSchema({
     published_r2_etag: v.optional(v.string()),
     published_bytes: v.optional(v.number()),
     published_at: v.optional(v.number()),
-    first_publication_admitted: v.optional(v.boolean()),
     status: v.union(
       v.literal('pending'),
       v.literal('leased'),
       v.literal('current'),
-      v.literal('blocked'),
-      // Widen-phase compatibility. Removed after item-claim migration evidence.
-      v.literal('cooldown')
+      v.literal('blocked')
     ),
-    next_eligible_at: v.optional(v.number()),
-    attempt_count: v.optional(v.number()),
-    consecutive_render_failures: v.optional(v.number()),
+    consecutive_render_failures: v.number(),
     last_error: v.optional(v.string()),
-    batch_token: v.optional(v.string()),
     claim_token: v.optional(v.string()),
     claimed_generation: v.optional(v.number()),
     claimed_renderer_version: v.optional(v.string()),
     lease_expires_at: v.optional(v.number()),
-    claim_payload_hash: v.optional(v.string()),
-    last_completed_batch_token: v.optional(v.string()),
     last_completed_claim_token: v.optional(v.string()),
     work_lane: v.optional(v.union(v.literal('foreground'), v.literal('rollout'))),
     rollout_id: v.optional(v.id('asset_rollouts')),
@@ -104,67 +96,15 @@ export default defineSchema({
     foreground_updated_at: v.optional(v.number()),
   })
     .index('by_faction_id_and_asset_type', ['faction_id', 'asset_type'])
-    .index('by_asset_type_and_status_and_next_eligible_at', [
-      'asset_type',
-      'status',
-      'next_eligible_at',
-    ])
     .index('by_asset_type_and_status_and_lease_expires_at', [
       'asset_type',
       'status',
       'lease_expires_at',
     ])
-    .index('by_asset_type_and_admitted_and_status_and_next_eligible_at', [
-      'asset_type',
-      'first_publication_admitted',
-      'status',
-      'next_eligible_at',
-    ])
-    .index('by_asset_type_and_admitted_and_status_and_lease_expires_at', [
-      'asset_type',
-      'first_publication_admitted',
-      'status',
-      'lease_expires_at',
-    ])
-    .index('by_asset_type_and_published_generation', ['asset_type', 'published_generation'])
     .index('by_asset_type', ['asset_type'])
-    .index('by_type_lane_status_eligible', [
-      'asset_type',
-      'work_lane',
-      'status',
-      'next_eligible_at',
-    ])
+    .index('by_asset_type_and_work_lane_and_status', ['asset_type', 'work_lane', 'status'])
     .index('by_type_lane_status_lease', ['asset_type', 'work_lane', 'status', 'lease_expires_at'])
-    .index('by_type_lane_admitted_status_eligible', [
-      'asset_type',
-      'work_lane',
-      'first_publication_admitted',
-      'status',
-      'next_eligible_at',
-    ])
-    .index('by_type_lane_admitted_status_lease', [
-      'asset_type',
-      'work_lane',
-      'first_publication_admitted',
-      'status',
-      'lease_expires_at',
-    ])
-    .index('by_batch_token', ['batch_token'])
     .index('by_claim_token', ['claim_token']),
-  asset_claim_snapshots: defineTable({
-    target_id: v.id('asset_targets'),
-    faction_id: v.id('factions'),
-    asset_type: v.literal('faction_sheet'),
-    batch_token: v.string(),
-    claim_token: v.string(),
-    generation: v.number(),
-    renderer_version: v.string(),
-    lease_expires_at: v.number(),
-    payload_hash: v.string(),
-    payload: v.any(),
-  })
-    .index('by_target_id', ['target_id'])
-    .index('by_batch_token', ['batch_token']),
   asset_type_configs: defineTable({
     asset_type: v.literal('faction_sheet'),
     status: v.union(v.literal('disabled'), v.literal('active'), v.literal('paused')),
@@ -172,26 +112,6 @@ export default defineSchema({
     active_rollout_id: v.optional(v.id('asset_rollouts')),
     updated_at: v.number(),
   }).index('by_asset_type', ['asset_type']),
-  asset_publisher_state: defineTable({
-    key: v.literal('singleton'),
-    status: v.union(v.literal('disabled'), v.literal('active'), v.literal('paused')),
-    batch_token: v.optional(v.string()),
-    batch_lease_expires_at: v.optional(v.number()),
-    cooldown_until: v.number(),
-    daily_browser_utc_date: v.string(),
-    daily_browser_ms: v.number(),
-    browser_reservation_batch_token: v.optional(v.string()),
-    browser_reservation_utc_date: v.optional(v.string()),
-    browser_reserved_ms: v.optional(v.number()),
-    last_browser_settlement_batch_token: v.optional(v.string()),
-    last_browser_settlement_ms: v.optional(v.number()),
-    last_browser_release_batch_token: v.optional(v.string()),
-    last_browser_release_mode: v.optional(
-      v.union(v.literal('no_browser'), v.literal('after_settlement'))
-    ),
-    next_lane: v.union(v.literal('foreground'), v.literal('rollout')),
-    lane_sequence_position: v.optional(v.number()),
-  }).index('by_key', ['key']),
   asset_rollouts: defineTable({
     asset_type: v.literal('faction_sheet'),
     target_renderer_version: v.string(),

--- a/docs/convex-migrations.md
+++ b/docs/convex-migrations.md
@@ -57,45 +57,6 @@ Rules:
   - `narrow`: schema-narrow checkpoint gated on completed widen work
 - `requires`: widen migration ids that must be `success + isDone=true` before narrow is allowed
 
-## Current asset-publisher migration pack
-
-The item-only paid-plan release uses these widen migrations:
-
-- `asset_targets_item_claims_v1`
-- `asset_claim_snapshots_retire_v1`
-- `asset_publisher_state_retire_v1`
-- `asset_publisher_admission_counter_retire_v1`
-- `asset_targets_item_claims_verify_v1`
-
-They are run alongside the repo's other widen migrations from the same guard manifest.
-
-### Preconditions
-
-- The faction-sheet publisher config must be `paused` or `disabled`.
-- No live item claim may exist when `asset_targets_item_claims_v1` runs.
-- The later schema narrow must wait for all required widen migrations to complete successfully.
-
-### What the migration pack does
-
-`asset_targets_item_claims_v1` converts legacy target coordination into the new per-target
-item-claim shape. It:
-
-- converts legacy `cooldown` targets back to plain `pending`;
-- initializes `consecutive_render_failures` without interpreting historical retry counts;
-- preserves blocked targets by forcing them to at least the ten-failure threshold;
-- clears retired retry timing, batch, claim, payload-hash, and admission-era fields; and
-- fails closed if publishing is active or a live claim is still leased.
-
-The retirement steps then remove the old tables and singleton state that no longer participate in
-runtime behavior:
-
-- `asset_claim_snapshots_retire_v1` deletes legacy claim snapshots;
-- `asset_publisher_state_retire_v1` deletes the retired singleton publisher state; and
-- `asset_publisher_admission_counter_retire_v1` deletes the first-publication counter.
-
-`asset_targets_item_claims_verify_v1` is the per-target proof pass. It fails if a target still has
-legacy fields, an invalid failure counter, or an impossible blocked-state combination.
-
 ## Automated production flow
 
 1. Deploy widen-compatible Convex code: `bun run convex:deploy`
@@ -152,8 +113,6 @@ bun run scripts/migration-guards.ts dev-strict 300000 2000
 # Alias used by convex:dev and for manual local catch-up
 bun run migrations:run-local-required
 
-# Raw status for selected ids
-npx convex run migrations:getStatus '{"ids":["asset_targets_item_claims_v1","asset_targets_item_claims_verify_v1"]}' --prod
 ```
 
 ## Templates and references

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,9 +32,8 @@ custom domain passes the release smoke, the workflow sets the production Convex 
 `https://dune.zone`.
 
 The workflow mutates only the publisher's pause/activation control boundary around deployment. It
-does not mutate publisher items outside the normal scheduled executor, execute the later schema
-narrow, or delete the retired remote Queue. The first post-deploy scheduled invocation remains an
-operator-observed production canary.
+does not mutate publisher items outside the normal scheduled executor or delete the retired remote
+Queue. The first post-deploy scheduled invocation remains an operator-observed production canary.
 
 ## Build process
 

--- a/workers/publisher/deployment-config.test.ts
+++ b/workers/publisher/deployment-config.test.ts
@@ -162,19 +162,4 @@ describe('scheduled production deployment shape', () => {
     expect(deploymentWorkflow).toContain('.status == "paused"');
     expect(deploymentWorkflow).toContain('.status == "active" and .rendererVersion == $renderer');
   });
-
-  test('documents the item-claim migration pack and its paused/no-live-claims preconditions', () => {
-    const migrationGuide = readFileSync(
-      path.resolve(process.cwd(), 'docs/convex-migrations.md'),
-      'utf8'
-    );
-    expect(migrationGuide).toContain('asset_targets_item_claims_v1');
-    expect(migrationGuide).toContain('asset_claim_snapshots_retire_v1');
-    expect(migrationGuide).toContain('asset_publisher_state_retire_v1');
-    expect(migrationGuide).toContain('asset_publisher_admission_counter_retire_v1');
-    expect(migrationGuide).toContain('asset_targets_item_claims_verify_v1');
-    expect(migrationGuide).toContain('paused');
-    expect(migrationGuide).toContain('disabled');
-    expect(migrationGuide).toContain('No live item claim may exist');
-  });
 });


### PR DESCRIPTION
## What changed

- remove the retired publisher batch/cooldown/admission fields and seven unused legacy indexes from `asset_targets`
- remove the empty `asset_claim_snapshots` and `asset_publisher_state` tables
- make the migrated `consecutive_render_failures` field required
- replace the foreground/rollout selector with the current lane-and-status index
- remove the completed item-claim migration implementations, guard entries, activation prerequisites, tests, and documentation
- retain the active per-item claim fields, rollout retry timing, and current publication behavior

This is the schema-narrow half of the already-completed item-claim migration. It reduces legacy code and setup without hardening or changing the publisher protocol.

## Production evidence

Before narrowing, all five item-claim migration steps reported `state: success` and `isDone: true` in production. The retired snapshot and publisher-state tables were empty. The production narrow gate passed again immediately before this commit.

No Cloudflare resources are deleted by this PR. The retired Queue and proof bucket remain explicitly out of scope.

## Verification

- `bun run test` — 243 tests passed
- `bun run typecheck`
- `bun run publisher:typecheck`
- `bun run build-storybook`
- `bun run migrations:narrow-check`
- `bun run check:convex-skip`
- canonical `bun run publisher:assets` using the production Convex URL
- `bun run publisher:assets:check`
- `bun run workers/publisher/capture-contract-regression.ts`
- `bun run publisher:release:dry-run`
- `bun run publisher:startup`
- `bunx biome check .` (one pre-existing warning only)
- `git diff --check`

The canonical renderer digest remains `42d3a10b16194c9c6c900ca967fb3267e744dc5bbd6198ab07289a3dfb10c2ac`, confirming this schema-only phase does not change rendered assets.

## Rollout gate

After merge, wait for the production deployment to finish, verify the publisher remains active on `faction-sheet-v3`, and smoke both the Worker origin and `https://dune.zone` before selecting the next cleanup phase.
