### PR TITLE
Improve faction editor form controls and stories

### DIFF
--- a/src/app/components/content/FormControls/AssetSelect/AssetSelect.stories.tsx
+++ b/src/app/components/content/FormControls/AssetSelect/AssetSelect.stories.tsx
@@ -1,0 +1,68 @@
+import preview from '@sb/preview';
+import { expect, within } from 'storybook/test';
+
+import { AssetSelect } from './AssetSelect';
+
+const previews = {
+  dune: `data:image/svg+xml,${encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><circle cx="16" cy="16" r="13" fill="#c78346"/></svg>'
+  )}`,
+  ocean: `data:image/svg+xml,${encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect x="4" y="4" width="24" height="24" rx="5" fill="#287f8f"/></svg>'
+  )}`,
+} as const;
+
+const options = [
+  { value: 'dune', label: 'Dune emblem' },
+  { value: 'ocean', label: 'Ocean emblem' },
+  { value: 'text-only', label: 'Text-only option' },
+];
+
+const meta = preview.meta({
+  title: 'Form Controls/Asset Select',
+  component: AssetSelect,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    'aria-label': 'Artifact symbol',
+    data: options,
+    getPreviewSrc: (value) => previews[value as keyof typeof previews],
+    onChange: () => {},
+    value: 'dune',
+  },
+});
+
+export const Default = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('combobox', { name: 'Artifact symbol' })).toBeVisible();
+    await expect(canvas.queryByText('Artifact symbol')).not.toBeInTheDocument();
+  },
+});
+
+export const TextOnlySelection = meta.story({
+  args: {
+    value: 'text-only',
+  },
+});
+
+export const DropdownOpen = meta.story({
+  args: {
+    dropdownOpened: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('option', { name: 'Dune emblem' })).toBeVisible();
+    await expect(canvas.getByRole('option', { name: 'Text-only option' })).toBeVisible();
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+  },
+});

--- a/src/app/components/content/FormControls/AssetSelect/AssetSelect.tsx
+++ b/src/app/components/content/FormControls/AssetSelect/AssetSelect.tsx
@@ -1,0 +1,86 @@
+import { Group, Image, Select, type SelectProps, Text } from '@mantine/core';
+
+export interface AssetSelectOption {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface AssetSelectProps
+  extends Omit<
+    SelectProps,
+    | 'data'
+    | 'description'
+    | 'descriptionProps'
+    | 'error'
+    | 'errorProps'
+    | 'inputContainer'
+    | 'inputWrapperOrder'
+    | 'label'
+    | 'labelProps'
+    | 'leftSection'
+    | 'renderOption'
+    | 'success'
+    | 'successProps'
+    | 'value'
+    | 'withAsterisk'
+    | 'wrapperProps'
+  > {
+  data: readonly AssetSelectOption[];
+  getPreviewSrc: (value: string) => string | null | undefined;
+  previewSize?: number;
+  value: string | null;
+}
+
+/**
+ * Searchable asset input for options that are easier to identify from a preview than text alone.
+ * Labels, descriptions and validation messages belong to the consuming form layout.
+ */
+export function AssetSelect({
+  'aria-describedby': ariaDescribedBy,
+  attributes,
+  comboboxProps,
+  data,
+  getPreviewSrc,
+  previewSize = 28,
+  value,
+  ...props
+}: AssetSelectProps) {
+  const selectedPreview = value ? getPreviewSrc(value) : null;
+
+  return (
+    <Select
+      searchable
+      {...props}
+      attributes={{
+        ...attributes,
+        input: {
+          ...attributes?.input,
+          'aria-describedby': ariaDescribedBy,
+        },
+      }}
+      data={[...data]}
+      value={value}
+      leftSection={
+        selectedPreview ? (
+          <Image src={selectedPreview} alt="" w={previewSize} h={previewSize} fit="contain" />
+        ) : undefined
+      }
+      leftSectionPointerEvents="none"
+      renderOption={({ option }) => {
+        const preview = getPreviewSrc(option.value);
+        return (
+          <Group gap="sm" wrap="nowrap">
+            {preview ? (
+              <Image src={preview} alt="" w={previewSize} h={previewSize} fit="contain" />
+            ) : null}
+            <Text size="sm" truncate>
+              {option.label}
+            </Text>
+          </Group>
+        );
+      }}
+      comboboxProps={{ withinPortal: false, ...comboboxProps }}
+    />
+  );
+}

--- a/src/app/components/content/FormControls/AssetSelect/index.ts
+++ b/src/app/components/content/FormControls/AssetSelect/index.ts
@@ -1,0 +1,1 @@
+export { AssetSelect, type AssetSelectOption, type AssetSelectProps } from './AssetSelect';

--- a/src/app/components/content/FormControls/ColorInput.stories.tsx
+++ b/src/app/components/content/FormControls/ColorInput.stories.tsx
@@ -1,0 +1,32 @@
+import { ColorInput } from '@mantine/core';
+import preview from '@sb/preview';
+
+const meta = preview.meta({
+  title: 'Form Controls/Color Input',
+  component: ColorInput,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    'aria-label': 'Color input',
+    format: 'hex',
+    defaultValue: '#444444',
+  },
+});
+
+export const Default = meta.story({});
+
+export const Empty = meta.story({
+  args: {
+    defaultValue: '',
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+  },
+});

--- a/src/app/components/content/FormControls/ControlBlock/ControlBlock.stories.tsx
+++ b/src/app/components/content/FormControls/ControlBlock/ControlBlock.stories.tsx
@@ -1,0 +1,95 @@
+import { ActionIcon, Box, Select } from '@mantine/core';
+import preview from '@sb/preview';
+import { Minus, Plus } from 'lucide-react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { ControlBlock } from './ControlBlock';
+
+const input = (
+  <Select
+    aria-label="Preferred player color"
+    data={['Green', 'Teal', 'Orange']}
+    defaultValue="Green"
+    allowDeselect={false}
+  />
+);
+
+const tool = (
+  <ActionIcon.Group>
+    <ActionIcon type="button" variant="light" color="red" size="sm" aria-label="Remove color">
+      <Minus size={16} aria-hidden />
+    </ActionIcon>
+    <ActionIcon type="button" variant="filled" color="green" size="sm" aria-label="Add color">
+      <Plus size={16} aria-hidden />
+    </ActionIcon>
+  </ActionIcon.Group>
+);
+
+const meta = preview.meta({
+  title: 'Form Controls/Control Block',
+  component: ControlBlock,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    input: { control: false },
+    tool: { control: false },
+  },
+  args: {
+    title: 'Tabletop Simulator colors',
+    description: 'Choose unique colors; drag to set their priority.',
+    tool,
+    input,
+  },
+});
+
+export const Default = meta.story({
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('group', { name: 'Tabletop Simulator colors' })
+    ).toHaveAccessibleDescription('Choose unique colors; drag to set their priority.');
+    await expect(canvas.getByRole('combobox', { name: 'Preferred player color' })).toBeVisible();
+  },
+});
+
+export const WithoutTool = meta.story({
+  args: {
+    tool: undefined,
+  },
+});
+
+const longTitle = 'Tabletop Simulator colors ordered by player priority and availability';
+const longDescription =
+  'Choose unique colors for every player position, then drag the rows to set their preferred priority.';
+
+export const TruncatedText = meta.story({
+  args: {
+    title: longTitle,
+    description: longDescription,
+  },
+  render: (args) => (
+    <Box w={280}>
+      <ControlBlock {...args} />
+    </Box>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const page = within(canvasElement.ownerDocument.body);
+    const title = canvas.getByText(longTitle);
+    const description = canvas.getByText(longDescription);
+
+    await expect(title.scrollWidth).toBeGreaterThan(title.clientWidth);
+    await expect(description.scrollWidth).toBeGreaterThan(description.clientWidth);
+
+    await userEvent.hover(title);
+    await expect(page.getByRole('tooltip')).toHaveTextContent(longTitle);
+
+    await userEvent.unhover(title);
+    await userEvent.hover(description);
+    await expect(page.getByRole('tooltip')).toHaveTextContent(longDescription);
+  },
+});

