### PR TITLE
Refine faction identity and background controls

### DIFF
--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -84,12 +84,10 @@ jobs:
         run: bun run publisher:test
       - name: Typecheck publisher
         run: bun run publisher:typecheck
-      - name: Build and dry-run unified Worker release
-        run: bun run publisher:dry-run
+      - name: Build, verify manifest, and dry-run unified Worker release
+        run: bun run publisher:release:verify
         env:
           VITE_CONVEX_URL: https://exuberant-finch-263.eu-west-1.convex.cloud
-      - name: Verify production renderer manifest is committed
-        run: git diff --exit-code -- workers/publisher/renderer-manifest.generated.ts
       - name: Install Chromium for publisher contract regression
         run: npx playwright install --with-deps chromium
       - name: Exercise narrow snapshot contract in Chromium

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,11 @@ Follow the canonical validation guidance in [`docs/data-layer.md`](docs/data-lay
 - Shared Zod schemas parsed in Convex handlers (`safeParse`) for authoritative semantic/business rules.
 - Client-side parsing only for UX feedback.
 
+Before opening or updating any PR that changes application code, publisher code, or release
+assets, run `bun run publisher:release:verify`. The publisher Worker contains the application
+release, while its Renderer identity intentionally excludes application-only shell and chunk
+files. A generated manifest diff must be resolved before push, not discovered by PR CI.
+
 ## Agent skills
 
 ### Issue tracker

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ bun run test             # Run tests
 bun run storybook        # Storybook dev (port 6006)
 bun run build-storybook  # Static Storybook → storybook-static
 bun run generate         # Regenerate the public asset catalog in src/game/data/generated.ts
+bun run publisher:release:verify # Exact pre-PR publisher build, manifest, and dry-run gate
 ```
 
 ### Disposable local app development

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "publisher:assets": "bun run app:build && vite build --config workers/publisher/vite.config.ts && bun run ./scripts/assemble-publisher-assets.ts",
     "publisher:assets:check": "bun run ./scripts/assemble-publisher-assets.ts --check-only",
     "publisher:dry-run": "bun run publisher:assets && wrangler deploy --dry-run --config workers/publisher/wrangler.jsonc",
+    "publisher:release:verify": "bun run publisher:dry-run && git diff --exit-code -- workers/publisher/renderer-manifest.generated.ts",
     "publisher:release:dry-run": "wrangler deploy --dry-run --config workers/publisher/wrangler.jsonc",
     "publisher:font-regression": "bun run publisher:assets && bun run workers/publisher/font-regression.ts",
     "publisher:capture-contract-regression": "bun run publisher:assets && bun run workers/publisher/capture-contract-regression.ts",

--- a/src/app/components/factions/editor/FactionEditor.module.css
+++ b/src/app/components/factions/editor/FactionEditor.module.css
@@ -84,7 +84,13 @@
 .tokenProof {
   position: relative;
   z-index: 1;
+  aspect-ratio: 1;
   width: 72%;
+}
+
+.tokenProof > div {
+  width: 100%;
+  height: 100%;
 }
 
 .leaderProof,

--- a/src/app/components/factions/editor/FactionEditor.stories.tsx
+++ b/src/app/components/factions/editor/FactionEditor.stories.tsx
@@ -1,7 +1,7 @@
 import { Box, Stack } from '@mantine/core';
 import preview from '@sb/preview';
 import { useRef } from 'react';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import type { Faction, FactionEntry } from '@db/factions';
 import { defaultFaction } from '@data/defaultFaction';
@@ -149,6 +149,35 @@ export const TabletContract = meta.story({
     viewport: {
       value: 'appAuthoringTablet',
     },
+  },
+});
+
+export const FactionTokenProofGeometry = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tokenChoice = canvas.getByRole('radio', { name: 'Faction token' });
+    const backgroundChoice = canvas.getByRole('radio', { name: 'Background' });
+
+    const expectSquareTokenProof = async () => {
+      await waitFor(() => {
+        const tokenProof = canvasElement.querySelector<HTMLElement>('[data-faction-token-proof]');
+        const renderedToken = tokenProof?.firstElementChild as HTMLElement | null;
+        expect(tokenProof).not.toBeNull();
+        expect(renderedToken).not.toBeNull();
+
+        const bounds = renderedToken?.getBoundingClientRect();
+        expect(bounds?.width).toBeGreaterThan(0);
+        expect(bounds?.height).toBeGreaterThan(0);
+        expect(Math.abs((bounds?.width ?? 0) - (bounds?.height ?? 0))).toBeLessThanOrEqual(1);
+      });
+    };
+
+    await userEvent.click(tokenChoice);
+    await expectSquareTokenProof();
+
+    await userEvent.click(backgroundChoice);
+    await userEvent.click(tokenChoice);
+    await expectSquareTokenProof();
   },
 });
 

--- a/src/app/components/factions/editor/FactionFormFields.tsx
+++ b/src/app/components/factions/editor/FactionFormFields.tsx
@@ -122,7 +122,7 @@ function ArtifactProof({
             {identityProof === 'background' ? (
               <BackgroundRenderer background={faction.background} />
             ) : (
-              <Box className={styles.tokenProof}>
+              <Box className={styles.tokenProof} data-faction-token-proof>
                 <Token background={faction.background} logo={faction.logo} />
               </Box>
             )}

--- a/src/app/components/factions/editor/FactionFormSectionBackground.module.css
+++ b/src/app/components/factions/editor/FactionFormSectionBackground.module.css
@@ -86,8 +86,25 @@
   place-items: center;
 }
 
-@media (max-width: 48em) {
-  .pipelineTop,
+@container connected-tabs-panel (max-width: 34rem) {
+  .pipelineTop {
+    gap: var(--mantine-spacing-sm);
+  }
+
+  .pipelineStage {
+    padding-top: 0;
+  }
+
+  .selectedPattern {
+    margin-top: var(--mantine-spacing-sm);
+  }
+}
+
+@container connected-tabs-panel (max-width: 26rem) {
+  .pipelineTop {
+    grid-template-columns: 1fr;
+  }
+
   .colorLayers {
     grid-template-columns: 1fr;
   }

--- a/src/app/components/factions/editor/FactionFormSectionBackground.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionBackground.tsx
@@ -29,6 +29,11 @@ import {
   withRandomPattern,
 } from './factionBackgroundRandomizer';
 import type { FactionFormApi } from './factionFormTypes';
+import {
+  clampInfluence,
+  influenceToSliderPosition,
+  sliderPositionToInfluence,
+} from './factionInfluenceScale';
 
 function RandomButton({ label, onClick }: { label: string; onClick: () => void }) {
   return (
@@ -168,33 +173,42 @@ function TreatmentControls({ form, onRandom }: { form: FactionFormApi; onRandom:
           )}
         </form.Field>
         <form.Field name="background.influence">
-          {(field) => (
-            <Stack gap={4}>
-              <Group justify="space-between">
-                <Text component="label" htmlFor="bg-influence" fw={600} size="sm">
-                  Influence
-                </Text>
-                <Text size="sm">{field.state.value.toFixed(2)}</Text>
-              </Group>
-              <Slider
-                id="bg-influence"
-                aria-label="Pattern influence from whisper to dominant"
-                min={0}
-                max={1}
-                step={0.01}
-                value={field.state.value}
-                onChange={field.handleChange}
-              />
-              <Group justify="space-between">
-                <Text size="xs" c="dimmed">
-                  Whisper
-                </Text>
-                <Text size="xs" c="dimmed">
-                  Dominant
-                </Text>
-              </Group>
-            </Stack>
-          )}
+          {(field) => {
+            const exactValue = clampInfluence(field.state.value);
+            return (
+              <Stack gap={4}>
+                <Group justify="space-between" align="baseline" wrap="nowrap">
+                  <Text component="label" htmlFor="bg-influence" fw={600} size="sm">
+                    Influence
+                  </Text>
+                  <Text size="sm" fw={700}>
+                    {exactValue.toFixed(2)}
+                  </Text>
+                </Group>
+                <Slider
+                  id="bg-influence"
+                  aria-label="Pattern influence with perceptual response from whisper to dominant"
+                  min={0}
+                  max={100}
+                  step={0.5}
+                  value={influenceToSliderPosition(exactValue)}
+                  label={(position) => sliderPositionToInfluence(position).toFixed(2)}
+                  onChange={(position) => field.handleChange(sliderPositionToInfluence(position))}
+                />
+                <Group justify="space-between">
+                  <Text size="xs" c="dimmed">
+                    Whisper
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    Strong
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    Dominant
+                  </Text>
+                </Group>
+              </Stack>
+            );
+          }}
         </form.Field>
       </Stack>
     </Box>
@@ -207,23 +221,8 @@ export function FactionFormSectionBackground({ form }: { form: FactionFormApi })
     form.setFieldValue('background', background);
 
   return (
-    <Stack component="section" gap="md" aria-labelledby="background-builder-heading">
+    <Stack component="section" gap="md" aria-label="Background builder">
       <Divider />
-      <Stack gap={2}>
-        <Text
-          id="background-builder-heading"
-          fw={800}
-          size="xs"
-          tt="uppercase"
-          c="dune.8"
-          lts="0.12em"
-        >
-          Background builder
-        </Text>
-        <Text c="dimmed" size="sm">
-          Pattern → treatment → two color layers → applied composite.
-        </Text>
-      </Stack>
 
       {libraryOpen ? (
         <form.Field name="background.image">
@@ -246,7 +245,15 @@ export function FactionFormSectionBackground({ form }: { form: FactionFormApi })
                 const treatment = backgroundTreatment(background);
                 return (
                   <Box className={styles.pipelineStage}>
-                    <Text className={styles.stageLabel}>01 · Pattern</Text>
+                    <Group justify="space-between" align="center">
+                      <Text className={styles.stageLabel}>01 · Pattern</Text>
+                      <RandomButton
+                        label="Random"
+                        onClick={() =>
+                          setBackground(withRandomPattern(form.state.values.background))
+                        }
+                      />
+                    </Group>
                     <Box className={styles.selectedPattern}>
                       <Image
                         src={background.image}
@@ -274,14 +281,6 @@ export function FactionFormSectionBackground({ form }: { form: FactionFormApi })
                         Browse
                       </Button>
                     </Group>
-                    <Box mt="xs">
-                      <RandomButton
-                        label="Random"
-                        onClick={() =>
-                          setBackground(withRandomPattern(form.state.values.background))
-                        }
-                      />
-                    </Box>
                   </Box>
                 );
               }}

--- a/src/app/components/factions/editor/FactionFormSectionIdentity.module.css
+++ b/src/app/components/factions/editor/FactionFormSectionIdentity.module.css
@@ -1,0 +1,26 @@
+.identityGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--mantine-spacing-md);
+  align-items: start;
+}
+
+.singleLineDescription {
+  display: block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@container connected-tabs-panel (max-width: 34rem) {
+  .identityGrid {
+    gap: var(--mantine-spacing-sm);
+  }
+}
+
+@container connected-tabs-panel (max-width: 26rem) {
+  .identityGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/app/components/factions/editor/FactionFormSectionIdentity.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionIdentity.tsx
@@ -1,16 +1,8 @@
-import {
-  ColorInput,
-  Group,
-  Image,
-  Select,
-  SimpleGrid,
-  Stack,
-  Text,
-  TextInput,
-} from '@mantine/core';
+import { Box, ColorInput, Group, Image, Select, Stack, Text, TextInput } from '@mantine/core';
 
 import type { Faction } from '@db/factions';
 
+import styles from './FactionFormSectionIdentity.module.css';
 import { assetOptionToPreviewSrc, logoOptions, logoOptionToLabel } from './factionFormAssetUtils';
 import type { FactionFormApi } from './factionFormTypes';
 import { TtsColorsEditor } from './TtsColorsEditor';
@@ -58,13 +50,14 @@ export function FactionFormSectionIdentity({
         </Stack>
       ) : null}
 
-      <SimpleGrid cols={{ base: 1, sm: 2 }}>
+      <Box className={styles.identityGrid}>
         <form.Field name="name">
           {(field) => (
             <TextInput
               id="faction-name"
               label="Faction name"
               description="Used on faction artifacts and to derive the canonical share URL."
+              classNames={{ description: styles.singleLineDescription }}
               error={nameError}
               value={field.state.value}
               onBlur={field.handleBlur}
@@ -79,6 +72,7 @@ export function FactionFormSectionIdentity({
               id="faction-logo"
               label="Faction logo"
               description="Used on faction tokens and faction-branded game artifacts."
+              classNames={{ description: styles.singleLineDescription }}
               searchable
               allowDeselect={false}
               data={logoSelectOptions}
@@ -109,6 +103,7 @@ export function FactionFormSectionIdentity({
               id="faction-theme-color"
               label="Faction sheet theme"
               description="Used for headings and accents on the complete faction sheet."
+              classNames={{ description: styles.singleLineDescription }}
               format="hex"
               value={field.state.value}
               onBlur={field.handleBlur}
@@ -116,11 +111,10 @@ export function FactionFormSectionIdentity({
             />
           )}
         </form.Field>
-      </SimpleGrid>
-
-      <form.Field name="colors">
-        {(field) => <TtsColorsEditor value={field.state.value} onChange={field.handleChange} />}
-      </form.Field>
+        <form.Field name="colors">
+          {(field) => <TtsColorsEditor value={field.state.value} onChange={field.handleChange} />}
+        </form.Field>
+      </Box>
     </Stack>
   );
 }

--- a/src/app/components/factions/editor/FactionIdentityBackground.architecture.test.ts
+++ b/src/app/components/factions/editor/FactionIdentityBackground.architecture.test.ts
@@ -15,6 +15,15 @@ const colorLayerSource = readFileSync(
   'utf8'
 );
 const ttsColorsSource = readFileSync(new URL('./TtsColorsEditor.tsx', import.meta.url), 'utf8');
+const identityStyles = readFileSync(
+  new URL('./FactionFormSectionIdentity.module.css', import.meta.url),
+  'utf8'
+);
+const backgroundStyles = readFileSync(
+  new URL('./FactionFormSectionBackground.module.css', import.meta.url),
+  'utf8'
+);
+const editorStyles = readFileSync(new URL('./FactionEditor.module.css', import.meta.url), 'utf8');
 const rendererSource = readFileSync(
   new URL('../../../../game/assets/utils/Background.tsx', import.meta.url),
   'utf8'
@@ -77,18 +86,45 @@ describe('Identity and Appearance chapter architecture', () => {
     const fieldsSource = readFileSync(new URL('./FactionFormFields.tsx', import.meta.url), 'utf8');
     expect(fieldsSource).toContain('BackgroundRenderer');
     expect(fieldsSource).toContain('<Token');
+    expect(fieldsSource).toContain('data-faction-token-proof');
     expect(fieldsSource).toContain('visibleFrom="sm"');
+    expect(editorStyles).toContain('aspect-ratio: 1');
     expect(rendererSource).not.toContain('@mantine');
   });
 
-  it('shows dots for TTS options and selected values while retaining keyboard ordering', () => {
+  it('uses one compact TTS row surface, unique choices, and heading-level add/remove actions', () => {
     expect(ttsColorsSource).toContain('TTS_COLOR_SWATCHES');
     expect(ttsColorsSource).toContain("color === 'White'");
     expect(ttsColorsSource).toContain('leftSection={<ColorDot');
     expect(ttsColorsSource).toContain('renderOption=');
+    expect(ttsColorsSource).toContain('availableTtsColors');
+    expect(ttsColorsSource).toContain('nextUnusedTtsColor');
+    expect(ttsColorsSource).toContain('<ActionIcon.Group>');
+    expect(ttsColorsSource).toContain('aria-label="Remove last TTS color"');
+    expect(ttsColorsSource).toContain('aria-label="Add TTS color"');
+    expect(ttsColorsSource).toContain('color="green"');
     expect(ttsColorsSource).toContain('PointerSensor');
     expect(ttsColorsSource).toContain('KeyboardSensor');
     expect(ttsColorsSource).toContain('sortableKeyboardCoordinates');
-    expect(ttsColorsSource).toContain('Repeated colors are allowed');
+    expect(ttsColorsSource).not.toContain('Repeated colors are allowed');
+    expect(ttsColorsSource).not.toContain('Order:');
+  });
+
+  it('uses the accepted perceptual influence mapping and labels without changing Definition', () => {
+    expect(backgroundSource).toContain('influenceToSliderPosition');
+    expect(backgroundSource).toContain('sliderPositionToInfluence');
+    for (const label of ['Whisper', 'Strong', 'Dominant']) {
+      expect(backgroundSource).toContain(label);
+    }
+    expect(backgroundSource).toContain('name="background.definition"');
+    expect(backgroundSource).toContain('max={1}');
+    expect(backgroundSource).toContain('step={0.01}');
+  });
+
+  it('compacts chapter internals from the connected panel container', () => {
+    expect(identityStyles).toContain('@container connected-tabs-panel');
+    expect(backgroundStyles).toContain('@container connected-tabs-panel');
+    expect(identityStyles).not.toContain('@media');
+    expect(backgroundStyles).not.toContain('@media');
   });
 });

--- a/src/app/components/factions/editor/TtsColorsEditor.module.css
+++ b/src/app/components/factions/editor/TtsColorsEditor.module.css
@@ -1,0 +1,38 @@
+.rows {
+  display: grid;
+  gap: 4px;
+}
+
+.unifiedRow {
+  display: flex;
+  min-width: 0;
+  overflow: hidden;
+  background: var(--mantine-color-white);
+  border: 1px solid var(--mantine-color-gray-4);
+  border-radius: var(--mantine-radius-sm);
+  box-shadow: var(--mantine-shadow-xs);
+}
+
+.unifiedRow:focus-within {
+  border-color: var(--mantine-color-dune-7);
+  outline: 1px solid var(--mantine-color-dune-7);
+}
+
+.unifiedSelect {
+  flex: 1;
+  min-width: 0;
+}
+
+.dragHandle {
+  flex: 0 0 30px;
+  width: 30px;
+  height: auto;
+  min-height: 30px;
+  border-radius: 0;
+  cursor: grab;
+  touch-action: none;
+}
+
+.dragHandle:active {
+  cursor: grabbing;
+}

--- a/src/app/components/factions/editor/TtsColorsEditor.test.ts
+++ b/src/app/components/factions/editor/TtsColorsEditor.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Faction } from '@db/factions';
+import { TTSColor } from '@game/schema/faction';
+
+import {
+  availableTtsColors,
+  moveTtsColor,
+  nextUnusedTtsColor,
+  removeLastTtsColor,
+} from './TtsColorsEditor';
+
+describe('TtsColorsEditor model', () => {
+  it('excludes colors used by other rows while retaining a legacy duplicate current value', () => {
+    const value: Faction['colors'] = ['Green', 'Green', 'Teal'];
+
+    const firstRowOptions = availableTtsColors(value, 0);
+
+    expect(firstRowOptions).toContain('Green');
+    expect(firstRowOptions).not.toContain('Teal');
+    expect(firstRowOptions.filter((color) => color === 'Green')).toHaveLength(1);
+    expect(value).toEqual(['Green', 'Green', 'Teal']);
+  });
+
+  it('appends the first unused color and disables addition after the catalogue is exhausted', () => {
+    expect(nextUnusedTtsColor(['White', 'Brown'])).toBe('Red');
+    expect(nextUnusedTtsColor([...TTSColor.options])).toBeUndefined();
+  });
+
+  it('removes only the bottom row', () => {
+    expect(removeLastTtsColor(['Green', 'Teal', 'Blue'])).toEqual(['Green', 'Teal']);
+    expect(removeLastTtsColor([])).toEqual([]);
+  });
+
+  it('uses the same stable reorder operation for pointer and keyboard drag completion', () => {
+    const value: Faction['colors'] = ['Green', 'Teal', 'Blue'];
+
+    expect(moveTtsColor(value, 0, 2)).toEqual(['Teal', 'Blue', 'Green']);
+    expect(moveTtsColor(value, 2, 0)).toEqual(['Blue', 'Green', 'Teal']);
+    expect(moveTtsColor(value, -1, 0)).toBe(value);
+  });
+});

--- a/src/app/components/factions/editor/TtsColorsEditor.tsx
+++ b/src/app/components/factions/editor/TtsColorsEditor.tsx
@@ -13,28 +13,48 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import {
-  ActionIcon,
-  Alert,
-  Box,
-  Button,
-  Group,
-  Paper,
-  Select,
-  Stack,
-  Text,
-  Tooltip,
-} from '@mantine/core';
-import { GripVertical, Plus, Trash2 } from 'lucide-react';
+import { ActionIcon, Box, Group, Select, Stack, Text, Tooltip } from '@mantine/core';
+import { GripVertical, Minus, Plus } from 'lucide-react';
 
 import type { Faction } from '@db/factions';
 import { getSortableIds, indexFromSortableId } from '@app/lib/dnd-sortable-ids';
 import { TTS_COLOR_SWATCHES } from '@game/data/ttsColors';
 import { TTSColor } from '@game/schema/faction';
 
+import styles from './TtsColorsEditor.module.css';
 import { useFactionSortableItem } from './useFactionSortableItem';
 
 type TtsColor = Faction['colors'][number];
+
+export function availableTtsColors(value: Faction['colors'], index: number): TtsColor[] {
+  const currentColor = value[index];
+  return TTSColor.options.filter(
+    (option) =>
+      option === currentColor ||
+      !value.some(
+        (selectedColor, selectedIndex) => selectedIndex !== index && selectedColor === option
+      )
+  ) as TtsColor[];
+}
+
+export function nextUnusedTtsColor(value: Faction['colors']): TtsColor | undefined {
+  return TTSColor.options.find((color) => !value.includes(color)) as TtsColor | undefined;
+}
+
+export function removeLastTtsColor(value: Faction['colors']): Faction['colors'] {
+  return value.slice(0, -1);
+}
+
+export function moveTtsColor(
+  value: Faction['colors'],
+  from: number,
+  to: number
+): Faction['colors'] {
+  if (from < 0 || to < 0 || from >= value.length || to >= value.length || from === to) {
+    return value;
+  }
+  return arrayMove(value, from, to);
+}
 
 function ColorDot({ color }: { color: TtsColor }) {
   return (
@@ -70,62 +90,49 @@ function TtsColorRow({
   color,
   index,
   itemId,
+  options,
   onChange,
-  onRemove,
 }: {
   color: TtsColor;
   index: number;
   itemId: string;
+  options: TtsColor[];
   onChange: (color: TtsColor) => void;
-  onRemove: () => void;
 }) {
   const sortable = useFactionSortableItem(itemId);
   return (
-    <Paper ref={sortable.setNodeRef} style={sortable.style} withBorder radius="md" p="sm">
-      <Group gap="sm" wrap="nowrap">
-        <Tooltip label={`Reorder TTS color ${index + 1}`}>
-          <ActionIcon
-            ref={sortable.handle.ref}
-            {...sortable.handle.attributes}
-            {...sortable.handle.listeners}
-            type="button"
-            variant="subtle"
-            color="gray"
-            size="lg"
-            aria-label={`Drag to reorder TTS color ${index + 1}`}
-            style={{ touchAction: 'none', cursor: 'grab' }}
-          >
-            <GripVertical size={18} aria-hidden />
-          </ActionIcon>
-        </Tooltip>
-
-        <Select
-          aria-label={`TTS color ${index + 1}`}
-          value={color}
-          allowDeselect={false}
-          data={TTSColor.options}
-          leftSection={<ColorDot color={color} />}
-          renderOption={({ option }) => <TtsColorOption color={option.value as TtsColor} />}
-          comboboxProps={{ withinPortal: false }}
-          style={{ flex: 1 }}
-          onChange={(value) => {
-            if (value) onChange(value as TtsColor);
-          }}
-        />
-
-        <Tooltip label={`Remove TTS color ${index + 1}`}>
-          <ActionIcon
-            type="button"
-            variant="light"
-            color="red"
-            aria-label={`Remove TTS color ${index + 1}`}
-            onClick={onRemove}
-          >
-            <Trash2 size={16} aria-hidden />
-          </ActionIcon>
-        </Tooltip>
-      </Group>
-    </Paper>
+    <Box ref={sortable.setNodeRef} style={sortable.style} className={styles.unifiedRow}>
+      <Select
+        className={styles.unifiedSelect}
+        aria-label={`TTS color ${index + 1}`}
+        size="xs"
+        variant="unstyled"
+        value={color}
+        allowDeselect={false}
+        data={options}
+        leftSection={<ColorDot color={color} />}
+        renderOption={({ option }) => <TtsColorOption color={option.value as TtsColor} />}
+        comboboxProps={{ withinPortal: false }}
+        onChange={(value) => {
+          if (value) onChange(value as TtsColor);
+        }}
+      />
+      <Tooltip label={`Reorder TTS color ${index + 1}`}>
+        <ActionIcon
+          ref={sortable.handle.ref}
+          {...sortable.handle.attributes}
+          {...sortable.handle.listeners}
+          className={styles.dragHandle}
+          type="button"
+          variant="transparent"
+          color="gray"
+          size="lg"
+          aria-label={`Drag to reorder TTS color ${index + 1}`}
+        >
+          <GripVertical size={17} aria-hidden />
+        </ActionIcon>
+      </Tooltip>
+    </Box>
   );
 }
 
@@ -142,22 +149,51 @@ export function TtsColorsEditor({
   );
   const sortablePrefix = 'tts-colors-';
   const itemIds = getSortableIds(sortablePrefix, value.length);
+  const nextAvailableColor = nextUnusedTtsColor(value);
 
   return (
-    <Stack gap="md">
-      <Stack gap={2}>
-        <Text fw={700}>Tabletop Simulator colors</Text>
-        <Text c="dimmed" size="sm">
-          Ordered preferred player colors for Tabletop Simulator. Repeated colors are allowed by the
-          faction format.
-        </Text>
-      </Stack>
+    <Stack gap={6}>
+      <Group gap="sm" justify="space-between" align="flex-start" wrap="nowrap">
+        <Stack gap={0}>
+          <Text fw={700} size="sm">
+            Tabletop Simulator colors
+          </Text>
+          <Text c="dimmed" size="xs">
+            Choose unique colors; drag to set their priority.
+          </Text>
+        </Stack>
 
-      {value.length === 0 ? (
-        <Alert color="gray" variant="light" title="No preferred TTS colors">
-          This faction does not currently recommend a player color.
-        </Alert>
-      ) : null}
+        <ActionIcon.Group>
+          <Tooltip label="Remove last color">
+            <ActionIcon
+              type="button"
+              variant="light"
+              color="red"
+              size="sm"
+              disabled={value.length === 0}
+              aria-label="Remove last TTS color"
+              onClick={() => onChange(removeLastTtsColor(value))}
+            >
+              <Minus size={16} aria-hidden />
+            </ActionIcon>
+          </Tooltip>
+          <Tooltip label="Add color">
+            <ActionIcon
+              type="button"
+              variant="filled"
+              color="green"
+              size="sm"
+              disabled={nextAvailableColor == null}
+              aria-label="Add TTS color"
+              onClick={() => {
+                if (nextAvailableColor) onChange([...value, nextAvailableColor]);
+              }}
+            >
+              <Plus size={16} aria-hidden />
+            </ActionIcon>
+          </Tooltip>
+        </ActionIcon.Group>
+      </Group>
 
       <DndContext
         sensors={sensors}
@@ -167,11 +203,11 @@ export function TtsColorsEditor({
           const from = indexFromSortableId(active.id, sortablePrefix);
           const to = indexFromSortableId(over.id, sortablePrefix);
           if (from == null || to == null || from === to) return;
-          onChange(arrayMove(value, from, to));
+          onChange(moveTtsColor(value, from, to));
         }}
       >
         <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-          <Stack gap="xs">
+          <Box className={styles.rows}>
             {value.map((color, index) => {
               const itemId = `${sortablePrefix}${index}`;
               return (
@@ -180,28 +216,24 @@ export function TtsColorsEditor({
                   color={color}
                   index={index}
                   itemId={itemId}
+                  options={availableTtsColors(value, index)}
                   onChange={(nextColor) => {
                     const next = [...value];
                     next[index] = nextColor;
                     onChange(next);
                   }}
-                  onRemove={() => onChange(value.filter((_, itemIndex) => itemIndex !== index))}
                 />
               );
             })}
-          </Stack>
+          </Box>
         </SortableContext>
       </DndContext>
 
-      <Button
-        type="button"
-        variant="light"
-        color="dune"
-        leftSection={<Plus size={16} aria-hidden />}
-        onClick={() => onChange([...value, 'White'])}
-      >
-        Add TTS color
-      </Button>
+      {value.length === 0 ? (
+        <Text size="xs" c="dimmed">
+          No preferred player colors selected.
+        </Text>
+      ) : null}
     </Stack>
   );
 }

--- a/src/app/components/factions/editor/factionBackgroundRandomizer.test.ts
+++ b/src/app/components/factions/editor/factionBackgroundRandomizer.test.ts
@@ -44,4 +44,31 @@ describe('background studio random actions', () => {
       expect(BACKGROUND_PATTERN_CATALOGUE.some((option) => option.image === next.image)).toBe(true);
     }
   });
+
+  it('never returns the exact current catalogue combination', () => {
+    for (let recipeIndex = 0; recipeIndex < backgroundRecipeCount; recipeIndex += 1) {
+      for (
+        let patternIndex = 0;
+        patternIndex < BACKGROUND_PATTERN_CATALOGUE.length;
+        patternIndex += 1
+      ) {
+        const sampledValues = [
+          (recipeIndex + 0.5) / backgroundRecipeCount,
+          (patternIndex + 0.5) / BACKGROUND_PATTERN_CATALOGUE.length,
+        ];
+        const current = randomizeBackground(original, () => sampledValues.shift() ?? 0);
+        const repeatedValues = [
+          (recipeIndex + 0.5) / backgroundRecipeCount,
+          (patternIndex + 0.5) / BACKGROUND_PATTERN_CATALOGUE.length,
+        ];
+        const next = randomizeBackground(current, () => repeatedValues.shift() ?? 0);
+
+        expect(next).not.toEqual(current);
+        expect(Background.safeParse(next).success).toBe(true);
+        expect(BACKGROUND_PATTERN_CATALOGUE.some((option) => option.image === next.image)).toBe(
+          true
+        );
+      }
+    }
+  });
 });

--- a/src/app/components/factions/editor/factionBackgroundRandomizer.ts
+++ b/src/app/components/factions/editor/factionBackgroundRandomizer.ts
@@ -113,6 +113,16 @@ function randomIndex(length: number, random: () => number): number {
   return Math.min(length - 1, Math.max(0, Math.floor(random() * length)));
 }
 
+function backgroundsMatch(left: FactionBackground, right: FactionBackground): boolean {
+  return (
+    left.image === right.image &&
+    left.invert === right.invert &&
+    left.definition === right.definition &&
+    left.influence === right.influence &&
+    JSON.stringify(left.colors) === JSON.stringify(right.colors)
+  );
+}
+
 export function randomPatternImage(random: () => number = Math.random): string {
   const option =
     BACKGROUND_PATTERN_CATALOGUE[randomIndex(BACKGROUND_PATTERN_CATALOGUE.length, random)];
@@ -133,17 +143,37 @@ export function withRandomPattern(
 }
 
 export function randomizeBackground(
-  _background: FactionBackground,
+  background: FactionBackground,
   random: () => number = Math.random
 ): FactionBackground {
-  const recipe = RECIPES[randomIndex(RECIPES.length, random)];
+  const recipeIndex = randomIndex(RECIPES.length, random);
+  const recipe = RECIPES[recipeIndex];
   if (!recipe) {
     throw new Error('The background recipe catalogue must contain at least one recipe');
   }
-  return {
+  const patternIndex = randomIndex(BACKGROUND_PATTERN_CATALOGUE.length, random);
+  const pattern = BACKGROUND_PATTERN_CATALOGUE[patternIndex];
+  if (!pattern) {
+    throw new Error('The background pattern catalogue must contain at least one pattern');
+  }
+  const candidate: FactionBackground = {
     ...structuredClone(recipe),
-    image: randomPatternImage(random),
+    image: pattern.image,
   };
+  if (!backgroundsMatch(candidate, background)) return candidate;
+
+  const nextPattern =
+    BACKGROUND_PATTERN_CATALOGUE[(patternIndex + 1) % BACKGROUND_PATTERN_CATALOGUE.length];
+  if (nextPattern && nextPattern.image !== candidate.image) {
+    return { ...candidate, image: nextPattern.image };
+  }
+
+  const nextRecipe = RECIPES[(recipeIndex + 1) % RECIPES.length];
+  if (nextRecipe && JSON.stringify(nextRecipe) !== JSON.stringify(recipe)) {
+    return { ...structuredClone(nextRecipe), image: candidate.image };
+  }
+
+  throw new Error('Random all requires at least two distinct catalogue combinations');
 }
 
 export function randomizeBackgroundTreatment(

--- a/src/app/components/factions/editor/factionInfluenceScale.test.ts
+++ b/src/app/components/factions/editor/factionInfluenceScale.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  clampInfluence,
+  influenceToSliderPosition,
+  sliderPositionToInfluence,
+} from './factionInfluenceScale';
+
+describe('faction influence perceptual scale', () => {
+  it('preserves the exact endpoints', () => {
+    expect(influenceToSliderPosition(0)).toBe(0);
+    expect(influenceToSliderPosition(1)).toBe(100);
+    expect(sliderPositionToInfluence(0)).toBe(0);
+    expect(sliderPositionToInfluence(100)).toBe(1);
+  });
+
+  it.each([
+    0, 0.1, 0.44, 0.58, 0.67, 0.72, 0.82, 0.95, 1,
+  ])('round-trips the existing stored value %s', (storedValue) => {
+    expect(sliderPositionToInfluence(influenceToSliderPosition(storedValue))).toBe(storedValue);
+  });
+
+  it('maps perceptual travel with v = 1 - (1 - p)^2', () => {
+    expect(sliderPositionToInfluence(25)).toBe(0.4375);
+    expect(sliderPositionToInfluence(50)).toBe(0.75);
+    expect(sliderPositionToInfluence(75)).toBe(0.9375);
+  });
+
+  it('clamps values to the stored contract', () => {
+    expect(clampInfluence(-1)).toBe(0);
+    expect(clampInfluence(2)).toBe(1);
+    expect(sliderPositionToInfluence(-10)).toBe(0);
+    expect(sliderPositionToInfluence(110)).toBe(1);
+  });
+});

--- a/src/app/components/factions/editor/factionInfluenceScale.ts
+++ b/src/app/components/factions/editor/factionInfluenceScale.ts
@@ -1,0 +1,12 @@
+export function clampInfluence(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+export function influenceToSliderPosition(storedValue: number): number {
+  return (1 - Math.sqrt(1 - clampInfluence(storedValue))) * 100;
+}
+
+export function sliderPositionToInfluence(position: number): number {
+  const normalized = clampInfluence(position / 100);
+  return Number((1 - (1 - normalized) ** 2).toFixed(4));
+}

--- a/workers/publisher/README.md
+++ b/workers/publisher/README.md
@@ -75,6 +75,7 @@ bun run publisher:assets:check
 bun run publisher:font-regression
 bun run publisher:capture-contract-regression
 bun run publisher:dry-run
+bun run publisher:release:verify
 bun run publisher:startup
 ```
 
@@ -82,9 +83,13 @@ bun run publisher:startup
 Browser DTO in Chromium and verifies capture readiness, payload identity, physical
 page bounds, corrupt-resource rejection, and the two-page PDF contract.
 
-The pull-request publisher job builds on Linux with the production Convex URL and
-rejects changes to generated Renderer output. Treat its generated manifest as
-authoritative because it covers assembled build artifacts as well as source.
+`publisher:release:verify` is the exact pre-PR publisher gate. It assembles and dry-runs the
+unified Worker release, regenerates the Renderer manifest, and rejects an uncommitted manifest
+change. The Renderer identity covers the capture bundle, renderer static assets, runtime closure,
+and PDF contract. It deliberately excludes application-only SPA shell and hashed chunk files so
+ordinary application UI changes do not create platform-specific Renderer identities.
+
+The pull-request publisher job runs the same command on Linux with the production Convex URL.
 
 The protected `main` workflow deploys Convex, initializes absent Publication
 settings, builds and deploys the Worker with the merged Git SHA, smokes both public

--- a/workers/publisher/deployment-config.test.ts
+++ b/workers/publisher/deployment-config.test.ts
@@ -106,9 +106,15 @@ describe('scheduled production deployment shape', () => {
       'scripts/assemble-publisher-assets.ts'
     );
     expect(packageConfig.scripts['publisher:dry-run']).toContain('bun run publisher:assets');
+    expect(packageConfig.scripts['publisher:release:verify']).toContain(
+      'bun run publisher:dry-run'
+    );
+    expect(packageConfig.scripts['publisher:release:verify']).toContain(
+      'git diff --exit-code -- workers/publisher/renderer-manifest.generated.ts'
+    );
   });
 
