### PR TITLE
Fix publisher renderer invalidation handling

### DIFF
--- a/workers/publisher/config.ts
+++ b/workers/publisher/config.ts
@@ -24,15 +24,6 @@ function integer(name: string, value: string, minimum: number, maximum: number):
   return parsed;
 }
 
-export function supportsRendererVersion(
-  config: Pick<PublisherConfig, 'supportedRendererVersions'>,
-  rendererVersion: string
-): boolean {
-  return config.supportedRendererVersions.some(
-    (supportedRendererVersion) => supportedRendererVersion === rendererVersion
-  );
-}
-
 function absoluteHttpsUrl(name: string, value: string): string {
   const url = new URL(value);
   if (url.protocol !== 'https:' || url.username || url.password || url.hash) {

--- a/workers/publisher/executor.test.ts
+++ b/workers/publisher/executor.test.ts
@@ -37,6 +37,53 @@ function capturedPdf(): CapturedPdf {
 }
 
 describe('item-list executor', () => {
+  test('renders an older invalidation version with the current renderer', async () => {
+    const olderVersionItem = {
+      ...item,
+      rendererVersion: 'faction-sheet-v3',
+    };
+    const capture = vi.fn(async () => capturedPdf());
+    const complete = vi.fn(async () => 'completed' as const);
+
+    await expect(
+      executeItemList(config, [olderVersionItem], {
+        bucket: {
+          head: async () => null,
+          put: async () => ({ etag: 'etag-one' }) as R2Object,
+        },
+        cacheTokenSecret: cacheSecret,
+        client: {
+          revalidate: async () => ({
+            status: 'valid' as const,
+            factionId: olderVersionItem.factionId,
+            assetType: olderVersionItem.assetType,
+            leaseExpiresAt: olderVersionItem.leaseExpiresAt,
+          }),
+          complete,
+          fail: async () => 'failed' as const,
+        },
+        openBrowser: async () => ({
+          capture,
+          close: async () => undefined,
+          sessionId: () => 'browser-session-older-version',
+        }),
+        now: () => NOW,
+        signCacheToken: async () => `v1.${'a'.repeat(22)}.${'b'.repeat(43)}`,
+      })
+    ).resolves.toMatchObject({
+      rendered: 1,
+      completed: 1,
+      stale: 0,
+      unprocessed: 0,
+    });
+    expect(capture).toHaveBeenCalledOnce();
+    expect(complete).toHaveBeenCalledWith(
+      expect.objectContaining({ rendererVersion: 'faction-sheet-v3' }),
+      expect.anything(),
+      expect.any(Number)
+    );
+  });
+
   test('closes the browser before awaiting deferred completions', async () => {
     let completeResolve: ((value: 'completed') => void) | undefined;
     let closeObservedResolve: (() => void) | undefined;

--- a/workers/publisher/executor.ts
+++ b/workers/publisher/executor.ts
@@ -1,7 +1,7 @@
 import { createCacheToken } from '../../convex/lib/assetPublisherHttp';
 import { publisherErrorMessage } from '../../src/app/capture/publisher-diagnostics';
 import { type CapturedPdf, type PublisherBrowserSession, TargetRenderError } from './browser';
-import { MAX_ASSIGNED_ITEMS, type PublisherConfig, supportsRendererVersion } from './config';
+import { MAX_ASSIGNED_ITEMS, type PublisherConfig } from './config';
 import type { AssignedItem, ConvexPublisherClient, ExactItemClaim } from './convex';
 import { type AssetBucket, conditionallyPutFactionSheet } from './r2';
 
@@ -119,9 +119,8 @@ export async function executeItemList(
 
     for (const item of items) {
       if (now() >= workDeadlineAt) break;
-      if (!supportsRendererVersion(config, item.rendererVersion)) {
-        throw new Error(`Unsupported assigned renderer: ${item.rendererVersion}`);
-      }
+      // The item version fences invalidation and completion; the deployed Worker always renders
+      // with its one current implementation.
 
       let captured: CapturedPdf;
       try {

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -5,8 +5,8 @@ export const rendererManifest = {
   rendererVersion: 'faction-sheet-v4',
   supportedRendererVersions: ['faction-sheet-v4'],
   rendererId:
-    'faction-sheet/sha256:05d3817c15fd17af008f1e21fb634e99469a6a462fed444a454c19058bd94da1',
-  digest: '05d3817c15fd17af008f1e21fb634e99469a6a462fed444a454c19058bd94da1',
+    'faction-sheet/sha256:960b2e636a3ddef5ffd80f76ebcc9fd31393d78089c920b7ed6eaea33fc7d48c',
+  digest: '960b2e636a3ddef5ffd80f76ebcc9fd31393d78089c920b7ed6eaea33fc7d48c',
   contract: {
     rendererVersion: 'faction-sheet-v4',
     supportedRendererVersions: ['faction-sheet-v4'],

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -5,8 +5,8 @@ export const rendererManifest = {
   rendererVersion: 'faction-sheet-v4',
   supportedRendererVersions: ['faction-sheet-v4'],
   rendererId:
-    'faction-sheet/sha256:960b2e636a3ddef5ffd80f76ebcc9fd31393d78089c920b7ed6eaea33fc7d48c',
-  digest: '960b2e636a3ddef5ffd80f76ebcc9fd31393d78089c920b7ed6eaea33fc7d48c',
+    'faction-sheet/sha256:05d3817c15fd17af008f1e21fb634e99469a6a462fed444a454c19058bd94da1',
+  digest: '05d3817c15fd17af008f1e21fb634e99469a6a462fed444a454c19058bd94da1',
   contract: {
     rendererVersion: 'faction-sheet-v4',
     supportedRendererVersions: ['faction-sheet-v4'],


### PR DESCRIPTION
## Summary

- treat the assigned renderer version as an invalidation and exact-completion token, not a selectable rendering implementation
- always capture assigned work with the single renderer deployed in the Worker
- cover the production failure with a regression test for an older queued version
- refresh the generated publisher release manifest

## Root cause

The v4 Worker rejected one queued v3 item before capture. The application has only one deployed renderer; version increments schedule regeneration and fence stale completion. The compatibility check incorrectly modeled those labels as separately available implementations.

## Verification

- bun run test — 55 files, 356 tests
- bun run publisher:test — 17 files, 189 tests
- bun run typecheck
- bun run publisher:typecheck
- bun run publisher:types:check
- bun run publisher:assets:check
- bun run publisher:dry-run
- targeted Biome check and git diff --check

Refs #96

This PR must not be merged until explicitly approved.