### PR TITLE
Reorganize Storybook around product surfaces

### DIFF
--- a/.storybook/legacyStoryParameters.ts
+++ b/.storybook/legacyStoryParameters.ts
@@ -1,0 +1,8 @@
+export const legacyStoryParameters = {
+  docs: {
+    description: {
+      component:
+        'Migration-only regression coverage for legacy application presentation. New application UI should compose Mantine directly.',
+    },
+  },
+};

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -71,10 +71,6 @@ export default defineMain({
       directory: '../src/game/components/block',
       titlePrefix: 'Game Assets/Composition/Blocks',
     },
-    {
-      directory: '../src/game/book',
-      titlePrefix: 'Book',
-    },
   ],
   addons: ['@storybook/addon-docs'],
   framework: {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,8 +3,49 @@ import { defineMain } from '@storybook/react-vite/node';
 export default defineMain({
   stories: [
     {
-      directory: '../src/app/components',
-      titlePrefix: 'App',
+      directory: '../src/app/components/factions',
+      files: '*.stories.tsx',
+      titlePrefix: 'Application/Factions',
+    },
+    {
+      directory: '../src/app/components/factions/editor',
+      titlePrefix: 'Application/Factions/Editor',
+    },
+    {
+      directory: '../src/app/components/faq',
+      titlePrefix: 'Application/FAQ',
+    },
+    {
+      directory: '../src/app/components/groups',
+      titlePrefix: 'Application/Groups',
+    },
+    {
+      directory: '../src/app/components/topics',
+      titlePrefix: 'Application/Topics',
+    },
+    {
+      directory: '../src/app/components/content',
+      titlePrefix: 'Application/Shared Content',
+    },
+    {
+      directory: '../src/app/components/foundation',
+      titlePrefix: 'Application/Foundation',
+    },
+    {
+      directory: '../src/app/components/form',
+      titlePrefix: 'Application/Legacy/Form',
+    },
+    {
+      directory: '../src/app/components/generic/layout',
+      titlePrefix: 'Application/Legacy/Layout',
+    },
+    {
+      directory: '../src/app/components/generic/surfaces',
+      titlePrefix: 'Application/Legacy/Surfaces',
+    },
+    {
+      directory: '../src/app/components/generic/ui',
+      titlePrefix: 'Application/Legacy/UI',
     },
     {
       directory: '../src/game/assets/faction',

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,19 +8,27 @@ export default defineMain({
     },
     {
       directory: '../src/game/assets/faction',
-      titlePrefix: 'Faction',
+      titlePrefix: 'Game Assets/Faction',
     },
     {
       directory: '../src/game/assets/card',
-      titlePrefix: 'Card',
+      titlePrefix: 'Game Assets/Cards',
+    },
+    {
+      directory: '../src/game/assets/treachery',
+      titlePrefix: 'Game Assets/Cards/Treachery',
     },
     {
       directory: '../src/game/assets/token',
-      titlePrefix: 'Token',
+      titlePrefix: 'Game Assets/Tokens',
     },
     {
       directory: '../src/game/assets/utils',
-      titlePrefix: 'Utils',
+      titlePrefix: 'Game Assets/Composition',
+    },
+    {
+      directory: '../src/game/components/block',
+      titlePrefix: 'Game Assets/Composition/Blocks',
     },
     {
       directory: '../src/game/book',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -128,7 +128,7 @@ export default definePreview({
         <Story />
       );
 
-      if (title.startsWith('App/')) {
+      if (title.startsWith('Application/')) {
         return (
           <MantineProvider theme={appContentTheme} forceColorScheme="light">
             {story}

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,10 +58,19 @@ perform this production copy.
 
 ### Writing Stories
 
-- Stories should render the component the story file is for.
-- Avoid wrappers unless required to demonstrate that component's own capability.
-- Prefer args-only stories over custom `render` functions.
-- For controlled components in this repo, use non-interactive args-only examples with static values and noop callbacks.
+- Keep stories colocated with the component they render. Storybook navigation is owned by the
+  source entries and `titlePrefix` values in `.storybook/main.ts`.
+- Prefer auto-titles. Add a relative `title` only when a filename cannot express the useful
+  product-facing label; never repeat `Application` or `Game Assets` in story metadata.
+- Application stories belong under Factions, FAQ, Groups, Topics, Shared Content, Foundation, or
+  Legacy. Legacy stories are migration-only regression coverage, not canonical APIs for new UI.
+- Game Assets stories belong under Faction, Cards, Tokens, or Composition. Comparative asset
+  catalogues may remain exhaustive when side-by-side inspection is the story's purpose.
+- Rulebook stories are intentionally not indexed while their redesign is pending.
+- Prefer args-only stories. Use wrappers, custom rendering, or interactions only when they
+  demonstrate behavior or comparison that args cannot.
+- Represent controlled components with static values and noop callbacks unless interaction itself
+  is the contract under test.
 
 ### Adding a New Domain
 

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.stories.tsx
@@ -131,7 +131,7 @@ function renderConnectedTabs({
 }
 
 const meta = preview.meta({
-  title: 'App/Content/ConnectedTabs',
+  title: 'Connected Tabs',
   component: ConnectedTabs as ComponentType<ConnectedTabsStoryArgs>,
   render: renderConnectedTabs,
   args: {

--- a/src/app/components/factions/FactionCard.stories.tsx
+++ b/src/app/components/factions/FactionCard.stories.tsx
@@ -19,7 +19,6 @@ const baseFaction = {
 } as unknown as FactionCatalogueEntry;
 
 const meta = preview.meta({
-  title: 'App/Factions/FactionCard',
   component: FactionCard,
   parameters: { layout: 'centered' },
   decorators: [

--- a/src/app/components/factions/editor/FactionEditor.stories.tsx
+++ b/src/app/components/factions/editor/FactionEditor.stories.tsx
@@ -114,7 +114,7 @@ function FactionEditorFixture() {
 }
 
 const meta = preview.meta({
-  title: 'App/Factions/Editor/CompleteAuthoringDocument',
+  title: 'Complete Authoring Document',
   component: FactionEditorFixture,
   globals: {
     viewport: {

--- a/src/app/components/factions/editor/FactionFormSectionBackground.stories.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionBackground.stories.tsx
@@ -37,7 +37,7 @@ function BackgroundStudioFixture({ background }: { background: Faction['backgrou
 }
 
 const meta = preview.meta({
-  title: 'App/Factions/Editor/BackgroundStudio',
+  title: 'Background Studio',
   component: BackgroundStudioFixture,
   globals: {
     viewport: {

--- a/src/app/components/factions/editor/FactionFormSectionLeadersAlliance.stories.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionLeadersAlliance.stories.tsx
@@ -63,7 +63,7 @@ function withLeadersAndDecals(leaderCount: number, decalCount: number): Faction 
 }
 
 const meta = preview.meta({
-  title: 'App/Factions/Editor/LeadersAndAlliance',
+  title: 'Leaders and Alliance',
   component: LeadersAllianceFixture,
   globals: {
     viewport: {

--- a/src/app/components/factions/editor/FactionSheetReview.stories.tsx
+++ b/src/app/components/factions/editor/FactionSheetReview.stories.tsx
@@ -73,7 +73,6 @@ function ReviewFixture({
 }
 
 const meta = preview.meta({
-  title: 'App/Factions/Editor/FactionSheetReview',
   component: ReviewFixture,
   globals: {
     viewport: {
@@ -119,18 +118,6 @@ export const ConstrainedStacked = meta.story({
     viewport: {
       value: 'appConstrained',
     },
-  },
-  render: (args) => (
-    <div data-testid="faction-review-story-root">
-      <ReviewFixture {...args} />
-    </div>
-  ),
-  play: async ({ canvasElement }) => openReview(canvasElement),
-});
-
-export const ReducedMotion = meta.story({
-  args: {
-    faction: storyFaction,
   },
   render: (args) => (
     <div data-testid="faction-review-story-root">

--- a/src/app/components/faq/Answer.stories.tsx
+++ b/src/app/components/faq/Answer.stories.tsx
@@ -42,12 +42,3 @@ export const Accepted = meta.story({
     </Answer.List>
   ),
 });
-
-export const Empty = meta.story({
-  render: () => (
-    <Stack gap={2}>
-      <p style={{ margin: 0 }}>No answers have been submitted yet.</p>
-      <Answer.List>{null}</Answer.List>
-    </Stack>
-  ),
-});

--- a/src/app/components/form/ColorLayerField.stories.tsx
+++ b/src/app/components/form/ColorLayerField.stories.tsx
@@ -1,9 +1,11 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { ColorLayerField } from './ColorLayerField';
 
 const meta = preview.meta({
   component: ColorLayerField,
+  parameters: legacyStoryParameters,
 });
 
 export const Solid = meta.story({

--- a/src/app/components/form/FormField.stories.tsx
+++ b/src/app/components/form/FormField.stories.tsx
@@ -1,3 +1,4 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { FormField } from './FormField';
@@ -5,6 +6,7 @@ import { TextField } from './TextField';
 
 const meta = preview.meta({
   component: FormField,
+  parameters: legacyStoryParameters,
 });
 
 export const WithLabelAndHint = meta.story({

--- a/src/app/components/form/FormPopover.stories.tsx
+++ b/src/app/components/form/FormPopover.stories.tsx
@@ -1,3 +1,4 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { UIButton } from '@app/components/generic/ui/UIButton';
@@ -6,6 +7,7 @@ import { FormPopover } from './FormPopover';
 
 const meta = preview.meta({
   component: FormPopover,
+  parameters: legacyStoryParameters,
 });
 
 export const Default = meta.story({

--- a/src/app/components/form/FormTabs.stories.tsx
+++ b/src/app/components/form/FormTabs.stories.tsx
@@ -1,35 +1,35 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
-import { useState } from 'react';
 
 import { FormTabs, type FormTabsItem, FormTabsPanel } from './FormTabs';
 
+const items: FormTabsItem[] = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'details', label: 'Details' },
+  { value: 'settings', label: 'Settings', disabled: true },
+];
+
 const meta = preview.meta({
   component: FormTabs,
+  parameters: legacyStoryParameters,
+  args: {
+    value: 'overview',
+    onValueChange: () => {},
+    items,
+    children: (
+      <>
+        <FormTabsPanel value="overview">
+          <p>Overview content.</p>
+        </FormTabsPanel>
+        <FormTabsPanel value="details">
+          <p>Details content.</p>
+        </FormTabsPanel>
+        <FormTabsPanel value="settings">
+          <p>Settings are disabled in this example.</p>
+        </FormTabsPanel>
+      </>
+    ),
+  },
 });
 
-function TabsExample() {
-  const items: FormTabsItem[] = [
-    { value: 'overview', label: 'Overview' },
-    { value: 'details', label: 'Details' },
-    { value: 'settings', label: 'Settings', disabled: true },
-  ];
-  const [value, setValue] = useState(items[0]?.value ?? 'overview');
-
-  return (
-    <FormTabs value={value} onValueChange={setValue} items={items}>
-      <FormTabsPanel value="overview">
-        <p>Overview content.</p>
-      </FormTabsPanel>
-      <FormTabsPanel value="details">
-        <p>Details content.</p>
-      </FormTabsPanel>
-      <FormTabsPanel value="settings">
-        <p>Settings are disabled in this example.</p>
-      </FormTabsPanel>
-    </FormTabs>
-  );
-}
-
-export const Default = meta.story({
-  render: () => <TabsExample />,
-});
+export const Default = meta.story({});

--- a/src/app/components/form/FormTooltip.stories.tsx
+++ b/src/app/components/form/FormTooltip.stories.tsx
@@ -1,3 +1,4 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { UIButton } from '@app/components/generic/ui/UIButton';
@@ -6,6 +7,7 @@ import { FormTooltip } from './FormTooltip';
 
 const meta = preview.meta({
   component: FormTooltip,
+  parameters: legacyStoryParameters,
 });
 
 export const Default = meta.story({

--- a/src/app/components/form/FormUnitToolbar.stories.tsx
+++ b/src/app/components/form/FormUnitToolbar.stories.tsx
@@ -1,3 +1,4 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 import { Trash2 } from 'lucide-react';
 
@@ -7,6 +8,7 @@ import { FormUnitToolbar } from './FormUnitToolbar';
 
 const meta = preview.meta({
   component: FormUnitToolbar,
+  parameters: legacyStoryParameters,
 });
 
 export const Default = meta.story({

--- a/src/app/components/form/HexColorPicker.stories.tsx
+++ b/src/app/components/form/HexColorPicker.stories.tsx
@@ -1,9 +1,11 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { HexColorPicker } from './HexColorPicker';
 
 const meta = preview.meta({
   component: HexColorPicker,
+  parameters: legacyStoryParameters,
 });
 
 export const SolidHex = meta.story({

--- a/src/app/components/form/LabeledRangeInput.stories.tsx
+++ b/src/app/components/form/LabeledRangeInput.stories.tsx
@@ -1,48 +1,42 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
-import { useState } from 'react';
 
 import { LabeledRangeInput } from './LabeledRangeInput';
 
 const meta = preview.meta({
   component: LabeledRangeInput,
+  parameters: legacyStoryParameters,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 'min(100%, 20rem)' }}>
+        <Story />
+      </div>
+    ),
+  ],
 });
 
 export const Default = meta.story({
-  render: () => {
-    const [value, setValue] = useState(0.42);
-    return (
-      <div style={{ width: 'min(100%, 20rem)' }}>
-        <LabeledRangeInput
-          id="story-range"
-          label="Opacity (0–1)"
-          min={0}
-          max={1}
-          step={0.01}
-          value={value}
-          onChange={setValue}
-          formatDisplay={(n) => n.toFixed(2)}
-        />
-      </div>
-    );
+  args: {
+    id: 'story-range',
+    label: 'Opacity (0–1)',
+    min: 0,
+    max: 1,
+    step: 0.01,
+    value: 0.42,
+    onChange: () => {},
+    formatDisplay: (n) => n.toFixed(2),
   },
 });
 
 export const IntegerClamped = meta.story({
-  render: () => {
-    const [value, setValue] = useState(0);
-    return (
-      <div style={{ width: 'min(100%, 20rem)' }}>
-        <LabeledRangeInput
-          id="story-int-range"
-          label="Offset (−500–500)"
-          min={-500}
-          max={500}
-          step={1}
-          integer
-          value={value}
-          onChange={setValue}
-        />
-      </div>
-    );
+  args: {
+    id: 'story-int-range',
+    label: 'Offset (−500–500)',
+    min: -500,
+    max: 500,
+    step: 1,
+    integer: true,
+    value: 620,
+    onChange: () => {},
   },
 });

--- a/src/app/components/form/MultilineTextField.stories.tsx
+++ b/src/app/components/form/MultilineTextField.stories.tsx
@@ -1,9 +1,11 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { MultilineTextField } from './MultilineTextField';
 
 const meta = preview.meta({
   component: MultilineTextField,
+  parameters: legacyStoryParameters,
 });
 
 export const Default = meta.story({

--- a/src/app/components/form/OptionPicker.stories.tsx
+++ b/src/app/components/form/OptionPicker.stories.tsx
@@ -1,9 +1,11 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { OptionPicker } from './OptionPicker';
 
 const meta = preview.meta({
   component: OptionPicker,
+  parameters: legacyStoryParameters,
 });
 
 export const Default = meta.story({

--- a/src/app/components/form/PrefixedField.stories.tsx
+++ b/src/app/components/form/PrefixedField.stories.tsx
@@ -1,3 +1,4 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { PrefixedField } from './PrefixedField';
@@ -5,6 +6,7 @@ import { TextField } from './TextField';
 
 const meta = preview.meta({
   component: PrefixedField,
+  parameters: legacyStoryParameters,
 });
 
 export const Default = meta.story({

--- a/src/app/components/form/SortableDnd.stories.tsx
+++ b/src/app/components/form/SortableDnd.stories.tsx
@@ -13,6 +13,7 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 import { useState } from 'react';
 
@@ -20,8 +21,8 @@ import { SortableItem } from './SortableItem';
 import { SortableReorderHandle } from './SortableReorderHandle';
 
 const meta = preview.meta({
-  title: 'Form/SortableDnd',
-  parameters: { layout: 'centered' },
+  title: 'Sortable DnD',
+  parameters: { ...legacyStoryParameters, layout: 'centered' },
 });
 
 function SortableListDemo() {

--- a/src/app/components/form/SuggestField.stories.tsx
+++ b/src/app/components/form/SuggestField.stories.tsx
@@ -1,3 +1,4 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { SuggestField } from './SuggestField';
@@ -12,6 +13,7 @@ function toPreviewSrc(path: string): string | null {
 
 const meta = preview.meta({
   component: SuggestField,
+  parameters: legacyStoryParameters,
 });
 
 export const Default = meta.story({

--- a/src/app/components/form/TextField.stories.tsx
+++ b/src/app/components/form/TextField.stories.tsx
@@ -1,9 +1,11 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { TextField } from './TextField';
 
 const meta = preview.meta({
   component: TextField,
+  parameters: legacyStoryParameters,
 });
 
 export const Default = meta.story({

--- a/src/app/components/generic/layout/AutoGrid.stories.tsx
+++ b/src/app/components/generic/layout/AutoGrid.stories.tsx
@@ -1,3 +1,4 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { AutoGrid } from './AutoGrid';
@@ -5,6 +6,7 @@ import { AutoGrid } from './AutoGrid';
 const meta = preview.meta({
   component: AutoGrid,
   parameters: {
+    ...legacyStoryParameters,
     layout: 'padded',
   },
 });

--- a/src/app/components/generic/layout/ButtonGroup.stories.tsx
+++ b/src/app/components/generic/layout/ButtonGroup.stories.tsx
@@ -1,3 +1,4 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { ButtonGroup } from './ButtonGroup';
@@ -5,6 +6,7 @@ import { ButtonGroup } from './ButtonGroup';
 const meta = preview.meta({
   component: ButtonGroup,
   parameters: {
+    ...legacyStoryParameters,
     layout: 'padded',
   },
 });

--- a/src/app/components/generic/layout/Stack.stories.tsx
+++ b/src/app/components/generic/layout/Stack.stories.tsx
@@ -1,11 +1,12 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
-import { Card } from '../surfaces/Card';
 import { Stack, type StackGap } from './Stack';
 
 const meta = preview.meta({
   component: Stack,
   parameters: {
+    ...legacyStoryParameters,
     layout: 'padded',
   },
 });
@@ -58,17 +59,5 @@ export const SemanticElement = meta.story({
       <li style={demoItemStyle}>Verify</li>
       <li style={demoItemStyle}>Deploy</li>
     </Stack>
-  ),
-});
-
-export const ComposedInCard = meta.story({
-  render: () => (
-    <Card header={<h3 style={{ margin: 0 }}>Faction summary</h3>}>
-      <Stack gap={2}>
-        <strong>House Atreides</strong>
-        <span>Three leaders selected</span>
-        <button type="button">Open faction</button>
-      </Stack>
-    </Card>
   ),
 });

--- a/src/app/components/generic/layout/Toolbar.stories.tsx
+++ b/src/app/components/generic/layout/Toolbar.stories.tsx
@@ -1,3 +1,4 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { Toolbar } from './Toolbar';
@@ -5,6 +6,7 @@ import { Toolbar } from './Toolbar';
 const meta = preview.meta({
   component: Toolbar,
   parameters: {
+    ...legacyStoryParameters,
     layout: 'padded',
   },
 });

--- a/src/app/components/generic/layout/ToolbarSearchField.stories.tsx
+++ b/src/app/components/generic/layout/ToolbarSearchField.stories.tsx
@@ -1,48 +1,35 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
-import { useState } from 'react';
 
 import { Toolbar } from './Toolbar';
 import { ToolbarSearchField } from './ToolbarSearchField';
 
 const meta = preview.meta({
   component: ToolbarSearchField,
+  args: {
+    value: 'spice',
+    onValueChange: () => {},
+    placeholder: 'Filter…',
+    'aria-label': 'Filter factions',
+  },
   parameters: {
+    ...legacyStoryParameters,
     layout: 'padded',
   },
 });
 
-export const Standalone = meta.story({
-  render: function ToolbarSearchFieldDemo() {
-    const [value, setValue] = useState('');
-    return (
-      <ToolbarSearchField
-        value={value}
-        onValueChange={setValue}
-        placeholder="Filter…"
-        aria-label="Demo search"
-      />
-    );
-  },
-});
+export const Standalone = meta.story({});
 
 export const InToolbar = meta.story({
-  render: function ToolbarWithSearchDemo() {
-    const [value, setValue] = useState('');
-    return (
-      <Toolbar>
-        <Toolbar.Left>
-          <button type="button">Action</button>
-          <ToolbarSearchField
-            value={value}
-            onValueChange={setValue}
-            placeholder="Search…"
-            aria-label="Toolbar search"
-          />
-        </Toolbar.Left>
-        <Toolbar.Right>
-          <span style={{ fontSize: '0.9rem', opacity: 0.85 }}>Meta</span>
-        </Toolbar.Right>
-      </Toolbar>
-    );
-  },
+  render: (args) => (
+    <Toolbar>
+      <Toolbar.Left>
+        <button type="button">Create faction</button>
+        <ToolbarSearchField {...args} />
+      </Toolbar.Left>
+      <Toolbar.Right>
+        <span style={{ fontSize: '0.9rem', opacity: 0.85 }}>12 factions</span>
+      </Toolbar.Right>
+    </Toolbar>
+  ),
 });

--- a/src/app/components/generic/surfaces/Accordion.stories.tsx
+++ b/src/app/components/generic/surfaces/Accordion.stories.tsx
@@ -1,49 +1,38 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
-import { useState } from 'react';
 
 import { AccordionSection } from './Accordion';
 
 const meta = preview.meta({
   component: AccordionSection,
-});
-
-export const SingleSection = meta.story({
-  render: () => {
-    const [open, setOpen] = useState(true);
-    return (
+  parameters: legacyStoryParameters,
+  decorators: [
+    (Story) => (
       <div style={{ width: 'min(100%, 22rem)' }}>
-        <AccordionSection
-          sectionId="demo"
-          title="Example section"
-          isOpen={open}
-          onToggle={() => setOpen((o) => !o)}
-        >
-          <p style={{ margin: 0 }}>Panel content goes here.</p>
-        </AccordionSection>
+        <Story />
       </div>
-    );
+    ),
+  ],
+  args: {
+    sectionId: 'rules',
+    title: 'Faction rules',
+    isOpen: true,
+    onToggle: () => {},
+    children: <p style={{ margin: 0 }}>Rules unique to this faction.</p>,
   },
 });
 
-export const WithIcon = meta.story({
-  render: () => {
-    const [open, setOpen] = useState(true);
-    return (
-      <div style={{ width: 'min(100%, 22rem)' }}>
-        <AccordionSection
-          sectionId="with-icon"
-          title="With leading icon"
-          icon={
-            <span style={{ fontSize: '0.85rem' }} aria-hidden>
-              ◆
-            </span>
-          }
-          isOpen={open}
-          onToggle={() => setOpen((o) => !o)}
-        >
-          <p style={{ margin: 0 }}>Icon slot is optional.</p>
-        </AccordionSection>
-      </div>
-    );
+export const Expanded = meta.story({});
+
+export const CollapsedWithIcon = meta.story({
+  args: {
+    sectionId: 'alliance',
+    title: 'Alliance ability',
+    icon: (
+      <span style={{ fontSize: '0.85rem' }} aria-hidden>
+        ◆
+      </span>
+    ),
+    isOpen: false,
   },
 });

--- a/src/app/components/generic/surfaces/Block.stories.tsx
+++ b/src/app/components/generic/surfaces/Block.stories.tsx
@@ -1,9 +1,11 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { Block, BlockLink } from './Block';
 
 const meta = preview.meta({
   component: Block,
+  parameters: legacyStoryParameters,
 });
 
 export const Default = meta.story({

--- a/src/app/components/generic/surfaces/BlockCover.stories.tsx
+++ b/src/app/components/generic/surfaces/BlockCover.stories.tsx
@@ -1,9 +1,11 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { BlockCover } from './BlockCover';
 
 const meta = preview.meta({
   component: BlockCover,
+  parameters: legacyStoryParameters,
 });
 
 export const WithImage = meta.story({

--- a/src/app/components/generic/surfaces/Card.stories.tsx
+++ b/src/app/components/generic/surfaces/Card.stories.tsx
@@ -1,9 +1,11 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 
 import { Card } from './Card';
 
 const meta = preview.meta({
   component: Card,
+  parameters: legacyStoryParameters,
 });
 
 export const Default = meta.story({

--- a/src/app/components/generic/ui/UIButton.stories.tsx
+++ b/src/app/components/generic/ui/UIButton.stories.tsx
@@ -1,3 +1,4 @@
+import { legacyStoryParameters } from '@sb/legacyStoryParameters';
 import preview from '@sb/preview';
 import { Download, Save, Trash2 } from 'lucide-react';
 
@@ -5,6 +6,7 @@ import { UIButton } from './UIButton';
 
 const meta = preview.meta({
   component: UIButton,
+  parameters: legacyStoryParameters,
 });
 
 export const Confirm = meta.story({

--- a/src/app/components/topics/TopicIcon.stories.tsx
+++ b/src/app/components/topics/TopicIcon.stories.tsx
@@ -1,6 +1,7 @@
+import { SimpleGrid, Stack, Text } from '@mantine/core';
 import preview from '@sb/preview';
 
-import { TopicIcon } from './TopicIcon';
+import { TOPIC_ICON_TOPICS, TopicIcon } from './TopicIcon';
 
 const meta = preview.meta({
   component: TopicIcon,
@@ -13,60 +14,24 @@ const meta = preview.meta({
   },
 });
 
-export const Identity = meta.story({
+export const Default = meta.story({
   args: { topic: 'identity' },
 });
 
-export const Background = meta.story({
-  args: { topic: 'background' },
-});
-
-export const Hero = meta.story({
-  args: { topic: 'hero' },
-});
-
-export const Leaders = meta.story({
-  args: { topic: 'leaders' },
-});
-
-export const Alliance = meta.story({
-  args: { topic: 'alliance' },
-});
-
-export const Decals = meta.story({
-  args: { topic: 'decals' },
-});
-
-export const Troops = meta.story({
-  args: { topic: 'troops' },
-});
-
-export const Rules = meta.story({
-  args: { topic: 'rules' },
-});
-
-export const Advantages = meta.story({
-  args: { topic: 'advantages' },
-});
-
-export const Spice = meta.story({
-  args: { topic: 'spice' },
-});
-
-export const Setup = meta.story({
-  args: { topic: 'setup' },
-});
-
-export const Karama = meta.story({
-  args: { topic: 'karama' },
-});
-
-export const Rulesets = meta.story({
-  args: { topic: 'rulesets' },
-});
-
-export const Fate = meta.story({
-  args: { topic: 'fate' },
+export const Catalogue = meta.story({
+  args: { topic: 'identity' },
+  render: (args) => (
+    <SimpleGrid cols={{ base: 2, sm: 4, md: 7 }} spacing="xl">
+      {TOPIC_ICON_TOPICS.map((topic) => (
+        <Stack key={topic} align="center" gap="xs">
+          <TopicIcon {...args} topic={topic} />
+          <Text size="sm" tt="capitalize">
+            {topic}
+          </Text>
+        </Stack>
+      ))}
+    </SimpleGrid>
+  ),
 });
 
 export const InheritedColor = meta.story({

--- a/src/game/assets/card/Spice.stories.ts
+++ b/src/game/assets/card/Spice.stories.ts
@@ -153,7 +153,7 @@ export const RedChasm = meta.story({
   },
 });
 
-export const RockOutcropppings = meta.story({
+export const RockOutcroppings = meta.story({
   args: {
     name: 'Rock Outcroppings',
     subName: 'Spice blow',

--- a/src/game/assets/card/SpiceSpecial.stories.ts
+++ b/src/game/assets/card/SpiceSpecial.stories.ts
@@ -3,6 +3,7 @@ import preview from '@sb/preview';
 import { TreacheryCard } from '../treachery/Treachery';
 
 const meta = preview.meta({
+  title: 'Spice Special',
   component: TreacheryCard,
   globals: {
     viewport: {
@@ -35,7 +36,7 @@ export const ShaiHulud = meta.story({
       },
     ],
     head: '/generated/utils/background/spice-2.jpg',
-    text: `Place a Shai-Hulud in the territory on top of this spice blow discard pile. At the end of the Spice Blow Phase, this Shai-Hulud kills all forces and destroys all spice in its territory. Keep drawing spice blow cards until until there spice blow or mine card on top of both discard piles, then a nexus occurs.`,
+    text: `Place a Shai-Hulud in the territory on top of this spice blow discard pile. At the end of the Spice Blow Phase, this Shai-Hulud kills all forces and destroys all spice in its territory. Keep drawing spice blow cards until there is a spice blow or mine card on top of both discard piles, then a nexus occurs.`,
   },
 });
 

--- a/src/game/assets/token/TechTokens.stories.ts
+++ b/src/game/assets/token/TechTokens.stories.ts
@@ -3,6 +3,7 @@ import preview from '@sb/preview';
 import { CustomToken } from './Custom';
 
 const meta = preview.meta({
+  title: 'Tech Tokens',
   component: CustomToken,
   argTypes: {
     image: {
@@ -44,7 +45,7 @@ export const Heighliners = meta.story({
     image: '/vector/icon/heighliners.svg',
     circle: false,
     top: 'Heighliners',
-    bottom: 'shipping & movement phase\nSpacing guild does not trigger',
+    bottom: 'shipping & movement phase\nSpacing Guild does not trigger',
   },
 });
 

--- a/src/game/assets/treachery/CheapHero.stories.ts
+++ b/src/game/assets/treachery/CheapHero.stories.ts
@@ -3,6 +3,7 @@ import preview from '@sb/preview';
 import { TreacheryCard } from './Treachery';
 
 const meta = preview.meta({
+  title: 'Cheap Hero',
   component: TreacheryCard,
   globals: {
     viewport: {

--- a/src/game/assets/treachery/Defense.stories.ts
+++ b/src/game/assets/treachery/Defense.stories.ts
@@ -96,7 +96,7 @@ export const ShieldSnooper = meta.story({
     head: `/generated/utils/background/defense.jpg`,
     icon: [`/generated/utils/background/striped-defense.jpg`, '/vector/icon/lightning.svg'],
     iconOffset: [0, 0],
-    name: 'ShieldSnooper',
+    name: 'Shield Snooper',
     decals: [
       {
         id: '/vector/decal/shield-snooper.svg',

--- a/src/game/assets/treachery/Supplies.stories.ts
+++ b/src/game/assets/treachery/Supplies.stories.ts
@@ -56,7 +56,7 @@ export const PhrinePen = meta.story({
     head: `/generated/utils/background/defense.jpg`,
     icon: [`/generated/utils/background/striped-defense.jpg`, '/vector/icon/poison.svg'],
     iconOffset: [0, 8],
-    name: 'Snooper!',
+    name: 'Phrine Pen!',
     decals: [
       {
         id: '/vector/decal/injection.svg',

--- a/src/game/assets/treachery/Unique.stories.ts
+++ b/src/game/assets/treachery/Unique.stories.ts
@@ -136,7 +136,7 @@ export const Hajr = meta.story({
     head: `/generated/utils/background/special.jpg`,
     icon: [`/generated/utils/background/striped-special.jpg`, '/vector/icon/hand-alt.svg'],
     iconOffset: [0, 2],
-    name: 'Family Atomics',
+    name: 'Hajr',
     decals: [
       {
         id: '/vector/decal/hajr.svg',
@@ -451,7 +451,7 @@ export const NullentropyBox = meta.story({
   },
 });
 
-export const Distrance = meta.story({
+export const Distrans = meta.story({
   args: {
     head: `/generated/utils/background/special.jpg`,
     icon: [`/generated/utils/background/striped-special.jpg`, '/vector/icon/hand-alt.svg'],

--- a/src/game/assets/treachery/Weapon.stories.ts
+++ b/src/game/assets/treachery/Weapon.stories.ts
@@ -306,7 +306,7 @@ export const Stunner = meta.story({
       `/generated/utils/background/striped-weapon.jpg`,
       '/vector/icon/projectile.svg',
     ] as const,
-    name: 'Slip Tip',
+    name: 'Stunner',
     decals: [
       {
         id: '/vector/decal/stunner.svg',

--- a/src/game/components/block/Definitions.stories.tsx
+++ b/src/game/components/block/Definitions.stories.tsx
@@ -9,17 +9,16 @@ const meta = preview.meta({
   args: {
     children: (
       <Fragment>
-        <dt>Beast of Bodmin</dt>
-        <dd>A large feline inhabiting Bodmin Moor.</dd>
+        <dt>Spice</dt>
+        <dd>The resource that drives commerce and conflict on Arrakis.</dd>
 
-        <dt>Morgawr</dt>
-        <dd>A sea serpent.</dd>
+        <dt>Stronghold</dt>
+        <dd>A named territory that can contribute to a faction victory.</dd>
 
-        <dt>Owlman</dt>
+        <dt>Treachery Card</dt>
         <dd>
-          <p>A giant owl-like creature.</p>
-          <p>A giant owl-like creature.</p>
-          <p>A giant owl-like creature.</p>
+          <p>A card held secretly until its timing permits it to be played.</p>
+          <p>Weapons and defenses are revealed as part of a Battle Plan.</p>
         </dd>
       </Fragment>
     ),

--- a/src/game/components/block/FactionSynopsis.stories.tsx
+++ b/src/game/components/block/FactionSynopsis.stories.tsx
@@ -3,6 +3,7 @@ import preview from '@sb/preview';
 import { FactionSynopsis } from './FactionSynopsis';
 
 const meta = preview.meta({
+  title: 'Faction Synopsis',
   component: FactionSynopsis,
   args: {},
 });
@@ -10,7 +11,8 @@ const meta = preview.meta({
 export const Default = meta.story({
   args: {
     image: '/generated/token/faction/choam.jpg',
-    children: 'Hello',
+    children:
+      'CHOAM turns commercial influence into leverage over the factions competing for Arrakis.',
     flip: false,
   },
 });
@@ -18,7 +20,8 @@ export const Default = meta.story({
 export const Flipped = meta.story({
   args: {
     image: '/generated/token/faction/choam.jpg',
-    children: 'Hello',
+    children:
+      'CHOAM turns commercial influence into leverage over the factions competing for Arrakis.',
     flip: true,
   },
 });

--- a/src/game/components/block/Fan.stories.tsx
+++ b/src/game/components/block/Fan.stories.tsx
@@ -71,7 +71,7 @@ export const Default = meta.story({
   },
 });
 
-export const Size = meta.story({
+export const SquareItems = meta.story({
   args: {
     size: squareSize,
     children: [
@@ -94,7 +94,7 @@ export const Size = meta.story({
   },
 });
 
-export const Spacing = meta.story({
+export const WideFan = meta.story({
   args: {
     size: squareSize,
     spacing: 10,
@@ -118,7 +118,7 @@ export const Spacing = meta.story({
   },
 });
 
-export const SpacingNegative = meta.story({
+export const OverlappingFan = meta.story({
   args: {
     size: squareSize,
     spacing: -10,

--- a/src/game/components/block/Outline.stories.tsx
+++ b/src/game/components/block/Outline.stories.tsx
@@ -9,8 +9,8 @@ const meta = preview.meta({
     variant: 'normal',
     children: (
       <Text>
-        <h1>A title</h1>
-        <p>A long long text</p>
+        <h1>Battle prescience</h1>
+        <p>Reveal one element of the opposing Battle Plan before committing your own.</p>
       </Text>
     ),
   },
@@ -19,7 +19,7 @@ const meta = preview.meta({
   },
 });
 
-export const Generic = meta.story({
+export const Standard = meta.story({
   args: { variant: 'normal' },
 });
 export const Example = meta.story({

--- a/src/game/components/block/Text.stories.tsx
+++ b/src/game/components/block/Text.stories.tsx
@@ -8,22 +8,22 @@ const meta = preview.meta({
   args: {
     children: (
       <Fragment>
-        <p>A long long text</p>
-        <p>A long long text</p>
+        <p>Arrakis is the only known source of the spice melange.</p>
+        <p>Control of the desert determines the balance of power between the factions.</p>
       </Fragment>
     ),
   },
 });
 
-export const Columns1 = meta.story({
+export const SingleColumn = meta.story({
   args: { columns: 1 },
 });
 
-export const Columns2 = meta.story({
+export const TwoColumns = meta.story({
   args: { columns: 2 },
 });
 
-export const RichContent = meta.story({
+export const ListsAndParagraphs = meta.story({
   args: {
     children: (
       <Fragment>
@@ -35,24 +35,24 @@ export const RichContent = meta.story({
         </ul>
         <p>An intermediate paragraph</p>
         <ol>
-          <li>ordered list item</li>
-          <li>ordered list item</li>
+          <li>A first ordered item</li>
+          <li>A second ordered item</li>
         </ol>
       </Fragment>
     ),
   },
 });
 
-export const HeadingsContent = meta.story({
+export const HeadingHierarchy = meta.story({
   args: {
     children: (
       <Fragment>
-        <h1>A short paragraph</h1>
-        <p>A second short paragraph</p>
-        <h2>A short paragraph</h2>
-        <p>A second short paragraph</p>
-        <h3>A short paragraph</h3>
-        <p>A second short paragraph</p>
+        <h1>Faction rules</h1>
+        <p>The complete set of rules unique to one faction.</p>
+        <h2>Advantages</h2>
+        <p>Abilities available while their stated conditions are met.</p>
+        <h3>Alliance</h3>
+        <p>The ability granted to another faction while allied.</p>
       </Fragment>
     ),
   },
@@ -64,26 +64,26 @@ export const Table = meta.story({
       <table>
         <thead>
           <tr>
-            <th>a</th>
-            <th>b</th>
-            <th>c</th>
+            <th>Faction</th>
+            <th>Forces</th>
+            <th>Spice</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>11</td>
-            <td>12</td>
-            <td>13</td>
+            <td>Atreides</td>
+            <td>10</td>
+            <td>10</td>
           </tr>
           <tr>
-            <td>21</td>
-            <td>22</td>
-            <td>22</td>
+            <td>Fremen</td>
+            <td>17</td>
+            <td>3</td>
           </tr>
           <tr>
-            <td>31</td>
-            <td>32</td>
-            <td>33</td>
+            <td>Guild</td>
+            <td>15</td>
+            <td>5</td>
           </tr>
         </tbody>
       </table>

--- a/src/game/components/block/Title.stories.tsx
+++ b/src/game/components/block/Title.stories.tsx
@@ -11,31 +11,31 @@ const meta = preview.meta({
   },
 });
 
-export const Simple = meta.story({
+export const Default = meta.story({
   args: {
     color: 'rgba(255,0,0)',
-    children: 'A short title',
+    children: 'Faction advantages',
   },
 });
 
-export const Contrast = meta.story({
+export const DarkBackground = meta.story({
   args: {
     color: 'rgba(80,100,15)',
-    children: 'A short title',
+    children: 'Faction advantages',
   },
 });
 
-export const CustomColor = meta.story({
+export const LightBackground = meta.story({
   args: {
     color: 'rgba(255,200,15)',
-    children: 'A short title',
+    children: 'Faction advantages',
   },
 });
 
-export const ContrastCheck = meta.story({
+export const ContrastPalette = meta.story({
   args: {
     color: '#000000',
-    children: 'A short title',
+    children: 'Faction advantages',
   },
   render: ({ children }) => (
     <Fragment>
@@ -52,7 +52,7 @@ export const ContrastCheck = meta.story({
 export const Sizes = meta.story({
   args: {
     color: '#000000',
-    children: 'A short title',
+    children: 'Faction advantages',
   },
   render: ({ children, color }) => (
     <Fragment>


### PR DESCRIPTION
## Summary

- reorganize Application stories under Factions, FAQ, Groups, Topics, Shared Content, Foundation, and Legacy
- reorganize Game Assets under Faction, Cards, Tokens, and Composition
- use Storybook source entries and `titlePrefix` for auto-title ownership, removing duplicated and obsolete title metadata
- consolidate redundant Application scenarios while retaining representative interaction and catalogue coverage
- exclude Rulebook stories from the index without changing their source files
- update the repository story-writing guidance to document the implemented hierarchy and conventions

## Impact

Storybook now has two coherent product-facing roots with 70 indexed modules and 335 stories. The generated index has exact non-Rulebook source coverage, zero Rulebook entries, and no obsolete top-level roots.

Production application behavior and the game renderer remain unchanged. The publisher renderer manifest is unchanged at digest `e50b2e7544e23095551b90c1441fd5ea631a0ed8b7793407b01b80f7da6a784b` with 915 entries.

## Validation

- `bunx biome check .storybook docs/README.md src/app/components src/game/assets src/game/components/block`
- `bun run typecheck`
- `bun run test` — 380 tests passed
- `bun run build-storybook`
- generated Storybook index coverage and hierarchy audit
- browser smoke of representative Application, interaction, Game Asset card, and composition stories with no browser errors
- `bun run publisher:release:verify`

## Wayfinder

Implements [Reorganize Storybook around product surfaces](https://github.com/ndelangen/dunezone/issues/127), including the completed Application, Game Assets, and integration decision tickets.