--- a/src/app/components/content/FormControls/ControlBlock/ControlBlock.tsx
+++ b/src/app/components/content/FormControls/ControlBlock/ControlBlock.tsx
@@ -1,0 +1,82 @@
+import { Box, Group, Stack, Text, Tooltip } from '@mantine/core';
+import { type ReactNode, useId, useLayoutEffect, useRef, useState } from 'react';
+
+export interface ControlBlockProps {
+  title: string;
+  description: string;
+  tool?: ReactNode;
+  input: ReactNode;
+}
+
+function OverflowTooltipText({
+  id,
+  text,
+  variant,
+}: {
+  id: string;
+  text: string;
+  variant: 'title' | 'description';
+}) {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const update = () =>
+      setIsOverflowing(text.length > 0 && element.scrollWidth > element.clientWidth);
+    update();
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(update);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [text]);
+
+  return (
+    <Tooltip
+      label={text}
+      disabled={!isOverflowing}
+      multiline
+      maw={360}
+      position="top-start"
+      withArrow
+    >
+      <Text
+        ref={ref}
+        id={id}
+        fw={variant === 'title' ? 700 : undefined}
+        c={variant === 'description' ? 'dimmed' : undefined}
+        size={variant === 'title' ? 'sm' : 'xs'}
+        truncate
+        tabIndex={isOverflowing ? 0 : undefined}
+      >
+        {text}
+      </Text>
+    </Tooltip>
+  );
+}
+
+/**
+ * Frames a composite form control with consistent guidance, tools and group semantics.
+ * Nested inputs and icon-only tools remain responsible for their own accessible names.
+ */
+export function ControlBlock({ title, description, tool, input }: ControlBlockProps) {
+  const id = useId();
+  const titleId = `${id}-title`;
+  const descriptionId = `${id}-description`;
+
+  return (
+    <Stack role="group" aria-labelledby={titleId} aria-describedby={descriptionId} gap={6}>
+      <Group gap="sm" justify="space-between" align="flex-start" wrap="nowrap">
+        <Stack gap={0} flex="1 1 12rem" miw={0}>
+          <OverflowTooltipText id={titleId} text={title} variant="title" />
+          <OverflowTooltipText id={descriptionId} text={description} variant="description" />
+        </Stack>
+        {tool ? <Box>{tool}</Box> : null}
+      </Group>
+      <Box w="100%">{input}</Box>
+    </Stack>
+  );
+}

--- a/src/app/components/content/FormControls/ControlBlock/index.ts
+++ b/src/app/components/content/FormControls/ControlBlock/index.ts
@@ -1,0 +1,1 @@
+export { ControlBlock, type ControlBlockProps } from './ControlBlock';

--- a/src/app/components/content/FormControls/NumberInput.stories.tsx
+++ b/src/app/components/content/FormControls/NumberInput.stories.tsx
@@ -1,0 +1,32 @@
+import { NumberInput } from '@mantine/core';
+import preview from '@sb/preview';
+
+const meta = preview.meta({
+  title: 'Form Controls/Number Input',
+  component: NumberInput,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    'aria-label': 'Number input',
+    defaultValue: 10,
+  },
+});
+
+export const Default = meta.story({});
+
+export const Bounded = meta.story({
+  args: {
+    min: 0,
+    max: 20,
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+  },
+});

--- a/src/app/components/content/FormControls/Select.stories.tsx
+++ b/src/app/components/content/FormControls/Select.stories.tsx
@@ -1,0 +1,45 @@
+import { Select } from '@mantine/core';
+import preview from '@sb/preview';
+
+const options = [
+  { value: 'green', label: 'Green' },
+  { value: 'teal', label: 'Teal' },
+  { value: 'orange', label: 'Orange' },
+];
+
+const meta = preview.meta({
+  title: 'Form Controls/Select',
+  component: Select,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    'aria-label': 'Select',
+    data: options,
+    defaultValue: 'green',
+  },
+});
+
+export const Default = meta.story({});
+
+export const Searchable = meta.story({
+  args: {
+    searchable: true,
+  },
+});
+
+export const Empty = meta.story({
+  args: {
+    defaultValue: null,
+    placeholder: 'Choose a color',
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+  },
+});

--- a/src/app/components/content/FormControls/Switch.stories.tsx
+++ b/src/app/components/content/FormControls/Switch.stories.tsx
@@ -1,0 +1,30 @@
+import { Switch } from '@mantine/core';
+import preview from '@sb/preview';
+
+const meta = preview.meta({
+  title: 'Form Controls/Switch',
+  component: Switch,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    'aria-label': 'Switch',
+  },
+});
+
+export const Default = meta.story({});
+
+export const Checked = meta.story({
+  args: {
+    defaultChecked: true,
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+  },
+});

--- a/src/app/components/content/FormControls/TextInput.stories.tsx
+++ b/src/app/components/content/FormControls/TextInput.stories.tsx
@@ -1,0 +1,31 @@
+import { TextInput } from '@mantine/core';
+import preview from '@sb/preview';
+
+const meta = preview.meta({
+  title: 'Form Controls/Text Input',
+  component: TextInput,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    'aria-label': 'Text input',
+    defaultValue: 'House Meridia',
+  },
+});
+
+export const Default = meta.story({});
+
+export const ValidationError = meta.story({
+  args: {
+    error: 'This name is already in use.',
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+  },
+});

--- a/src/app/components/content/FormControls/Textarea.stories.tsx
+++ b/src/app/components/content/FormControls/Textarea.stories.tsx
@@ -1,0 +1,32 @@
+import { Textarea } from '@mantine/core';
+import preview from '@sb/preview';
+
+const meta = preview.meta({
+  title: 'Form Controls/Textarea',
+  component: Textarea,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    'aria-label': 'Textarea',
+    defaultValue: 'The sleeper must awaken.',
+    minRows: 3,
+  },
+});
+
+export const Default = meta.story({});
+
+export const Autosize = meta.story({
+  args: {
+    autosize: true,
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    disabled: true,
+  },
+});

--- a/src/app/components/factions/editor/FactionBackgroundColorLayer.tsx
+++ b/src/app/components/factions/editor/FactionBackgroundColorLayer.tsx
@@ -18,6 +18,7 @@ import { ArrowDown, ArrowUp, Plus, Trash2 } from 'lucide-react';
 import { useEffect, useRef } from 'react';
 
 import type { Faction } from '@db/factions';
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
 
 type ColorLayer = Faction['background']['colors'][number];
 type LinearLayer = Extract<ColorLayer, { type: 'linear' }>;
