### PR TITLE
Productionize responsive connected tabs for faction authoring

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -61,6 +61,27 @@ export default definePreview({
             height: '900px',
           },
         },
+        appAuthoringWide: {
+          name: 'Authoring wide',
+          styles: {
+            width: '1280px',
+            height: '900px',
+          },
+        },
+        appAuthoringCompact: {
+          name: 'Authoring compact',
+          styles: {
+            width: '1074px',
+            height: '1199px',
+          },
+        },
+        appAuthoringTablet: {
+          name: 'Authoring tablet',
+          styles: {
+            width: '900px',
+            height: '1000px',
+          },
+        },
         appLarge: {
           name: 'App large',
           styles: {

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.module.css
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.module.css
@@ -6,6 +6,7 @@
   --connected-tabs-panel-padding: var(--mantine-spacing-lg);
 
   container: connected-tabs / inline-size;
+  width: 100%;
   min-width: 0;
 }
 
@@ -166,7 +167,6 @@
   position: relative;
   z-index: 3;
   min-width: 0;
-  min-height: 36rem;
   padding: var(--connected-tabs-panel-padding);
   overflow: visible;
 }

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.module.css
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.module.css
@@ -1,0 +1,208 @@
+.host {
+  --connected-tabs-rail-width: 11.5rem;
+  --connected-tabs-tab-height: 4.2rem;
+  --connected-tabs-gap: 0.45rem;
+  --connected-tabs-radius: 8px;
+  --connected-tabs-panel-padding: var(--mantine-spacing-lg);
+
+  container: connected-tabs / inline-size;
+  min-width: 0;
+}
+
+.root {
+  position: relative;
+  display: grid;
+  grid-template-columns: var(--connected-tabs-rail-width) minmax(0, 1fr);
+  align-items: start;
+  min-width: 0;
+  isolation: isolate;
+  overflow: visible;
+}
+
+.surfaceLayer {
+  position: absolute;
+  z-index: 0;
+  inset: 0;
+  display: block;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.definitions {
+  position: absolute;
+}
+
+.geometryShadow,
+.geometryContour {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.geometryShadow {
+  z-index: 0;
+  fill: #000;
+}
+
+.glassSurface {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  background: var(--glass-surface-1, rgb(255 255 255 / 12%));
+  backdrop-filter: blur(8px);
+}
+
+.geometryContour {
+  z-index: 2;
+  fill: none;
+  stroke: var(--panel-border, #fee7c0);
+  stroke-width: 1;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.tabList {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  flex-direction: column;
+  gap: var(--connected-tabs-gap);
+  align-self: stretch;
+  width: 100%;
+  min-width: 0;
+}
+
+.tab {
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: 2rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.65rem;
+  width: 100%;
+  min-width: 0;
+  height: var(--connected-tabs-tab-height);
+  margin: 0;
+  padding: 0.65rem 0.8rem;
+  color: var(--mantine-color-dark-9);
+  font: inherit;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  opacity: 0.58;
+  cursor: pointer;
+  transition: opacity 140ms ease;
+}
+
+.tab:hover {
+  opacity: 0.78;
+}
+
+.tab[data-state="active"] {
+  opacity: 1;
+}
+
+.tab:disabled {
+  opacity: 0.28;
+  cursor: not-allowed;
+}
+
+.tab:focus-visible {
+  outline: none;
+}
+
+.iconDisc {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 50%;
+  transition:
+    color 150ms ease,
+    background-color 150ms ease,
+    border-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.iconDisc img {
+  max-width: 1.4rem;
+  max-height: 1.4rem;
+}
+
+.tab[data-state="active"] .iconDisc {
+  color: rgb(250 246 238 / 92%);
+  background: var(--mantine-color-dark-9, #151515);
+  border-color: rgb(250 246 238 / 52%);
+  box-shadow: 0 0 0 2px rgb(0 0 0 / 12%);
+}
+
+.tab[data-state="active"] .iconDisc img {
+  filter: brightness(0) invert(1);
+  opacity: 0.92;
+}
+
+.tab:focus-visible .iconDisc {
+  box-shadow:
+    0 0 0 2px rgb(250 246 238 / 90%),
+    0 0 0 4px var(--mantine-color-dark-9, #151515);
+}
+
+.label {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-weight: 700;
+}
+
+.indicator {
+  display: inline-flex;
+}
+
+.panelShell {
+  container: connected-tabs-panel / inline-size;
+  position: relative;
+  z-index: 3;
+  min-width: 0;
+  min-height: 36rem;
+  padding: var(--connected-tabs-panel-padding);
+  overflow: visible;
+}
+
+.panel {
+  min-width: 0;
+  outline: none;
+}
+
+.panel:focus-visible {
+  outline: 2px solid var(--mantine-primary-color-filled, #8f2717);
+  outline-offset: 0.3rem;
+}
+
+@container connected-tabs (max-width: 46rem) {
+  .root {
+    --connected-tabs-rail-width: 9.25rem;
+    --connected-tabs-panel-padding: var(--mantine-spacing-md);
+  }
+
+  .tab {
+    grid-template-columns: 2rem minmax(0, 1fr);
+    gap: 0.45rem;
+    padding-inline: 0.55rem;
+  }
+
+  .indicator {
+    position: absolute;
+    top: 0.3rem;
+    right: 0.3rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab,
+  .iconDisc {
+    transition: none;
+  }
+}

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.module.css
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.module.css
@@ -29,6 +29,10 @@
   pointer-events: none;
 }
 
+.mobilePicker {
+  display: none;
+}
+
 .definitions {
   position: absolute;
 }
@@ -181,6 +185,184 @@
   outline-offset: 0.3rem;
 }
 
+@container connected-tabs (max-width: 34rem) {
+  .root {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    overflow: visible;
+    background: var(--glass-surface-1, rgb(255 255 255 / 12%));
+    border: 1px solid var(--panel-border, #fee7c0);
+    border-radius: var(--connected-tabs-radius);
+    box-shadow: var(--panel-shadow, 0 0 20px rgb(0 0 0 / 16.5%));
+    backdrop-filter: blur(8px);
+  }
+
+  .surfaceLayer,
+  .tabList {
+    display: none;
+  }
+
+  .mobilePicker {
+    position: relative;
+    z-index: 3;
+    display: grid;
+    grid-template-columns: 2.25rem minmax(0, 1fr) 2.25rem;
+    gap: 0.25rem;
+    align-items: center;
+    min-width: 0;
+    margin: var(--mantine-spacing-sm);
+    padding: 0.2rem;
+    background: rgb(255 255 255 / 22%);
+    border: 1px solid var(--panel-border, #fee7c0);
+    border-radius: var(--mantine-radius-sm);
+  }
+
+  .mobileStepButton {
+    display: grid;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    color: var(--mantine-color-dark-9, #151515);
+    background: transparent;
+    border: 0;
+    border-radius: var(--mantine-radius-sm);
+    cursor: pointer;
+    place-items: center;
+  }
+
+  .mobileStepButton:hover {
+    background: rgb(255 255 255 / 34%);
+  }
+
+  .mobileStepButton:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+  }
+
+  .mobileStepButton:focus-visible,
+  .mobileSelect:focus-visible {
+    outline: 2px solid var(--mantine-color-dark-9, #151515);
+    outline-offset: 2px;
+  }
+
+  .mobileSelect {
+    display: grid;
+    grid-template-columns: 2rem minmax(0, 1fr) auto auto;
+    gap: 0.5rem;
+    align-items: center;
+    min-width: 0;
+    height: 2.25rem;
+    padding: 0 0.3rem;
+    color: var(--mantine-color-dark-9, #151515);
+    font: inherit;
+    text-align: left;
+    background: transparent;
+    border: 0;
+    border-radius: var(--mantine-radius-sm);
+    cursor: pointer;
+  }
+
+  .mobileSelect:hover {
+    background: rgb(255 255 255 / 24%);
+  }
+
+  .mobileIconDisc {
+    display: grid;
+    width: 1.75rem;
+    height: 1.75rem;
+    color: rgb(250 246 238 / 92%);
+    background: var(--mantine-color-dark-9, #151515);
+    border: 1px solid rgb(250 246 238 / 52%);
+    border-radius: 50%;
+    box-shadow: 0 0 0 2px rgb(0 0 0 / 12%);
+    place-items: center;
+  }
+
+  .mobileIconDisc img {
+    max-width: 1.25rem;
+    max-height: 1.25rem;
+    filter: brightness(0) invert(1);
+    opacity: 0.92;
+  }
+
+  .mobileSelectValue {
+    min-width: 0;
+    overflow: hidden;
+    font-weight: 700;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mobileSelectIcon {
+    display: inline-flex;
+    color: var(--mantine-color-dimmed);
+  }
+
+  .panelShell {
+    padding: 0 var(--mantine-spacing-md) var(--mantine-spacing-md);
+  }
+}
+
+.mobileIndicator {
+  display: inline-flex;
+}
+
+.mobileSelectContent {
+  z-index: 400;
+  min-width: var(--radix-select-trigger-width);
+  max-height: min(24rem, var(--radix-select-content-available-height));
+  overflow: hidden;
+  background: rgb(250 246 238 / 96%);
+  border: 1px solid var(--panel-border, #fee7c0);
+  border-radius: var(--mantine-radius-sm);
+  box-shadow: var(--mantine-shadow-lg);
+  backdrop-filter: blur(10px);
+}
+
+.mobileSelectViewport {
+  padding: 0.3rem;
+}
+
+.mobileSelectItem {
+  display: grid;
+  grid-template-columns: 1.75rem minmax(0, 1fr) auto;
+  gap: 0.55rem;
+  align-items: center;
+  min-height: 2.6rem;
+  padding: 0.4rem 0.55rem;
+  overflow: hidden;
+  color: var(--mantine-color-dark-9, #151515);
+  border-radius: var(--mantine-radius-sm);
+  cursor: pointer;
+  user-select: none;
+}
+
+.mobileSelectItem[data-highlighted] {
+  background: var(--mantine-color-dune-1);
+  outline: none;
+}
+
+.mobileSelectItem[data-state="checked"] {
+  font-weight: 700;
+}
+
+.mobileSelectItem[data-disabled] {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.mobileItemIcon {
+  display: grid;
+  width: 1.75rem;
+  height: 1.75rem;
+  place-items: center;
+}
+
+.mobileItemIcon img {
+  max-width: 1.25rem;
+  max-height: 1.25rem;
+}
+
 @container connected-tabs (max-width: 46rem) {
   .root {
     --connected-tabs-rail-width: 9.25rem;
@@ -202,7 +384,9 @@
 
 @media (prefers-reduced-motion: reduce) {
   .tab,
-  .iconDisc {
+  .iconDisc,
+  .mobileStepButton,
+  .mobileSelect {
     transition: none;
   }
 }

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.module.css
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.module.css
@@ -1,13 +1,8 @@
-.animatedFrame {
-  transition: width 600ms cubic-bezier(0.2, 0.8, 0.2, 1);
-}
-
 .animatedContent {
   transition: height 600ms cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .animatedFrame,
   .animatedContent {
     transition: none;
   }

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.module.css
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.module.css
@@ -1,0 +1,14 @@
+.animatedFrame {
+  transition: width 600ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.animatedContent {
+  transition: height 600ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animatedFrame,
+  .animatedContent {
+    transition: none;
+  }
+}

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
@@ -86,6 +86,15 @@ const meta = preview.meta({
 
 export const FirstActive = meta.story({
   args: { initialValue: 'overview' },
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      expect(canvasElement.querySelector('[class*="glassSurface"]')).not.toBeNull();
+      expect(canvasElement.querySelector('svg[class*="geometryContour"] path')).not.toBeNull();
+    });
+
+    const surface = canvasElement.querySelector<HTMLElement>('[class*="glassSurface"]');
+    await expect(getComputedStyle(surface as HTMLElement).backdropFilter).toBe('blur(8px)');
+  },
 });
 
 export const MiddleActive = meta.story({

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
@@ -1,59 +1,93 @@
-import { Box, Button, Title } from '@mantine/core';
+import { Box, Title } from '@mantine/core';
 import preview from '@sb/preview';
 import { BookOpen, CircleUserRound, Settings } from 'lucide-react';
 import { useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { ConnectedTabs } from './ConnectedTabs';
+import storyStyles from './ConnectedTabs.stories.module.css';
 
 type ExampleTab = 'overview' | 'people' | 'settings';
 
-const items = [
-  {
-    value: 'overview',
-    label: 'Overview',
-    icon: <BookOpen size={20} />,
-    panel: <Panel title="Overview">A short representative content panel.</Panel>,
-  },
-  {
-    value: 'people',
-    label: 'People',
-    icon: <CircleUserRound size={20} />,
-    panel: (
-      <Panel title="People">
-        This taller middle state proves the joined contour responds to content changes.
-        <Box h={240} />
-      </Panel>
-    ),
-  },
-  {
-    value: 'settings',
-    label: 'Settings',
-    icon: <Settings size={20} />,
-    panel: <Panel title="Settings">The final tab joins the panel at its lower edge.</Panel>,
-  },
-] as const;
+interface ConnectedTabsFixtureProps {
+  initialValue?: ExampleTab;
+  containerWidth?: number;
+  contentHeight?: number;
+  animateDimensions?: boolean;
+}
 
-function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+function Panel({
+  title,
+  children,
+  contentHeight,
+  animateDimensions,
+}: {
+  title: string;
+  children: React.ReactNode;
+  contentHeight: number;
+  animateDimensions: boolean;
+}) {
   return (
     <Box>
       <Title order={2}>{title}</Title>
       <Box mt="sm">{children}</Box>
-      <Box mt="xl" h={180} />
+      <Box
+        data-testid="content-height"
+        className={animateDimensions ? storyStyles.animatedContent : undefined}
+        mt="xl"
+        h={contentHeight}
+      />
     </Box>
   );
 }
 
 function ConnectedTabsFixture({
   initialValue = 'overview',
-  width = 760,
-}: {
-  initialValue?: ExampleTab;
-  width?: number;
-}) {
+  containerWidth = 760,
+  contentHeight = 180,
+  animateDimensions = false,
+}: ConnectedTabsFixtureProps) {
   const [value, setValue] = useState<ExampleTab>(initialValue);
+  const items = [
+    {
+      value: 'overview',
+      label: 'Overview',
+      icon: <BookOpen size={20} />,
+      panel: (
+        <Panel title="Overview" contentHeight={contentHeight} animateDimensions={animateDimensions}>
+          A short representative content panel.
+        </Panel>
+      ),
+    },
+    {
+      value: 'people',
+      label: 'People',
+      icon: <CircleUserRound size={20} />,
+      panel: (
+        <Panel title="People" contentHeight={contentHeight} animateDimensions={animateDimensions}>
+          The joined contour follows this panel as its dimensions change.
+        </Panel>
+      ),
+    },
+    {
+      value: 'settings',
+      label: 'Settings',
+      icon: <Settings size={20} />,
+      panel: (
+        <Panel title="Settings" contentHeight={contentHeight} animateDimensions={animateDimensions}>
+          The final tab joins the panel at its lower edge.
+        </Panel>
+      ),
+    },
+  ] as const;
+
   return (
-    <Box p="xl" w={width} maw="calc(100vw - 2rem)">
+    <Box
+      className={animateDimensions ? storyStyles.animatedFrame : undefined}
+      p="xl"
+      w={containerWidth}
+      maw="calc(100vw - 2rem)"
+    >
       <ConnectedTabs
         value={value}
         onValueChange={setValue}
@@ -64,21 +98,27 @@ function ConnectedTabsFixture({
   );
 }
 
-function ResizeDrivenFixture() {
-  const [width, setWidth] = useState(760);
-  return (
-    <Box p="xl">
-      <Button type="button" mb="md" onClick={() => setWidth((current) => current - 240)}>
-        Resize workbench
-      </Button>
-      <ConnectedTabsFixture initialValue="people" width={width} />
-    </Box>
-  );
-}
-
 const meta = preview.meta({
   title: 'App/Content/ConnectedTabs',
   component: ConnectedTabsFixture,
+  args: {
+    containerWidth: 760,
+    contentHeight: 180,
+  },
+  argTypes: {
+    initialValue: { control: false, table: { disable: true } },
+    containerWidth: {
+      name: 'Container width',
+      description: 'Width supplied by the component’s parent container, in pixels.',
+      control: { type: 'range', min: 360, max: 960, step: 20 },
+    },
+    contentHeight: {
+      name: 'Content height',
+      description: 'Selected-panel content height in pixels.',
+      control: { type: 'range', min: 40, max: 800, step: 20 },
+    },
+    animateDimensions: { control: false, table: { disable: true } },
+  },
   parameters: {
     layout: 'fullscreen',
   },
@@ -105,14 +145,35 @@ export const FinalActive = meta.story({
   args: { initialValue: 'settings' },
 });
 
+export const ContentDrivenHeight = meta.story({
+  args: {
+    initialValue: 'overview',
+    contentHeight: 720,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The surface grows beyond the tab rail when its selected panel contains taller content.',
+      },
+    },
+  },
+});
+
 export const ResizeDrivenGeometry = meta.story({
-  render: () => <ResizeDrivenFixture />,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    const contour = canvasElement.querySelector('svg[class*="geometryContour"] path');
-    const initialPath = contour?.getAttribute('d');
-    await userEvent.click(canvas.getByRole('button', { name: 'Resize workbench' }));
-    await waitFor(() => expect(contour?.getAttribute('d')).not.toBe(initialPath));
+  args: {
+    initialValue: 'people',
+    containerWidth: 760,
+    contentHeight: 320,
+  },
+  render: (args) => <ConnectedTabsFixture {...args} animateDimensions />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use the Container width and Content height controls to animate both axes. Width follows the parent container; height is the greater of the left tab rail and selected-panel content. The SVG contour and clipped glass surface follow every intermediate size.',
+      },
+    },
   },
 });
 
@@ -135,7 +196,7 @@ export const KeyboardAndPointerActivation = meta.story({
 });
 
 export const OverflowPreserved = meta.story({
-  args: { initialValue: 'people', width: 560 },
+  args: { initialValue: 'people', containerWidth: 560 },
   render: (args) => (
     <Box p="xl">
       <ConnectedTabsFixture {...args} />

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
@@ -177,6 +177,50 @@ export const ResizeDrivenGeometry = meta.story({
   },
 });
 
+export const MobileViewport = meta.story({
+  args: {
+    initialValue: 'overview',
+    containerWidth: 760,
+    contentHeight: 180,
+  },
+  globals: {
+    viewport: {
+      value: 'appMobile',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Uses Storybook’s App mobile viewport. The rail remains on the left, the component width follows the available viewport, and its compact container-query values apply.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const tabList = canvasElement.querySelector<HTMLElement>('[role="tablist"]');
+    const root = tabList?.parentElement;
+    const panel = canvasElement.querySelector<HTMLElement>('[role="tabpanel"]');
+    const contour = canvasElement.querySelector<SVGElement>('svg[class*="geometryContour"]');
+
+    await waitFor(() => {
+      const canvasRect = canvasElement.getBoundingClientRect();
+      const rootRect = root?.getBoundingClientRect();
+
+      expect(root).not.toBeNull();
+      expect(panel).not.toBeNull();
+      expect(contour).not.toBeNull();
+      expect(rootRect?.width).toBeLessThanOrEqual(390);
+      expect(rootRect?.right).toBeLessThanOrEqual(canvasRect.right);
+      expect(tabList?.getBoundingClientRect().right).toBeLessThanOrEqual(
+        panel?.getBoundingClientRect().left ?? 0
+      );
+      expect(
+        getComputedStyle(root as HTMLElement).getPropertyValue('--connected-tabs-rail-width')
+      ).toBe('9.25rem');
+    });
+  },
+});
+
 export const KeyboardAndPointerActivation = meta.story({
   args: { initialValue: 'overview' },
   play: async ({ canvasElement }) => {

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
@@ -80,14 +80,12 @@ function ConnectedTabsFixture({
   ] as const;
 
   return (
-    <Box p="xl" w="100%">
-      <ConnectedTabs
-        value={value}
-        onValueChange={setValue}
-        items={items}
-        ariaLabel="Workbench sections"
-      />
-    </Box>
+    <ConnectedTabs
+      value={value}
+      onValueChange={setValue}
+      items={items}
+      ariaLabel="Workbench sections"
+    />
   );
 }
 
@@ -194,7 +192,7 @@ export const MobileViewport = meta.story({
       expect(root).not.toBeNull();
       expect(panel).not.toBeNull();
       expect(contour).not.toBeNull();
-      expect(rootRect?.width).toBeLessThanOrEqual(390);
+      expect(rootRect?.width).toBeCloseTo(canvasRect.width);
       expect(rootRect?.right).toBeLessThanOrEqual(canvasRect.right);
       expect(tabList?.getBoundingClientRect().right).toBeLessThanOrEqual(
         panel?.getBoundingClientRect().left ?? 0

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
@@ -13,6 +13,7 @@ interface ConnectedTabsFixtureProps {
   initialValue?: ExampleTab;
   contentHeight?: number;
   animateDimensions?: boolean;
+  showPanelTitle?: boolean;
 }
 
 function Panel({
@@ -20,16 +21,18 @@ function Panel({
   children,
   contentHeight,
   animateDimensions,
+  showPanelTitle,
 }: {
   title: string;
   children: React.ReactNode;
   contentHeight: number;
   animateDimensions: boolean;
+  showPanelTitle: boolean;
 }) {
   return (
     <Box>
-      <Title order={2}>{title}</Title>
-      <Box mt="sm">{children}</Box>
+      {showPanelTitle ? <Title order={2}>{title}</Title> : null}
+      <Box mt={showPanelTitle ? 'sm' : 0}>{children}</Box>
       <Box
         data-testid="content-height"
         className={animateDimensions ? storyStyles.animatedContent : undefined}
@@ -44,6 +47,7 @@ function ConnectedTabsFixture({
   initialValue = 'overview',
   contentHeight = 180,
   animateDimensions = false,
+  showPanelTitle = true,
 }: ConnectedTabsFixtureProps) {
   const [value, setValue] = useState<ExampleTab>(initialValue);
   const items = [
@@ -52,7 +56,12 @@ function ConnectedTabsFixture({
       label: 'Overview',
       icon: <BookOpen size={20} />,
       panel: (
-        <Panel title="Overview" contentHeight={contentHeight} animateDimensions={animateDimensions}>
+        <Panel
+          title="Overview"
+          contentHeight={contentHeight}
+          animateDimensions={animateDimensions}
+          showPanelTitle={showPanelTitle}
+        >
           A short representative content panel.
         </Panel>
       ),
@@ -62,7 +71,12 @@ function ConnectedTabsFixture({
       label: 'People',
       icon: <CircleUserRound size={20} />,
       panel: (
-        <Panel title="People" contentHeight={contentHeight} animateDimensions={animateDimensions}>
+        <Panel
+          title="People"
+          contentHeight={contentHeight}
+          animateDimensions={animateDimensions}
+          showPanelTitle={showPanelTitle}
+        >
           The joined contour follows this panel as its dimensions change.
         </Panel>
       ),
@@ -72,7 +86,12 @@ function ConnectedTabsFixture({
       label: 'Settings',
       icon: <Settings size={20} />,
       panel: (
-        <Panel title="Settings" contentHeight={contentHeight} animateDimensions={animateDimensions}>
+        <Panel
+          title="Settings"
+          contentHeight={contentHeight}
+          animateDimensions={animateDimensions}
+          showPanelTitle={showPanelTitle}
+        >
           The final tab joins the panel at its lower edge.
         </Panel>
       ),
@@ -103,6 +122,7 @@ const meta = preview.meta({
       control: { type: 'range', min: 40, max: 800, step: 20 },
     },
     animateDimensions: { control: false, table: { disable: true } },
+    showPanelTitle: { control: false, table: { disable: true } },
   },
   parameters: {
     layout: 'fullscreen',
@@ -165,6 +185,7 @@ export const MobileViewport = meta.story({
   args: {
     initialValue: 'overview',
     contentHeight: 180,
+    showPanelTitle: false,
   },
   globals: {
     viewport: {
@@ -175,7 +196,7 @@ export const MobileViewport = meta.story({
     docs: {
       description: {
         story:
-          'Uses Storybook’s App mobile viewport. The rail remains on the left, the component width follows the available viewport, and its compact container-query values apply.',
+          'Uses Storybook’s App mobile viewport. Below the narrow container threshold, the left rail becomes the selected compact title stepper while the same controlled panel remains mounted.',
       },
     },
   },
@@ -183,7 +204,10 @@ export const MobileViewport = meta.story({
     const tabList = canvasElement.querySelector<HTMLElement>('[role="tablist"]');
     const root = tabList?.parentElement;
     const panel = canvasElement.querySelector<HTMLElement>('[role="tabpanel"]');
-    const contour = canvasElement.querySelector<SVGElement>('svg[class*="geometryContour"]');
+    const mobilePicker = canvasElement.querySelector<HTMLElement>(
+      '[data-connected-tabs-mobile-picker]'
+    );
+    const canvas = within(canvasElement);
 
     await waitFor(() => {
       const canvasRect = canvasElement.getBoundingClientRect();
@@ -191,16 +215,21 @@ export const MobileViewport = meta.story({
 
       expect(root).not.toBeNull();
       expect(panel).not.toBeNull();
-      expect(contour).not.toBeNull();
+      expect(mobilePicker).not.toBeNull();
       expect(rootRect?.width).toBeCloseTo(canvasRect.width);
       expect(rootRect?.right).toBeLessThanOrEqual(canvasRect.right);
-      expect(tabList?.getBoundingClientRect().right).toBeLessThanOrEqual(
-        panel?.getBoundingClientRect().left ?? 0
-      );
-      expect(
-        getComputedStyle(root as HTMLElement).getPropertyValue('--connected-tabs-rail-width')
-      ).toBe('9.25rem');
+      expect(getComputedStyle(tabList as HTMLElement).display).toBe('none');
+      expect(getComputedStyle(mobilePicker as HTMLElement).display).toBe('grid');
+      expect(getComputedStyle(root as HTMLElement).backdropFilter).toBe('blur(8px)');
     });
+
+    const picker = canvas.getByRole('combobox', { name: 'Workbench sections' });
+    await expect(picker).toHaveTextContent('Overview');
+    await userEvent.click(canvas.getByRole('button', { name: 'Next section' }));
+    await expect(picker).toHaveTextContent('People');
+    await expect(
+      canvas.getByText('The joined contour follows this panel as its dimensions change.')
+    ).toBeVisible();
   },
 });
 

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
@@ -1,0 +1,141 @@
+import { Box, Button, Title } from '@mantine/core';
+import preview from '@sb/preview';
+import { BookOpen, CircleUserRound, Settings } from 'lucide-react';
+import { useState } from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+
+import { ConnectedTabs } from './ConnectedTabs';
+
+type ExampleTab = 'overview' | 'people' | 'settings';
+
+const items = [
+  {
+    value: 'overview',
+    label: 'Overview',
+    icon: <BookOpen size={20} />,
+    panel: <Panel title="Overview">A short representative content panel.</Panel>,
+  },
+  {
+    value: 'people',
+    label: 'People',
+    icon: <CircleUserRound size={20} />,
+    panel: (
+      <Panel title="People">
+        This taller middle state proves the joined contour responds to content changes.
+        <Box h={240} />
+      </Panel>
+    ),
+  },
+  {
+    value: 'settings',
+    label: 'Settings',
+    icon: <Settings size={20} />,
+    panel: <Panel title="Settings">The final tab joins the panel at its lower edge.</Panel>,
+  },
+] as const;
+
+function Panel({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Box>
+      <Title order={2}>{title}</Title>
+      <Box mt="sm">{children}</Box>
+      <Box mt="xl" h={180} />
+    </Box>
+  );
+}
+
+function ConnectedTabsFixture({
+  initialValue = 'overview',
+  width = 760,
+}: {
+  initialValue?: ExampleTab;
+  width?: number;
+}) {
+  const [value, setValue] = useState<ExampleTab>(initialValue);
+  return (
+    <Box p="xl" w={width} maw="calc(100vw - 2rem)">
+      <ConnectedTabs
+        value={value}
+        onValueChange={setValue}
+        items={items}
+        ariaLabel="Workbench sections"
+      />
+    </Box>
+  );
+}
+
+function ResizeDrivenFixture() {
+  const [width, setWidth] = useState(760);
+  return (
+    <Box p="xl">
+      <Button type="button" mb="md" onClick={() => setWidth((current) => current - 240)}>
+        Resize workbench
+      </Button>
+      <ConnectedTabsFixture initialValue="people" width={width} />
+    </Box>
+  );
+}
+
+const meta = preview.meta({
+  title: 'App/Content/ConnectedTabs',
+  component: ConnectedTabsFixture,
+  parameters: {
+    layout: 'fullscreen',
+  },
+});
+
+export const FirstActive = meta.story({
+  args: { initialValue: 'overview' },
+});
+
+export const MiddleActive = meta.story({
+  args: { initialValue: 'people' },
+});
+
+export const FinalActive = meta.story({
+  args: { initialValue: 'settings' },
+});
+
+export const ResizeDrivenGeometry = meta.story({
+  render: () => <ResizeDrivenFixture />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const contour = canvasElement.querySelector('svg[class*="geometryContour"] path');
+    const initialPath = contour?.getAttribute('d');
+    await userEvent.click(canvas.getByRole('button', { name: 'Resize workbench' }));
+    await waitFor(() => expect(contour?.getAttribute('d')).not.toBe(initialPath));
+  },
+});
+
+export const KeyboardAndPointerActivation = meta.story({
+  args: { initialValue: 'overview' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const overview = canvas.getByRole('tab', { name: 'Overview' });
+    overview.focus();
+    await userEvent.keyboard('{ArrowDown}');
+    await expect(canvas.getByRole('tab', { name: 'People' })).toHaveAttribute(
+      'data-state',
+      'active'
+    );
+    await userEvent.click(canvas.getByRole('tab', { name: 'Settings' }));
+    await expect(
+      canvas.getByText('The final tab joins the panel at its lower edge.')
+    ).toBeVisible();
+  },
+});
+
+export const OverflowPreserved = meta.story({
+  args: { initialValue: 'people', width: 560 },
+  render: (args) => (
+    <Box p="xl">
+      <ConnectedTabsFixture {...args} />
+      <Box data-testid="overflow-marker" w={48} h={48} ml={540} mt={-80} bg="dune.7" />
+    </Box>
+  ),
+  play: async ({ canvasElement }) => {
+    await expect(within(canvasElement).getByTestId('overflow-marker')).toBeVisible();
+    const root = canvasElement.querySelector('[role="tablist"]')?.parentElement;
+    await expect(getComputedStyle(root as Element).overflow).toBe('visible');
+  },
+});

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
@@ -11,7 +11,6 @@ type ExampleTab = 'overview' | 'people' | 'settings';
 
 interface ConnectedTabsFixtureProps {
   initialValue?: ExampleTab;
-  containerWidth?: number;
   contentHeight?: number;
   animateDimensions?: boolean;
 }
@@ -43,7 +42,6 @@ function Panel({
 
 function ConnectedTabsFixture({
   initialValue = 'overview',
-  containerWidth = 760,
   contentHeight = 180,
   animateDimensions = false,
 }: ConnectedTabsFixtureProps) {
@@ -82,12 +80,7 @@ function ConnectedTabsFixture({
   ] as const;
 
   return (
-    <Box
-      className={animateDimensions ? storyStyles.animatedFrame : undefined}
-      p="xl"
-      w={containerWidth}
-      maw="calc(100vw - 2rem)"
-    >
+    <Box p="xl" w="100%">
       <ConnectedTabs
         value={value}
         onValueChange={setValue}
@@ -102,16 +95,10 @@ const meta = preview.meta({
   title: 'App/Content/ConnectedTabs',
   component: ConnectedTabsFixture,
   args: {
-    containerWidth: 760,
     contentHeight: 180,
   },
   argTypes: {
     initialValue: { control: false, table: { disable: true } },
-    containerWidth: {
-      name: 'Container width',
-      description: 'Width supplied by the component’s parent container, in pixels.',
-      control: { type: 'range', min: 360, max: 960, step: 20 },
-    },
     contentHeight: {
       name: 'Content height',
       description: 'Selected-panel content height in pixels.',
@@ -163,7 +150,6 @@ export const ContentDrivenHeight = meta.story({
 export const ResizeDrivenGeometry = meta.story({
   args: {
     initialValue: 'people',
-    containerWidth: 760,
     contentHeight: 320,
   },
   render: (args) => <ConnectedTabsFixture {...args} animateDimensions />,
@@ -171,7 +157,7 @@ export const ResizeDrivenGeometry = meta.story({
     docs: {
       description: {
         story:
-          'Use the Container width and Content height controls to animate both axes. Width follows the parent container; height is the greater of the left tab rail and selected-panel content. The SVG contour and clipped glass surface follow every intermediate size.',
+          'Resize the Storybook canvas with the Viewport toolbar, browser window, or sidebar; use the Content height control for the other axis. Width always follows the canvas, while height is the greater of the left tab rail and selected-panel content. The SVG contour and clipped glass surface follow every intermediate size.',
       },
     },
   },
@@ -180,7 +166,6 @@ export const ResizeDrivenGeometry = meta.story({
 export const MobileViewport = meta.story({
   args: {
     initialValue: 'overview',
-    containerWidth: 760,
     contentHeight: 180,
   },
   globals: {
@@ -240,7 +225,7 @@ export const KeyboardAndPointerActivation = meta.story({
 });
 
 export const OverflowPreserved = meta.story({
-  args: { initialValue: 'people', containerWidth: 560 },
+  args: { initialValue: 'people' },
   render: (args) => (
     <Box p="xl">
       <ConnectedTabsFixture {...args} />

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
@@ -1,16 +1,22 @@
 import { Box, Title } from '@mantine/core';
 import preview from '@sb/preview';
 import { BookOpen, CircleUserRound, Settings } from 'lucide-react';
-import { useState } from 'react';
+import { type ComponentType, type CSSProperties, useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
-import { ConnectedTabs } from './ConnectedTabs';
+import { ConnectedTabs, type ConnectedTabsProps } from './ConnectedTabs';
 import storyStyles from './ConnectedTabs.stories.module.css';
 
 type ExampleTab = 'overview' | 'people' | 'settings';
 
-interface ConnectedTabsFixtureProps {
-  initialValue?: ExampleTab;
+interface ConnectedTabsStoryArgs {
+  value?: ExampleTab;
+  onValueChange?: (value: ExampleTab) => void;
+  items?: ConnectedTabsProps<ExampleTab>['items'];
+  ariaLabel?: string;
+  className?: string;
+  panelClassName?: string;
+  style?: CSSProperties;
   contentHeight?: number;
   animateDimensions?: boolean;
   showPanelTitle?: boolean;
@@ -43,14 +49,18 @@ function Panel({
   );
 }
 
-function ConnectedTabsFixture({
-  initialValue = 'overview',
-  contentHeight = 180,
-  animateDimensions = false,
-  showPanelTitle = true,
-}: ConnectedTabsFixtureProps) {
-  const [value, setValue] = useState<ExampleTab>(initialValue);
-  const items = [
+function createItems({
+  contentHeight,
+  animateDimensions,
+  showPanelTitle,
+}: Pick<
+  ConnectedTabsStoryArgs,
+  'contentHeight' | 'animateDimensions' | 'showPanelTitle'
+>): ConnectedTabsProps<ExampleTab>['items'] {
+  const resolvedContentHeight = contentHeight ?? 180;
+  const resolvedAnimateDimensions = animateDimensions ?? false;
+  const resolvedShowPanelTitle = showPanelTitle ?? true;
+  return [
     {
       value: 'overview',
       label: 'Overview',
@@ -58,9 +68,9 @@ function ConnectedTabsFixture({
       panel: (
         <Panel
           title="Overview"
-          contentHeight={contentHeight}
-          animateDimensions={animateDimensions}
-          showPanelTitle={showPanelTitle}
+          contentHeight={resolvedContentHeight}
+          animateDimensions={resolvedAnimateDimensions}
+          showPanelTitle={resolvedShowPanelTitle}
         >
           A short representative content panel.
         </Panel>
@@ -73,9 +83,9 @@ function ConnectedTabsFixture({
       panel: (
         <Panel
           title="People"
-          contentHeight={contentHeight}
-          animateDimensions={animateDimensions}
-          showPanelTitle={showPanelTitle}
+          contentHeight={resolvedContentHeight}
+          animateDimensions={resolvedAnimateDimensions}
+          showPanelTitle={resolvedShowPanelTitle}
         >
           The joined contour follows this panel as its dimensions change.
         </Panel>
@@ -88,34 +98,55 @@ function ConnectedTabsFixture({
       panel: (
         <Panel
           title="Settings"
-          contentHeight={contentHeight}
-          animateDimensions={animateDimensions}
-          showPanelTitle={showPanelTitle}
+          contentHeight={resolvedContentHeight}
+          animateDimensions={resolvedAnimateDimensions}
+          showPanelTitle={resolvedShowPanelTitle}
         >
           The final tab joins the panel at its lower edge.
         </Panel>
       ),
     },
-  ] as const;
+  ];
+}
 
+function renderConnectedTabs({
+  contentHeight,
+  animateDimensions,
+  showPanelTitle,
+  value = 'overview',
+  onValueChange = () => {},
+  items: _storyItems,
+  ariaLabel = 'Workbench sections',
+  ...optionalTabsProps
+}: ConnectedTabsStoryArgs) {
   return (
     <ConnectedTabs
+      {...optionalTabsProps}
       value={value}
-      onValueChange={setValue}
-      items={items}
-      ariaLabel="Workbench sections"
+      onValueChange={onValueChange}
+      ariaLabel={ariaLabel}
+      items={createItems({ contentHeight, animateDimensions, showPanelTitle })}
     />
   );
 }
 
 const meta = preview.meta({
   title: 'App/Content/ConnectedTabs',
-  component: ConnectedTabsFixture,
+  component: ConnectedTabs as ComponentType<ConnectedTabsStoryArgs>,
+  render: renderConnectedTabs,
   args: {
+    value: 'overview',
+    onValueChange: () => {},
+    ariaLabel: 'Workbench sections',
     contentHeight: 180,
+    animateDimensions: false,
+    showPanelTitle: true,
   },
   argTypes: {
-    initialValue: { control: false, table: { disable: true } },
+    value: { control: false, table: { disable: true } },
+    onValueChange: { control: false, table: { disable: true } },
+    items: { control: false, table: { disable: true } },
+    ariaLabel: { control: false, table: { disable: true } },
     contentHeight: {
       name: 'Content height',
       description: 'Selected-panel content height in pixels.',
@@ -126,11 +157,31 @@ const meta = preview.meta({
   },
   parameters: {
     layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'ConnectedTabs is controlled: consumers own the selected value. These stories use a small decorator-only state harness to demonstrate interaction without changing the component contract.',
+      },
+    },
   },
+  decorators: [
+    function ControlledSelection(Story, context) {
+      const [value, setValue] = useState<ExampleTab>(context.args.value ?? 'overview');
+      return (
+        <Story
+          args={{
+            ...context.args,
+            value,
+            onValueChange: setValue,
+          }}
+        />
+      );
+    },
+  ],
 });
 
 export const FirstActive = meta.story({
-  args: { initialValue: 'overview' },
+  args: { value: 'overview' },
   play: async ({ canvasElement }) => {
     await waitFor(() => {
       expect(canvasElement.querySelector('[class*="glassSurface"]')).not.toBeNull();
@@ -143,16 +194,16 @@ export const FirstActive = meta.story({
 });
 
 export const MiddleActive = meta.story({
-  args: { initialValue: 'people' },
+  args: { value: 'people' },
 });
 
 export const FinalActive = meta.story({
-  args: { initialValue: 'settings' },
+  args: { value: 'settings' },
 });
 
 export const ContentDrivenHeight = meta.story({
   args: {
-    initialValue: 'overview',
+    value: 'overview',
     contentHeight: 720,
   },
   parameters: {
@@ -167,10 +218,10 @@ export const ContentDrivenHeight = meta.story({
 
 export const ResizeDrivenGeometry = meta.story({
   args: {
-    initialValue: 'people',
+    value: 'people',
     contentHeight: 320,
+    animateDimensions: true,
   },
-  render: (args) => <ConnectedTabsFixture {...args} animateDimensions />,
   parameters: {
     docs: {
       description: {
@@ -183,7 +234,7 @@ export const ResizeDrivenGeometry = meta.story({
 
 export const MobileViewport = meta.story({
   args: {
-    initialValue: 'overview',
+    value: 'overview',
     contentHeight: 180,
     showPanelTitle: false,
   },
@@ -234,7 +285,7 @@ export const MobileViewport = meta.story({
 });
 
 export const KeyboardAndPointerActivation = meta.story({
-  args: { initialValue: 'overview' },
+  args: { value: 'overview' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const overview = canvas.getByRole('tab', { name: 'Overview' });
@@ -252,10 +303,10 @@ export const KeyboardAndPointerActivation = meta.story({
 });
 
 export const OverflowPreserved = meta.story({
-  args: { initialValue: 'people' },
+  args: { value: 'people' },
   render: (args) => (
     <Box p="xl">
-      <ConnectedTabsFixture {...args} />
+      {renderConnectedTabs(args)}
       <Box data-testid="overflow-marker" w={48} h={48} ml={540} mt={-80} bg="dune.7" />
     </Box>
   ),

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.test.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.test.tsx
@@ -24,6 +24,34 @@ class ResizeObserverStub {
 let container: HTMLDivElement | undefined;
 let root: Root | undefined;
 
+const items = [
+  {
+    value: 'first',
+    label: 'First',
+    icon: <span>1</span>,
+    panel: <p>First panel</p>,
+  },
+  {
+    value: 'middle',
+    label: 'Middle',
+    icon: <span>2</span>,
+    panel: <p>Middle panel</p>,
+  },
+  {
+    value: 'final',
+    label: 'Final',
+    icon: <span>3</span>,
+    panel: <p>Final panel</p>,
+  },
+  {
+    value: 'disabled',
+    label: 'Unavailable',
+    icon: <span>4</span>,
+    disabled: true,
+    panel: <p>Unavailable panel</p>,
+  },
+] as const;
+
 function rect({
   left,
   top,
@@ -55,33 +83,7 @@ function Fixture() {
       value={value}
       onValueChange={setValue}
       ariaLabel="Example sections"
-      items={[
-        {
-          value: 'first',
-          label: 'First',
-          icon: <span>1</span>,
-          panel: <p>First panel</p>,
-        },
-        {
-          value: 'middle',
-          label: 'Middle',
-          icon: <span>2</span>,
-          panel: <p>Middle panel</p>,
-        },
-        {
-          value: 'final',
-          label: 'Final',
-          icon: <span>3</span>,
-          panel: <p>Final panel</p>,
-        },
-        {
-          value: 'disabled',
-          label: 'Unavailable',
-          icon: <span>4</span>,
-          disabled: true,
-          panel: <p>Unavailable panel</p>,
-        },
-      ]}
+      items={items}
     />
   );
 }
@@ -132,6 +134,45 @@ describe('ConnectedTabs', () => {
   it('renders the joined surface for the initially selected tab before interaction', () => {
     expect(container?.querySelector('[class*="glassSurface"]')).not.toBeNull();
     expect(container?.querySelector('svg[class*="geometryContour"] path')).not.toBeNull();
+  });
+
+  it('emits selection requests without owning the selected tab', async () => {
+    const onValueChange = vi.fn();
+    await act(async () =>
+      root?.render(
+        <ConnectedTabs
+          value="first"
+          onValueChange={onValueChange}
+          ariaLabel="Example sections"
+          items={items}
+        />
+      )
+    );
+
+    const middle = getTab('2Middle');
+    await act(async () => {
+      middle.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+      middle.click();
+    });
+
+    expect(onValueChange).toHaveBeenCalledWith('middle');
+    expect(getTab('1First').getAttribute('data-state')).toBe('active');
+    expect(middle.getAttribute('data-state')).toBe('inactive');
+    expect(container?.textContent).toContain('First panel');
+
+    await act(async () =>
+      root?.render(
+        <ConnectedTabs
+          value="middle"
+          onValueChange={onValueChange}
+          ariaLabel="Example sections"
+          items={items}
+        />
+      )
+    );
+
+    expect(getTab('2Middle').getAttribute('data-state')).toBe('active');
+    expect(container?.textContent).toContain('Middle panel');
   });
 
   it('updates the joined surface throughout width and content-height changes', async () => {

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.test.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.test.tsx
@@ -94,6 +94,14 @@ function getTab(name: string) {
   return tab;
 }
 
+function getButton(name: string) {
+  const button = [...(container?.querySelectorAll('button') ?? [])].find(
+    (candidate) => candidate.getAttribute('aria-label') === name
+  );
+  if (!(button instanceof HTMLButtonElement)) throw new Error(`Missing button: ${name}`);
+  return button;
+}
+
 beforeEach(async () => {
   resizeObserverCallbacks.length = 0;
   vi.stubGlobal('ResizeObserver', ResizeObserverStub);
@@ -203,6 +211,22 @@ describe('ConnectedTabs', () => {
     });
 
     expect(final.getAttribute('data-state')).toBe('active');
+    expect(container?.textContent).toContain('Final panel');
+  });
+
+  it('steps through enabled items in the compact picker and wraps', async () => {
+    const next = getButton('Next section');
+    const previous = getButton('Previous section');
+
+    await act(async () => next.click());
+    expect(getTab('2Middle').getAttribute('data-state')).toBe('active');
+    expect(container?.textContent).toContain('Middle panel');
+
+    await act(async () => previous.click());
+    expect(getTab('1First').getAttribute('data-state')).toBe('active');
+
+    await act(async () => previous.click());
+    expect(getTab('3Final').getAttribute('data-state')).toBe('active');
     expect(container?.textContent).toContain('Final panel');
   });
 

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.test.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.test.tsx
@@ -90,6 +90,11 @@ afterEach(async () => {
 });
 
 describe('ConnectedTabs', () => {
+  it('renders the joined surface for the initially selected tab before interaction', () => {
+    expect(container?.querySelector('[class*="glassSurface"]')).not.toBeNull();
+    expect(container?.querySelector('svg[class*="geometryContour"] path')).not.toBeNull();
+  });
+
   it('uses automatic Radix keyboard activation and focus movement', async () => {
     const first = getTab('1First');
     const middle = getTab('2Middle');

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.test.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+
+import { act, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { buildConnectedTabsPath, ConnectedTabs } from './ConnectedTabs';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+let container: HTMLDivElement | undefined;
+let root: Root | undefined;
+
+function Fixture() {
+  const [value, setValue] = useState('first');
+  return (
+    <ConnectedTabs
+      value={value}
+      onValueChange={setValue}
+      ariaLabel="Example sections"
+      items={[
+        {
+          value: 'first',
+          label: 'First',
+          icon: <span>1</span>,
+          panel: <p>First panel</p>,
+        },
+        {
+          value: 'middle',
+          label: 'Middle',
+          icon: <span>2</span>,
+          panel: <p>Middle panel</p>,
+        },
+        {
+          value: 'final',
+          label: 'Final',
+          icon: <span>3</span>,
+          panel: <p>Final panel</p>,
+        },
+        {
+          value: 'disabled',
+          label: 'Unavailable',
+          icon: <span>4</span>,
+          disabled: true,
+          panel: <p>Unavailable panel</p>,
+        },
+      ]}
+    />
+  );
+}
+
+function getTab(name: string) {
+  const tab = [...(container?.querySelectorAll('[role="tab"]') ?? [])].find(
+    (candidate) => candidate.textContent?.trim() === name
+  );
+  if (!(tab instanceof HTMLButtonElement)) throw new Error(`Missing tab: ${name}`);
+  return tab;
+}
+
+beforeEach(async () => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+  vi.stubGlobal(
+    'requestAnimationFrame',
+    vi.fn().mockImplementation((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    })
+  );
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => root?.render(<Fixture />));
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root?.unmount());
+  container?.remove();
+  root = undefined;
+  container = undefined;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('ConnectedTabs', () => {
+  it('uses automatic Radix keyboard activation and focus movement', async () => {
+    const first = getTab('1First');
+    const middle = getTab('2Middle');
+
+    first.focus();
+    await act(async () =>
+      first.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+    );
+
+    expect(document.activeElement).toBe(middle);
+    expect(middle.getAttribute('data-state')).toBe('active');
+    expect(container?.textContent).toContain('Middle panel');
+  });
+
+  it('supports pointer activation with controlled state', async () => {
+    const final = getTab('3Final');
+    await act(async () => {
+      final.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, button: 0 }));
+      final.click();
+    });
+
+    expect(final.getAttribute('data-state')).toBe('active');
+    expect(container?.textContent).toContain('Final panel');
+  });
+
+  it('preserves disabled trigger semantics', () => {
+    const disabled = getTab('4Unavailable');
+    expect(disabled.disabled).toBe(true);
+    expect(disabled.hasAttribute('data-disabled')).toBe(true);
+  });
+
+  it('builds distinct joined contours for first, middle, and final tabs', () => {
+    const shared = { width: 800, height: 600, panelX: 180, radius: 8 };
+    const first = buildConnectedTabsPath({ ...shared, tabTop: 0, tabBottom: 64 });
+    const middle = buildConnectedTabsPath({ ...shared, tabTop: 144, tabBottom: 208 });
+    const final = buildConnectedTabsPath({ ...shared, tabTop: 536, tabBottom: 600 });
+
+    expect(new Set([first, middle, final]).size).toBe(3);
+    expect(first).toContain('M 8 0');
+    expect(middle).toContain('V 211');
+    expect(final).toContain('H 8');
+  });
+});

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.test.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.test.tsx
@@ -9,7 +9,13 @@ import { buildConnectedTabsPath, ConnectedTabs } from './ConnectedTabs';
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
 
+const resizeObserverCallbacks: ResizeObserverCallback[] = [];
+
 class ResizeObserverStub {
+  constructor(callback: ResizeObserverCallback) {
+    resizeObserverCallbacks.push(callback);
+  }
+
   observe() {}
   unobserve() {}
   disconnect() {}
@@ -17,6 +23,30 @@ class ResizeObserverStub {
 
 let container: HTMLDivElement | undefined;
 let root: Root | undefined;
+
+function rect({
+  left,
+  top,
+  width,
+  height,
+}: {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}): DOMRect {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({}),
+  };
+}
 
 function Fixture() {
   const [value, setValue] = useState('first');
@@ -65,6 +95,7 @@ function getTab(name: string) {
 }
 
 beforeEach(async () => {
+  resizeObserverCallbacks.length = 0;
   vi.stubGlobal('ResizeObserver', ResizeObserverStub);
   vi.stubGlobal(
     'requestAnimationFrame',
@@ -93,6 +124,61 @@ describe('ConnectedTabs', () => {
   it('renders the joined surface for the initially selected tab before interaction', () => {
     expect(container?.querySelector('[class*="glassSurface"]')).not.toBeNull();
     expect(container?.querySelector('svg[class*="geometryContour"] path')).not.toBeNull();
+  });
+
+  it('updates the joined surface throughout width and content-height changes', async () => {
+    const tabList = container?.querySelector('[role="tablist"]');
+    const tabsRoot = tabList?.parentElement;
+    const panelShell = container?.querySelector('[role="tabpanel"]')?.parentElement;
+    const activeTab = getTab('1First');
+    if (!tabsRoot || !panelShell) throw new Error('Missing connected-tabs geometry elements');
+
+    const dimensions = {
+      width: 760,
+      height: 400,
+      panelX: 180,
+      tabHeight: 64,
+    };
+    vi.spyOn(tabsRoot, 'getBoundingClientRect').mockImplementation(() =>
+      rect({ left: 0, top: 0, width: dimensions.width, height: dimensions.height })
+    );
+    vi.spyOn(panelShell, 'getBoundingClientRect').mockImplementation(() =>
+      rect({
+        left: dimensions.panelX,
+        top: 0,
+        width: dimensions.width - dimensions.panelX,
+        height: dimensions.height,
+      })
+    );
+    vi.spyOn(activeTab, 'getBoundingClientRect').mockImplementation(() =>
+      rect({ left: 0, top: 0, width: dimensions.panelX, height: dimensions.tabHeight })
+    );
+
+    await act(async () => {
+      for (const callback of resizeObserverCallbacks) callback([], {} as ResizeObserver);
+    });
+
+    const contour = container?.querySelector<SVGPathElement>('svg[class*="geometryContour"] path');
+    const contourSvg = contour?.closest('svg');
+    let previousPath = contour?.getAttribute('d');
+    expect(contourSvg?.getAttribute('viewBox')).toBe('0 0 760 400');
+
+    for (const frame of [
+      { width: 680, height: 500, panelX: 170 },
+      { width: 600, height: 610, panelX: 158 },
+      { width: 520, height: 720, panelX: 148 },
+    ]) {
+      dimensions.width = frame.width;
+      dimensions.height = frame.height;
+      dimensions.panelX = frame.panelX;
+      await act(async () => {
+        for (const callback of resizeObserverCallbacks) callback([], {} as ResizeObserver);
+      });
+
+      expect(contourSvg?.getAttribute('viewBox')).toBe(`0 0 ${frame.width} ${frame.height}`);
+      expect(contour?.getAttribute('d')).not.toBe(previousPath);
+      previousPath = contour?.getAttribute('d');
+    }
   });
 
   it('uses automatic Radix keyboard activation and focus movement', async () => {

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.tsx
@@ -1,5 +1,7 @@
+import * as Select from '@radix-ui/react-select';
 import * as Tabs from '@radix-ui/react-tabs';
 import clsx from 'clsx';
+import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import {
   type CSSProperties,
   type ReactNode,
@@ -262,6 +264,29 @@ function ConnectedTabsSurface({ geometry }: { geometry: ConnectedTabsGeometry | 
   );
 }
 
+function findAdjacentEnabledValue<Value extends string>({
+  value,
+  items,
+  direction,
+}: {
+  value: Value;
+  items: readonly ConnectedTabsItem<Value>[];
+  direction: -1 | 1;
+}): Value {
+  const selectedIndex = Math.max(
+    0,
+    items.findIndex((item) => item.value === value)
+  );
+
+  for (let offset = 1; offset <= items.length; offset += 1) {
+    const index = (selectedIndex + direction * offset + items.length) % items.length;
+    const item = items[index];
+    if (item && !item.disabled) return item.value;
+  }
+
+  return value;
+}
+
 export function ConnectedTabs<Value extends string>({
   value,
   onValueChange,
@@ -274,6 +299,10 @@ export function ConnectedTabs<Value extends string>({
   const rootRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const geometry = useConnectedTabsGeometry({ value, rootRef, panelRef });
+  const activeItem = items.find((item) => item.value === value);
+  const hasMultipleEnabledItems = items.filter((item) => !item.disabled).length > 1;
+  const selectAdjacent = (direction: -1 | 1) =>
+    onValueChange(findAdjacentEnabledValue({ value, items, direction }));
 
   return (
     <div className={clsx(styles.host, className)} style={style}>
@@ -286,6 +315,71 @@ export function ConnectedTabs<Value extends string>({
         activationMode="automatic"
       >
         <ConnectedTabsSurface geometry={geometry} />
+        {activeItem ? (
+          <div className={styles.mobilePicker} data-connected-tabs-mobile-picker>
+            <button
+              type="button"
+              className={styles.mobileStepButton}
+              aria-label="Previous section"
+              disabled={!hasMultipleEnabledItems}
+              onClick={() => selectAdjacent(-1)}
+            >
+              <ChevronLeft size={18} aria-hidden />
+            </button>
+            <Select.Root
+              value={value}
+              onValueChange={(nextValue) => onValueChange(nextValue as Value)}
+            >
+              <Select.Trigger className={styles.mobileSelect} aria-label={ariaLabel}>
+                <span className={styles.mobileIconDisc} aria-hidden>
+                  {activeItem.icon}
+                </span>
+                <Select.Value className={styles.mobileSelectValue}>{activeItem.label}</Select.Value>
+                {activeItem.indicator ? (
+                  <span className={styles.mobileIndicator}>{activeItem.indicator}</span>
+                ) : null}
+                <Select.Icon className={styles.mobileSelectIcon}>
+                  <ChevronDown size={15} aria-hidden />
+                </Select.Icon>
+              </Select.Trigger>
+              <Select.Portal>
+                <Select.Content
+                  className={styles.mobileSelectContent}
+                  position="popper"
+                  sideOffset={4}
+                >
+                  <Select.Viewport className={styles.mobileSelectViewport}>
+                    {items.map((item) => (
+                      <Select.Item
+                        className={styles.mobileSelectItem}
+                        key={item.value}
+                        value={item.value}
+                        disabled={item.disabled}
+                      >
+                        <span className={styles.mobileItemIcon} aria-hidden>
+                          {item.icon}
+                        </span>
+                        <Select.ItemText>{item.label}</Select.ItemText>
+                        {item.indicator ? (
+                          <span className={styles.mobileIndicator}>{item.indicator}</span>
+                        ) : null}
+                      </Select.Item>
+                    ))}
+                  </Select.Viewport>
+                </Select.Content>
+              </Select.Portal>
+            </Select.Root>
+            <button
+              type="button"
+              className={styles.mobileStepButton}
+              aria-label="Next section"
+              disabled={!hasMultipleEnabledItems}
+              onClick={() => selectAdjacent(1)}
+            >
+              <ChevronRight size={18} aria-hidden />
+            </button>
+          </div>
+        ) : null}
         <Tabs.List className={styles.tabList} aria-label={ariaLabel}>
           {items.map((item) => (
             <Tabs.Trigger

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.tsx
@@ -116,7 +116,7 @@ export function buildConnectedTabsPath({
   ].join(' ');
 }
 
-function ConnectedTabsSurface({
+function useConnectedTabsGeometry({
   value,
   rootRef,
   panelRef,
@@ -126,63 +126,76 @@ function ConnectedTabsSurface({
   panelRef: React.RefObject<HTMLDivElement | null>;
 }) {
   const [geometry, setGeometry] = useState<ConnectedTabsGeometry | null>(null);
-  const instanceId = useId().replaceAll(':', '');
-  const clipId = `connected-tabs-clip-${instanceId}`;
-  const shadowId = `connected-tabs-shadow-${instanceId}`;
 
   useLayoutEffect(() => {
+    // The selected trigger changes without changing either element ref.
     void value;
     const root = rootRef.current;
     const panel = panelRef.current;
     const activeTab = root?.querySelector<HTMLElement>('[data-connected-tab][data-state="active"]');
-    if (!root || !panel || !activeTab || typeof ResizeObserver === 'undefined') return;
+    if (!root || !panel || !activeTab) {
+      setGeometry(null);
+      return;
+    }
 
     let animationFrame = 0;
     const measure = () => {
-      cancelAnimationFrame(animationFrame);
-      animationFrame = requestAnimationFrame(() => {
-        const rootRect = root.getBoundingClientRect();
-        const panelRect = panel.getBoundingClientRect();
-        const tabRect = activeTab.getBoundingClientRect();
-        const devicePixelRatio = window.devicePixelRatio || 1;
-        const round = (number: number) => Math.round(number * devicePixelRatio) / devicePixelRatio;
-        const width = round(rootRect.width);
-        const height = round(rootRect.height);
-        const panelX = round(panelRect.left - rootRect.left);
-        const tabTop = round(tabRect.top - rootRect.top);
-        const tabBottom = round(tabRect.bottom - rootRect.top);
-        const configuredRadius = Number.parseFloat(
-          getComputedStyle(root).getPropertyValue('--connected-tabs-radius')
-        );
-        const radius = Number.isFinite(configuredRadius) ? configuredRadius : 8;
-        const path = buildConnectedTabsPath({
-          width,
-          height,
-          panelX,
-          tabTop,
-          tabBottom,
-          radius,
-        });
-
-        setGeometry((current) =>
-          current?.width === width && current.height === height && current.path === path
-            ? current
-            : { width, height, path }
-        );
+      const rootRect = root.getBoundingClientRect();
+      const panelRect = panel.getBoundingClientRect();
+      const tabRect = activeTab.getBoundingClientRect();
+      const devicePixelRatio = window.devicePixelRatio || 1;
+      const round = (number: number) => Math.round(number * devicePixelRatio) / devicePixelRatio;
+      const width = round(rootRect.width);
+      const height = round(rootRect.height);
+      const panelX = round(panelRect.left - rootRect.left);
+      const tabTop = round(tabRect.top - rootRect.top);
+      const tabBottom = round(tabRect.bottom - rootRect.top);
+      const configuredRadius = Number.parseFloat(
+        getComputedStyle(root).getPropertyValue('--connected-tabs-radius')
+      );
+      const radius = Number.isFinite(configuredRadius) ? configuredRadius : 8;
+      const path = buildConnectedTabsPath({
+        width,
+        height,
+        panelX,
+        tabTop,
+        tabBottom,
+        radius,
       });
+
+      setGeometry((current) =>
+        current?.width === width && current.height === height && current.path === path
+          ? current
+          : { width, height, path }
+      );
     };
 
-    const observer = new ResizeObserver(measure);
+    const scheduleMeasure = () => {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = requestAnimationFrame(measure);
+    };
+
+    measure();
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(scheduleMeasure);
     observer.observe(root);
     observer.observe(panel);
     observer.observe(activeTab);
-    measure();
 
     return () => {
       cancelAnimationFrame(animationFrame);
       observer.disconnect();
     };
   }, [panelRef, rootRef, value]);
+
+  return geometry;
+}
+
+function ConnectedTabsSurface({ geometry }: { geometry: ConnectedTabsGeometry | null }) {
+  const instanceId = useId().replaceAll(':', '');
+  const clipId = `connected-tabs-clip-${instanceId}`;
+  const shadowId = `connected-tabs-shadow-${instanceId}`;
 
   return (
     <div className={styles.surfaceLayer} aria-hidden>
@@ -260,6 +273,7 @@ export function ConnectedTabs<Value extends string>({
 }: ConnectedTabsProps<Value>) {
   const rootRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const geometry = useConnectedTabsGeometry({ value, rootRef, panelRef });
 
   return (
     <div className={clsx(styles.host, className)} style={style}>
@@ -271,7 +285,7 @@ export function ConnectedTabs<Value extends string>({
         orientation="vertical"
         activationMode="automatic"
       >
-        <ConnectedTabsSurface value={value} rootRef={rootRef} panelRef={panelRef} />
+        <ConnectedTabsSurface geometry={geometry} />
         <Tabs.List className={styles.tabList} aria-label={ariaLabel}>
           {items.map((item) => (
             <Tabs.Trigger

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.tsx
@@ -1,0 +1,302 @@
+import * as Tabs from '@radix-ui/react-tabs';
+import clsx from 'clsx';
+import {
+  type CSSProperties,
+  type ReactNode,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import styles from './ConnectedTabs.module.css';
+
+export interface ConnectedTabsItem<Value extends string> {
+  value: Value;
+  label: ReactNode;
+  icon: ReactNode;
+  indicator?: ReactNode;
+  disabled?: boolean;
+  panel: ReactNode;
+}
+
+export interface ConnectedTabsProps<Value extends string> {
+  value: Value;
+  onValueChange: (value: Value) => void;
+  items: readonly ConnectedTabsItem<Value>[];
+  ariaLabel: string;
+  className?: string;
+  panelClassName?: string;
+  style?: CSSProperties;
+}
+
+interface ConnectedTabsGeometry {
+  width: number;
+  height: number;
+  path: string;
+}
+
+export function buildConnectedTabsPath({
+  width,
+  height,
+  panelX,
+  tabTop,
+  tabBottom,
+  radius,
+}: {
+  width: number;
+  height: number;
+  panelX: number;
+  tabTop: number;
+  tabBottom: number;
+  radius: number;
+}): string {
+  const joinRadius = Math.min(3, radius);
+  const tabRadius = Math.min(radius, (tabBottom - tabTop) / 2, panelX / 2);
+  const touchesTop = tabTop <= 0.5;
+  const touchesBottom = tabBottom >= height - 0.5;
+
+  if (touchesTop) {
+    return [
+      `M ${tabRadius} 0`,
+      `H ${width - radius}`,
+      `Q ${width} 0 ${width} ${radius}`,
+      `V ${height - radius}`,
+      `Q ${width} ${height} ${width - radius} ${height}`,
+      `H ${panelX + radius}`,
+      `Q ${panelX} ${height} ${panelX} ${height - radius}`,
+      `V ${tabBottom + joinRadius}`,
+      `Q ${panelX} ${tabBottom} ${panelX - joinRadius} ${tabBottom}`,
+      `H ${tabRadius}`,
+      `Q 0 ${tabBottom} 0 ${tabBottom - tabRadius}`,
+      `V ${tabRadius}`,
+      `Q 0 0 ${tabRadius} 0`,
+      'Z',
+    ].join(' ');
+  }
+
+  if (touchesBottom) {
+    return [
+      `M ${panelX + radius} 0`,
+      `H ${width - radius}`,
+      `Q ${width} 0 ${width} ${radius}`,
+      `V ${height - radius}`,
+      `Q ${width} ${height} ${width - radius} ${height}`,
+      `H ${tabRadius}`,
+      `Q 0 ${height} 0 ${height - tabRadius}`,
+      `V ${tabTop + tabRadius}`,
+      `Q 0 ${tabTop} ${tabRadius} ${tabTop}`,
+      `H ${panelX - joinRadius}`,
+      `Q ${panelX} ${tabTop} ${panelX} ${tabTop - joinRadius}`,
+      `V ${radius}`,
+      `Q ${panelX} 0 ${panelX + radius} 0`,
+      'Z',
+    ].join(' ');
+  }
+
+  return [
+    `M ${panelX + radius} 0`,
+    `H ${width - radius}`,
+    `Q ${width} 0 ${width} ${radius}`,
+    `V ${height - radius}`,
+    `Q ${width} ${height} ${width - radius} ${height}`,
+    `H ${panelX + radius}`,
+    `Q ${panelX} ${height} ${panelX} ${height - radius}`,
+    `V ${tabBottom + joinRadius}`,
+    `Q ${panelX} ${tabBottom} ${panelX - joinRadius} ${tabBottom}`,
+    `H ${tabRadius}`,
+    `Q 0 ${tabBottom} 0 ${tabBottom - tabRadius}`,
+    `V ${tabTop + tabRadius}`,
+    `Q 0 ${tabTop} ${tabRadius} ${tabTop}`,
+    `H ${panelX - joinRadius}`,
+    `Q ${panelX} ${tabTop} ${panelX} ${tabTop - joinRadius}`,
+    `V ${radius}`,
+    `Q ${panelX} 0 ${panelX + radius} 0`,
+    'Z',
+  ].join(' ');
+}
+
+function ConnectedTabsSurface({
+  value,
+  rootRef,
+  panelRef,
+}: {
+  value: string;
+  rootRef: React.RefObject<HTMLDivElement | null>;
+  panelRef: React.RefObject<HTMLDivElement | null>;
+}) {
+  const [geometry, setGeometry] = useState<ConnectedTabsGeometry | null>(null);
+  const instanceId = useId().replaceAll(':', '');
+  const clipId = `connected-tabs-clip-${instanceId}`;
+  const shadowId = `connected-tabs-shadow-${instanceId}`;
+
+  useLayoutEffect(() => {
+    void value;
+    const root = rootRef.current;
+    const panel = panelRef.current;
+    const activeTab = root?.querySelector<HTMLElement>('[data-connected-tab][data-state="active"]');
+    if (!root || !panel || !activeTab || typeof ResizeObserver === 'undefined') return;
+
+    let animationFrame = 0;
+    const measure = () => {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = requestAnimationFrame(() => {
+        const rootRect = root.getBoundingClientRect();
+        const panelRect = panel.getBoundingClientRect();
+        const tabRect = activeTab.getBoundingClientRect();
+        const devicePixelRatio = window.devicePixelRatio || 1;
+        const round = (number: number) => Math.round(number * devicePixelRatio) / devicePixelRatio;
+        const width = round(rootRect.width);
+        const height = round(rootRect.height);
+        const panelX = round(panelRect.left - rootRect.left);
+        const tabTop = round(tabRect.top - rootRect.top);
+        const tabBottom = round(tabRect.bottom - rootRect.top);
+        const configuredRadius = Number.parseFloat(
+          getComputedStyle(root).getPropertyValue('--connected-tabs-radius')
+        );
+        const radius = Number.isFinite(configuredRadius) ? configuredRadius : 8;
+        const path = buildConnectedTabsPath({
+          width,
+          height,
+          panelX,
+          tabTop,
+          tabBottom,
+          radius,
+        });
+
+        setGeometry((current) =>
+          current?.width === width && current.height === height && current.path === path
+            ? current
+            : { width, height, path }
+        );
+      });
+    };
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(root);
+    observer.observe(panel);
+    observer.observe(activeTab);
+    measure();
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      observer.disconnect();
+    };
+  }, [panelRef, rootRef, value]);
+
+  return (
+    <div className={styles.surfaceLayer} aria-hidden>
+      {geometry ? (
+        <>
+          <svg
+            className={styles.definitions}
+            width="0"
+            height="0"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <defs>
+              <clipPath id={clipId} clipPathUnits="userSpaceOnUse">
+                <path d={geometry.path} />
+              </clipPath>
+              <filter
+                id={shadowId}
+                x="-20%"
+                y="-20%"
+                width="140%"
+                height="140%"
+                colorInterpolationFilters="sRGB"
+              >
+                <feGaussianBlur in="SourceAlpha" stdDeviation="10" result="shadowBlur" />
+                <feComposite
+                  in="shadowBlur"
+                  in2="SourceAlpha"
+                  operator="out"
+                  result="outsideShadowAlpha"
+                />
+                <feFlood floodColor="#000000" floodOpacity="0.165" result="shadowColor" />
+                <feComposite
+                  in="shadowColor"
+                  in2="outsideShadowAlpha"
+                  operator="in"
+                  result="shadow"
+                />
+              </filter>
+            </defs>
+          </svg>
+          <svg
+            className={styles.geometryShadow}
+            viewBox={`0 0 ${geometry.width} ${geometry.height}`}
+            preserveAspectRatio="none"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d={geometry.path} filter={`url(#${shadowId})`} />
+          </svg>
+          <div className={styles.glassSurface} style={{ clipPath: `url(#${clipId})` }} />
+          <svg
+            className={styles.geometryContour}
+            viewBox={`0 0 ${geometry.width} ${geometry.height}`}
+            preserveAspectRatio="none"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d={geometry.path} />
+          </svg>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+export function ConnectedTabs<Value extends string>({
+  value,
+  onValueChange,
+  items,
+  ariaLabel,
+  className,
+  panelClassName,
+  style,
+}: ConnectedTabsProps<Value>) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <div className={clsx(styles.host, className)} style={style}>
+      <Tabs.Root
+        ref={rootRef}
+        className={styles.root}
+        value={value}
+        onValueChange={(nextValue) => onValueChange(nextValue as Value)}
+        orientation="vertical"
+        activationMode="automatic"
+      >
+        <ConnectedTabsSurface value={value} rootRef={rootRef} panelRef={panelRef} />
+        <Tabs.List className={styles.tabList} aria-label={ariaLabel}>
+          {items.map((item) => (
+            <Tabs.Trigger
+              className={styles.tab}
+              data-connected-tab
+              key={item.value}
+              value={item.value}
+              disabled={item.disabled}
+            >
+              <span className={styles.iconDisc} aria-hidden>
+                {item.icon}
+              </span>
+              <span className={styles.label}>{item.label}</span>
+              {item.indicator ? <span className={styles.indicator}>{item.indicator}</span> : null}
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+        <div ref={panelRef} className={clsx(styles.panelShell, panelClassName)}>
+          {items.map((item) => (
+            <Tabs.Content className={styles.panel} key={item.value} value={item.value}>
+              {item.panel}
+            </Tabs.Content>
+          ))}
+        </div>
+      </Tabs.Root>
+    </div>
+  );
+}

--- a/src/app/components/content/ConnectedTabs/index.ts
+++ b/src/app/components/content/ConnectedTabs/index.ts
@@ -1,0 +1,6 @@
+export {
+  buildConnectedTabsPath,
+  ConnectedTabs,
+  type ConnectedTabsItem,
+  type ConnectedTabsProps,
+} from './ConnectedTabs';

--- a/src/app/components/factions/editor/FactionAuthoring.architecture.test.ts
+++ b/src/app/components/factions/editor/FactionAuthoring.architecture.test.ts
@@ -12,6 +12,14 @@ const toolbarStyles = readFileSync(
   new URL('./FactionAuthoringToolbar.module.css', import.meta.url),
   'utf8'
 );
+const connectedTabsSource = readFileSync(
+  new URL('../../content/ConnectedTabs/ConnectedTabs.tsx', import.meta.url),
+  'utf8'
+);
+const connectedTabsStyles = readFileSync(
+  new URL('../../content/ConnectedTabs/ConnectedTabs.module.css', import.meta.url),
+  'utf8'
+);
 const collectionShelfSource = readFileSync(
   new URL('./FactionCollectionShelf.tsx', import.meta.url),
   'utf8'
@@ -33,13 +41,22 @@ const productionEditorSources = readdirSync(editorDirectory)
     name,
     source: readFileSync(new URL(name, editorDirectory), 'utf8'),
   }));
+const rendererDirectory = new URL('../../../../game/', import.meta.url);
+const rendererSources = readdirSync(rendererDirectory, { recursive: true })
+  .map(String)
+  .filter((name) => /\.(?:ts|tsx|css)$/.test(name))
+  .map((name) => ({
+    name,
+    source: readFileSync(new URL(name, rendererDirectory), 'utf8'),
+  }));
 
 describe('faction authoring architecture', () => {
   it('uses one in-memory eight-tab workbench without route or hash state', () => {
-    expect(formFieldsSource).toContain('<Tabs');
+    expect(formFieldsSource).toContain('<ConnectedTabs');
     expect(formFieldsSource).toContain('factionAuthoringChapters.map');
     expect(formFieldsSource).toContain("useState<FactionAuthoringChapterId>('identity')");
     expect(formFieldsSource).toContain('<ArtifactProof');
+    expect(formFieldsSource).not.toContain('Tabs,');
     expect(formFieldsSource).not.toContain('Accordion');
     expect(formFieldsSource).not.toContain('useEditorAccordionHash');
     expect(formFieldsSource).not.toContain('navigate(');
@@ -80,14 +97,39 @@ describe('faction authoring architecture', () => {
     }
   });
 
-  it('shares a Mantine-first sticky toolbar across terminal Create and Edit routes', () => {
+  it('shares one fixed-height authoring toolbar across terminal Create and Edit routes', () => {
     expect(toolbarSource).toContain("from '@mantine/core'");
     expect(toolbarStyles).toContain('position: sticky');
+    expect(toolbarStyles).toContain('height: 60px');
+    expect(toolbarSource).toContain('Review faction sheet');
+    expect(toolbarSource).toContain('aria-label="Back"');
     for (const routeSource of [createRouteSource, editRouteSource]) {
       expect(routeSource).toContain('<PageLayout');
       expect(routeSource).toContain('<FactionAuthoringToolbar');
       expect(routeSource).not.toContain("from '@app/components/generic/layout'");
       expect(routeSource).not.toContain("from '@app/components/generic/ui/UIButton'");
+    }
+  });
+
+  it('keeps the reusable connected-tabs surface domain-neutral and Radix-owned', () => {
+    expect(connectedTabsSource).toContain("from '@radix-ui/react-tabs'");
+    expect(connectedTabsSource).toContain('activationMode="automatic"');
+    expect(connectedTabsSource).toContain('ResizeObserver');
+    expect(connectedTabsSource).toContain('buildConnectedTabsPath');
+    expect(connectedTabsStyles).toContain('backdrop-filter: blur(8px)');
+    expect(connectedTabsStyles).toContain('var(--panel-border, #fee7c0)');
+    expect(connectedTabsStyles).toContain('container: connected-tabs-panel / inline-size');
+    expect(connectedTabsSource).not.toMatch(/Faction|@app\/routes|@db|Convex|publication/);
+    expect(connectedTabsStyles).not.toContain(':global');
+    expect(connectedTabsStyles).not.toContain('!important');
+  });
+
+  it('keeps the renderer tree isolated from application tabs and UI frameworks', () => {
+    for (const { name, source } of rendererSources) {
+      expect(source, name).not.toContain('@radix-ui');
+      expect(source, name).not.toContain('@mantine');
+      expect(source, name).not.toContain('ConnectedTabs');
+      expect(source, name).not.toContain('/app/components/content/');
     }
   });
 

--- a/src/app/components/factions/editor/FactionAuthoring.architecture.test.ts
+++ b/src/app/components/factions/editor/FactionAuthoring.architecture.test.ts
@@ -58,6 +58,8 @@ describe('faction authoring architecture', () => {
     expect(formFieldsSource).toContain('<ArtifactProof');
     expect(formFieldsSource).not.toContain('Tabs,');
     expect(formFieldsSource).not.toContain('Accordion');
+    expect(formFieldsSource).not.toContain('useMediaQuery');
+    expect(formFieldsSource).not.toContain('mobileDocument');
     expect(formFieldsSource).not.toContain('useEditorAccordionHash');
     expect(formFieldsSource).not.toContain('navigate(');
   });
@@ -113,12 +115,15 @@ describe('faction authoring architecture', () => {
 
   it('keeps the reusable connected-tabs surface domain-neutral and Radix-owned', () => {
     expect(connectedTabsSource).toContain("from '@radix-ui/react-tabs'");
+    expect(connectedTabsSource).toContain("from '@radix-ui/react-select'");
     expect(connectedTabsSource).toContain('activationMode="automatic"');
     expect(connectedTabsSource).toContain('ResizeObserver');
     expect(connectedTabsSource).toContain('buildConnectedTabsPath');
+    expect(connectedTabsSource).toContain('data-connected-tabs-mobile-picker');
     expect(connectedTabsStyles).toContain('backdrop-filter: blur(8px)');
     expect(connectedTabsStyles).toContain('var(--panel-border, #fee7c0)');
     expect(connectedTabsStyles).toContain('container: connected-tabs-panel / inline-size');
+    expect(connectedTabsStyles).toContain('@container connected-tabs (max-width: 34rem)');
     expect(connectedTabsSource).not.toMatch(/Faction|@app\/routes|@db|Convex|publication/);
     expect(connectedTabsStyles).not.toContain(':global');
     expect(connectedTabsStyles).not.toContain('!important');

--- a/src/app/components/factions/editor/FactionAuthoringToolbar.module.css
+++ b/src/app/components/factions/editor/FactionAuthoringToolbar.module.css
@@ -1,12 +1,55 @@
 .toolbar {
+  box-sizing: border-box;
   position: sticky;
   top: 0.75rem;
   z-index: 10;
-  background: color-mix(in srgb, var(--mantine-color-body) 94%, transparent);
-  backdrop-filter: blur(12px);
+  height: 60px;
+  overflow: visible;
+  background: var(--glass-surface-1);
+  border-color: var(--panel-border);
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(8px);
+}
+
+.toolbarRow {
+  height: 100%;
+}
+
+.leading {
+  min-width: 0;
 }
 
 .status {
   min-width: 0;
-  flex: 1 1 18rem;
+}
+
+.statusDetails {
+  min-width: 0;
+}
+
+.statusDetails p {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.actions {
+  flex: 0 0 auto;
+}
+
+.auxiliarySlot,
+.destructiveSlot {
+  display: contents;
+}
+
+@media (max-width: 70em) {
+  .statusDetails {
+    display: none;
+  }
+}
+
+@media (max-width: 48em) {
+  .reviewAction {
+    display: none;
+  }
 }

--- a/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
+++ b/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Badge, Button, Group, Paper, Stack, Text, Tooltip } from '@mantine/core';
-import { RotateCcw, Save, X } from 'lucide-react';
+import { ArrowLeft, Eye, RotateCcw, Save } from 'lucide-react';
 import type { ReactNode } from 'react';
 
 import {
@@ -25,8 +25,9 @@ export function FactionAuthoringToolbar({
   assetPublishing,
   onSave,
   onReviewWarnings,
+  onReview,
   onReset,
-  onClose,
+  onBack,
   auxiliaryActions,
   context,
   destructiveActions,
@@ -38,8 +39,9 @@ export function FactionAuthoringToolbar({
   assetPublishing?: PublicAssetPublishingStatusProjection;
   onSave: () => void;
   onReviewWarnings: () => void;
+  onReview: (trigger: HTMLButtonElement) => void;
   onReset: () => void;
-  onClose: () => void;
+  onBack: () => void;
   auxiliaryActions?: ReactNode;
   context?: ReactNode;
   destructiveActions?: ReactNode;
@@ -72,44 +74,70 @@ export function FactionAuthoringToolbar({
 
   return (
     <Paper withBorder p="sm" radius="md" className={styles.toolbar}>
-      <Group justify="space-between" gap="sm" wrap="wrap">
-        <Stack gap={3} className={styles.status}>
-          <Group gap="xs" wrap="wrap">
-            <Badge color={statusColor} variant="light">
-              {statusLabel}
-            </Badge>
-            {warningCount > 0 ? (
-              <Button
-                type="button"
-                variant="subtle"
-                color="yellow"
-                size="compact-xs"
-                onClick={onReviewWarnings}
-              >
-                {warningCount} {warningCount === 1 ? 'field may' : 'fields may'} be incomplete
-              </Button>
-            ) : null}
-            {assetPublishing?.lastPublishedAt != null ? (
-              <Text
-                component="time"
-                dateTime={new Date(assetPublishing.lastPublishedAt).toISOString()}
-                size="xs"
-                c="dimmed"
-              >
-                Last published {formatPublishedAt(assetPublishing.lastPublishedAt)}
+      <Group justify="space-between" gap="sm" wrap="nowrap" className={styles.toolbarRow}>
+        <Group gap="sm" wrap="nowrap" className={styles.leading}>
+          <Tooltip label="Back">
+            <ActionIcon
+              type="button"
+              variant="light"
+              color="gray"
+              size="lg"
+              aria-label="Back"
+              onClick={onBack}
+            >
+              <ArrowLeft size={17} aria-hidden />
+            </ActionIcon>
+          </Tooltip>
+          <Stack gap={3} className={styles.status}>
+            <Group gap="xs" wrap="nowrap">
+              <Badge color={statusColor} variant="light">
+                {statusLabel}
+              </Badge>
+              {warningCount > 0 ? (
+                <Button
+                  type="button"
+                  variant="subtle"
+                  color="yellow"
+                  size="compact-xs"
+                  onClick={onReviewWarnings}
+                >
+                  {warningCount} {warningCount === 1 ? 'field may' : 'fields may'} be incomplete
+                </Button>
+              ) : null}
+              {assetPublishing?.lastPublishedAt != null ? (
+                <Text
+                  className={styles.statusDetails}
+                  component="time"
+                  dateTime={new Date(assetPublishing.lastPublishedAt).toISOString()}
+                  size="xs"
+                  c="dimmed"
+                >
+                  Last published {formatPublishedAt(assetPublishing.lastPublishedAt)}
+                </Text>
+              ) : null}
+            </Group>
+            <div className={styles.statusDetails}>
+              <Text size="xs" c={saveState === 'error' ? 'red' : 'dimmed'} role="status">
+                {isNameBlank
+                  ? 'Add a faction name before saving; it determines the faction URL.'
+                  : publishingCopy}
               </Text>
-            ) : null}
-          </Group>
-          <Text size="xs" c={saveState === 'error' ? 'red' : 'dimmed'} role="status">
-            {isNameBlank
-              ? 'Add a faction name before saving; it determines the faction URL.'
-              : publishingCopy}
-          </Text>
-          {context}
-        </Stack>
+              {context}
+            </div>
+          </Stack>
+        </Group>
 
-        <Group gap="xs" wrap="wrap">
-          {auxiliaryActions}
+        <Group gap="xs" wrap="nowrap" className={styles.actions}>
+          <div className={styles.auxiliarySlot}>{auxiliaryActions}</div>
+          <Button
+            className={styles.reviewAction}
+            type="button"
+            variant="default"
+            leftSection={<Eye size={17} aria-hidden />}
+            onClick={(event) => onReview(event.currentTarget)}
+          >
+            Review faction sheet
+          </Button>
           <Tooltip label="Reset unsaved edits">
             <ActionIcon
               type="button"
@@ -123,19 +151,7 @@ export function FactionAuthoringToolbar({
               <RotateCcw size={17} aria-hidden />
             </ActionIcon>
           </Tooltip>
-          <Tooltip label="Close editor">
-            <ActionIcon
-              type="button"
-              variant="light"
-              color="gray"
-              size="lg"
-              aria-label="Close editor"
-              onClick={onClose}
-            >
-              <X size={17} aria-hidden />
-            </ActionIcon>
-          </Tooltip>
-          {destructiveActions}
+          <div className={styles.destructiveSlot}>{destructiveActions}</div>
           <Button
             type="button"
             color="confirm"

--- a/src/app/components/factions/editor/FactionEditor.module.css
+++ b/src/app/components/factions/editor/FactionEditor.module.css
@@ -16,65 +16,13 @@
 
 .workbench {
   display: grid;
-  grid-template-columns: 11.5rem minmax(0, 1fr) minmax(17rem, 21rem);
+  grid-template-columns: minmax(0, 1fr) minmax(17rem, 21rem);
   align-items: start;
   width: 100%;
   min-width: 0;
 }
 
-.chapterTabs {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-  align-self: stretch;
-  width: 100%;
-  min-width: 0;
-  padding: var(--mantine-spacing-sm) 0;
-  border: 0;
-}
-
-.chapterTab {
-  width: 100%;
-  min-width: 0;
-  min-height: 4.2rem;
-  margin-right: -1px;
-  padding: 0.75rem 0.8rem;
-  color: var(--mantine-color-dark-7);
-  background: color-mix(in srgb, var(--mantine-color-white) 82%, transparent);
-  border: 1px solid var(--mantine-color-dune-2);
-  border-right-color: var(--mantine-color-dune-3);
-  border-radius: var(--mantine-radius-md) 0 0 var(--mantine-radius-md);
-  white-space: normal;
-  overflow-wrap: anywhere;
-}
-
-.chapterTab[data-active] {
-  z-index: 2;
-  color: var(--mantine-color-dark-9);
-  background: var(--mantine-color-white);
-  border-color: var(--mantine-color-dune-5);
-  border-right-color: var(--mantine-color-white);
-  box-shadow: inset 0.3rem 0 0 var(--mantine-color-dune-6);
-}
-
-.chapterNumber {
-  margin-right: 0.42rem;
-  color: var(--mantine-color-dimmed);
-  font-family: var(--mantine-font-family-monospace);
-  font-size: var(--mantine-font-size-xs);
-}
-
-.editorPlane {
-  min-width: 0;
-  min-height: 36rem;
-  padding: var(--mantine-spacing-lg);
-  background: var(--mantine-color-white);
-  border: 1px solid var(--mantine-color-dune-3);
-  border-radius: 0 var(--mantine-radius-lg) var(--mantine-radius-lg) 0;
-  box-shadow: var(--mantine-shadow-sm);
-}
-
-.editorPanel {
+.connectedTabs {
   min-width: 0;
 }
 
@@ -97,22 +45,32 @@
   border-bottom: 1px solid var(--mantine-color-dune-3);
 }
 
+.chapterNumber {
+  margin-right: 0.42rem;
+  color: var(--mantine-color-dimmed);
+  font-family: var(--mantine-font-family-monospace);
+  font-size: var(--mantine-font-size-xs);
+}
+
 .artifactColumn {
   min-width: 0;
   padding-left: var(--mantine-spacing-md);
 }
 
 .artifactDesk {
-  --paper-bg: var(--mantine-color-white);
+  --paper-bg: var(--glass-surface-1);
 
   position: sticky;
   top: calc(var(--app-shell-header-offset, 0px) + 5.5rem);
   overflow: hidden;
-  background-color: var(--mantine-color-white);
+  background-color: var(--glass-surface-1);
   background-image:
     linear-gradient(rgb(145 107 52 / 7%) 1px, transparent 1px),
     linear-gradient(90deg, rgb(145 107 52 / 7%) 1px, transparent 1px);
   background-size: 1.5rem 1.5rem;
+  border-color: var(--panel-border);
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(8px);
 }
 
 .liveBadge {
@@ -206,51 +164,22 @@
 
 @media (max-width: 74em) {
   .workbench {
-    grid-template-columns: 10rem minmax(0, 1fr) minmax(15rem, 18rem);
+    grid-template-columns: minmax(0, 1fr) minmax(14rem, 17rem);
   }
 }
 
 @media (max-width: 62em) {
   .workbench {
-    grid-template-columns: minmax(0, 1fr) minmax(15rem, 18rem);
-  }
-
-  .chapterTabs {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    grid-column: 1 / -1;
-    padding: 0;
-  }
-
-  .chapterTab,
-  .chapterTab[data-active] {
-    min-height: 3.4rem;
-    margin: 0 0 -1px;
-    border-radius: var(--mantine-radius-sm) var(--mantine-radius-sm) 0 0;
-    border-right-color: var(--mantine-color-dune-3);
-  }
-
-  .chapterTab[data-active] {
-    border-bottom-color: var(--mantine-color-white);
-    box-shadow: inset 0 -0.22rem 0 var(--mantine-color-dune-6);
-  }
-
-  .editorPlane {
-    border-radius: 0 0 var(--mantine-radius-lg) var(--mantine-radius-lg);
+    grid-template-columns: minmax(0, 1fr) minmax(13rem, 15rem);
   }
 
   .artifactColumn {
-    padding-left: var(--mantine-spacing-sm);
+    padding-left: 0.6rem;
   }
 }
 
 @media (max-width: 48em) {
-  .chapterTabs {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .editorPlane {
-    min-height: auto;
-    padding: var(--mantine-spacing-md);
+  .workbench {
+    display: block;
   }
 }

--- a/src/app/components/factions/editor/FactionEditor.module.css
+++ b/src/app/components/factions/editor/FactionEditor.module.css
@@ -26,32 +26,6 @@
   min-width: 0;
 }
 
-.mobileDocument {
-  width: 100%;
-}
-
-.mobileChapter {
-  overflow: hidden;
-  background: var(--mantine-color-white);
-  border: 1px solid var(--mantine-color-dune-3);
-  border-radius: var(--mantine-radius-lg);
-  box-shadow: var(--mantine-shadow-xs);
-}
-
-.mobileChapterHeading {
-  min-height: 3.5rem;
-  padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
-  background: var(--mantine-color-dune-0);
-  border-bottom: 1px solid var(--mantine-color-dune-3);
-}
-
-.chapterNumber {
-  margin-right: 0.42rem;
-  color: var(--mantine-color-dimmed);
-  font-family: var(--mantine-font-family-monospace);
-  font-size: var(--mantine-font-size-xs);
-}
-
 .artifactColumn {
   min-width: 0;
   padding-left: var(--mantine-spacing-md);

--- a/src/app/components/factions/editor/FactionEditor.stories.tsx
+++ b/src/app/components/factions/editor/FactionEditor.stories.tsx
@@ -1,11 +1,13 @@
-import { Box } from '@mantine/core';
+import { Box, Stack } from '@mantine/core';
 import preview from '@sb/preview';
+import { useRef } from 'react';
 
 import type { Faction, FactionEntry } from '@db/factions';
 import { defaultFaction } from '@data/defaultFaction';
 import { DECAL, LEADERS, PLANET, TROOP_MODIFIER } from '@game/data/generated';
 
-import { FactionEditor } from './FactionEditor';
+import { FactionAuthoringToolbar } from './FactionAuthoringToolbar';
+import { FactionEditor, type FactionEditorHandle } from './FactionEditor';
 
 function representativeFaction(): Faction {
   const faction = structuredClone(defaultFaction);
@@ -84,13 +86,28 @@ function factionEntry(data: Faction): FactionEntry {
 }
 
 function FactionEditorFixture() {
+  const editorRef = useRef<FactionEditorHandle>(null);
   return (
     <Box w="min(78rem, calc(100vw - 2rem))" p="md">
-      <FactionEditor
-        factionEntry={factionEntry(representativeFaction())}
-        errors={[]}
-        onSubmit={() => undefined}
-      />
+      <Stack gap="xl">
+        <FactionAuthoringToolbar
+          isDirty={false}
+          isNameBlank={false}
+          warningCount={0}
+          saveState="idle"
+          onSave={() => editorRef.current?.submit()}
+          onReviewWarnings={() => editorRef.current?.focusFirstWarning()}
+          onReview={(trigger) => editorRef.current?.review(trigger)}
+          onReset={() => editorRef.current?.load()}
+          onBack={() => undefined}
+        />
+        <FactionEditor
+          ref={editorRef}
+          factionEntry={factionEntry(representativeFaction())}
+          errors={[]}
+          onSubmit={() => undefined}
+        />
+      </Stack>
     </Box>
   );
 }
@@ -109,6 +126,30 @@ const meta = preview.meta({
 });
 
 export const Desktop = meta.story({});
+
+export const WideContract = meta.story({
+  globals: {
+    viewport: {
+      value: 'appAuthoringWide',
+    },
+  },
+});
+
+export const CompactContract = meta.story({
+  globals: {
+    viewport: {
+      value: 'appAuthoringCompact',
+    },
+  },
+});
+
+export const TabletContract = meta.story({
+  globals: {
+    viewport: {
+      value: 'appAuthoringTablet',
+    },
+  },
+});
 
 export const PreviewFreeMobile = meta.story({
   globals: {

--- a/src/app/components/factions/editor/FactionEditor.stories.tsx
+++ b/src/app/components/factions/editor/FactionEditor.stories.tsx
@@ -1,6 +1,7 @@
 import { Box, Stack } from '@mantine/core';
 import preview from '@sb/preview';
 import { useRef } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
 
 import type { Faction, FactionEntry } from '@db/factions';
 import { defaultFaction } from '@data/defaultFaction';
@@ -156,5 +157,16 @@ export const PreviewFreeMobile = meta.story({
     viewport: {
       value: 'appMobile',
     },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const picker = canvas.getByRole('combobox', { name: 'Faction editor sections' });
+
+    await expect(picker).toHaveTextContent('Identity & Appearance');
+    await expect(canvas.queryByRole('region', { name: 'Faction leader' })).not.toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Next section' }));
+    await expect(picker).toHaveTextContent('Faction leader');
+    await expect(canvas.getByRole('textbox', { name: 'Faction leader name' })).toBeVisible();
   },
 });

--- a/src/app/components/factions/editor/FactionEditor.tsx
+++ b/src/app/components/factions/editor/FactionEditor.tsx
@@ -5,7 +5,7 @@ import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import { type Faction, type FactionEntry } from '@db/factions';
 
 import styles from './FactionEditor.module.css';
-import { FactionFormFields } from './FactionFormFields';
+import { FactionFormFields, type FactionFormFieldsHandle } from './FactionFormFields';
 import { FactionSheetReview, type FactionSheetReviewHandle } from './FactionSheetReview';
 import {
   type FactionAuthoringWarning,
@@ -40,6 +40,7 @@ export const FactionEditor = forwardRef<FactionEditorHandle, FactionEditorProps>
     const initialValuesRef = useRef<Faction>(structuredClone(factionEntry.data));
     const baselineRef = useRef<Faction>(structuredClone(factionEntry.data));
     const reviewRef = useRef<FactionSheetReviewHandle>(null);
+    const fieldsRef = useRef<FactionFormFieldsHandle>(null);
 
     useEffect(() => {
       initialValuesRef.current = structuredClone(factionEntry.data);
@@ -101,9 +102,7 @@ export const FactionEditor = forwardRef<FactionEditorHandle, FactionEditorProps>
       focusFirstWarning: () => {
         const firstWarning = factionAuthoringWarnings(form.state.values)[0];
         if (!firstWarning) return;
-        const target = document.getElementById(firstWarning.targetId);
-        target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        target?.focus({ preventScroll: true });
+        fieldsRef.current?.focusWarning(firstWarning);
       },
       review: (trigger) => reviewRef.current?.open(trigger),
       getValues: () => form.state.values,
@@ -126,6 +125,7 @@ export const FactionEditor = forwardRef<FactionEditorHandle, FactionEditorProps>
             return (
               <FactionSheetReview ref={reviewRef} faction={values}>
                 <FactionFormFields
+                  ref={fieldsRef}
                   form={form}
                   warnings={warnings}
                   nameError={

--- a/src/app/components/factions/editor/FactionEditor.tsx
+++ b/src/app/components/factions/editor/FactionEditor.tsx
@@ -6,7 +6,7 @@ import { type Faction, type FactionEntry } from '@db/factions';
 
 import styles from './FactionEditor.module.css';
 import { FactionFormFields } from './FactionFormFields';
-import { FactionSheetReview } from './FactionSheetReview';
+import { FactionSheetReview, type FactionSheetReviewHandle } from './FactionSheetReview';
 import {
   type FactionAuthoringWarning,
   factionAuthoringWarnings,
@@ -31,6 +31,7 @@ export interface FactionEditorHandle {
   load: (entry?: FactionEntry['data']) => void;
   markSaved: (entry: FactionEntry['data']) => void;
   focusFirstWarning: () => void;
+  review: (trigger?: HTMLElement | null) => void;
   getValues: () => Faction;
 }
 
@@ -38,6 +39,7 @@ export const FactionEditor = forwardRef<FactionEditorHandle, FactionEditorProps>
   ({ factionEntry, errors, onSubmit, onStateChange }, ref) => {
     const initialValuesRef = useRef<Faction>(structuredClone(factionEntry.data));
     const baselineRef = useRef<Faction>(structuredClone(factionEntry.data));
+    const reviewRef = useRef<FactionSheetReviewHandle>(null);
 
     useEffect(() => {
       initialValuesRef.current = structuredClone(factionEntry.data);
@@ -103,6 +105,7 @@ export const FactionEditor = forwardRef<FactionEditorHandle, FactionEditorProps>
         target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
         target?.focus({ preventScroll: true });
       },
+      review: (trigger) => reviewRef.current?.open(trigger),
       getValues: () => form.state.values,
     }));
 
@@ -121,7 +124,7 @@ export const FactionEditor = forwardRef<FactionEditorHandle, FactionEditorProps>
             const warnings = factionAuthoringWarnings(values);
             const isNameBlank = values.name.trim().length === 0;
             return (
-              <FactionSheetReview faction={values}>
+              <FactionSheetReview ref={reviewRef} faction={values}>
                 <FactionFormFields
                   form={form}
                   warnings={warnings}

--- a/src/app/components/factions/editor/FactionFormFields.mobile.test.tsx
+++ b/src/app/components/factions/editor/FactionFormFields.mobile.test.tsx
@@ -2,14 +2,14 @@
 
 import { MantineProvider } from '@mantine/core';
 import { useForm } from '@tanstack/react-form';
-import { act } from 'react';
+import { act, useRef } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { appContentTheme } from '@app/theme';
 import { defaultFaction } from '@data/defaultFaction';
 
-import { FactionFormFields } from './FactionFormFields';
+import { FactionFormFields, type FactionFormFieldsHandle } from './FactionFormFields';
 import type { FactionFormApi } from './factionFormTypes';
 
 vi.mock('./FactionFormSectionIdentity', () => ({
@@ -54,26 +54,35 @@ vi.mock('./FactionFormSectionAdvantages', () => ({
 let container: HTMLDivElement | undefined;
 let root: Root | undefined;
 
+const warningFixtures = [
+  {
+    path: 'troops[0].back.name',
+    chapter: 'forces' as const,
+    label: 'Troop back needs a name',
+    targetId: 'troop-0-back-name',
+  },
+  {
+    path: 'planet[0].name',
+    chapter: 'worlds' as const,
+    label: 'World needs a name',
+    targetId: 'planet-0-name',
+  },
+];
+
 function Harness() {
   const form = useForm({ defaultValues: structuredClone(defaultFaction) });
+  const fieldsRef = useRef<FactionFormFieldsHandle>(null);
   return (
-    <FactionFormFields
-      form={form as unknown as FactionFormApi}
-      warnings={[
-        {
-          path: 'troops[0].back.name',
-          chapter: 'forces',
-          label: 'Troop back needs a name',
-          targetId: 'troop-0-back-name',
-        },
-        {
-          path: 'planet[0].name',
-          chapter: 'worlds',
-          label: 'World needs a name',
-          targetId: 'planet-0-name',
-        },
-      ]}
-    />
+    <>
+      <button type="button" onClick={() => fieldsRef.current?.focusWarning(warningFixtures[0])}>
+        Focus first warning
+      </button>
+      <FactionFormFields
+        ref={fieldsRef}
+        form={form as unknown as FactionFormApi}
+        warnings={warningFixtures}
+      />
+    </>
   );
 }
 
@@ -98,6 +107,12 @@ function buttonWithText(text: string) {
   return button;
 }
 
+function buttonWithLabel(label: string) {
+  const button = container?.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+  if (!button) throw new Error(`Missing button: ${label}`);
+  return button;
+}
+
 beforeEach(() => {
   vi.stubGlobal(
     'ResizeObserver',
@@ -110,7 +125,7 @@ beforeEach(() => {
   vi.stubGlobal(
     'matchMedia',
     vi.fn().mockImplementation((query: string) => ({
-      matches: query === '(max-width: 48em)',
+      matches: false,
       media: query,
       onchange: null,
       addEventListener: vi.fn(),
@@ -123,7 +138,7 @@ beforeEach(() => {
   vi.stubGlobal(
     'requestAnimationFrame',
     vi.fn().mockImplementation((callback: FrameRequestCallback) => {
-      callback(0);
+      window.setTimeout(() => callback(0), 0);
       return 1;
     })
   );
@@ -143,45 +158,55 @@ afterEach(async () => {
   Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView');
 });
 
-describe('FactionFormFields mobile document', () => {
-  it('renders every editor section in one preview-free vertical document', async () => {
+describe('FactionFormFields responsive workbench', () => {
+  it('mounts one active chapter while keeping both responsive navigation interfaces available', async () => {
     await renderFields();
 
-    expect(container?.querySelectorAll('section')).toHaveLength(8);
-    expect(container?.querySelectorAll('[data-mobile-section]')).toHaveLength(9);
-    expect(container?.querySelector('[role="tablist"]')).toBeNull();
-    expect(container?.textContent).not.toContain('Artifact workbench');
+    expect(container?.querySelectorAll('[data-mobile-section]')).toHaveLength(2);
+    expect(container?.querySelector('[data-mobile-section="identity"]')).not.toBeNull();
+    expect(container?.querySelector('[data-mobile-section="background"]')).not.toBeNull();
+    expect(container?.querySelector('[role="tablist"]')).not.toBeNull();
+    expect(container?.querySelector('[data-connected-tabs-mobile-picker]')).not.toBeNull();
   });
 
-  it('focuses warning targets without switching or unmounting chapters', async () => {
+  it('navigates compact chapters and focuses warning targets in the active panel', async () => {
     await renderFields();
 
-    await act(async () => buttonWithText('Troop back needs a name').click());
+    for (let step = 0; step < 5; step += 1) {
+      await act(async () => buttonWithLabel('Next section').click());
+    }
+
+    expect(container?.querySelector('[data-mobile-section="forces"]')).not.toBeNull();
+    await act(async () => {
+      buttonWithText('Troop back needs a name').click();
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
     expect(document.activeElement?.id).toBe('troop-0-back-name');
 
-    await act(async () => buttonWithText('World needs a name').click());
+    await act(async () => buttonWithLabel('Previous section').click());
+    expect(container?.querySelector('[data-mobile-section="worlds"]')).not.toBeNull();
+    await act(async () => {
+      buttonWithText('World needs a name').click();
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
     expect(document.activeElement?.id).toBe('planet-0-name');
   });
-});
 
-describe('FactionFormFields tablet workbench', () => {
-  beforeEach(() => {
-    vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }));
-  });
-
-  it('keeps the tabbed editor and adjacent artifact proof mounted above the mobile breakpoint', async () => {
+  it('selects an inactive warning chapter before focusing through its imperative handle', async () => {
     await renderFields();
 
-    expect(container?.querySelector('[role="tablist"]')).not.toBeNull();
+    await act(async () => {
+      buttonWithText('Focus first warning').click();
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+
+    expect(container?.querySelector('[data-mobile-section="forces"]')).not.toBeNull();
+    expect(document.activeElement?.id).toBe('troop-0-back-name');
+  });
+
+  it('keeps the adjacent artifact proof mounted for container-driven presentation', async () => {
+    await renderFields();
+
     expect(container?.textContent).toContain('Artifact workbench');
     expect(container?.querySelector('section')).toBeNull();
   });

--- a/src/app/components/factions/editor/FactionFormFields.tsx
+++ b/src/app/components/factions/editor/FactionFormFields.tsx
@@ -10,9 +10,8 @@ import {
   Stack,
   Text,
 } from '@mantine/core';
-import { useMediaQuery } from '@mantine/hooks';
 import { Globe2 } from 'lucide-react';
-import { useState } from 'react';
+import { forwardRef, useImperativeHandle, useState } from 'react';
 
 import { ConnectedTabs } from '@app/components/content/ConnectedTabs';
 import { TopicIcon } from '@app/components/topics/TopicIcon';
@@ -41,6 +40,10 @@ import { assetOptionToPreviewSrc } from './factionFormAssetUtils';
 import type { FactionFormApi } from './factionFormTypes';
 
 export type { FactionFormApi } from './factionFormTypes';
+
+export interface FactionFormFieldsHandle {
+  focusWarning: (warning: FactionAuthoringWarning) => void;
+}
 
 const chapterIcons: Record<
   Exclude<FactionAuthoringChapterId, 'identity' | 'worlds'>,
@@ -327,16 +330,14 @@ function ChapterWarnings({
   );
 }
 
-export function FactionFormFields({
-  form,
-  warnings,
-  nameError,
-}: {
-  form: FactionFormApi;
-  warnings: FactionAuthoringWarning[];
-  nameError?: string;
-}) {
-  const isMobile = useMediaQuery('(max-width: 48em)', false);
+export const FactionFormFields = forwardRef<
+  FactionFormFieldsHandle,
+  {
+    form: FactionFormApi;
+    warnings: FactionAuthoringWarning[];
+    nameError?: string;
+  }
+>(function FactionFormFields({ form, warnings, nameError }, ref) {
   const [activeChapter, setActiveChapter] = useState<FactionAuthoringChapterId>('identity');
   const [selectedItem, setSelectedItem] = useState({
     leader: 0,
@@ -349,13 +350,15 @@ export function FactionFormFields({
     warnings.filter((warning) => warning.chapter === chapter);
 
   const focusWarning = (warning: FactionAuthoringWarning) => {
-    if (!isMobile) setActiveChapter(warning.chapter);
+    setActiveChapter(warning.chapter);
     window.requestAnimationFrame(() => {
       const target = document.getElementById(warning.targetId);
       target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
       target?.focus({ preventScroll: true });
     });
   };
+
+  useImperativeHandle(ref, () => ({ focusWarning }));
 
   const chapterEditor = (chapter: FactionAuthoringChapterId) => (
     <>
@@ -412,44 +415,6 @@ export function FactionFormFields({
     </>
   );
 
-  if (isMobile) {
-    return (
-      <Stack className={styles.mobileDocument} gap="md">
-        {factionAuthoringChapters.map((chapter, index) => {
-          const chapterWarnings = forChapter(chapter.id);
-          const headingId = `mobile-faction-chapter-${chapter.id}`;
-          return (
-            <Box
-              component="section"
-              className={styles.mobileChapter}
-              key={chapter.id}
-              aria-labelledby={headingId}
-            >
-              <Group className={styles.mobileChapterHeading} gap="sm" wrap="nowrap">
-                <ChapterIcon chapter={chapter.id} form={form} />
-                <Text component="span" className={styles.chapterNumber}>
-                  {String(index + 1).padStart(2, '0')}
-                </Text>
-                <Text id={headingId} component="h2" fw={700} size="md">
-                  {chapter.label}
-                </Text>
-                {chapterWarnings.length > 0 ? (
-                  <Badge circle size="sm" color="yellow" ml="auto">
-                    {chapterWarnings.length}
-                  </Badge>
-                ) : null}
-              </Group>
-              <Stack gap="lg" p="md">
-                <ChapterWarnings warnings={chapterWarnings} onFocus={focusWarning} />
-                {chapterEditor(chapter.id)}
-              </Stack>
-            </Box>
-          );
-        })}
-      </Stack>
-    );
-  }
-
   const connectedTabItems = factionAuthoringChapters.map((chapter) => {
     const chapterWarnings = forChapter(chapter.id);
     return {
@@ -485,4 +450,4 @@ export function FactionFormFields({
       </Box>
     </div>
   );
-}
+});

--- a/src/app/components/factions/editor/FactionFormFields.tsx
+++ b/src/app/components/factions/editor/FactionFormFields.tsx
@@ -8,13 +8,13 @@ import {
   Paper,
   SegmentedControl,
   Stack,
-  Tabs,
   Text,
 } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
 import { Globe2 } from 'lucide-react';
 import { useState } from 'react';
 
+import { ConnectedTabs } from '@app/components/content/ConnectedTabs';
 import { TopicIcon } from '@app/components/topics/TopicIcon';
 import { AllianceCard } from '@game/assets/faction/alliance/Alliance';
 import { LeaderToken } from '@game/assets/faction/leader/Leader';
@@ -247,13 +247,7 @@ function ArtifactProof({
         }
 
         return (
-          <Paper
-            className={styles.artifactDesk}
-            withBorder
-            radius="lg"
-            p="md"
-            style={{ backgroundColor: 'var(--mantine-color-white)' }}
-          >
+          <Paper className={styles.artifactDesk} withBorder radius="lg" p="md">
             <Badge className={styles.liveBadge} color="teal" variant="light">
               Live
             </Badge>
@@ -456,58 +450,39 @@ export function FactionFormFields({
     );
   }
 
+  const connectedTabItems = factionAuthoringChapters.map((chapter) => {
+    const chapterWarnings = forChapter(chapter.id);
+    return {
+      value: chapter.id,
+      label: chapter.label,
+      icon: <ChapterIcon chapter={chapter.id} form={form} />,
+      indicator:
+        chapterWarnings.length > 0 ? (
+          <Badge circle size="sm" color="yellow">
+            {chapterWarnings.length}
+          </Badge>
+        ) : undefined,
+      panel: (
+        <Stack gap="lg">
+          <ChapterWarnings warnings={chapterWarnings} onFocus={focusWarning} />
+          {chapterEditor(chapter.id)}
+        </Stack>
+      ),
+    };
+  });
+
   return (
-    <Tabs
-      className={styles.workbench}
-      value={activeChapter}
-      onChange={(value) => {
-        if (value) setActiveChapter(value as FactionAuthoringChapterId);
-      }}
-      orientation="vertical"
-      keepMounted={false}
-    >
-      <Tabs.List className={styles.chapterTabs} aria-label="Faction editor sections">
-        {factionAuthoringChapters.map((chapter, index) => {
-          const chapterWarnings = forChapter(chapter.id);
-          return (
-            <Tabs.Tab
-              className={styles.chapterTab}
-              key={chapter.id}
-              value={chapter.id}
-              leftSection={<ChapterIcon chapter={chapter.id} form={form} />}
-              rightSection={
-                chapterWarnings.length > 0 ? (
-                  <Badge circle size="sm" color="yellow">
-                    {chapterWarnings.length}
-                  </Badge>
-                ) : undefined
-              }
-            >
-              <Text component="span" className={styles.chapterNumber}>
-                {String(index + 1).padStart(2, '0')}
-              </Text>
-              <Text component="span" fw={700}>
-                {chapter.label}
-              </Text>
-            </Tabs.Tab>
-          );
-        })}
-      </Tabs.List>
-
-      <Box className={styles.editorPlane}>
-        {factionAuthoringChapters.map((chapter) => (
-          <Tabs.Panel key={chapter.id} value={chapter.id} className={styles.editorPanel}>
-            <Stack gap="lg">
-              <ChapterWarnings warnings={forChapter(chapter.id)} onFocus={focusWarning} />
-              {chapterEditor(chapter.id)}
-            </Stack>
-          </Tabs.Panel>
-        ))}
-      </Box>
-
+    <div className={styles.workbench}>
+      <ConnectedTabs
+        className={styles.connectedTabs}
+        value={activeChapter}
+        onValueChange={setActiveChapter}
+        items={connectedTabItems}
+        ariaLabel="Faction editor sections"
+      />
       <Box className={styles.artifactColumn} visibleFrom="sm">
         <ArtifactProof activeChapter={activeChapter} form={form} selectedItem={selectedItem} />
       </Box>
-    </Tabs>
+    </div>
   );
 }

--- a/src/app/components/factions/editor/FactionSheetReview.architecture.test.ts
+++ b/src/app/components/factions/editor/FactionSheetReview.architecture.test.ts
@@ -23,7 +23,8 @@ describe('adaptive faction sheet review architecture', () => {
     expect(reviewSource).toContain('setReviewMounted(true)');
     expect(reviewSource).not.toContain('setReviewMounted(false)');
     expect(reviewSource).toContain('{reviewMounted ? (');
-    expect(editorSource).toContain('<FactionSheetReview faction={values}>');
+    expect(editorSource).toContain('<FactionSheetReview ref={reviewRef} faction={values}>');
+    expect(editorSource).toContain('review: (trigger) => reviewRef.current?.open(trigger)');
   });
 
   it('uses real isolated Sheet and Shield output without app-layer internal styling', () => {
@@ -65,12 +66,12 @@ describe('adaptive faction sheet review architecture', () => {
     expect(reviewSource).toContain('Return to editing');
     expect(reviewSource).toContain('Close faction sheet review');
     expect(reviewStyles).toContain('@media (max-width: 47.99em)');
-    expect(reviewStyles).toContain('.reviewAction,');
     expect(reviewStyles).toContain('.reviewPanel,');
+    expect(reviewSource).not.toContain('Review faction sheet');
   });
 
   it('switches in-memory chapter tabs and exposes warning counts without URL state', () => {
-    expect(formFieldsSource).toContain('<Tabs');
+    expect(formFieldsSource).toContain('<ConnectedTabs');
     expect(formFieldsSource).toContain('chapterWarnings.length');
     expect(formFieldsSource).not.toContain('navigate');
     expect(formFieldsSource).not.toContain('location.hash');

--- a/src/app/components/factions/editor/FactionSheetReview.module.css
+++ b/src/app/components/factions/editor/FactionSheetReview.module.css
@@ -5,7 +5,7 @@
   --editor-strip-width: clamp(9rem, 14%, 11rem);
   position: relative;
   width: 100%;
-  overflow: clip;
+  overflow: visible;
   border-radius: var(--mantine-radius-lg);
 }
 
@@ -50,11 +50,6 @@
 .editorCloseTarget:focus-visible {
   outline: 3px solid var(--mantine-primary-color-filled);
   outline-offset: -3px;
-}
-
-.reviewAction {
-  background: color-mix(in srgb, var(--mantine-color-dune-0) 72%, white);
-  border-color: var(--mantine-color-dune-3);
 }
 
 .reviewPanel {
@@ -284,7 +279,6 @@
 }
 
 @media (max-width: 47.99em) {
-  .reviewAction,
   .reviewPanel,
   .editorCloseTarget {
     display: none;

--- a/src/app/components/factions/editor/FactionSheetReview.stories.tsx
+++ b/src/app/components/factions/editor/FactionSheetReview.stories.tsx
@@ -1,11 +1,12 @@
-import { Box, Paper, Stack, Text, Title } from '@mantine/core';
+import { Box, Button, Paper, Stack, Text, Title } from '@mantine/core';
 import preview from '@sb/preview';
+import { useRef } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 
 import type { Faction } from '@db/factions';
 import { defaultFaction } from '@data/defaultFaction';
 
-import { FactionSheetReview } from './FactionSheetReview';
+import { FactionSheetReview, type FactionSheetReviewHandle } from './FactionSheetReview';
 
 function EditorChapter({ index }: { index: number }) {
   return (
@@ -40,9 +41,17 @@ function ReviewFixture({
   faction: Faction;
   longContent?: boolean;
 }) {
+  const reviewRef = useRef<FactionSheetReviewHandle>(null);
   return (
     <Box w="min(78rem, calc(100vw - 2rem))" p="md">
-      <FactionSheetReview faction={faction}>
+      <Button
+        visibleFrom="sm"
+        mb="md"
+        onClick={(event) => reviewRef.current?.open(event.currentTarget)}
+      >
+        Review faction sheet
+      </Button>
+      <FactionSheetReview ref={reviewRef} faction={faction}>
         <Stack gap="xl">
           {[1, 2, 3, 4, 5].map((index) => (
             <EditorChapter key={index} index={index} />

--- a/src/app/components/factions/editor/FactionSheetReview.test.tsx
+++ b/src/app/components/factions/editor/FactionSheetReview.test.tsx
@@ -1,14 +1,14 @@
 // @vitest-environment jsdom
 
 import { MantineProvider } from '@mantine/core';
-import { act } from 'react';
+import { act, useRef } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { appContentTheme } from '@app/theme';
 import { defaultFaction } from '@data/defaultFaction';
 
-import { FactionSheetReview } from './FactionSheetReview';
+import { FactionSheetReview, type FactionSheetReviewHandle } from './FactionSheetReview';
 
 vi.mock('./FactionSheetPagePreview', () => ({
   factionDraftForRenderer: (faction: unknown) => faction,
@@ -45,12 +45,24 @@ async function renderReview() {
   await act(async () => {
     root?.render(
       <MantineProvider theme={appContentTheme} forceColorScheme="light">
-        <FactionSheetReview faction={structuredClone(defaultFaction)}>
-          <div data-testid="editor-content">Editor content</div>
-        </FactionSheetReview>
+        <ReviewFixture />
       </MantineProvider>
     );
   });
+}
+
+function ReviewFixture() {
+  const reviewRef = useRef<FactionSheetReviewHandle>(null);
+  return (
+    <>
+      <button type="button" onClick={(event) => reviewRef.current?.open(event.currentTarget)}>
+        Review faction sheet
+      </button>
+      <FactionSheetReview ref={reviewRef} faction={structuredClone(defaultFaction)}>
+        <div data-testid="editor-content">Editor content</div>
+      </FactionSheetReview>
+    </>
+  );
 }
 
 async function clickButton(name: string) {

--- a/src/app/components/factions/editor/FactionSheetReview.tsx
+++ b/src/app/components/factions/editor/FactionSheetReview.tsx
@@ -1,10 +1,12 @@
-import { ActionIcon, Alert, Box, Button, Group, Paper, Stack, Text, Title } from '@mantine/core';
-import { ChevronDown, Eye, Link2, X } from 'lucide-react';
+import { ActionIcon, Alert, Box, Button, Group, Stack, Text, Title } from '@mantine/core';
+import { ChevronDown, Link2, X } from 'lucide-react';
 import {
   type CSSProperties,
+  forwardRef,
   type ReactNode,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useLayoutEffect,
   useRef,
   useState,
@@ -185,15 +187,19 @@ function ReviewHeading({
   );
 }
 
-export function FactionSheetReview({
-  faction,
-  children,
-}: {
-  faction: Faction;
-  children: ReactNode;
-}) {
+export interface FactionSheetReviewHandle {
+  open: (trigger?: HTMLElement | null) => void;
+}
+
+export const FactionSheetReview = forwardRef<
+  FactionSheetReviewHandle,
+  {
+    faction: Faction;
+    children: ReactNode;
+  }
+>(({ faction, children }, ref) => {
   const stageRef = useRef<HTMLElement>(null);
-  const reviewTriggerRef = useRef<HTMLButtonElement>(null);
+  const reviewTriggerRef = useRef<HTMLElement | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const mountFrameRef = useRef<number | null>(null);
   const [editorPlaneWidth, setEditorPlaneWidth] = useState(0);
@@ -205,18 +211,24 @@ export function FactionSheetReview({
     reviewTriggerRef.current?.focus({ preventScroll: true });
   }, []);
 
-  const openReview = () => {
-    if (!window.matchMedia(DESKTOP_REVIEW_MEDIA).matches) return;
-    setEditorPlaneWidth(stageRef.current?.clientWidth ?? 0);
-    if (reviewMounted) {
-      setReviewOpen(true);
-      return;
-    }
-    setReviewMounted(true);
-    mountFrameRef.current = requestAnimationFrame(() => {
-      mountFrameRef.current = requestAnimationFrame(() => setReviewOpen(true));
-    });
-  };
+  const openReview = useCallback(
+    (trigger?: HTMLElement | null) => {
+      if (!window.matchMedia(DESKTOP_REVIEW_MEDIA).matches) return;
+      reviewTriggerRef.current = trigger ?? null;
+      setEditorPlaneWidth(stageRef.current?.clientWidth ?? 0);
+      if (reviewMounted) {
+        setReviewOpen(true);
+        return;
+      }
+      setReviewMounted(true);
+      mountFrameRef.current = requestAnimationFrame(() => {
+        mountFrameRef.current = requestAnimationFrame(() => setReviewOpen(true));
+      });
+    },
+    [reviewMounted]
+  );
+
+  useImperativeHandle(ref, () => ({ open: openReview }), [openReview]);
 
   useEffect(() => {
     const media = window.matchMedia(DESKTOP_REVIEW_MEDIA);
@@ -262,34 +274,7 @@ export function FactionSheetReview({
           aria-hidden={reviewOpen || undefined}
           inert={reviewOpen ? true : undefined}
         >
-          <Stack gap="xl">
-            {children}
-            <Paper
-              withBorder
-              radius="lg"
-              p={{ base: 'md', sm: 'xl' }}
-              className={styles.reviewAction}
-              visibleFrom="sm"
-            >
-              <Group justify="space-between" align="center" gap="lg" wrap="wrap">
-                <Box>
-                  <Title order={3}>Ready to review the complete faction?</Title>
-                  <Text size="sm" c="dimmed">
-                    Inspect the real two-page sheet and shield without leaving this draft.
-                  </Text>
-                </Box>
-                <Button
-                  ref={reviewTriggerRef}
-                  type="button"
-                  color="dune"
-                  leftSection={<Eye size={17} aria-hidden />}
-                  onClick={openReview}
-                >
-                  Review faction sheet
-                </Button>
-              </Group>
-            </Paper>
-          </Stack>
+          {children}
         </div>
         {reviewOpen ? (
           <button
@@ -316,4 +301,4 @@ export function FactionSheetReview({
       ) : null}
     </section>
   );
-}
+});

--- a/src/app/routes/_app/factions/$factionId/edit.tsx
+++ b/src/app/routes/_app/factions/$factionId/edit.tsx
@@ -164,8 +164,9 @@ function FactionEditPage() {
           assetPublishing={assetPublishing}
           onSave={() => editorRef.current?.submit()}
           onReviewWarnings={() => editorRef.current?.focusFirstWarning()}
+          onReview={(trigger) => editorRef.current?.review(trigger)}
           onReset={() => editorRef.current?.load()}
-          onClose={() =>
+          onBack={() =>
             navigate({
               to: '/factions/$factionId',
               params: { factionId },

--- a/src/app/routes/_app/factions/create.tsx
+++ b/src/app/routes/_app/factions/create.tsx
@@ -138,8 +138,9 @@ function CreateFactionPage() {
           saveState={saveState}
           onSave={() => editorRef.current?.submit()}
           onReviewWarnings={() => editorRef.current?.focusFirstWarning()}
+          onReview={(trigger) => editorRef.current?.review(trigger)}
           onReset={() => editorRef.current?.load()}
-          onClose={() => navigate({ to: '/factions' })}
+          onBack={() => navigate({ to: '/factions' })}
           auxiliaryActions={
             <FactionLoadPopover
               disabled={createFaction.isPending}

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -3,8 +3,8 @@
 export const rendererManifest = {
   schemaVersion: 1,
   rendererIdentity:
-    'faction-sheet/sha256:6da556d9ffe7b9f3bdc3735cfa2b56471e029e5afd59bbdb40289212cac45649',
-  digest: '6da556d9ffe7b9f3bdc3735cfa2b56471e029e5afd59bbdb40289212cac45649',
+    'faction-sheet/sha256:7e93c8216996b2e2f53834fbe64346118017d850f0169fd4464a909613220d41',
+  digest: '7e93c8216996b2e2f53834fbe64346118017d850f0169fd4464a909613220d41',
   contract: {
     viewport: {
       width: 2100,


### PR DESCRIPTION
## Summary
- add a reusable connected-tabs content component with one continuous glass surface and measured SVG contour
- replace the faction editor’s page-specific chapter layout with the shared controlled component
- add a container-query mobile title stepper while preserving the left rail on wider containers
- keep selection state parent-owned and use a decorator-only state harness in Storybook
- align the authoring toolbar/review actions and preserve warning focus across unmounted chapters

## Why
The faction authoring UI needed the accepted continuous tab/panel visual language, reusable responsive behavior, and a compact mobile UX without duplicating page-specific state or media-query branches.

## Impact
Consumers pass `value` and `onValueChange`; `ConnectedTabs` never owns the selected tab. Its only internal React state is derived SVG geometry from private DOM measurements. Mobile behavior switches by container width, so embedded instances respond to their own available space.

No faction schema, persisted faction identity, asset rendering procedure, or game renderer output changes are included.

## Validation
- `bun run test` — 54 files, 350 tests
- `bun run typecheck`
- `bun run app:build`
- `bun run build-storybook`
- targeted Biome and `git diff --check`
- Storybook browser smoke for desktop, 390×844 mobile, and decorator-driven controlled interaction

Implements #122.
