### PR TITLE
Regenerate faction sheets at revision 5

### DIFF
--- a/src/shared/asset-publishing/renderer-revisions.ts
+++ b/src/shared/asset-publishing/renderer-revisions.ts
@@ -5,5 +5,5 @@ import { FACTION_SHEET_ASSET_TYPE } from './publication';
  * It never selects a historical Renderer implementation.
  */
 export const CHECKED_IN_RENDERER_REVISIONS = {
-  [FACTION_SHEET_ASSET_TYPE]: 4,
+  [FACTION_SHEET_ASSET_TYPE]: 5,
 } as const;


### PR DESCRIPTION
## Summary

- increase the checked-in `faction_sheet` Renderer revision from `4` to `5`
- keep the deployed Renderer implementation singular and unchanged
- cause the production deployment to schedule the bounded asynchronous regeneration scan for active factions

## Deployment behavior

After the Worker deploy and health smoke succeed, CI compares the checked-in revision with production. The higher revision is stored atomically and schedules the regeneration scan. CI does not wait for captures to finish. Existing save-triggered jobs coalesce through the same Publication job model.

Publication pickup remains enabled from the successful Release 1 production proof.

Do not merge without explicit approval.

## Validation

- Biome
- TypeScript
- Convex skip guard
- 53 test files / 337 tests
- targeted Publication revision and regeneration tests: 16 passed

Implements Release 2 of the accepted contract in #110 and advances #103.