@@ -220,16 +221,10 @@ function GradientFields({
         </SimpleGrid>
       )}
 
-      <Stack gap="xs">
-        <Group justify="space-between" align="flex-end">
-          <Box>
-            <Text fw={600} size="sm">
-              Gradient stops
-            </Text>
-            <Text c="dimmed" size="xs">
-              Ordered colors with positions from 0 to 1. Existing uncommon arrays remain editable.
-            </Text>
-          </Box>
+      <ControlBlock
+        title="Gradient stops"
+        description="Ordered colors with positions from 0 to 1. Existing uncommon arrays remain editable."
+        tool={
           <Button
             type="button"
             variant="light"
@@ -243,95 +238,98 @@ function GradientFields({
           >
             Add stop
           </Button>
-        </Group>
+        }
+        input={
+          <Stack gap="xs">
+            {value.stops.length === 0 ? (
+              <Text size="sm" c="dimmed" fs="italic">
+                This gradient has no stops. Add one to make its color visible.
+              </Text>
+            ) : null}
 
-        {value.stops.length === 0 ? (
-          <Text size="sm" c="dimmed" fs="italic">
-            This gradient has no stops. Add one to make its color visible.
-          </Text>
-        ) : null}
-
-        {value.stops.map((stop, index) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: gradient stops have no stored identity
-          <Paper key={`${label}-stop-${index}`} withBorder radius="sm" p="sm">
-            <SimpleGrid cols={{ base: 1, xs: 2 }}>
-              <ColorInput
-                label={`Stop ${index + 1} color`}
-                value={stop[0]}
-                format="hex"
-                onChange={(color) => {
-                  const next = [...value.stops];
-                  next[index] = [color, stop[1]];
-                  updateStops(next);
-                }}
-              />
-              <NumberInput
-                label={`Stop ${index + 1} position`}
-                min={0}
-                max={1}
-                step={0.01}
-                decimalScale={2}
-                value={stop[1]}
-                onChange={(position) => {
-                  const next = [...value.stops];
-                  next[index] = [
-                    stop[0],
-                    typeof position === 'number' ? Math.min(1, Math.max(0, position)) : stop[1],
-                  ];
-                  updateStops(next);
-                }}
-              />
-            </SimpleGrid>
-            <Group justify="flex-end" gap={4} mt="xs">
-              <Tooltip label={`Move stop ${index + 1} earlier`}>
-                <ActionIcon
-                  type="button"
-                  variant="subtle"
-                  color="gray"
-                  disabled={index === 0}
-                  aria-label={`Move stop ${index + 1} earlier`}
-                  onClick={() => {
-                    if (index === 0) return;
-                    const next = [...value.stops];
-                    [next[index - 1], next[index]] = [next[index], next[index - 1]];
-                    updateStops(next);
-                  }}
-                >
-                  <ArrowUp size={16} aria-hidden />
-                </ActionIcon>
-              </Tooltip>
-              <Tooltip label={`Move stop ${index + 1} later`}>
-                <ActionIcon
-                  type="button"
-                  variant="subtle"
-                  color="gray"
-                  disabled={index === value.stops.length - 1}
-                  aria-label={`Move stop ${index + 1} later`}
-                  onClick={() => {
-                    if (index === value.stops.length - 1) return;
-                    const next = [...value.stops];
-                    [next[index], next[index + 1]] = [next[index + 1], next[index]];
-                    updateStops(next);
-                  }}
-                >
-                  <ArrowDown size={16} aria-hidden />
-                </ActionIcon>
-              </Tooltip>
-              <Tooltip label={`Remove stop ${index + 1}`}>
-                <ActionIcon
-                  type="button"
-                  variant="light"
-                  color="red"
-                  aria-label={`Remove stop ${index + 1}`}
-                  onClick={() => updateStops(value.stops.filter((_, i) => i !== index))}
-                >
-                  <Trash2 size={16} aria-hidden />
-                </ActionIcon>
-              </Tooltip>
-            </Group>
-          </Paper>
-        ))}
-      </Stack>
+            {value.stops.map((stop, index) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: gradient stops have no stored identity
+              <Paper key={`${label}-stop-${index}`} withBorder radius="sm" p="sm">
+                <SimpleGrid cols={{ base: 1, xs: 2 }}>
+                  <ColorInput
+                    label={`Stop ${index + 1} color`}
+                    value={stop[0]}
+                    format="hex"
+                    onChange={(color) => {
+                      const next = [...value.stops];
+                      next[index] = [color, stop[1]];
+                      updateStops(next);
+                    }}
+                  />
+                  <NumberInput
+                    label={`Stop ${index + 1} position`}
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    decimalScale={2}
+                    value={stop[1]}
+                    onChange={(position) => {
+                      const next = [...value.stops];
+                      next[index] = [
+                        stop[0],
+                        typeof position === 'number' ? Math.min(1, Math.max(0, position)) : stop[1],
+                      ];
+                      updateStops(next);
+                    }}
+                  />
+                </SimpleGrid>
+                <Group justify="flex-end" gap={4} mt="xs">
+                  <Tooltip label={`Move stop ${index + 1} earlier`}>
+                    <ActionIcon
+                      type="button"
+                      variant="subtle"
+                      color="gray"
+                      disabled={index === 0}
+                      aria-label={`Move stop ${index + 1} earlier`}
+                      onClick={() => {
+                        if (index === 0) return;
+                        const next = [...value.stops];
+                        [next[index - 1], next[index]] = [next[index], next[index - 1]];
+                        updateStops(next);
+                      }}
+                    >
+                      <ArrowUp size={16} aria-hidden />
+                    </ActionIcon>
+                  </Tooltip>
+                  <Tooltip label={`Move stop ${index + 1} later`}>
+                    <ActionIcon
+                      type="button"
+                      variant="subtle"
+                      color="gray"
+                      disabled={index === value.stops.length - 1}
+                      aria-label={`Move stop ${index + 1} later`}
+                      onClick={() => {
+                        if (index === value.stops.length - 1) return;
+                        const next = [...value.stops];
+                        [next[index], next[index + 1]] = [next[index + 1], next[index]];
+                        updateStops(next);
+                      }}
+                    >
+                      <ArrowDown size={16} aria-hidden />
+                    </ActionIcon>
+                  </Tooltip>
+                  <Tooltip label={`Remove stop ${index + 1}`}>
+                    <ActionIcon
+                      type="button"
+                      variant="light"
+                      color="red"
+                      aria-label={`Remove stop ${index + 1}`}
+                      onClick={() => updateStops(value.stops.filter((_, i) => i !== index))}
+                    >
+                      <Trash2 size={16} aria-hidden />
+                    </ActionIcon>
+                  </Tooltip>
+                </Group>
+              </Paper>
+            ))}
+          </Stack>
+        }
+      />
     </Stack>
   );
 }

