### PR TITLE
Remove unused publisher protocol surface

### DIFF
--- a/convex/assetPublisher.test.ts
+++ b/convex/assetPublisher.test.ts
@@ -130,7 +130,6 @@ describe('item claim assignment', () => {
     });
     const [item] = await takeAssigned(t, 1);
     expect(item.targetId).toBe(targetIds[0]);
-    expect(item.workLane).toBe('foreground');
   });
 
   test('recovers expired claims and gives each recovered target a new token', async () => {
@@ -211,27 +210,6 @@ describe('exact item operations', () => {
       published_cache_token: CACHE_TOKEN,
     });
     expect(targets.second).toMatchObject({ status: 'leased', claim_token: second.claimToken });
-  });
-
-  test('infrastructure failure retains ownership and never increments the target counter', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-    const { t } = await seed();
-    const [item] = await takeAssigned(t, 1);
-    await expect(
-      t.mutation(internal.assetPublisher.failItem, {
-        ...exact(item),
-        attribution: 'infrastructure',
-        error: 'Browser session unavailable',
-      })
-    ).resolves.toMatchObject({ status: 'retained' });
-    const target = await t.run(async (ctx) => await ctx.db.get('asset_targets', item.targetId));
-    expect(target).toMatchObject({
-      status: 'leased',
-      claim_token: item.claimToken,
-      consecutive_render_failures: 0,
-    });
-    expect(target?.last_error).toBeUndefined();
   });
 
   test('target failures one through nine return pending and the tenth blocks the generation', async () => {

--- a/convex/assetPublisher.ts
+++ b/convex/assetPublisher.ts
@@ -177,7 +177,6 @@ async function assignClaim(
     generation: target.desired_generation,
     rendererVersion: target.desired_renderer_version,
     leaseExpiresAt,
-    workLane: target.work_lane === 'rollout' ? ('rollout' as const) : ('foreground' as const),
   };
 }
 
@@ -360,7 +359,7 @@ export const completeItem = internalMutation({
 export const failItem = internalMutation({
   args: {
     ...exactItemArgs,
-    attribution: v.union(v.literal('target'), v.literal('infrastructure')),
+    attribution: v.literal('target'),
     error: v.string(),
   },
   handler: async (ctx, args) => {
@@ -381,13 +380,6 @@ export const failItem = internalMutation({
     ) {
       return { status: 'stale' as const };
     }
-    if (failure.data.attribution === 'infrastructure') {
-      return {
-        status: 'retained' as const,
-        leaseExpiresAt: target.lease_expires_at,
-      };
-    }
-
     const consecutiveFailures = target.consecutive_render_failures + 1;
     const blocked = consecutiveFailures >= MAX_CONSECUTIVE_RENDER_FAILURES;
     const rolloutOutcome = await failRolloutItem(

--- a/convex/assetRollouts.test.ts
+++ b/convex/assetRollouts.test.ts
@@ -80,7 +80,7 @@ describe('rollout compatibility with independent item claims', () => {
   test('takeWork claims rollout items when foreground work is empty', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
-    const { t } = await seedCurrentTargets(2);
+    const { t, targetIds } = await seedCurrentTargets(2);
     await runningRollout(t);
     const result = await t.mutation(internal.assetPublisher.takeWork, {
       claimTokens: ['rollout-claim-token-00000001', 'rollout-claim-token-00000002'],
@@ -88,7 +88,7 @@ describe('rollout compatibility with independent item claims', () => {
     expect(result).toMatchObject({ status: 'assigned' });
     if (result.status !== 'assigned') throw new Error('Expected assigned rollout work');
     expect(result.items).toHaveLength(2);
-    expect(result.items.every((item) => item.workLane === 'rollout')).toBe(true);
+    expect(result.items.map((item) => item.targetId)).toEqual(targetIds);
   });
 
   test('foreground pending work retains priority over rollout work', async () => {
@@ -96,7 +96,7 @@ describe('rollout compatibility with independent item claims', () => {
     vi.setSystemTime(NOW);
     const { t } = await seedCurrentTargets(1);
     await runningRollout(t);
-    await t.run(async (ctx) => {
+    const foregroundTargetId = await t.run(async (ctx) => {
       const userId = await ctx.db.insert('users', { name: 'Foreground owner' });
       const factionId = await ctx.db.insert('factions', {
         owner_id: userId,
@@ -107,7 +107,7 @@ describe('rollout compatibility with independent item claims', () => {
         is_deleted: false,
         group_id: null,
       });
-      await ctx.db.insert('asset_targets', {
+      return await ctx.db.insert('asset_targets', {
         faction_id: factionId,
         asset_type: 'faction_sheet',
         desired_generation: 1,
@@ -118,7 +118,7 @@ describe('rollout compatibility with independent item claims', () => {
         foreground_updated_at: NOW,
       });
     });
-    await expect(takeOne(t, 1)).resolves.toMatchObject({ workLane: 'foreground' });
+    await expect(takeOne(t, 1)).resolves.toMatchObject({ targetId: foregroundTargetId });
   });
 
   test('successful completion finalizes the rollout and resets target failures', async () => {

--- a/convex/lib/assetPublisherSchemas.ts
+++ b/convex/lib/assetPublisherSchemas.ts
@@ -30,7 +30,7 @@ export const completionMetadataSchema = z.strictObject({
 });
 
 export const itemFailureSchema = z.strictObject({
-  attribution: z.enum(['target', 'infrastructure']),
+  attribution: z.literal('target'),
   error: z.string().trim().min(1).max(2_000),
 });
 
@@ -95,6 +95,6 @@ export const completeItemRequestSchema = exactItemRequestSchema.extend({
 });
 
 export const failItemRequestSchema = exactItemRequestSchema.extend({
-  attribution: z.enum(['target', 'infrastructure']),
+  attribution: z.literal('target'),
   error: z.string().trim().min(1).max(2_000),
 });

--- a/workers/publisher/convex.test.ts
+++ b/workers/publisher/convex.test.ts
@@ -11,7 +11,6 @@ function assignedItem(index = 1) {
     generation: 1,
     rendererVersion: 'faction-sheet-v3',
     leaseExpiresAt: 2_000_000_000_000,
-    workLane: 'foreground',
   };
 }
 
@@ -44,6 +43,18 @@ describe('Convex item-list parsing', () => {
       leaseExpiresAt: 2_000_000_000_000,
       items: [],
     });
+  });
+
+  test('ignores legacy work-lane metadata during a rolling deployment', () => {
+    const result = parseTakeWork({
+      ok: true,
+      schemaVersion: 1,
+      status: 'assigned',
+      leaseExpiresAt: 2_000_000_000_000,
+      items: [{ ...assignedItem(), workLane: 'foreground' }],
+    });
+    if (result.status !== 'assigned') throw new Error('Expected assigned work');
+    expect(result.items[0]).not.toHaveProperty('workLane');
   });
 
   test('rejects oversized, duplicate, and mismatched-lease assignments', () => {
@@ -111,7 +122,7 @@ describe('Convex item client', () => {
     await client.revalidate(claim);
     const cacheToken = `v1.${'a'.repeat(22)}.${'b'.repeat(43)}`;
     await client.complete(claim, { r2Etag: 'etag', bytes: 123, cacheToken });
-    await client.fail(claim, 'target', 'invalid output');
+    await client.fail(claim, 'invalid output');
 
     expect(requests.map((request) => request.url.split('/').at(-1))).toEqual([
       'take-work',

--- a/workers/publisher/convex.ts
+++ b/workers/publisher/convex.ts
@@ -13,7 +13,6 @@ export type AssignedItem = ExactItemClaim & {
   factionId: string;
   assetType: 'faction_sheet';
   leaseExpiresAt: number;
-  workLane?: 'foreground' | 'rollout';
 };
 
 export type TakeWorkResult =
@@ -40,7 +39,6 @@ type CompleteItemResult =
 
 type FailItemResult =
   | { status: 'stale' }
-  | { status: 'retained'; leaseExpiresAt: number }
   | { status: 'failed' | 'blocked'; consecutiveFailures: number };
 
 type RecordValue = Record<string, unknown>;
@@ -75,10 +73,7 @@ function parseAssignedItem(value: unknown): AssignedItem {
     !token(value.claimToken) ||
     !positiveInteger(value.generation) ||
     typeof value.rendererVersion !== 'string' ||
-    !finite(value.leaseExpiresAt) ||
-    (value.workLane !== undefined &&
-      value.workLane !== 'foreground' &&
-      value.workLane !== 'rollout')
+    !finite(value.leaseExpiresAt)
   ) {
     throw new Error('Convex assigned item response is invalid');
   }
@@ -90,9 +85,6 @@ function parseAssignedItem(value: unknown): AssignedItem {
     generation: value.generation,
     rendererVersion: value.rendererVersion,
     leaseExpiresAt: value.leaseExpiresAt,
-    ...(value.workLane === 'foreground' || value.workLane === 'rollout'
-      ? { workLane: value.workLane }
-      : {}),
   };
 }
 
@@ -196,9 +188,6 @@ function parseCompleteItem(value: unknown): CompleteItemResult {
 function parseFailItem(value: unknown): FailItemResult {
   const body = okRecord(value);
   if (body.status === 'stale') return { status: 'stale' };
-  if (body.status === 'retained' && finite(body.leaseExpiresAt)) {
-    return { status: 'retained', leaseExpiresAt: body.leaseExpiresAt };
-  }
   if (
     (body.status === 'failed' || body.status === 'blocked') &&
     positiveInteger(body.consecutiveFailures)
@@ -264,14 +253,13 @@ export class ConvexPublisherClient {
 
   async fail(
     claim: ExactItemClaim,
-    attribution: 'target' | 'infrastructure',
     error: unknown,
     deadlineAt?: number
   ): Promise<FailItemResult['status']> {
     const result = parseFailItem(
       await this.postExecutor(
         'fail-item',
-        { schemaVersion: 1, ...claim, attribution, error: truncatedError(error) },
+        { schemaVersion: 1, ...claim, attribution: 'target', error: truncatedError(error) },
         deadlineAt
       )
     );

--- a/workers/publisher/executor.ts
+++ b/workers/publisher/executor.ts
@@ -136,13 +136,11 @@ export async function executeItemList(
         if (!(error instanceof TargetRenderError)) throw error;
         const failure = await dependencies.client.fail(
           exact(item),
-          'target',
           publisherErrorMessage(error),
           requestDeadline(now, completionDeadlineAt)
         );
         if (failure === 'failed' || failure === 'blocked') result.targetFailed += 1;
-        else if (failure === 'stale') result.stale += 1;
-        else throw new Error(`Target failure unexpectedly retained its claim: ${failure}`);
+        else result.stale += 1;
         result.unprocessed -= 1;
         continue;
       }

--- a/workers/publisher/index.test.ts
+++ b/workers/publisher/index.test.ts
@@ -128,7 +128,6 @@ describe('publisher Worker scheduled item-list flow', () => {
                 generation: 2,
                 rendererVersion: rendererManifest.rendererVersion,
                 leaseExpiresAt: NOW + 240_000,
-                workLane: 'foreground',
               },
             ],
           });


### PR DESCRIPTION
## What changed

- stop returning the unused `workLane` field from Convex item assignments
- stop parsing and exposing that field in the publisher Worker
- narrow item failure attribution to the only caller-owned case, `target`
- remove the unused `infrastructure` / `retained` request-response branch
- assert rollout scheduling through claimed target identity instead of leaked lane metadata
- retain a compatibility test proving the new Worker ignores the legacy response field during rolling deployment

## Why

This is phase 9 of the staged asset-publishing cleanup. The removed protocol surface described implementation details or a failure path that no caller used. Rollout lanes remain part of Convex scheduling, and genuine infrastructure exceptions still leave claims leased for expiry without being reported as target failures.

The change is rolling-deployment compatible: the previous Worker accepted an assignment without `workLane`, while the new Worker ignores an extra legacy `workLane` field. The Worker continues sending `attribution: "target"` on the wire for compatibility with the previous Convex deployment.

## Impact

No renderer, PDF, delivery, asset storage, rollout policy, schema storage, deployment configuration, or infrastructure behavior changes.

## Validation

- `bunx vitest run convex/assetPublisher.test.ts convex/assetRollouts.test.ts convex/lib/assetPublisherHttp.test.ts workers/publisher/convex.test.ts workers/publisher/executor.test.ts workers/publisher/index.test.ts`
- `bun run test` (27 files, 243 tests)
- `bun run typecheck`
- `bun run publisher:typecheck`
- `bun run check:convex-skip`
- `bun run migrations:narrow-check`
- `bun run build-storybook`
- canonical `bun run publisher:assets` against production Convex
- `bun run publisher:assets:check`
- `bun run workers/publisher/capture-contract-regression.ts`
- `bun run publisher:release:dry-run`
- `bun run publisher:startup`
- `bunx biome check .` (one pre-existing warning)
