### PR TITLE
Remove unused publisher query surface

### DIFF
--- a/convex/assetPublisher.ts
+++ b/convex/assetPublisher.ts
@@ -3,7 +3,7 @@ import SHA256 from 'crypto-js/sha256';
 
 import { FactionInputSchema } from '../src/game/schema/faction';
 import type { Doc, Id } from './_generated/dataModel';
-import { internalMutation, internalQuery, query } from './_generated/server';
+import { internalMutation, internalQuery } from './_generated/server';
 import {
   completeRolloutItem,
   failRolloutItem,
@@ -415,50 +415,6 @@ export const failItem = internalMutation({
     return {
       status: blocked ? ('blocked' as const) : ('failed' as const),
       consecutiveFailures,
-    };
-  },
-});
-
-export const getPublicMetadata = query({
-  args: { factionId: v.id('factions'), assetType: v.literal('faction_sheet') },
-  handler: async (ctx, args) => {
-    const target = await ctx.db
-      .query('asset_targets')
-      .withIndex('by_faction_id_and_asset_type', (q) =>
-        q.eq('faction_id', args.factionId).eq('asset_type', args.assetType)
-      )
-      .unique();
-    if (!target) return null;
-
-    const stablePath = `/published/factions/${encodeURIComponent(target.faction_id)}/sheet.pdf`;
-    const publication =
-      target.published_generation === undefined ||
-      target.published_renderer_version === undefined ||
-      target.published_cache_token === undefined ||
-      target.published_r2_etag === undefined ||
-      target.published_bytes === undefined ||
-      target.published_at === undefined
-        ? null
-        : {
-            generation: target.published_generation,
-            rendererVersion: target.published_renderer_version,
-            cacheToken: target.published_cache_token,
-            r2Etag: target.published_r2_etag,
-            bytes: target.published_bytes,
-            publishedAt: target.published_at,
-            stablePath,
-            href: `${stablePath}?v=${encodeURIComponent(target.published_cache_token)}`,
-          };
-    return {
-      factionId: target.faction_id,
-      assetType: target.asset_type,
-      status:
-        target.status === 'current' &&
-        target.desired_generation === target.published_generation &&
-        target.desired_renderer_version === target.published_renderer_version
-          ? ('current' as const)
-          : ('pending' as const),
-      publication,
     };
   },
 });

--- a/convex/assetPublishingStatus.test.ts
+++ b/convex/assetPublishingStatus.test.ts
@@ -4,6 +4,7 @@
 import { convexTest } from 'convex-test';
 import { describe, expect, test } from 'vitest';
 
+import { assetPublishingFaction } from '../src/game/fixtures/assetPublishingFaction';
 import { api } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import schema from './schema';
@@ -13,9 +14,17 @@ const modules = import.meta.glob('./**/*.ts');
 async function seedFaction(t: ReturnType<typeof convexTest>) {
   return await t.run(async (ctx) => {
     const ownerId = await ctx.db.insert('users', { name: 'Status projection owner' });
+    await ctx.db.insert('profiles', {
+      user_id: ownerId,
+      username: 'Status projection owner',
+      avatar_url: null,
+      slug: 'status-projection-owner',
+      created_at: '2026-07-16T12:00:00.000Z',
+      updated_at: '2026-07-16T12:00:00.000Z',
+    });
     return await ctx.db.insert('factions', {
       owner_id: ownerId,
-      data: {},
+      data: assetPublishingFaction,
       slug: 'status-projection',
       created_at: '2026-07-16T12:00:00.000Z',
       updated_at: '2026-07-16T12:00:00.000Z',
@@ -49,7 +58,10 @@ async function insertTarget(
 }
 
 async function publicStatus(t: ReturnType<typeof convexTest>, factionId: Id<'factions'>) {
-  return await t.query(api.assetPublishingStatus.getFactionSheet, { factionId });
+  const faction = await t.run(async (ctx) => await ctx.db.get('factions', factionId));
+  if (!faction) throw new Error('Missing status projection faction');
+  const detail = await t.query(api.factions.getBySlug, { slug: faction.slug });
+  return detail.assetPublishing;
 }
 
 describe('public asset publishing status projection', () => {

--- a/convex/assetPublishingStatus.ts
+++ b/convex/assetPublishingStatus.ts
@@ -1,7 +1,4 @@
-import { v } from 'convex/values';
-
 import type { Doc, Id } from './_generated/dataModel';
-import { query } from './_generated/server';
 import type { QueryCtx } from './types';
 
 export type PublicAssetPublishingStatus = 'waiting' | 'publishing' | 'delayed' | 'current';
@@ -75,8 +72,3 @@ export async function factionSheetPublishingStatus(
   }
   return projectPublicAssetPublishingStatus(targets[0] ?? null);
 }
-
-export const getFactionSheet = query({
-  args: { factionId: v.id('factions') },
-  handler: async (ctx, args) => await factionSheetPublishingStatus(ctx, args.factionId),
-});

--- a/convex/lib/assetPublisherSchemas.ts
+++ b/convex/lib/assetPublisherSchemas.ts
@@ -5,10 +5,8 @@ import {
   MAX_PUBLISHER_ITEMS,
 } from './assetPublisherConstants';
 
-export const assetTypeSchema = z.literal('faction_sheet');
 export const publisherTokenSchema = z.string().min(16).max(256);
 export const rendererVersionSchema = z.string().trim().min(1).max(128);
-export const payloadHashSchema = z.string().regex(/^[0-9a-f]{64}$/);
 
 export const takeWorkArgsSchema = z.strictObject({
   claimTokens: z


### PR DESCRIPTION
## What changed

- remove `assetPublisher.getPublicMetadata`, an original control-plane query with no repository caller, test, or documentation
- remove `assetPublishingStatus.getFactionSheet`, a test-only public wrapper around the status helper
- exercise publication-status behavior through `factions.getBySlug`, the actual faction-detail boundary used by the UI
- remove the unused `assetTypeSchema` and `payloadHashSchema` exports left from earlier publisher protocol shapes

## Why

The publisher exposed two overlapping public query surfaces even though the application has always consumed publication status as part of the faction-detail payload. Keeping the unused endpoints duplicated publication completeness, status, and URL projection logic without serving current functionality.

This phase removes legacy surface only. It does not change the Convex schema or data, Worker protocol, renderer, PDF delivery route, rollout behavior, or Cloudflare configuration.

## Verification

- focused Convex publisher/status/faction tests — 20 passed
- `bun run test` — 243 tests passed
- `bun run typecheck`
- `bun run publisher:typecheck`
- `bun run build-storybook`
- `bun run migrations:narrow-check`
- `bun run check:convex-skip`
- canonical `bun run publisher:assets` using the production Convex URL
- `bun run publisher:assets:check`
- `bun run workers/publisher/capture-contract-regression.ts`
- `bun run publisher:release:dry-run`
- `bun run publisher:startup`
- `bunx biome check .` (one pre-existing warning only)
- `git diff --check`

The renderer digest remains `42d3a10b16194c9c6c900ca967fb3267e744dc5bbd6198ab07289a3dfb10c2ac`. A direct production `factions:getBySlug` query also confirmed the retained application boundary returns a current status and cache-busted PDF link.

## Rollout gate

After merge, wait for the production deployment to finish, verify the publisher remains active on `faction-sheet-v3`, and smoke both the Worker origin and `https://dune.zone` before beginning the next cleanup phase.
