### PR TITLE
Delete legacy publication rows

### DIFF
--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -31,6 +31,36 @@
       "requires": ["faction_slug_reservations_v1"]
     },
     {
+      "id": "publication_delete_legacy_rollout_items_v1",
+      "phase": "widen",
+      "requires": []
+    },
+    {
+      "id": "publication_delete_legacy_rollouts_v1",
+      "phase": "widen",
+      "requires": ["publication_delete_legacy_rollout_items_v1"]
+    },
+    {
+      "id": "publication_delete_legacy_targets_v1",
+      "phase": "widen",
+      "requires": ["publication_delete_legacy_rollout_items_v1"]
+    },
+    {
+      "id": "publication_delete_legacy_type_configs_v1",
+      "phase": "widen",
+      "requires": ["publication_delete_legacy_rollouts_v1"]
+    },
+    {
+      "id": "publication_legacy_tables_narrow",
+      "phase": "narrow",
+      "requires": [
+        "publication_delete_legacy_rollout_items_v1",
+        "publication_delete_legacy_rollouts_v1",
+        "publication_delete_legacy_targets_v1",
+        "publication_delete_legacy_type_configs_v1"
+      ]
+    },
+    {
       "id": "profiles_backfill_guard",
       "phase": "narrow",
       "requires": ["profiles_from_users_v1"]

--- a/convex/migrations.publicationLegacyDeletion.test.ts
+++ b/convex/migrations.publicationLegacyDeletion.test.ts
@@ -1,0 +1,126 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import migrationsTest from '@convex-dev/migrations/test';
+import { convexTest } from 'convex-test';
+import { describe, expect, test } from 'vitest';
+
+import { assetPublishingFaction } from '../src/game/fixtures/assetPublishingFaction';
+import { internal } from './_generated/api';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+
+describe('legacy Publication deletion migrations', () => {
+  test('delete only the four legacy publication tables', async () => {
+    const t = convexTest(schema, modules);
+    migrationsTest.register(t);
+
+    const seeded = await t.run(async (ctx) => {
+      const ownerId = await ctx.db.insert('users', { name: 'Legacy publication owner' });
+      const factionId = await ctx.db.insert('factions', {
+        owner_id: ownerId,
+        data: assetPublishingFaction,
+        slug: 'legacy-publication-faction',
+        created_at: '2026-07-25T00:00:00.000Z',
+        updated_at: '2026-07-25T00:00:00.000Z',
+        is_deleted: false,
+        group_id: null,
+      });
+      const rolloutId = await ctx.db.insert('asset_rollouts', {
+        asset_type: 'faction_sheet',
+        target_renderer_version: 'legacy-v4',
+        status: 'completed',
+        cutoff_creation_time: 1,
+        discovery_pages: 1,
+        discovery_continuations: 0,
+        discovered: 1,
+        pending: 0,
+        leased: 0,
+        succeeded: 1,
+        superseded: 0,
+        cancelled: 0,
+        terminal_errors: 0,
+        created_at: 1,
+        updated_at: 2,
+      });
+      const targetId = await ctx.db.insert('asset_targets', {
+        faction_id: factionId,
+        asset_type: 'faction_sheet',
+        desired_generation: 1,
+        desired_renderer_version: 'legacy-v4',
+        published_generation: 1,
+        published_renderer_version: 'legacy-v4',
+        status: 'current',
+        consecutive_render_failures: 0,
+        rollout_id: rolloutId,
+      });
+      await ctx.db.insert('asset_rollout_items', {
+        rollout_id: rolloutId,
+        target_id: targetId,
+        enrolled_generation: 1,
+        enrolled_renderer_version: 'legacy-v4',
+        state: 'succeeded',
+        retry_count: 0,
+        next_eligible_at: 0,
+        created_at: 1,
+        updated_at: 2,
+      });
+      await ctx.db.insert('asset_type_configs', {
+        asset_type: 'faction_sheet',
+        status: 'active',
+        active_renderer_version: 'legacy-v4',
+        active_rollout_id: rolloutId,
+        updated_at: 2,
+      });
+
+      const publicationAssetId = await ctx.db.insert('publication_assets', {
+        asset_type: 'faction_sheet',
+        asset_id: factionId,
+        cache_token: 'current-cache-token',
+        published_at: 3,
+      });
+      const publicationJobId = await ctx.db.insert('publication_jobs', {
+        asset_type: 'faction_sheet',
+        asset_id: factionId,
+        asset_data: assetPublishingFaction,
+        status: 'pending',
+        attempt_counter: 0,
+        created_at: 4,
+        updated_at: 4,
+      });
+
+      return { publicationAssetId, publicationJobId };
+    });
+
+    await t.mutation(internal.migrations.publication_delete_legacy_rollout_items_v1, {});
+    await t.mutation(internal.migrations.publication_delete_legacy_rollouts_v1, {});
+    await t.mutation(internal.migrations.publication_delete_legacy_targets_v1, {});
+    await t.mutation(internal.migrations.publication_delete_legacy_type_configs_v1, {});
+
+    const result = await t.run(async (ctx) => ({
+      legacy: {
+        rolloutItems: await ctx.db.query('asset_rollout_items').collect(),
+        rollouts: await ctx.db.query('asset_rollouts').collect(),
+        targets: await ctx.db.query('asset_targets').collect(),
+        typeConfigs: await ctx.db.query('asset_type_configs').collect(),
+      },
+      publicationAsset: await ctx.db.get(seeded.publicationAssetId),
+      publicationJob: await ctx.db.get(seeded.publicationJobId),
+    }));
+
+    expect(result.legacy).toEqual({
+      rolloutItems: [],
+      rollouts: [],
+      targets: [],
+      typeConfigs: [],
+    });
+    expect(result.publicationAsset).toMatchObject({
+      cache_token: 'current-cache-token',
+    });
+    expect(result.publicationJob).toMatchObject({
+      status: 'pending',
+      attempt_counter: 0,
+    });
+  });
+});

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -21,6 +21,12 @@ const MIGRATION_IDS: Record<string, MigrationRef> = {
   profiles_from_users_v1: internal.migrations.profiles_from_users_v1,
   faction_slug_reservations_v1: internal.migrations.faction_slug_reservations_v1,
   faction_slug_reservations_verify_v1: internal.migrations.faction_slug_reservations_verify_v1,
+  publication_delete_legacy_rollout_items_v1:
+    internal.migrations.publication_delete_legacy_rollout_items_v1,
+  publication_delete_legacy_rollouts_v1: internal.migrations.publication_delete_legacy_rollouts_v1,
+  publication_delete_legacy_targets_v1: internal.migrations.publication_delete_legacy_targets_v1,
+  publication_delete_legacy_type_configs_v1:
+    internal.migrations.publication_delete_legacy_type_configs_v1,
 };
 
 type MigrationId = keyof typeof MIGRATION_IDS;
@@ -231,6 +237,38 @@ export const faction_slug_reservations_verify_v1 = migrations.define({
   },
 });
 
