### PR TITLE
Show faction capture status on detail pages

### DIFF
--- a/convex/assetPublishingStatus.test.ts
+++ b/convex/assetPublishingStatus.test.ts
@@ -47,16 +47,16 @@ describe('public asset publishing status projection', () => {
 
     expect(await publicStatus(t, factionId)).toEqual({
       status: null,
+      captureStatus: null,
       publicationHref: null,
       lastPublishedAt: null,
     });
   });
 
   test.each([
-    'pending',
-    'in_progress',
-    'error',
-  ] as const)('does not expose %s job state publicly', async (status) => {
+    ['pending', 'scheduled'],
+    ['in_progress', 'in_progress'],
+  ] as const)('projects %s job state as %s capture state', async (status, captureStatus) => {
     const t = convexTest(schema, modules);
     const factionId = await seedFaction(t);
     await t.run(
@@ -78,6 +78,35 @@ describe('public asset publishing status projection', () => {
 
     expect(await publicStatus(t, factionId)).toEqual({
       status: null,
+      captureStatus,
+      publicationHref: null,
+      lastPublishedAt: null,
+    });
+  });
+
+  test('does not expose failed work as an active capture', async () => {
+    const t = convexTest(schema, modules);
+    const factionId = await seedFaction(t);
+    await t.run(
+      async (ctx) =>
+        await ctx.db.insert('publication_jobs', {
+          asset_type: 'faction_sheet',
+          asset_id: factionId,
+          asset_data: {
+            factionId,
+            slug: 'status-projection',
+            faction: assetPublishingFaction,
+          },
+          status: 'error',
+          attempt_counter: 10,
+          created_at: 1,
+          updated_at: 1,
+        })
+    );
+
+    expect(await publicStatus(t, factionId)).toEqual({
+      status: null,
+      captureStatus: null,
       publicationHref: null,
       lastPublishedAt: null,
     });
@@ -110,8 +139,33 @@ describe('public asset publishing status projection', () => {
 
     expect(await publicStatus(t, factionId)).toEqual({
       status: 'current',
+      captureStatus: 'scheduled',
       publicationHref: `/published/factions/${factionId}/sheet.pdf?v=private-cache-token`,
       lastPublishedAt: 789,
     });
+  });
+
+  test('shows active capture ahead of a pending successor', async () => {
+    const t = convexTest(schema, modules);
+    const factionId = await seedFaction(t);
+    await t.run(async (ctx) => {
+      for (const status of ['in_progress', 'pending'] as const) {
+        await ctx.db.insert('publication_jobs', {
+          asset_type: 'faction_sheet',
+          asset_id: factionId,
+          asset_data: {
+            factionId,
+            slug: 'status-projection',
+            faction: assetPublishingFaction,
+          },
+          status,
+          attempt_counter: 0,
+          created_at: status === 'in_progress' ? 1 : 2,
+          updated_at: status === 'in_progress' ? 1 : 2,
+        });
+      }
+    });
+
+    expect((await publicStatus(t, factionId)).captureStatus).toBe('in_progress');
   });
 });

--- a/convex/assetPublishingStatus.ts
+++ b/convex/assetPublishingStatus.ts
@@ -2,9 +2,11 @@ import type { Doc, Id } from './_generated/dataModel';
 import type { QueryCtx } from './types';
 
 export type PublicAssetPublishingStatus = 'current';
+export type PublicAssetCaptureStatus = 'scheduled' | 'in_progress';
 
 export type PublicAssetPublishingStatusProjection = {
   status: PublicAssetPublishingStatus | null;
+  captureStatus: PublicAssetCaptureStatus | null;
   publicationHref: string | null;
   lastPublishedAt: number | null;
 };
@@ -15,15 +17,23 @@ type ProjectablePublicationAsset = Pick<
 >;
 
 /**
- * Public state is deliberately independent from ephemeral job state. Once an
- * asset exists, replacement work never removes or downgrades its public link.
+ * Once an asset exists, replacement work never removes or downgrades its
+ * public link. Capture state is added separately by the faction projection.
  */
 export function projectPublicAssetPublishingStatus(
   asset: ProjectablePublicationAsset | null
 ): PublicAssetPublishingStatusProjection {
-  if (!asset) return { status: null, publicationHref: null, lastPublishedAt: null };
+  if (!asset) {
+    return {
+      status: null,
+      captureStatus: null,
+      publicationHref: null,
+      lastPublishedAt: null,
+    };
+  }
   return {
     status: 'current',
+    captureStatus: null,
     publicationHref: `/published/factions/${encodeURIComponent(asset.asset_id)}/sheet.pdf?v=${encodeURIComponent(asset.cache_token)}`,
     lastPublishedAt: asset.published_at,
   };
@@ -33,14 +43,34 @@ export async function factionSheetPublishingStatus(
   ctx: Pick<QueryCtx, 'db'>,
   factionId: Id<'factions'>
 ): Promise<PublicAssetPublishingStatusProjection> {
-  const assets = await ctx.db
-    .query('publication_assets')
-    .withIndex('by_asset_type_and_asset_id', (q) =>
-      q.eq('asset_type', 'faction_sheet').eq('asset_id', factionId)
-    )
-    .take(2);
+  const [assets, jobs] = await Promise.all([
+    ctx.db
+      .query('publication_assets')
+      .withIndex('by_asset_type_and_asset_id', (q) =>
+        q.eq('asset_type', 'faction_sheet').eq('asset_id', factionId)
+      )
+      .take(2),
+    ctx.db
+      .query('publication_jobs')
+      .withIndex('by_asset_type_and_asset_id', (q) =>
+        q.eq('asset_type', 'faction_sheet').eq('asset_id', factionId)
+      )
+      .take(4),
+  ]);
   if (assets.length > 1) {
     throw new Error('Publication invariant violated: duplicate faction-sheet assets');
   }
-  return projectPublicAssetPublishingStatus(assets[0] ?? null);
+
+  const captureStatus: PublicAssetCaptureStatus | null = jobs.some(
+    (job) => job.status === 'in_progress'
+  )
+    ? 'in_progress'
+    : jobs.some((job) => job.status === 'pending')
+      ? 'scheduled'
+      : null;
+
+  return {
+    ...projectPublicAssetPublishingStatus(assets[0] ?? null),
+    captureStatus,
+  };
 }

--- a/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
+++ b/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
@@ -65,7 +65,7 @@ export function FactionAuthoringToolbar({
             ? 'green'
             : 'gray';
   const publishingCopy = assetPublishing
-    ? factionAssetPublishingCopy(assetPublishing.status, saveState)
+    ? factionAssetPublishingCopy(assetPublishing.status, saveState, assetPublishing.captureStatus)
     : saveState === 'saved'
       ? 'Saved. Publication scheduled.'
       : 'Saving this faction schedules its public assets.';

--- a/src/app/factions/assetPublishingStatus.test.ts
+++ b/src/app/factions/assetPublishingStatus.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'vitest';
 import { factionAssetPublishingCopy } from './assetPublishingStatus';
 
 describe('faction save and publishing feedback', () => {
-  test('moves from saving to immediate save confirmation without exposing job state', () => {
+  test('moves from saving to immediate save confirmation', () => {
     expect(factionAssetPublishingCopy('current', 'saving')).toBe('Saving changes…');
     expect(factionAssetPublishingCopy('current', 'saved')).toBe(
       'Saved. Publication scheduled. Public assets are current.'
@@ -16,5 +16,20 @@ describe('faction save and publishing feedback', () => {
   test('keeps absent and failed-save semantics explicit', () => {
     expect(factionAssetPublishingCopy(null)).toBe('The public asset will be available soon.');
     expect(factionAssetPublishingCopy('current', 'error')).toBe('Changes were not saved.');
+  });
+
+  test('explains active capture work without hiding the current PDF', () => {
+    expect(factionAssetPublishingCopy('current', 'idle', 'scheduled')).toBe(
+      'A new faction sheet capture is scheduled. The current PDF remains available.'
+    );
+    expect(factionAssetPublishingCopy('current', 'idle', 'in_progress')).toBe(
+      'A new faction sheet capture is in progress. The current PDF remains available.'
+    );
+    expect(factionAssetPublishingCopy(null, 'idle', 'scheduled')).toBe(
+      'A new faction sheet capture is scheduled.'
+    );
+    expect(factionAssetPublishingCopy('current', 'saved', 'scheduled')).toBe(
+      'Saved. A new faction sheet capture is scheduled. The current PDF remains available.'
+    );
   });
 });

--- a/src/app/factions/assetPublishingStatus.ts
+++ b/src/app/factions/assetPublishingStatus.ts
@@ -1,4 +1,7 @@
-import type { PublicAssetPublishingStatus } from '../../../convex/assetPublishingStatus';
+import type {
+  PublicAssetCaptureStatus,
+  PublicAssetPublishingStatus,
+} from '../../../convex/assetPublishingStatus';
 
 export type FactionSaveState = 'idle' | 'saving' | 'saved' | 'error';
 
@@ -8,11 +11,22 @@ const statusCopy: Record<PublicAssetPublishingStatus, string> = {
 
 export function factionAssetPublishingCopy(
   status: PublicAssetPublishingStatus | null,
-  saveState: FactionSaveState = 'idle'
+  saveState: FactionSaveState = 'idle',
+  captureStatus: PublicAssetCaptureStatus | null = null
 ) {
   if (saveState === 'saving') return 'Saving changes…';
   if (saveState === 'error') return 'Changes were not saved.';
 
-  const publishingCopy = status ? statusCopy[status] : 'The public asset will be available soon.';
-  return saveState === 'saved' ? `Saved. Publication scheduled. ${publishingCopy}` : publishingCopy;
+  const publishingCopy =
+    captureStatus === 'in_progress'
+      ? `A new faction sheet capture is in progress.${status === 'current' ? ' The current PDF remains available.' : ''}`
+      : captureStatus === 'scheduled'
+        ? `A new faction sheet capture is scheduled.${status === 'current' ? ' The current PDF remains available.' : ''}`
+        : status
+          ? statusCopy[status]
+          : 'The public asset will be available soon.';
+  if (saveState !== 'saved') return publishingCopy;
+  return captureStatus
+    ? `Saved. ${publishingCopy}`
+    : `Saved. Publication scheduled. ${publishingCopy}`;
 }

--- a/src/app/factions/db.ts
+++ b/src/app/factions/db.ts
@@ -180,6 +180,7 @@ export function useFaction(
     groupAccess: result.data?.groupAccess ?? null,
     assetPublishing: result.data?.assetPublishing ?? {
       status: null,
+      captureStatus: null,
       publicationHref: null,
       lastPublishedAt: null,
     },

--- a/src/app/routes/_app/factions/$factionId/index.tsx
+++ b/src/app/routes/_app/factions/$factionId/index.tsx
@@ -161,6 +161,7 @@ function FactionDetailPage() {
   const data = faction.data;
   const planets = data.planet ?? [];
   const troopCount = data.troops.reduce((total, troop) => total + troop.count, 0);
+  const publishingStatus = assetPublishing.captureStatus ?? assetPublishing.status;
 
   return (
     <PageLayout
@@ -608,18 +609,32 @@ function FactionDetailPage() {
                 <Badge
                   variant="light"
                   color={
-                    assetPublishing.status === 'current'
+                    publishingStatus === 'current'
                       ? 'green'
-                      : assetPublishing.status === 'delayed'
+                      : publishingStatus === 'scheduled'
                         ? 'yellow'
-                        : 'gray'
+                        : publishingStatus === 'in_progress'
+                          ? 'blue'
+                          : 'gray'
                   }
+                  role="status"
+                  aria-live="polite"
                 >
-                  {assetPublishing.status ?? 'Unavailable'}
+                  {publishingStatus === 'in_progress'
+                    ? 'In progress'
+                    : publishingStatus === 'scheduled'
+                      ? 'Scheduled'
+                      : publishingStatus === 'current'
+                        ? 'Current'
+                        : 'Unavailable'}
                 </Badge>
               </Group>
               <Text size="sm" c="dimmed">
-                {factionAssetPublishingCopy(assetPublishing.status)}
+                {factionAssetPublishingCopy(
+                  assetPublishing.status,
+                  'idle',
+                  assetPublishing.captureStatus
+                )}
               </Text>
               <Anchor
                 fw={600}

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -3,8 +3,8 @@
 export const rendererManifest = {
   schemaVersion: 1,
   rendererIdentity:
-    'faction-sheet/sha256:6709f1d9657f12ca9ae9175318a9984418fa1dcde7aaf008c44a14919338f61c',
-  digest: '6709f1d9657f12ca9ae9175318a9984418fa1dcde7aaf008c44a14919338f61c',
+    'faction-sheet/sha256:6da556d9ffe7b9f3bdc3735cfa2b56471e029e5afd59bbdb40289212cac45649',
+  digest: '6da556d9ffe7b9f3bdc3735cfa2b56471e029e5afd59bbdb40289212cac45649',
   contract: {
     viewport: {
       width: 2100,


### PR DESCRIPTION
## Summary
- project pending and in-progress faction-sheet work through the existing faction detail query
- show Scheduled or In progress in the Files card while keeping the current PDF available
- keep editor publication feedback aligned with the live capture state

## Validation
- `bun run test` (339 tests)
- `bun run typecheck`
- `bun run app:build`
- local visual smoke check of the faction detail page