-  test('checks the Linux production renderer manifest before merge', () => {
+  test('runs the complete Linux publisher release verification before merge', () => {
     const verifyWorkflow = readFileSync(
       path.resolve(process.cwd(), '.github/workflows/reusable-verify.yml'),
       'utf8'
@@ -116,9 +122,7 @@ describe('scheduled production deployment shape', () => {
     expect(verifyWorkflow).toContain(
       'VITE_CONVEX_URL: https://exuberant-finch-263.eu-west-1.convex.cloud'
     );
-    expect(verifyWorkflow).toContain(
-      'git diff --exit-code -- workers/publisher/renderer-manifest.generated.ts'
-    );
+    expect(verifyWorkflow).toContain('bun run publisher:release:verify');
   });
 
   test('ignores publisher secret files while retaining the tracked example', () => {

--- a/workers/publisher/renderer-manifest-build.test.ts
+++ b/workers/publisher/renderer-manifest-build.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, test } from 'vitest';
 import { PUBLISHER_RENDERER_CONTRACT } from './renderer-contract';
 import {
   computeRendererManifestDigest,
+  isRendererManifestAsset,
   RENDERER_RUNTIME_CLOSURE_PATHS,
   type RendererManifestEntry,
 } from './renderer-manifest-build';
@@ -80,5 +81,50 @@ describe('current Renderer manifest digest', () => {
     const duplicate = entries();
     duplicate.push(duplicate[0] as RendererManifestEntry);
     expect(() => computeRendererManifestDigest(duplicate)).toThrow(/unique/);
+  });
+
+  test.each([
+    'publisher-capture.html',
+    'publisher-capture/publisher-capture-hash.js',
+    'font/font.woff2',
+    'image/texture/021.jpg',
+    'vector/icon/karama.svg',
+    'generated/utils/background/special.jpg',
+    'dice.svg',
+  ])('includes Renderer release asset %s', (assetPath) => {
+    expect(isRendererManifestAsset(assetPath)).toBe(true);
+  });
+
+  test.each([
+    '_shell.html',
+    'index.html',
+    'public/FactionEditor-hash.js',
+  ])('excludes application-only release asset %s', (assetPath) => {
+    expect(isRendererManifestAsset(assetPath)).toBe(false);
+  });
+
+  test('keeps application-only chunk changes out of the Renderer identity', () => {
+    const releaseEntries: RendererManifestEntry[] = [
+      {
+        path: 'publisher-capture/publisher-capture-hash.js',
+        bytes: encoder.encode('capture'),
+      },
+      {
+        path: 'public/FactionEditor-platform-hash.js',
+        bytes: encoder.encode('platform-specific application chunk'),
+      },
+    ];
+    const rendererEntries = releaseEntries.filter((entry) => isRendererManifestAsset(entry.path));
+    const changedApplicationEntries = releaseEntries
+      .map((entry) =>
+        entry.path.startsWith('public/')
+          ? { ...entry, bytes: encoder.encode('different platform chunk') }
+          : entry
+      )
+      .filter((entry) => isRendererManifestAsset(entry.path));
+
+    expect(computeRendererManifestDigest(changedApplicationEntries)).toBe(
+      computeRendererManifestDigest(rendererEntries)
+    );
   });
 });

--- a/workers/publisher/renderer-manifest-build.ts
+++ b/workers/publisher/renderer-manifest-build.ts
@@ -48,12 +48,23 @@ function filesBelow(directory: string): string[] {
   });
 }
 
+export function isRendererManifestAsset(relativePath: string): boolean {
+  const normalizedPath = relativePath.split(path.sep).join('/');
+  return (
+    normalizedPath !== '_shell.html' &&
+    normalizedPath !== 'index.html' &&
+    !normalizedPath.startsWith('public/')
+  );
+}
+
 export function writeRendererManifest(
   repositoryRoot: string,
   publisherDirectory: string
 ): { digest: string; entryCount: number } {
   const files = [
-    ...filesBelow(publisherDirectory),
+    ...filesBelow(publisherDirectory).filter((file) =>
+      isRendererManifestAsset(path.relative(publisherDirectory, file))
+    ),
     ...RENDERER_RUNTIME_CLOSURE_PATHS.map((relativePath) =>
       path.join(repositoryRoot, relativePath)
     ),
@@ -90,7 +101,7 @@ export function writeRendererManifest(
   writeFileSync(
     path.join(repositoryRoot, 'workers/publisher/renderer-manifest.generated.ts'),
     `// Generated after assembling the complete publisher Static Assets release.\n` +
-      `// Run \`bun run publisher:assets\` after changing release assets or the PDF contract.\n` +
+      `// Run \`bun run publisher:assets\` after changing Renderer assets or the PDF contract.\n` +
       `export const rendererManifest = {\n` +
       `  schemaVersion: 1,\n` +
       `  rendererIdentity:\n` +

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -1,10 +1,10 @@
 // Generated after assembling the complete publisher Static Assets release.
-// Run `bun run publisher:assets` after changing release assets or the PDF contract.
+// Run `bun run publisher:assets` after changing Renderer assets or the PDF contract.
 export const rendererManifest = {
   schemaVersion: 1,
   rendererIdentity:
-    'faction-sheet/sha256:7e93c8216996b2e2f53834fbe64346118017d850f0169fd4464a909613220d41',
-  digest: '7e93c8216996b2e2f53834fbe64346118017d850f0169fd4464a909613220d41',
+    'faction-sheet/sha256:e50b2e7544e23095551b90c1441fd5ea631a0ed8b7793407b01b80f7da6a784b',
+  digest: 'e50b2e7544e23095551b90c1441fd5ea631a0ed8b7793407b01b80f7da6a784b',
   contract: {
     viewport: {
       width: 2100,


### PR DESCRIPTION
## Summary

- compact the shared Create/Edit identity chapter into a container-query-driven two-column composition
- replace per-row TTS delete controls with unified rows, unique choices, and heading-level bottom-remove/next-unused-add actions
- apply the accepted perceptual Influence mapping while preserving the stored 0–1 contract
- guarantee `Random all` changes a catalogue-backed background and give the application token proof positive square geometry
- add deterministic model, architecture, randomizer, and Storybook interaction coverage
- stabilize the publisher Renderer identity by excluding platform-dependent application shell/chunks while retaining capture, renderer asset, runtime, and PDF-contract inputs
- make `bun run publisher:release:verify` the shared local/CI release gate and document it as a mandatory pre-PR check

## Validation

- `bun run test` (56 files, 380 tests)
- `bun run typecheck`
- `bun run publisher:test` (17 files, 190 tests)
- `bun run publisher:typecheck`
- `bun run publisher:release:verify`
- `bun run app:build`
- `bun run build-storybook`
- browser verification at 1280×900, 1074×1199, 900×1000, and 390×844
- PR CI: all checks green, including `publisher_release` and `e2e_docker`

Implements #123.
Part of #116.