--- a/src/app/components/factions/editor/FactionFormSectionAlliance.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionAlliance.tsx
@@ -6,10 +6,9 @@ import {
   Button,
   Grid,
   Group,
-  Image,
+  Input,
   NumberInput,
   Paper,
-  Select,
   Slider,
   Stack,
   Switch,
@@ -21,6 +20,8 @@ import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
 import type { Faction } from '@db/factions';
+import { AssetSelect } from '@app/components/content/FormControls/AssetSelect';
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
 import { AllianceCard } from '@game/assets/faction/alliance/Alliance';
 
 import { FactionCollectionShelf } from './FactionCollectionShelf';
@@ -37,17 +38,6 @@ const decalOptions = decalAssetOptions.map((value) => ({
   value,
   label: decalAssetOptionToLabel(value),
 }));
-
-function DecalOption({ value, label }: { value: string; label: string }) {
-  return (
-    <Group gap="sm" wrap="nowrap">
-      <Image src={assetOptionToPreviewSrc(value)} alt="" w={32} h={32} fit="contain" />
-      <Text size="sm" truncate>
-        {label}
-      </Text>
-    </Group>
-  );
-}
 
 function DecalCard({
   form,
@@ -85,34 +75,31 @@ function DecalCard({
         </Group>
 
         <form.Field name={`decals[${index}].id`}>
-          {(field) => (
-            <Select
-              id={`decal-${index}-id`}
-              label="Decal asset"
-              description="Artwork layered onto the alliance card in collection order."
-              searchable
-              allowDeselect={false}
-              limit={30}
-              data={decalOptions}
-              value={field.state.value}
-              leftSection={
-                <Image
-                  src={assetOptionToPreviewSrc(field.state.value)}
-                  alt=""
-                  w={24}
-                  h={24}
-                  fit="contain"
+          {(field) => {
+            const id = `decal-${index}-id`;
+            const descriptionId = `${id}-description`;
+            return (
+              <Input.Wrapper
+                id={id}
+                descriptionProps={{ id: descriptionId }}
+                label="Decal asset"
+                description="Artwork layered onto the alliance card in collection order."
+              >
+                <AssetSelect
+                  id={id}
+                  aria-describedby={descriptionId}
+                  allowDeselect={false}
+                  limit={30}
+                  data={decalOptions}
+                  getPreviewSrc={assetOptionToPreviewSrc}
+                  value={field.state.value}
+                  onChange={(value) => {
+                    if (value) field.handleChange(value as Faction['decals'][number]['id']);
+                  }}
                 />
-              }
-              renderOption={({ option }) => (
-                <DecalOption value={option.value} label={option.label} />
-              )}
-              comboboxProps={{ withinPortal: false }}
-              onChange={(value) => {
-                if (value) field.handleChange(value as Faction['decals'][number]['id']);
-              }}
-            />
-          )}
+              </Input.Wrapper>
+            );
+          }}
         </form.Field>
 
         <Grid>
@@ -148,16 +135,10 @@ function DecalCard({
 
         <form.Field name={`decals[${index}].scale`}>
           {(field) => (
-            <Stack gap="xs">
-              <Group justify="space-between" align="flex-end">
-                <Box>
-                  <Text fw={600} size="sm">
-                    Scale
-                  </Text>
-                  <Text c="dimmed" size="xs">
-                    Resize the decal from 0 (hidden) to 1 (full reference size).
-                  </Text>
-                </Box>
+            <ControlBlock
+              title="Scale"
+              description="Resize the decal from 0 (hidden) to 1 (full reference size)."
+              tool={
                 <NumberInput
                   aria-label={`Scale for alliance decal ${index + 1}`}
                   w={96}
@@ -171,17 +152,19 @@ function DecalCard({
                     if (typeof value === 'number') field.handleChange(value);
                   }}
                 />
-              </Group>
-              <Slider
-                aria-label={`Scale slider for alliance decal ${index + 1}`}
-                min={0}
-                max={1}
-                step={0.01}
-                value={field.state.value}
-                label={(value) => value.toFixed(2)}
-                onChange={field.handleChange}
-              />
-            </Stack>
+              }
+              input={
+                <Slider
+                  aria-label={`Scale slider for alliance decal ${index + 1}`}
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  value={field.state.value}
+                  label={(value) => value.toFixed(2)}
+                  onChange={field.handleChange}
+                />
+              }
+            />
           )}
         </form.Field>
 

--- a/src/app/components/factions/editor/FactionFormSectionBackground.module.css
+++ b/src/app/components/factions/editor/FactionFormSectionBackground.module.css
@@ -9,18 +9,9 @@
   padding-top: var(--mantine-spacing-xs);
 }
 
-.stageLabel {
-  color: var(--mantine-color-dune-8);
-  font-size: var(--mantine-font-size-xs);
-  font-weight: 800;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-}
-
 .selectedPattern {
   aspect-ratio: 1.7;
   overflow: hidden;
-  margin-top: var(--mantine-spacing-md);
   background: var(--mantine-color-gray-1);
   border: 1px solid var(--mantine-color-dune-2);
   border-radius: var(--mantine-radius-md);
@@ -93,10 +84,6 @@
 
   .pipelineStage {
     padding-top: 0;
-  }
-
-  .selectedPattern {
-    margin-top: var(--mantine-spacing-sm);
   }
 }
 

--- a/src/app/components/factions/editor/FactionFormSectionBackground.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionBackground.tsx
@@ -17,6 +17,7 @@ import { Check, Shuffle, X } from 'lucide-react';
 import { useState } from 'react';
 
 import type { Faction } from '@db/factions';
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
 import { backgroundTreatment } from '@game/assets/utils/Background';
 
 import { BACKGROUND_PATTERN_CATALOGUE } from './backgroundPatternCatalogue';
@@ -128,89 +129,94 @@ function PatternCatalogue({
 function TreatmentControls({ form, onRandom }: { form: FactionFormApi; onRandom: () => void }) {
   return (
     <Box className={styles.pipelineStage}>
-      <Group justify="space-between" align="center">
-        <Text className={styles.stageLabel}>02 · Treatment</Text>
-        <RandomButton label="Random" onClick={onRandom} />
-      </Group>
-      <Stack gap="lg" mt="md">
-        <form.Field name="background.invert">
-          {(field) => (
-            <Switch
-              label="Invert"
-              checked={field.state.value}
-              onBlur={field.handleBlur}
-              onChange={(event) => field.handleChange(event.currentTarget.checked)}
-            />
-          )}
-        </form.Field>
-        <form.Field name="background.definition">
-          {(field) => (
-            <Stack gap={4}>
-              <Group justify="space-between">
-                <Text component="label" htmlFor="bg-definition" fw={600} size="sm">
-                  Definition
-                </Text>
-                <Text size="sm">{field.state.value.toFixed(2)}</Text>
-              </Group>
-              <Slider
-                id="bg-definition"
-                aria-label="Pattern definition from soft to extreme"
-                min={0}
-                max={1}
-                step={0.01}
-                value={field.state.value}
-                onChange={field.handleChange}
-              />
-              <Group justify="space-between">
-                <Text size="xs" c="dimmed">
-                  Soft
-                </Text>
-                <Text size="xs" c="dimmed">
-                  Extreme
-                </Text>
-              </Group>
-            </Stack>
-          )}
-        </form.Field>
-        <form.Field name="background.influence">
-          {(field) => {
-            const exactValue = clampInfluence(field.state.value);
-            return (
-              <Stack gap={4}>
-                <Group justify="space-between" align="baseline" wrap="nowrap">
-                  <Text component="label" htmlFor="bg-influence" fw={600} size="sm">
-                    Influence
-                  </Text>
-                  <Text size="sm" fw={700}>
-                    {exactValue.toFixed(2)}
-                  </Text>
-                </Group>
-                <Slider
-                  id="bg-influence"
-                  aria-label="Pattern influence with perceptual response from whisper to dominant"
-                  min={0}
-                  max={100}
-                  step={0.5}
-                  value={influenceToSliderPosition(exactValue)}
-                  label={(position) => sliderPositionToInfluence(position).toFixed(2)}
-                  onChange={(position) => field.handleChange(sliderPositionToInfluence(position))}
+      <ControlBlock
+        title="02 · Treatment"
+        description="Tune how the selected pattern is blended into the faction background."
+        tool={<RandomButton label="Random" onClick={onRandom} />}
+        input={
+          <Stack gap="lg">
+            <form.Field name="background.invert">
+              {(field) => (
+                <Switch
+                  label="Invert"
+                  checked={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(event.currentTarget.checked)}
                 />
-                <Group justify="space-between">
-                  <Text size="xs" c="dimmed">
-                    Whisper
-                  </Text>
-                  <Text size="xs" c="dimmed">
-                    Strong
-                  </Text>
-                  <Text size="xs" c="dimmed">
-                    Dominant
-                  </Text>
-                </Group>
-              </Stack>
-            );
-          }}
-        </form.Field>
-      </Stack>
+              )}
+            </form.Field>
+            <form.Field name="background.definition">
+              {(field) => (
+                <Stack gap={4}>
+                  <Group justify="space-between">
+                    <Text component="label" htmlFor="bg-definition" fw={600} size="sm">
+                      Definition
+                    </Text>
+                    <Text size="sm">{field.state.value.toFixed(2)}</Text>
+                  </Group>
+                  <Slider
+                    id="bg-definition"
+                    aria-label="Pattern definition from soft to extreme"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                  <Group justify="space-between">
+                    <Text size="xs" c="dimmed">
+                      Soft
+                    </Text>
+                    <Text size="xs" c="dimmed">
+                      Extreme
+                    </Text>
+                  </Group>
+                </Stack>
+              )}
+            </form.Field>
+            <form.Field name="background.influence">
+              {(field) => {
+                const exactValue = clampInfluence(field.state.value);
+                return (
+                  <Stack gap={4}>
+                    <Group justify="space-between" align="baseline" wrap="nowrap">
+                      <Text component="label" htmlFor="bg-influence" fw={600} size="sm">
+                        Influence
+                      </Text>
+                      <Text size="sm" fw={700}>
+                        {exactValue.toFixed(2)}
+                      </Text>
+                    </Group>
+                    <Slider
+                      id="bg-influence"
+                      aria-label="Pattern influence with perceptual response from whisper to dominant"
+                      min={0}
+                      max={100}
+                      step={0.5}
+                      value={influenceToSliderPosition(exactValue)}
+                      label={(position) => sliderPositionToInfluence(position).toFixed(2)}
+                      onChange={(position) =>
+                        field.handleChange(sliderPositionToInfluence(position))
+                      }
+                    />
+                    <Group justify="space-between">
+                      <Text size="xs" c="dimmed">
+                        Whisper
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        Strong
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        Dominant
+                      </Text>
+                    </Group>
+                  </Stack>
+                );
+              }}
+            </form.Field>
+          </Stack>
+        }
+      />
     </Box>
   );
 }
@@ -245,42 +251,49 @@ export function FactionFormSectionBackground({ form }: { form: FactionFormApi })
                 const treatment = backgroundTreatment(background);
                 return (
                   <Box className={styles.pipelineStage}>
-                    <Group justify="space-between" align="center">
-                      <Text className={styles.stageLabel}>01 · Pattern</Text>
-                      <RandomButton
-                        label="Random"
-                        onClick={() =>
-                          setBackground(withRandomPattern(form.state.values.background))
-                        }
-                      />
-                    </Group>
-                    <Box className={styles.selectedPattern}>
-                      <Image
-                        src={background.image}
-                        alt=""
-                        fit="cover"
-                        w="100%"
-                        h="100%"
-                        style={{
-                          filter: treatment.patternFilter,
-                          opacity: treatment.patternOpacity,
-                        }}
-                      />
-                    </Box>
-                    <Group justify="space-between" gap="xs" mt="xs" wrap="nowrap">
-                      <Text fw={700} size="sm" truncate>
-                        {selected?.label ?? 'Existing pattern'}
-                      </Text>
-                      <Button
-                        type="button"
-                        variant="subtle"
-                        color="dune"
-                        size="compact-sm"
-                        onClick={() => setLibraryOpen(true)}
-                      >
-                        Browse
-                      </Button>
-                    </Group>
+                    <ControlBlock
+                      title="01 · Pattern"
+                      description="Choose the texture used to build the faction background."
+                      tool={
+                        <RandomButton
+                          label="Random"
+                          onClick={() =>
+                            setBackground(withRandomPattern(form.state.values.background))
+                          }
+                        />
+                      }
+                      input={
+                        <Stack gap="xs">
+                          <Box className={styles.selectedPattern}>
+                            <Image
+                              src={background.image}
+                              alt=""
+                              fit="cover"
+                              w="100%"
+                              h="100%"
+                              style={{
+                                filter: treatment.patternFilter,
+                                opacity: treatment.patternOpacity,
+                              }}
+                            />
+                          </Box>
+                          <Group justify="space-between" gap="xs" wrap="nowrap">
+                            <Text fw={700} size="sm" truncate>
+                              {selected?.label ?? 'Existing pattern'}
+                            </Text>
+                            <Button
+                              type="button"
+                              variant="subtle"
+                              color="dune"
+                              size="compact-sm"
+                              onClick={() => setLibraryOpen(true)}
+                            >
+                              Browse
+                            </Button>
+                          </Group>
+                        </Stack>
+                      }
+                    />
                   </Box>
                 );
               }}
@@ -296,38 +309,43 @@ export function FactionFormSectionBackground({ form }: { form: FactionFormApi })
 
           <Divider />
 
-          <Box>
-            <Group justify="space-between" align="center" mb="sm">
-              <Text className={styles.stageLabel}>03 · Base + pattern colors</Text>
-              <RandomButton
-                label="Random"
-                onClick={() =>
-                  setBackground(randomizeBackgroundColors(form.state.values.background))
-                }
-              />
-            </Group>
-            <Box className={styles.colorLayers}>
-              <form.Field name="background.colors[0]">
-                {(field) => (
-                  <FactionBackgroundColorLayer
-                    label="Base"
-                    description="The uninterrupted color beneath the pattern."
-                    value={field.state.value}
-                    onChange={field.handleChange}
-                  />
-                )}
-              </form.Field>
-              <form.Field name="background.colors[1]">
-                {(field) => (
-                  <FactionBackgroundColorLayer
-                    label="Pattern"
-                    description="The color or gradient revealed by the treated pattern."
-                    value={field.state.value}
-                    onChange={field.handleChange}
-                  />
-                )}
-              </form.Field>
-            </Box>
+          <Box className={styles.pipelineStage}>
+            <ControlBlock
+              title="03 · Base + pattern colors"
+              description="Choose the uninterrupted base color and the color revealed by the treated pattern."
+              tool={
+                <RandomButton
+                  label="Random"
+                  onClick={() =>
+                    setBackground(randomizeBackgroundColors(form.state.values.background))
+                  }
+                />
+              }
+              input={
+                <Box className={styles.colorLayers}>
+                  <form.Field name="background.colors[0]">
+                    {(field) => (
+                      <FactionBackgroundColorLayer
+                        label="Base"
+                        description="The uninterrupted color beneath the pattern."
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                      />
+                    )}
+                  </form.Field>
+                  <form.Field name="background.colors[1]">
+                    {(field) => (
+                      <FactionBackgroundColorLayer
+                        label="Pattern"
+                        description="The color or gradient revealed by the treated pattern."
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                      />
+                    )}
+                  </form.Field>
+                </Box>
+              }
+            />
           </Box>
         </>
       )}

--- a/src/app/components/factions/editor/FactionFormSectionHero.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionHero.tsx
@@ -1,6 +1,7 @@
-import { Box, Grid, Group, Image, Select, Stack, Text, TextInput } from '@mantine/core';
+import { Box, Grid, Input, Stack, Text, TextInput } from '@mantine/core';
 
 import type { Faction } from '@db/factions';
+import { AssetSelect } from '@app/components/content/FormControls/AssetSelect';
 import { LeaderToken } from '@game/assets/faction/leader/Leader';
 import { LEADERS } from '@game/data/generated';
 
@@ -11,17 +12,6 @@ const leaderImageOptions = LEADERS.options.map((value) => ({
   value,
   label: leaderOptionToLabel(value),
 }));
-
-function LeaderImageOption({ value, label }: { value: string; label: string }) {
-  return (
-    <Group gap="sm" wrap="nowrap">
-      <Image src={assetOptionToPreviewSrc(value)} alt="" w={32} h={32} fit="contain" />
-      <Text size="sm" truncate>
-        {label}
-      </Text>
-    </Group>
-  );
-}
 
 export function FactionFormSectionHero({
   form,
@@ -69,34 +59,31 @@ export function FactionFormSectionHero({
             </form.Field>
 
             <form.Field name="hero.image">
-              {(field) => (
-                <Select
-                  id="hero-image"
-                  label="Faction leader portrait"
-                  description="Choose the portrait rendered for this hero."
-                  searchable
-                  allowDeselect={false}
-                  limit={24}
-                  data={leaderImageOptions}
-                  value={field.state.value}
-                  leftSection={
-                    <Image
-                      src={assetOptionToPreviewSrc(field.state.value)}
-                      alt=""
-                      w={24}
-                      h={24}
-                      fit="contain"
+              {(field) => {
+                const id = 'hero-image';
+                const descriptionId = `${id}-description`;
+                return (
+                  <Input.Wrapper
+                    id={id}
+                    descriptionProps={{ id: descriptionId }}
+                    label="Faction leader portrait"
+                    description="Choose the portrait rendered for this hero."
+                  >
+                    <AssetSelect
+                      id={id}
+                      aria-describedby={descriptionId}
+                      allowDeselect={false}
+                      limit={24}
+                      data={leaderImageOptions}
+                      getPreviewSrc={assetOptionToPreviewSrc}
+                      value={field.state.value}
+                      onChange={(value) => {
+                        if (value) field.handleChange(value as Faction['hero']['image']);
+                      }}
                     />
-                  }
-                  renderOption={({ option }) => (
-                    <LeaderImageOption value={option.value} label={option.label} />
-                  )}
-                  comboboxProps={{ withinPortal: false }}
-                  onChange={(value) => {
-                    if (value) field.handleChange(value as Faction['hero']['image']);
-                  }}
-                />
-              )}
+                  </Input.Wrapper>
+                );
+              }}
             </form.Field>
           </Stack>
         </Grid.Col>

--- a/src/app/components/factions/editor/FactionFormSectionIdentity.module.css
+++ b/src/app/components/factions/editor/FactionFormSectionIdentity.module.css
@@ -5,14 +5,6 @@
   align-items: start;
 }
 
-.singleLineDescription {
-  display: block;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 @container connected-tabs-panel (max-width: 34rem) {
   .identityGrid {
     gap: var(--mantine-spacing-sm);

--- a/src/app/components/factions/editor/FactionFormSectionIdentity.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionIdentity.tsx
@@ -1,6 +1,7 @@
-import { Box, ColorInput, Group, Image, Select, Stack, Text, TextInput } from '@mantine/core';
+import { Box, ColorInput, Input, Stack, Text, TextInput } from '@mantine/core';
 
 import type { Faction } from '@db/factions';
+import { AssetSelect } from '@app/components/content/FormControls/AssetSelect';
 
 import styles from './FactionFormSectionIdentity.module.css';
 import { assetOptionToPreviewSrc, logoOptions, logoOptionToLabel } from './factionFormAssetUtils';
@@ -11,17 +12,6 @@ const logoSelectOptions = logoOptions.map((value) => ({
   value,
   label: logoOptionToLabel(value),
 }));
-
-function LogoOption({ value, label }: { value: string; label: string }) {
-  return (
-    <Group gap="sm" wrap="nowrap">
-      <Image src={assetOptionToPreviewSrc(value)} alt="" w={30} h={30} fit="contain" />
-      <Text size="sm" truncate>
-        {label}
-      </Text>
-    </Group>
-  );
-}
 
 export function FactionFormSectionIdentity({
   form,
@@ -57,7 +47,6 @@ export function FactionFormSectionIdentity({
               id="faction-name"
               label="Faction name"
               description="Used on faction artifacts and to derive the canonical share URL."
-              classNames={{ description: styles.singleLineDescription }}
               error={nameError}
               value={field.state.value}
               onBlur={field.handleBlur}
@@ -67,34 +56,30 @@ export function FactionFormSectionIdentity({
         </form.Field>
 
         <form.Field name="logo">
-          {(field) => (
-            <Select
-              id="faction-logo"
-              label="Faction logo"
-              description="Used on faction tokens and faction-branded game artifacts."
-              classNames={{ description: styles.singleLineDescription }}
-              searchable
-              allowDeselect={false}
-              data={logoSelectOptions}
-              value={field.state.value}
-              leftSection={
-                <Image
-                  src={assetOptionToPreviewSrc(field.state.value)}
-                  alt=""
-                  w={24}
-                  h={24}
-                  fit="contain"
+          {(field) => {
+            const id = 'faction-logo';
+            const descriptionId = `${id}-description`;
+            return (
+              <Input.Wrapper
+                id={id}
+                descriptionProps={{ id: descriptionId }}
+                label="Faction logo"
+                description="Used on faction tokens and faction-branded game artifacts."
+              >
+                <AssetSelect
+                  id={id}
+                  aria-describedby={descriptionId}
+                  allowDeselect={false}
+                  data={logoSelectOptions}
+                  getPreviewSrc={assetOptionToPreviewSrc}
+                  value={field.state.value}
+                  onChange={(value) => {
+                    if (value) field.handleChange(value as Faction['logo']);
+                  }}
                 />
-              }
-              renderOption={({ option }) => (
-                <LogoOption value={option.value} label={option.label} />
-              )}
-              comboboxProps={{ withinPortal: false }}
-              onChange={(value) => {
-                if (value) field.handleChange(value as Faction['logo']);
-              }}
-            />
-          )}
+              </Input.Wrapper>
+            );
+          }}
         </form.Field>
 
         <form.Field name="themeColor">
@@ -103,7 +88,6 @@ export function FactionFormSectionIdentity({
               id="faction-theme-color"
               label="Faction sheet theme"
               description="Used for headings and accents on the complete faction sheet."
-              classNames={{ description: styles.singleLineDescription }}
               format="hex"
               value={field.state.value}
               onBlur={field.handleBlur}

--- a/src/app/components/factions/editor/FactionFormSectionLeaders.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionLeaders.tsx
@@ -7,9 +7,8 @@ import {
   Button,
   Grid,
   Group,
-  Image,
+  Input,
   Paper,
-  Select,
   Stack,
   Text,
   TextInput,
@@ -19,6 +18,7 @@ import { Plus, Trash2 } from 'lucide-react';
 import { useLayoutEffect, useState } from 'react';
 
 import type { Faction } from '@db/factions';
+import { AssetSelect } from '@app/components/content/FormControls/AssetSelect';
 import { LeaderToken } from '@game/assets/faction/leader/Leader';
 import { LEADERS } from '@game/data/generated';
 
@@ -37,17 +37,6 @@ const leaderImageOptions = LEADERS.options.map((value) => ({
 
 export function canAddSupportingLeader(count: number): boolean {
   return count >= 0 && count < SUPPORTING_LEADER_LIMIT;
-}
-
-function LeaderImageOption({ value, label }: { value: string; label: string }) {
-  return (
-    <Group gap="sm" wrap="nowrap">
-      <Image src={assetOptionToPreviewSrc(value)} alt="" w={32} h={32} fit="contain" />
-      <Text size="sm" truncate>
-        {label}
-      </Text>
-    </Group>
-  );
 }
 
 function SupportingLeaderCard({
@@ -147,36 +136,33 @@ function SupportingLeaderCard({
                 </Grid.Col>
                 <Grid.Col span={{ base: 12, xs: 8 }}>
                   <form.Field name={`leaders[${index}].image`}>
-                    {(field) => (
-                      <Select
-                        id={`leader-${index}-img`}
-                        label="Leader portrait"
-                        description="Choose the portrait rendered on this token."
-                        searchable
-                        allowDeselect={false}
-                        limit={24}
-                        data={leaderImageOptions}
-                        value={field.state.value}
-                        leftSection={
-                          <Image
-                            src={assetOptionToPreviewSrc(field.state.value)}
-                            alt=""
-                            w={24}
-                            h={24}
-                            fit="contain"
+                    {(field) => {
+                      const id = `leader-${index}-img`;
+                      const descriptionId = `${id}-description`;
+                      return (
+                        <Input.Wrapper
+                          id={id}
+                          descriptionProps={{ id: descriptionId }}
+                          label="Leader portrait"
+                          description="Choose the portrait rendered on this token."
+                        >
+                          <AssetSelect
+                            id={id}
+                            aria-describedby={descriptionId}
+                            allowDeselect={false}
+                            limit={24}
+                            data={leaderImageOptions}
+                            getPreviewSrc={assetOptionToPreviewSrc}
+                            value={field.state.value}
+                            onChange={(value) => {
+                              if (value) {
+                                field.handleChange(value as Faction['leaders'][number]['image']);
+                              }
+                            }}
                           />
-                        }
-                        renderOption={({ option }) => (
-                          <LeaderImageOption value={option.value} label={option.label} />
-                        )}
-                        comboboxProps={{ withinPortal: false }}
-                        onChange={(value) => {
-                          if (value) {
-                            field.handleChange(value as Faction['leaders'][number]['image']);
-                          }
-                        }}
-                      />
-                    )}
+                        </Input.Wrapper>
+                      );
+                    }}
                   </form.Field>
                 </Grid.Col>
               </Grid>

--- a/src/app/components/factions/editor/TroopSideFields.tsx
+++ b/src/app/components/factions/editor/TroopSideFields.tsx
@@ -1,17 +1,7 @@
-import {
-  Box,
-  Group,
-  Image,
-  Select,
-  SimpleGrid,
-  Stack,
-  Switch,
-  Text,
-  Textarea,
-  TextInput,
-} from '@mantine/core';
+import { Box, Input, SimpleGrid, Stack, Switch, Textarea, TextInput } from '@mantine/core';
 
 import type { Faction } from '@db/factions';
+import { AssetSelect } from '@app/components/content/FormControls/AssetSelect';
 import { TROOP, TROOP_MODIFIER } from '@game/data/generated';
 
 import {
@@ -30,18 +20,6 @@ const troopStarOptions = TROOP_MODIFIER.options.map((value) => ({
   value,
   label: troopStarOptionToLabel(value),
 }));
-
-function AssetOption({ value, label }: { value: string; label: string }) {
-  const preview = assetOptionToPreviewSrc(value);
-  return (
-    <Group gap="sm" wrap="nowrap">
-      {preview ? <Image src={preview} alt="" w={28} h={28} fit="contain" /> : null}
-      <Text size="sm" truncate>
-        {label}
-      </Text>
-    </Group>
-  );
-}
 
 export function TroopSideFields({
   form,
@@ -88,37 +66,32 @@ export function TroopSideFields({
         </form.Field>
 
         <form.Field name={imageField}>
-          {(field) => (
-            <Select
-              id={`${idBase}-img`}
-              label={isBack ? 'Back-side symbol' : 'Troop symbol'}
-              description="Select the symbol rendered inside the troop token."
-              searchable
-              allowDeselect={false}
-              data={troopImageOptions}
-              value={field.state.value}
-              leftSection={
-                field.state.value ? (
-                  <Image
-                    src={assetOptionToPreviewSrc(field.state.value)}
-                    alt=""
-                    w={22}
-                    h={22}
-                    fit="contain"
-                  />
-                ) : null
-              }
-              renderOption={({ option }) => (
-                <AssetOption value={option.value} label={option.label} />
-              )}
-              comboboxProps={{ withinPortal: false }}
-              onChange={(value) => {
-                if (value) {
-                  field.handleChange(value as Faction['troops'][number]['image']);
-                }
-              }}
-            />
-          )}
+          {(field) => {
+            const id = `${idBase}-img`;
+            const descriptionId = `${id}-description`;
+            return (
+              <Input.Wrapper
+                id={id}
+                descriptionProps={{ id: descriptionId }}
+                label={isBack ? 'Back-side symbol' : 'Troop symbol'}
+                description="Select the symbol rendered inside the troop token."
+              >
+                <AssetSelect
+                  id={id}
+                  aria-describedby={descriptionId}
+                  allowDeselect={false}
+                  data={troopImageOptions}
+                  getPreviewSrc={assetOptionToPreviewSrc}
+                  value={field.state.value ?? null}
+                  onChange={(value) => {
+                    if (value) {
+                      field.handleChange(value as Faction['troops'][number]['image']);
+                    }
+                  }}
+                />
+              </Input.Wrapper>
+            );
+          }}
         </form.Field>
       </SimpleGrid>
 
@@ -139,24 +112,33 @@ export function TroopSideFields({
 
       <SimpleGrid cols={{ base: 1, sm: 2 }}>
         <form.Field name={starField}>
-          {(field) => (
-            <Select
-              label={isBack ? 'Back-side star modifier' : 'Star modifier'}
-              description="Optional marker rendered on the troop token."
-              placeholder="No star modifier"
-              clearable
-              searchable
-              data={troopStarOptions}
-              value={field.state.value ?? null}
-              renderOption={({ option }) => (
-                <AssetOption value={option.value} label={option.label} />
-              )}
-              comboboxProps={{ withinPortal: false }}
-              onChange={(value) =>
-                field.handleChange(value ? (value as Faction['troops'][number]['star']) : undefined)
-              }
-            />
-          )}
+          {(field) => {
+            const id = `${idBase}-star`;
+            const descriptionId = `${id}-description`;
+            return (
+              <Input.Wrapper
+                id={id}
+                descriptionProps={{ id: descriptionId }}
+                label={isBack ? 'Back-side star modifier' : 'Star modifier'}
+                description="Optional marker rendered on the troop token."
+              >
+                <AssetSelect
+                  id={id}
+                  aria-describedby={descriptionId}
+                  placeholder="No star modifier"
+                  clearable
+                  data={troopStarOptions}
+                  getPreviewSrc={assetOptionToPreviewSrc}
+                  value={field.state.value ?? null}
+                  onChange={(value) =>
+                    field.handleChange(
+                      value ? (value as Faction['troops'][number]['star']) : undefined
+                    )
+                  }
+                />
+              </Input.Wrapper>
+            );
+          }}
         </form.Field>
 
         <Box pt={{ base: 0, sm: 'xl' }}>

--- a/src/app/components/factions/editor/TtsColorsEditor.tsx
+++ b/src/app/components/factions/editor/TtsColorsEditor.tsx
@@ -17,6 +17,7 @@ import { ActionIcon, Box, Group, Select, Stack, Text, Tooltip } from '@mantine/c
 import { GripVertical, Minus, Plus } from 'lucide-react';
 
 import type { Faction } from '@db/factions';
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
 import { getSortableIds, indexFromSortableId } from '@app/lib/dnd-sortable-ids';
 import { TTS_COLOR_SWATCHES } from '@game/data/ttsColors';
 import { TTSColor } from '@game/schema/faction';
@@ -152,17 +153,10 @@ export function TtsColorsEditor({
   const nextAvailableColor = nextUnusedTtsColor(value);
 
   return (
-    <Stack gap={6}>
-      <Group gap="sm" justify="space-between" align="flex-start" wrap="nowrap">
-        <Stack gap={0}>
-          <Text fw={700} size="sm">
-            Tabletop Simulator colors
-          </Text>
-          <Text c="dimmed" size="xs">
-            Choose unique colors; drag to set their priority.
-          </Text>
-        </Stack>
-
+    <ControlBlock
+      title="Tabletop Simulator colors"
+      description="Choose unique colors; drag to set their priority."
+      tool={
         <ActionIcon.Group>
           <Tooltip label="Remove last color">
             <ActionIcon
@@ -193,47 +187,50 @@ export function TtsColorsEditor({
             </ActionIcon>
           </Tooltip>
         </ActionIcon.Group>
-      </Group>
+      }
+      input={
+        <Stack gap={6}>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={({ active, over }: DragEndEvent) => {
+              if (!over) return;
+              const from = indexFromSortableId(active.id, sortablePrefix);
+              const to = indexFromSortableId(over.id, sortablePrefix);
+              if (from == null || to == null || from === to) return;
+              onChange(moveTtsColor(value, from, to));
+            }}
+          >
+            <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
+              <Box className={styles.rows}>
+                {value.map((color, index) => {
+                  const itemId = `${sortablePrefix}${index}`;
+                  return (
+                    <TtsColorRow
+                      key={itemId}
+                      color={color}
+                      index={index}
+                      itemId={itemId}
+                      options={availableTtsColors(value, index)}
+                      onChange={(nextColor) => {
+                        const next = [...value];
+                        next[index] = nextColor;
+                        onChange(next);
+                      }}
+                    />
+                  );
+                })}
+              </Box>
+            </SortableContext>
+          </DndContext>
 
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={({ active, over }: DragEndEvent) => {
-          if (!over) return;
-          const from = indexFromSortableId(active.id, sortablePrefix);
-          const to = indexFromSortableId(over.id, sortablePrefix);
-          if (from == null || to == null || from === to) return;
-          onChange(moveTtsColor(value, from, to));
-        }}
-      >
-        <SortableContext items={itemIds} strategy={verticalListSortingStrategy}>
-          <Box className={styles.rows}>
-            {value.map((color, index) => {
-              const itemId = `${sortablePrefix}${index}`;
-              return (
-                <TtsColorRow
-                  key={itemId}
-                  color={color}
-                  index={index}
-                  itemId={itemId}
-                  options={availableTtsColors(value, index)}
-                  onChange={(nextColor) => {
-                    const next = [...value];
-                    next[index] = nextColor;
-                    onChange(next);
-                  }}
-                />
-              );
-            })}
-          </Box>
-        </SortableContext>
-      </DndContext>
-
-      {value.length === 0 ? (
-        <Text size="xs" c="dimmed">
-          No preferred player colors selected.
-        </Text>
-      ) : null}
-    </Stack>
+          {value.length === 0 ? (
+            <Text size="xs" c="dimmed">
+              No preferred player colors selected.
+            </Text>
+          ) : null}
+        </Stack>
+      }
+    />
   );
 }

--- a/src/app/components/faq/Answer.stories.tsx
+++ b/src/app/components/faq/Answer.stories.tsx
@@ -6,6 +6,9 @@ import { Answer } from './Answer';
 
 const meta = preview.meta({
   component: Answer.List,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
   parameters: {
     layout: 'padded',
   },

--- a/src/app/components/faq/FaqItemList.stories.tsx
+++ b/src/app/components/faq/FaqItemList.stories.tsx
@@ -4,6 +4,9 @@ import { FaqItemList, FaqItemListRow } from './FaqItemList';
 
 const meta = preview.meta({
   component: FaqItemList,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
   parameters: {
     layout: 'padded',
   },

--- a/src/app/components/faq/FaqList.stories.tsx
+++ b/src/app/components/faq/FaqList.stories.tsx
@@ -51,6 +51,9 @@ const faqItems = [
 
 const meta = preview.meta({
   component: FaqList,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
   parameters: {
     layout: 'padded',
   },


### PR DESCRIPTION
## Summary

- add reusable Mantine-based `AssetSelect` and `ControlBlock` form controls
- reuse those components across faction identity, portrait, troop, alliance, color, and background authoring fields
- reorganize form-control stories so each component is shown in isolation under one Storybook group
- enforce light canvases for FAQ stories and consistent centered layouts for isolated form-control stories
- truncate `ControlBlock` title and description to one line, with overflow-only tooltips exposing the full text

## Why

The faction editor repeated asset-picker and titled control-block patterns, while Storybook mixed multiple controls in a catalogue and used inconsistent canvas layouts. Centralizing the proven compositions keeps Mantine theming, accessibility, truncation behavior, interactions, and responsive layout consistent without component-level CSS overrides.

## Impact

This is a UI component refactor and Storybook organization change. Existing faction editing behavior is preserved while shared form patterns become independently testable and reusable.

## Validation

- `bunx biome check` on the changed files
- `bun run typecheck`
- `bun run test` — 56 files, 380 tests
- `bun run app:build`
- `bun run build-storybook`
- `bun run publisher:release:verify`
- Storybook browser checks for isolated controls, keyboard/accessibility semantics, overflow tooltips, and desktop/compact faction-editor layouts