+export const publication_delete_legacy_rollout_items_v1 = migrations.define({
+  table: 'asset_rollout_items',
+  batchSize: 50,
+  migrateOne: async (ctx, row) => {
+    await ctx.db.delete(row._id);
+  },
+});
+
+export const publication_delete_legacy_rollouts_v1 = migrations.define({
+  table: 'asset_rollouts',
+  batchSize: 50,
+  migrateOne: async (ctx, row) => {
+    await ctx.db.delete(row._id);
+  },
+});
+
+export const publication_delete_legacy_targets_v1 = migrations.define({
+  table: 'asset_targets',
+  batchSize: 50,
+  migrateOne: async (ctx, row) => {
+    await ctx.db.delete(row._id);
+  },
+});
+
+export const publication_delete_legacy_type_configs_v1 = migrations.define({
+  table: 'asset_type_configs',
+  batchSize: 50,
+  migrateOne: async (ctx, row) => {
+    await ctx.db.delete(row._id);
+  },
+});
+
 export const run = migrations.runner();
 
 export const runDeployMigrations = migrations.runner([
@@ -241,6 +279,10 @@ export const runDeployMigrations = migrations.runner([
   internal.migrations.profiles_from_users_v1,
   internal.migrations.faction_slug_reservations_v1,
   internal.migrations.faction_slug_reservations_verify_v1,
+  internal.migrations.publication_delete_legacy_rollout_items_v1,
+  internal.migrations.publication_delete_legacy_rollouts_v1,
+  internal.migrations.publication_delete_legacy_targets_v1,
+  internal.migrations.publication_delete_legacy_type_configs_v1,
 ]);
 
 export const runRequired = mutation({

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -105,8 +105,8 @@ export default defineSchema({
     renderer_revisions: v.record(v.string(), v.number()),
     updated_at: v.number(),
   }).index('by_key', ['key']),
-  // Release 1 keeps these populated legacy declarations inert. No active code
-  // reads or writes them; a later bounded migration empties them before removal.
+  // Release 3 empties these inert legacy tables with bounded migrations.
+  // Release 4 removes their declarations after production verifies completion.
   asset_targets: defineTable({
     faction_id: v.id('factions'),
     asset_type: v.literal('faction_sheet'),


### PR DESCRIPTION
## Summary

- add bounded, resumable deletion migrations for `asset_rollout_items`, `asset_rollouts`, `asset_targets`, and `asset_type_configs`
- require all four migrations to complete before the Release 4 schema narrow is allowed
- prove the deletion leaves `publication_assets` and `publication_jobs` unchanged

## Release behavior

This is Release 3 of the approved single-Renderer cutover. The required-migration deploy step runs and waits for the four deletions, recording component progress and completion. It does not backfill, transform, or import legacy rows. The legacy table declarations remain until the separately reviewed Release 4 narrow.

Do not merge without approval.

## Validation

- `bun run biome:check`
- `bun run check:convex-skip`
- `bun run typecheck`
- `bun run test` (54 files, 338 tests)
- `bun run app:build`
- `git diff --check`

Related to #103 and #110.