### PR TITLE
Refine faction authoring experience

### DIFF
--- a/.storybook/vite.config.ts
+++ b/.storybook/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   build: {
     assetsDir: 'public',
   },
-  publicDir: 'public',
+  publicDir: false,
   resolve: {
     // Keep Storybook path resolution aligned with the app config.
     ...({ tsconfigPaths: true } as Record<string, unknown>),

--- a/src/app/components/content/ConnectedTabs/ConnectedTabs.module.css
+++ b/src/app/components/content/ConnectedTabs/ConnectedTabs.module.css
@@ -210,11 +210,8 @@
     gap: 0.25rem;
     align-items: center;
     min-width: 0;
-    margin: var(--mantine-spacing-sm);
-    padding: 0.2rem;
-    background: rgb(255 255 255 / 22%);
-    border: 1px solid var(--panel-border, #fee7c0);
-    border-radius: var(--mantine-radius-sm);
+    padding: 0.45rem 0.5rem;
+    border-bottom: 1px solid var(--panel-border, #fee7c0);
   }
 
   .mobileStepButton {
@@ -247,7 +244,7 @@
 
   .mobileSelect {
     display: grid;
-    grid-template-columns: 2rem minmax(0, 1fr) auto auto;
+    grid-template-columns: 1.5rem minmax(0, 1fr) auto auto;
     gap: 0.5rem;
     align-items: center;
     min-width: 0;
@@ -268,21 +265,15 @@
 
   .mobileIconDisc {
     display: grid;
-    width: 1.75rem;
-    height: 1.75rem;
-    color: rgb(250 246 238 / 92%);
-    background: var(--mantine-color-dark-9, #151515);
-    border: 1px solid rgb(250 246 238 / 52%);
-    border-radius: 50%;
-    box-shadow: 0 0 0 2px rgb(0 0 0 / 12%);
+    width: 1.5rem;
+    height: 1.5rem;
+    color: var(--mantine-color-dark-9, #151515);
     place-items: center;
   }
 
   .mobileIconDisc img {
-    max-width: 1.25rem;
-    max-height: 1.25rem;
-    filter: brightness(0) invert(1);
-    opacity: 0.92;
+    max-width: 1.35rem;
+    max-height: 1.35rem;
   }
 
   .mobileSelectValue {
@@ -299,7 +290,7 @@
   }
 
   .panelShell {
-    padding: 0 var(--mantine-spacing-md) var(--mantine-spacing-md);
+    padding: var(--mantine-spacing-md);
   }
 }
 

--- a/src/app/components/content/FormControls/ControlBlock/ControlBlock.stories.tsx
+++ b/src/app/components/content/FormControls/ControlBlock/ControlBlock.stories.tsx
@@ -1,8 +1,8 @@
-import { ActionIcon, Box, Select } from '@mantine/core';
+import { Box, Select } from '@mantine/core';
 import preview from '@sb/preview';
-import { Minus, Plus } from 'lucide-react';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
+import { ListLengthActions } from '../ListLengthActions';
 import { ControlBlock } from './ControlBlock';
 
 const input = (
@@ -15,14 +15,7 @@ const input = (
 );
 
 const tool = (
-  <ActionIcon.Group>
-    <ActionIcon type="button" variant="light" color="red" size="sm" aria-label="Remove color">
-      <Minus size={16} aria-hidden />
-    </ActionIcon>
-    <ActionIcon type="button" variant="filled" color="green" size="sm" aria-label="Add color">
-      <Plus size={16} aria-hidden />
-    </ActionIcon>
-  </ActionIcon.Group>
+  <ListLengthActions removeLabel="Remove color" addLabel="Add color" onRemove={fn()} onAdd={fn()} />
 );
 
 const meta = preview.meta({

--- a/src/app/components/content/FormControls/ControlBlock/ControlBlock.tsx
+++ b/src/app/components/content/FormControls/ControlBlock/ControlBlock.tsx
@@ -59,8 +59,9 @@ function OverflowTooltipText({
 }
 
 /**
- * Frames a composite form control with consistent guidance, tools and group semantics.
- * Nested inputs and icon-only tools remain responsible for their own accessible names.
+ * Frames a descriptive form control with single-line guidance, overflow help,
+ * optional tools, and group semantics. Nested inputs and icon-only tools remain
+ * responsible for their own accessible names.
  */
 export function ControlBlock({ title, description, tool, input }: ControlBlockProps) {
   const id = useId();

--- a/src/app/components/content/FormControls/ListLengthActions/ListLengthActions.stories.tsx
+++ b/src/app/components/content/FormControls/ListLengthActions/ListLengthActions.stories.tsx
@@ -1,0 +1,32 @@
+import preview from '@sb/preview';
+import { fn } from 'storybook/test';
+
+import { ListLengthActions } from './ListLengthActions';
+
+const meta = preview.meta({
+  title: 'Form Controls/List Length Actions',
+  component: ListLengthActions,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    addLabel: 'Add item',
+    removeLabel: 'Remove last item',
+    onAdd: fn(),
+    onRemove: fn(),
+  },
+});
+
+export const Default = meta.story({});
+
+export const AtMinimum = meta.story({
+  args: {
+    removeDisabled: true,
+  },
+});
+
+export const AtMaximum = meta.story({
+  args: {
+    addDisabled: true,
+  },
+});

--- a/src/app/components/content/FormControls/ListLengthActions/ListLengthActions.tsx
+++ b/src/app/components/content/FormControls/ListLengthActions/ListLengthActions.tsx
@@ -1,0 +1,57 @@
+import { ActionIcon, Group, Tooltip } from '@mantine/core';
+import { Minus, Plus } from 'lucide-react';
+
+export interface ListLengthActionsProps {
+  addLabel: string;
+  removeLabel: string;
+  addDisabled?: boolean;
+  removeDisabled?: boolean;
+  onAdd: () => void;
+  onRemove: () => void;
+}
+
+/**
+ * Changes an ordered collection only at its end.
+ *
+ * Callers own the collection count and mutation details; this component owns the
+ * repeated standalone action treatment and accessible add/remove semantics.
+ */
+export function ListLengthActions({
+  addLabel,
+  removeLabel,
+  addDisabled = false,
+  removeDisabled = false,
+  onAdd,
+  onRemove,
+}: ListLengthActionsProps) {
+  return (
+    <Group gap={6} wrap="nowrap">
+      <Tooltip label={removeLabel}>
+        <ActionIcon
+          type="button"
+          variant="light"
+          color="red"
+          size="sm"
+          aria-label={removeLabel}
+          disabled={removeDisabled}
+          onClick={onRemove}
+        >
+          <Minus size={15} aria-hidden />
+        </ActionIcon>
+      </Tooltip>
+      <Tooltip label={addLabel}>
+        <ActionIcon
+          type="button"
+          variant="light"
+          color="green"
+          size="sm"
+          aria-label={addLabel}
+          disabled={addDisabled}
+          onClick={onAdd}
+        >
+          <Plus size={15} aria-hidden />
+        </ActionIcon>
+      </Tooltip>
+    </Group>
+  );
+}

--- a/src/app/components/content/FormControls/ListLengthActions/index.ts
+++ b/src/app/components/content/FormControls/ListLengthActions/index.ts
@@ -1,0 +1,1 @@
+export { ListLengthActions, type ListLengthActionsProps } from './ListLengthActions';

--- a/src/app/components/factions/editor/FactionAuthoring.architecture.test.ts
+++ b/src/app/components/factions/editor/FactionAuthoring.architecture.test.ts
@@ -105,6 +105,9 @@ describe('faction authoring architecture', () => {
     expect(toolbarStyles).toContain('height: 60px');
     expect(toolbarSource).toContain('Review faction sheet');
     expect(toolbarSource).toContain('aria-label="Back"');
+    expect(toolbarSource.indexOf('aria-label="Reset unsaved edits"')).toBeLessThan(
+      toolbarSource.indexOf('Review faction sheet')
+    );
     for (const routeSource of [createRouteSource, editRouteSource]) {
       expect(routeSource).toContain('<PageLayout');
       expect(routeSource).toContain('<FactionAuthoringToolbar');

--- a/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
+++ b/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
@@ -129,15 +129,6 @@ export function FactionAuthoringToolbar({
 
         <Group gap="xs" wrap="nowrap" className={styles.actions}>
           <div className={styles.auxiliarySlot}>{auxiliaryActions}</div>
-          <Button
-            className={styles.reviewAction}
-            type="button"
-            variant="default"
-            leftSection={<Eye size={17} aria-hidden />}
-            onClick={(event) => onReview(event.currentTarget)}
-          >
-            Review faction sheet
-          </Button>
           <Tooltip label="Reset unsaved edits">
             <ActionIcon
               type="button"
@@ -151,6 +142,15 @@ export function FactionAuthoringToolbar({
               <RotateCcw size={17} aria-hidden />
             </ActionIcon>
           </Tooltip>
+          <Button
+            className={styles.reviewAction}
+            type="button"
+            variant="default"
+            leftSection={<Eye size={17} aria-hidden />}
+            onClick={(event) => onReview(event.currentTarget)}
+          >
+            Review faction sheet
+          </Button>
           <div className={styles.destructiveSlot}>{destructiveActions}</div>
           <Button
             type="button"

--- a/src/app/components/factions/editor/FactionBackgroundColorLayer.tsx
+++ b/src/app/components/factions/editor/FactionBackgroundColorLayer.tsx
@@ -176,23 +176,28 @@ function GradientFields({
   return (
     <Stack gap="md">
       {value.type === 'linear' ? (
-        <NumberInput
-          label="Gradient angle"
+        <ControlBlock
+          title="Gradient angle"
           description="Direction in degrees. The complete admitted range is 0–360."
-          min={0}
-          max={360}
-          step={1}
-          allowDecimal={false}
-          value={value.angle}
-          suffix="°"
-          onChange={(next) =>
-            onChange({
-              ...value,
-              angle:
-                typeof next === 'number' && Number.isInteger(next)
-                  ? Math.min(360, Math.max(0, next))
-                  : 0,
-            })
+          input={
+            <NumberInput
+              aria-label="Gradient angle"
+              min={0}
+              max={360}
+              step={1}
+              allowDecimal={false}
+              value={value.angle}
+              suffix="°"
+              onChange={(next) =>
+                onChange({
+                  ...value,
+                  angle:
+                    typeof next === 'number' && Number.isInteger(next)
+                      ? Math.min(360, Math.max(0, next))
+                      : 0,
+                })
+              }
+            />
           }
         />
       ) : (

--- a/src/app/components/factions/editor/FactionChapters.architecture.test.ts
+++ b/src/app/components/factions/editor/FactionChapters.architecture.test.ts
@@ -61,7 +61,25 @@ describe('Forces and Worlds and Rules and Advantages chapter architecture', () =
     expect(collectionShelfSource).toContain('Drag to reorder');
     for (const source of [troopsSource, planetsSource, advantagesSource]) {
       expect(source).toContain('<FactionCollectionShelf');
+      expect(source).toContain('<ListLengthActions');
     }
+  });
+
+  it('uses end-of-list actions instead of card-level remove or footer add buttons', () => {
+    for (const [source, labels] of [
+      [troopsSource, ['Remove last troop type', 'Add troop type', 'Remove troop']],
+      [planetsSource, ['Remove last faction world', 'Add faction world', 'Remove planet']],
+      [
+        advantagesSource,
+        ['Remove last faction advantage', 'Add faction advantage', 'Remove advantage'],
+      ],
+    ] as const) {
+      expect(source).toContain(`removeLabel="${labels[0]}"`);
+      expect(source).toContain(`addLabel="${labels[1]}"`);
+      expect(source).not.toContain(labels[2]);
+      expect(source).not.toContain('leftSection={<Plus');
+    }
+    expect(troopsSource).not.toContain('Troops are rendered as tokens');
   });
 
   it('uses only the informative troop renderer and removes previews on mobile', () => {

--- a/src/app/components/factions/editor/FactionControlBlocks.architecture.test.ts
+++ b/src/app/components/factions/editor/FactionControlBlocks.architecture.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const authoringSources = [
+  'FactionBackgroundColorLayer.tsx',
+  'FactionFormSectionAdvantages.tsx',
+  'FactionFormSectionAlliance.tsx',
+  'FactionFormSectionBackground.tsx',
+  'FactionFormSectionHero.tsx',
+  'FactionFormSectionIdentity.tsx',
+  'FactionFormSectionLeaders.tsx',
+  'FactionFormSectionPlanets.tsx',
+  'FactionFormSectionRules.tsx',
+  'FactionFormSectionTroops.tsx',
+  'TroopSideFields.tsx',
+  'TtsColorsEditor.tsx',
+].map((file) => ({
+  file,
+  source: readFileSync(new URL(file, import.meta.url), 'utf8'),
+}));
+
+const nativeDescriptiveControl =
+  /<(?:ColorInput|NumberInput|Select|Switch|Textarea|TextInput)\b(?:(?!\/>)[\s\S])*?\bdescription=/u;
+const rulesSource = authoringSources.find(
+  ({ file }) => file === 'FactionFormSectionRules.tsx'
+)?.source;
+
+describe('Faction authoring control guidance', () => {
+  it('routes descriptive fields through ControlBlock instead of native wrapping descriptions', () => {
+    for (const { file, source } of authoringSources) {
+      expect(source, file).not.toMatch(nativeDescriptiveControl);
+      expect(source, file).not.toContain('<Input.Wrapper');
+
+      if (source.includes('description=')) {
+        expect(source, file).toContain('<ControlBlock');
+      }
+    }
+  });
+
+  it('keeps the Rules tab flat and separates setup from Fate with a divider', () => {
+    expect(rulesSource).toBeDefined();
+    expect(rulesSource).toContain('<Divider my="lg" />');
+    expect(rulesSource).not.toContain('<Paper');
+    expect(rulesSource).not.toContain('<Alert');
+    expect(rulesSource).not.toContain('Keep free-form instructions separate');
+    expect(rulesSource).not.toContain('Structured setup fact');
+    expect(rulesSource).toContain(
+      'Rendered in At start as “Starting spice: N”; use a positive whole number.'
+    );
+  });
+});

--- a/src/app/components/factions/editor/FactionEditor.module.css
+++ b/src/app/components/factions/editor/FactionEditor.module.css
@@ -47,20 +47,17 @@
   backdrop-filter: blur(8px);
 }
 
-.liveBadge {
-  position: absolute;
-  z-index: 2;
-  top: var(--mantine-spacing-sm);
-  right: var(--mantine-spacing-sm);
+.identityProof {
+  margin-top: var(--mantine-spacing-md);
+  overflow: hidden;
+  border-radius: var(--mantine-radius-md);
 }
 
 .sheetColorReference {
   display: flex;
   justify-content: space-between;
   gap: var(--mantine-spacing-sm);
-  margin: calc(var(--mantine-spacing-md) * -1);
-  margin-bottom: 0;
-  padding: 0.55rem 4.2rem 0.55rem 0.75rem;
+  padding: 0.55rem 0.75rem;
   color: white;
   text-shadow: 0 1px 2px rgb(0 0 0 / 80%);
 }
@@ -74,6 +71,11 @@
   width: 100%;
   margin-top: var(--mantine-spacing-md);
   border-radius: var(--mantine-radius-md);
+}
+
+.identityProof .squareProof {
+  margin-top: 0;
+  border-radius: 0;
 }
 
 .squareProof > div:first-child:not(.tokenProof) {
@@ -161,5 +163,14 @@
 @media (max-width: 48em) {
   .workbench {
     display: block;
+  }
+
+  .artifactColumn {
+    padding-top: var(--mantine-spacing-sm);
+    padding-left: 0;
+  }
+
+  .artifactDesk {
+    position: static;
   }
 }

--- a/src/app/components/factions/editor/FactionEditor.stories.tsx
+++ b/src/app/components/factions/editor/FactionEditor.stories.tsx
@@ -90,7 +90,7 @@ function FactionEditorFixture() {
   const editorRef = useRef<FactionEditorHandle>(null);
   return (
     <Box w="min(78rem, calc(100vw - 2rem))" p="md">
-      <Stack gap="xl">
+      <Stack gap="clamp(var(--mantine-spacing-sm), 3vw, var(--mantine-spacing-xl))">
         <FactionAuthoringToolbar
           isDirty={false}
           isNameBlank={false}
@@ -182,6 +182,7 @@ export const FactionTokenProofGeometry = meta.story({
 });
 
 export const PreviewFreeMobile = meta.story({
+  name: 'Mobile authoring',
   globals: {
     viewport: {
       value: 'appMobile',
@@ -192,10 +193,15 @@ export const PreviewFreeMobile = meta.story({
     const picker = canvas.getByRole('combobox', { name: 'Faction editor sections' });
 
     await expect(picker).toHaveTextContent('Identity & Appearance');
-    await expect(canvas.queryByRole('region', { name: 'Faction leader' })).not.toBeInTheDocument();
+    await expect(
+      canvas.getByRole('region', { name: 'Background composite live preview' })
+    ).toBeVisible();
 
     await userEvent.click(canvas.getByRole('button', { name: 'Next section' }));
     await expect(picker).toHaveTextContent('Faction leader');
     await expect(canvas.getByRole('textbox', { name: 'Faction leader name' })).toBeVisible();
+    await expect(
+      canvas.getByRole('region', { name: 'Faction leader token live preview' })
+    ).toBeVisible();
   },
 });

--- a/src/app/components/factions/editor/FactionFormFields.mobile.test.tsx
+++ b/src/app/components/factions/editor/FactionFormFields.mobile.test.tsx
@@ -208,6 +208,8 @@ describe('FactionFormFields responsive workbench', () => {
     await renderFields();
 
     expect(container?.textContent).toContain('Artifact workbench');
-    expect(container?.querySelector('section')).toBeNull();
+    expect(
+      container?.querySelector('section[aria-label="Background composite live preview"]')
+    ).not.toBeNull();
   });
 });

--- a/src/app/components/factions/editor/FactionFormFields.tsx
+++ b/src/app/components/factions/editor/FactionFormFields.tsx
@@ -250,26 +250,32 @@ function ArtifactProof({
         }
 
         return (
-          <Paper className={styles.artifactDesk} withBorder radius="lg" p="md">
-            <Badge className={styles.liveBadge} color="teal" variant="light">
-              Live
-            </Badge>
-
+          <Paper
+            className={styles.artifactDesk}
+            component="section"
+            aria-label={`${title} live preview`}
+            withBorder
+            radius="lg"
+            p="md"
+          >
             {activeChapter === 'identity' ? (
-              <Box
-                className={styles.sheetColorReference}
-                style={{ backgroundColor: faction.themeColor }}
-              >
-                <Text size="xs" fw={800} tt="uppercase">
-                  Sheet color
-                </Text>
-                <Text size="xs" ff="monospace">
-                  {faction.themeColor}
-                </Text>
+              <Box className={styles.identityProof}>
+                {artifact}
+                <Box
+                  className={styles.sheetColorReference}
+                  style={{ backgroundColor: faction.themeColor }}
+                >
+                  <Text size="xs" fw={800} tt="uppercase">
+                    Sheet color
+                  </Text>
+                  <Text size="xs" ff="monospace">
+                    {faction.themeColor}
+                  </Text>
+                </Box>
               </Box>
-            ) : null}
-
-            {artifact}
+            ) : (
+              artifact
+            )}
 
             {activeChapter === 'identity' ? (
               <SegmentedControl
@@ -445,7 +451,7 @@ export const FactionFormFields = forwardRef<
         items={connectedTabItems}
         ariaLabel="Faction editor sections"
       />
-      <Box className={styles.artifactColumn} visibleFrom="sm">
+      <Box className={styles.artifactColumn}>
         <ArtifactProof activeChapter={activeChapter} form={form} selectedItem={selectedItem} />
       </Box>
     </div>

--- a/src/app/components/factions/editor/FactionFormSectionAdvantages.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionAdvantages.tsx
@@ -1,33 +1,15 @@
 import { arrayMove } from '@dnd-kit/sortable';
-import {
-  ActionIcon,
-  Alert,
-  Box,
-  Button,
-  Group,
-  Paper,
-  Stack,
-  Text,
-  Textarea,
-  TextInput,
-  Tooltip,
-} from '@mantine/core';
-import { Plus, Trash2 } from 'lucide-react';
+import { Alert, Box, Group, Paper, Stack, Text, Textarea, TextInput } from '@mantine/core';
 import { useState } from 'react';
+
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
+import { ListLengthActions } from '@app/components/content/FormControls/ListLengthActions';
 
 import { FactionCollectionShelf } from './FactionCollectionShelf';
 import { defaultAdvantage } from './factionFormDefaults';
 import type { FactionFormApi } from './factionFormTypes';
 
-function AdvantageCard({
-  form,
-  index,
-  onRemove,
-}: {
-  form: FactionFormApi;
-  index: number;
-  onRemove: () => void;
-}) {
+function AdvantageCard({ form, index }: { form: FactionFormApi; index: number }) {
   const advantage = form.state.values.rules.advantages[index];
   if (!advantage) return null;
   const warningId = `adv-${index}-text-warning`;
@@ -35,35 +17,27 @@ function AdvantageCard({
   return (
     <Paper withBorder radius="md" p="md">
       <Stack gap="md">
-        <Group justify="space-between" align="flex-start" wrap="wrap">
-          <Box>
-            <Text fw={700}>Advantage {index + 1}</Text>
-            <Text c="dimmed" size="xs">
-              {advantage.title?.trim() || 'Untitled advantage'}
-            </Text>
-          </Box>
-          <Tooltip label={`Remove advantage ${index + 1}`}>
-            <ActionIcon
-              type="button"
-              variant="light"
-              color="red"
-              aria-label={`Remove advantage ${index + 1}`}
-              onClick={onRemove}
-            >
-              <Trash2 size={16} aria-hidden />
-            </ActionIcon>
-          </Tooltip>
-        </Group>
+        <Box>
+          <Text fw={700}>Advantage {index + 1}</Text>
+          <Text c="dimmed" size="xs">
+            {advantage.title?.trim() || 'Untitled advantage'}
+          </Text>
+        </Box>
 
         <form.Field name={`rules.advantages[${index}].title`}>
           {(field) => (
-            <TextInput
-              id={`adv-${index}-title`}
-              label="Title (optional)"
+            <ControlBlock
+              title="Title (optional)"
               description="Leave blank when the rule text is sufficient on its own."
-              value={field.state.value ?? ''}
-              onBlur={field.handleBlur}
-              onChange={(event) => field.handleChange(event.currentTarget.value || undefined)}
+              input={
+                <TextInput
+                  id={`adv-${index}-title`}
+                  aria-label="Title (optional)"
+                  value={field.state.value ?? ''}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(event.currentTarget.value || undefined)}
+                />
+              }
             />
           )}
         </form.Field>
@@ -73,16 +47,21 @@ function AdvantageCard({
             const textIsBlank = field.state.value.trim().length === 0;
             return (
               <Stack gap={4}>
-                <Textarea
-                  id={`adv-${index}-text`}
-                  label="Advantage rule"
+                <ControlBlock
+                  title="Advantage rule"
                   description="The primary rules text for this faction advantage."
-                  autosize
-                  minRows={3}
-                  value={field.state.value}
-                  aria-describedby={textIsBlank ? warningId : undefined}
-                  onBlur={field.handleBlur}
-                  onChange={(event) => field.handleChange(event.currentTarget.value)}
+                  input={
+                    <Textarea
+                      id={`adv-${index}-text`}
+                      aria-label="Advantage rule"
+                      autosize
+                      minRows={3}
+                      value={field.state.value}
+                      aria-describedby={textIsBlank ? warningId : undefined}
+                      onBlur={field.handleBlur}
+                      onChange={(event) => field.handleChange(event.currentTarget.value)}
+                    />
+                  }
                 />
                 {textIsBlank ? (
                   <Text id={warningId} c="yellow.9" size="xs" role="status">
@@ -96,15 +75,20 @@ function AdvantageCard({
 
         <form.Field name={`rules.advantages[${index}].karama`}>
           {(field) => (
-            <Textarea
-              id={`adv-${index}-karama`}
-              label="Karama interaction (optional)"
+            <ControlBlock
+              title="Karama interaction (optional)"
               description="Describe the Karama effect only when this advantage has one."
-              autosize
-              minRows={2}
-              value={field.state.value ?? ''}
-              onBlur={field.handleBlur}
-              onChange={(event) => field.handleChange(event.currentTarget.value || undefined)}
+              input={
+                <Textarea
+                  id={`adv-${index}-karama`}
+                  aria-label="Karama interaction (optional)"
+                  autosize
+                  minRows={2}
+                  value={field.state.value ?? ''}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(event.currentTarget.value || undefined)}
+                />
+              }
             />
           )}
         </form.Field>
@@ -140,19 +124,41 @@ export function FactionFormSectionAdvantages({
       <form.Field name="rules.advantages" mode="array">
         {(field) => {
           const sortablePrefix = 'advantages-';
+          const count = field.state.value.length;
           const safeSelectedIndex = Math.min(
             Math.max(currentSelectedIndex, 0),
-            Math.max(field.state.value.length - 1, 0)
+            Math.max(count - 1, 0)
           );
           return (
             <Stack gap="md">
-              {field.state.value.length === 0 ? (
+              <Group justify="flex-end">
+                <ListLengthActions
+                  removeLabel="Remove last faction advantage"
+                  addLabel="Add faction advantage"
+                  removeDisabled={count === 0}
+                  onRemove={() => {
+                    const lastIndex = count - 1;
+                    if (lastIndex < 0) return;
+                    if (currentSelectedIndex >= lastIndex) {
+                      selectIndex(Math.max(0, lastIndex - 1));
+                    }
+                    field.removeValue(lastIndex);
+                  }}
+                  onAdd={() => {
+                    const newIndex = count;
+                    field.pushValue(defaultAdvantage());
+                    selectIndex(newIndex);
+                  }}
+                />
+              </Group>
+
+              {count === 0 ? (
                 <Alert color="gray" variant="light" title="No faction advantages">
                   This faction currently has no authored special advantages.
                 </Alert>
               ) : null}
 
-              {field.state.value.length > 0 ? (
+              {count > 0 ? (
                 <>
                   <FactionCollectionShelf
                     label="Ordered faction advantages"
@@ -168,32 +174,9 @@ export function FactionFormSectionAdvantages({
                       field.handleChange(arrayMove(field.state.value, from, to))
                     }
                   />
-                  <AdvantageCard
-                    form={form}
-                    index={safeSelectedIndex}
-                    onRemove={() => {
-                      field.removeValue(safeSelectedIndex);
-                      selectIndex(
-                        Math.max(0, Math.min(safeSelectedIndex, field.state.value.length - 2))
-                      );
-                    }}
-                  />
+                  <AdvantageCard form={form} index={safeSelectedIndex} />
                 </>
               ) : null}
-
-              <Button
-                type="button"
-                variant="light"
-                color="dune"
-                leftSection={<Plus size={16} aria-hidden />}
-                onClick={() => {
-                  const newIndex = field.state.value.length;
-                  field.pushValue(defaultAdvantage());
-                  selectIndex(newIndex);
-                }}
-              >
-                Add faction advantage
-              </Button>
             </Stack>
           );
         }}

--- a/src/app/components/factions/editor/FactionFormSectionAlliance.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionAlliance.tsx
@@ -1,12 +1,9 @@
 import { arrayMove } from '@dnd-kit/sortable';
 import {
-  ActionIcon,
   Alert,
   Box,
-  Button,
   Grid,
   Group,
-  Input,
   NumberInput,
   Paper,
   Slider,
@@ -14,14 +11,13 @@ import {
   Switch,
   Text,
   Textarea,
-  Tooltip,
 } from '@mantine/core';
-import { Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
 import type { Faction } from '@db/factions';
 import { AssetSelect } from '@app/components/content/FormControls/AssetSelect';
 import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
+import { ListLengthActions } from '@app/components/content/FormControls/ListLengthActions';
 import { AllianceCard } from '@game/assets/faction/alliance/Alliance';
 
 import { FactionCollectionShelf } from './FactionCollectionShelf';
@@ -39,55 +35,29 @@ const decalOptions = decalAssetOptions.map((value) => ({
   label: decalAssetOptionToLabel(value),
 }));
 
-function DecalCard({
-  form,
-  index,
-  onRemove,
-}: {
-  form: FactionFormApi;
-  index: number;
-  onRemove: () => void;
-}) {
+function DecalCard({ form, index }: { form: FactionFormApi; index: number }) {
   const decal = form.state.values.decals[index];
   if (!decal) return null;
 
   return (
     <Paper withBorder radius="md" p="md">
       <Stack gap="md">
-        <Group justify="space-between" align="flex-start" wrap="wrap">
-          <Box>
-            <Text fw={700}>Alliance decal {index + 1}</Text>
-            <Text size="xs" c="dimmed">
-              {decalAssetOptionToLabel(decal.id)}
-            </Text>
-          </Box>
-          <Tooltip label={`Remove alliance decal ${index + 1}`}>
-            <ActionIcon
-              type="button"
-              variant="light"
-              color="red"
-              aria-label={`Remove alliance decal ${index + 1}`}
-              onClick={onRemove}
-            >
-              <Trash2 size={16} aria-hidden />
-            </ActionIcon>
-          </Tooltip>
-        </Group>
+        <Box>
+          <Text fw={700}>Alliance decal {index + 1}</Text>
+          <Text size="xs" c="dimmed">
+            {decalAssetOptionToLabel(decal.id)}
+          </Text>
+        </Box>
 
         <form.Field name={`decals[${index}].id`}>
-          {(field) => {
-            const id = `decal-${index}-id`;
-            const descriptionId = `${id}-description`;
-            return (
-              <Input.Wrapper
-                id={id}
-                descriptionProps={{ id: descriptionId }}
-                label="Decal asset"
-                description="Artwork layered onto the alliance card in collection order."
-              >
+          {(field) => (
+            <ControlBlock
+              title="Decal asset"
+              description="Artwork layered onto the alliance card in collection order."
+              input={
                 <AssetSelect
-                  id={id}
-                  aria-describedby={descriptionId}
+                  id={`decal-${index}-id`}
+                  aria-label="Decal asset"
                   allowDeselect={false}
                   limit={30}
                   data={decalOptions}
@@ -97,22 +67,27 @@ function DecalCard({
                     if (value) field.handleChange(value as Faction['decals'][number]['id']);
                   }}
                 />
-              </Input.Wrapper>
-            );
-          }}
+              }
+            />
+          )}
         </form.Field>
 
         <Grid>
           <Grid.Col span={{ base: 12, xs: 6 }}>
             <form.Field name={`decals[${index}].muted`}>
               {(field) => (
-                <Switch
-                  id={`decal-${index}-muted`}
-                  label="Muted treatment"
+                <ControlBlock
+                  title="Muted treatment"
                   description="Uses the artwork as a subtle cutout layer."
-                  checked={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(event) => field.handleChange(event.currentTarget.checked)}
+                  input={
+                    <Switch
+                      id={`decal-${index}-muted`}
+                      aria-label="Muted treatment"
+                      checked={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) => field.handleChange(event.currentTarget.checked)}
+                    />
+                  }
                 />
               )}
             </form.Field>
@@ -120,13 +95,18 @@ function DecalCard({
           <Grid.Col span={{ base: 12, xs: 6 }}>
             <form.Field name={`decals[${index}].outline`}>
               {(field) => (
-                <Switch
-                  id={`decal-${index}-outline`}
-                  label="Outline artwork"
+                <ControlBlock
+                  title="Outline artwork"
                   description="Adds a light border around an unmuted decal."
-                  checked={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(event) => field.handleChange(event.currentTarget.checked)}
+                  input={
+                    <Switch
+                      id={`decal-${index}-outline`}
+                      aria-label="Outline artwork"
+                      checked={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) => field.handleChange(event.currentTarget.checked)}
+                    />
+                  }
                 />
               )}
             </form.Field>
@@ -172,16 +152,21 @@ function DecalCard({
           <Grid.Col span={{ base: 12, xs: 6 }}>
             <form.Field name={`decals[${index}].offset[0]`}>
               {(field) => (
-                <NumberInput
-                  id={`decal-${index}-offset-x`}
-                  label="Horizontal offset"
+                <ControlBlock
+                  title="Horizontal offset"
                   description="Move left with a negative value or right with a positive value."
-                  step={1}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(value) => {
-                    if (typeof value === 'number') field.handleChange(value);
-                  }}
+                  input={
+                    <NumberInput
+                      id={`decal-${index}-offset-x`}
+                      aria-label="Horizontal offset"
+                      step={1}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(value) => {
+                        if (typeof value === 'number') field.handleChange(value);
+                      }}
+                    />
+                  }
                 />
               )}
             </form.Field>
@@ -189,16 +174,21 @@ function DecalCard({
           <Grid.Col span={{ base: 12, xs: 6 }}>
             <form.Field name={`decals[${index}].offset[1]`}>
               {(field) => (
-                <NumberInput
-                  id={`decal-${index}-offset-y`}
-                  label="Vertical offset"
+                <ControlBlock
+                  title="Vertical offset"
                   description="Move up with a negative value or down with a positive value."
-                  step={1}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(value) => {
-                    if (typeof value === 'number') field.handleChange(value);
-                  }}
+                  input={
+                    <NumberInput
+                      id={`decal-${index}-offset-y`}
+                      aria-label="Vertical offset"
+                      step={1}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(value) => {
+                        if (typeof value === 'number') field.handleChange(value);
+                      }}
+                    />
+                  }
                 />
               )}
             </form.Field>
@@ -278,16 +268,21 @@ export function FactionFormSectionAlliance({
                 const blank = field.state.value.trim().length === 0;
                 return (
                   <Stack gap={4}>
-                    <Textarea
-                      id="rules-alliance"
-                      label="Alliance ability"
+                    <ControlBlock
+                      title="Alliance ability"
                       description="Rules text printed on the alliance card. Markdown is supported."
-                      autosize
-                      minRows={4}
-                      value={field.state.value}
-                      aria-describedby={blank ? 'rules-alliance-warning' : undefined}
-                      onBlur={field.handleBlur}
-                      onChange={(event) => field.handleChange(event.currentTarget.value)}
+                      input={
+                        <Textarea
+                          id="rules-alliance"
+                          aria-label="Alliance ability"
+                          autosize
+                          minRows={4}
+                          value={field.state.value}
+                          aria-describedby={blank ? 'rules-alliance-warning' : undefined}
+                          onBlur={field.handleBlur}
+                          onChange={(event) => field.handleChange(event.currentTarget.value)}
+                        />
+                      }
                     />
                     {blank ? (
                       <Text id="rules-alliance-warning" c="yellow.9" size="xs" role="status">
@@ -310,20 +305,42 @@ export function FactionFormSectionAlliance({
             <form.Field name="decals" mode="array">
               {(field) => {
                 const sortablePrefix = 'decals-';
+                const count = field.state.value.length;
                 const safeSelectedIndex = Math.min(
                   Math.max(currentSelectedDecalIndex, 0),
-                  Math.max(field.state.value.length - 1, 0)
+                  Math.max(count - 1, 0)
                 );
                 return (
                   <Stack gap="md">
-                    {field.state.value.length === 0 ? (
+                    <Group justify="flex-end">
+                      <ListLengthActions
+                        removeLabel="Remove last alliance decal"
+                        addLabel="Add alliance decal"
+                        removeDisabled={count === 0}
+                        onRemove={() => {
+                          const lastIndex = count - 1;
+                          if (lastIndex < 0) return;
+                          if (currentSelectedDecalIndex >= lastIndex) {
+                            selectDecalIndex(Math.max(0, lastIndex - 1));
+                          }
+                          field.removeValue(lastIndex);
+                        }}
+                        onAdd={() => {
+                          const newIndex = count;
+                          field.pushValue(defaultDecal());
+                          selectDecalIndex(newIndex);
+                        }}
+                      />
+                    </Group>
+
+                    {count === 0 ? (
                       <Alert color="gray" variant="light" title="No alliance decals">
                         Decals are optional. The alliance card remains valid without decorative
                         artwork.
                       </Alert>
                     ) : null}
 
-                    {field.state.value.length > 0 ? (
+                    {count > 0 ? (
                       <>
                         <FactionCollectionShelf
                           label="Ordered alliance decals"
@@ -339,32 +356,9 @@ export function FactionFormSectionAlliance({
                             field.handleChange(arrayMove(field.state.value, from, to))
                           }
                         />
-                        <DecalCard
-                          form={form}
-                          index={safeSelectedIndex}
-                          onRemove={() => {
-                            field.removeValue(safeSelectedIndex);
-                            selectDecalIndex(
-                              Math.max(0, Math.min(safeSelectedIndex, field.state.value.length - 2))
-                            );
-                          }}
-                        />
+                        <DecalCard form={form} index={safeSelectedIndex} />
                       </>
                     ) : null}
-
-                    <Button
-                      type="button"
-                      variant="light"
-                      color="dune"
-                      leftSection={<Plus size={16} aria-hidden />}
-                      onClick={() => {
-                        const newIndex = field.state.value.length;
-                        field.pushValue(defaultDecal());
-                        selectDecalIndex(newIndex);
-                      }}
-                    >
-                      Add alliance decal
-                    </Button>
                   </Stack>
                 );
               }}

--- a/src/app/components/factions/editor/FactionFormSectionBackground.module.css
+++ b/src/app/components/factions/editor/FactionFormSectionBackground.module.css
@@ -34,7 +34,6 @@
 .patternCatalogue {
   min-width: 0;
   padding-block: var(--mantine-spacing-xs);
-  border-block: 1px solid var(--mantine-color-dune-2);
 }
 
 .patternScroller {

--- a/src/app/components/factions/editor/FactionFormSectionHero.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionHero.tsx
@@ -1,7 +1,8 @@
-import { Box, Grid, Input, Stack, Text, TextInput } from '@mantine/core';
+import { Box, Grid, Stack, Text, TextInput } from '@mantine/core';
 
 import type { Faction } from '@db/factions';
 import { AssetSelect } from '@app/components/content/FormControls/AssetSelect';
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
 import { LeaderToken } from '@game/assets/faction/leader/Leader';
 import { LEADERS } from '@game/data/generated';
 
@@ -21,16 +22,7 @@ export function FactionFormSectionHero({
   showPreview?: boolean;
 }) {
   return (
-    <Stack component="section" gap="md" aria-labelledby="faction-leader-heading">
-      <Stack gap={2}>
-        <Text id="faction-leader-heading" fw={700} size="lg">
-          Faction leader
-        </Text>
-        <Text c="dimmed" size="sm">
-          Every faction has one required hero. This leader is used on the Faction shield.
-        </Text>
-      </Stack>
-
+    <Stack component="section" gap="md" aria-label="Faction leader">
       <Grid gap="xl" align="center">
         <Grid.Col span={{ base: 12, sm: showPreview ? 8 : 12 }}>
           <Stack gap="md">
@@ -39,14 +31,19 @@ export function FactionFormSectionHero({
                 const blank = field.state.value.trim().length === 0;
                 return (
                   <Stack gap={4}>
-                    <TextInput
-                      id="hero-name"
-                      label="Faction leader name"
+                    <ControlBlock
+                      title="Faction leader name"
                       description="Printed around the leader portrait on the Faction shield."
-                      value={field.state.value}
-                      aria-describedby={blank ? 'hero-name-warning' : undefined}
-                      onBlur={field.handleBlur}
-                      onChange={(event) => field.handleChange(event.currentTarget.value)}
+                      input={
+                        <TextInput
+                          id="hero-name"
+                          aria-label="Faction leader name"
+                          value={field.state.value}
+                          aria-describedby={blank ? 'hero-name-warning' : undefined}
+                          onBlur={field.handleBlur}
+                          onChange={(event) => field.handleChange(event.currentTarget.value)}
+                        />
+                      }
                     />
                     {blank ? (
                       <Text id="hero-name-warning" c="yellow.9" size="xs" role="status">
@@ -59,19 +56,14 @@ export function FactionFormSectionHero({
             </form.Field>
 
             <form.Field name="hero.image">
-              {(field) => {
-                const id = 'hero-image';
-                const descriptionId = `${id}-description`;
-                return (
-                  <Input.Wrapper
-                    id={id}
-                    descriptionProps={{ id: descriptionId }}
-                    label="Faction leader portrait"
-                    description="Choose the portrait rendered for this hero."
-                  >
+              {(field) => (
+                <ControlBlock
+                  title="Faction leader portrait"
+                  description="Choose the portrait rendered for this hero."
+                  input={
                     <AssetSelect
-                      id={id}
-                      aria-describedby={descriptionId}
+                      id="hero-image"
+                      aria-label="Faction leader portrait"
                       allowDeselect={false}
                       limit={24}
                       data={leaderImageOptions}
@@ -81,9 +73,9 @@ export function FactionFormSectionHero({
                         if (value) field.handleChange(value as Faction['hero']['image']);
                       }}
                     />
-                  </Input.Wrapper>
-                );
-              }}
+                  }
+                />
+              )}
             </form.Field>
           </Stack>
         </Grid.Col>

--- a/src/app/components/factions/editor/FactionFormSectionIdentity.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionIdentity.tsx
@@ -1,7 +1,8 @@
-import { Box, ColorInput, Input, Stack, Text, TextInput } from '@mantine/core';
+import { Box, ColorInput, Stack, Text, TextInput } from '@mantine/core';
 
 import type { Faction } from '@db/factions';
 import { AssetSelect } from '@app/components/content/FormControls/AssetSelect';
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
 
 import styles from './FactionFormSectionIdentity.module.css';
 import { assetOptionToPreviewSrc, logoOptions, logoOptionToLabel } from './factionFormAssetUtils';
@@ -43,32 +44,32 @@ export function FactionFormSectionIdentity({
       <Box className={styles.identityGrid}>
         <form.Field name="name">
           {(field) => (
-            <TextInput
-              id="faction-name"
-              label="Faction name"
+            <ControlBlock
+              title="Faction name"
               description="Used on faction artifacts and to derive the canonical share URL."
-              error={nameError}
-              value={field.state.value}
-              onBlur={field.handleBlur}
-              onChange={(event) => field.handleChange(event.currentTarget.value)}
+              input={
+                <TextInput
+                  id="faction-name"
+                  aria-label="Faction name"
+                  error={nameError}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(event.currentTarget.value)}
+                />
+              }
             />
           )}
         </form.Field>
 
         <form.Field name="logo">
-          {(field) => {
-            const id = 'faction-logo';
-            const descriptionId = `${id}-description`;
-            return (
-              <Input.Wrapper
-                id={id}
-                descriptionProps={{ id: descriptionId }}
-                label="Faction logo"
-                description="Used on faction tokens and faction-branded game artifacts."
-              >
+          {(field) => (
+            <ControlBlock
+              title="Faction logo"
+              description="Used on faction tokens and faction-branded game artifacts."
+              input={
                 <AssetSelect
-                  id={id}
-                  aria-describedby={descriptionId}
+                  id="faction-logo"
+                  aria-label="Faction logo"
                   allowDeselect={false}
                   data={logoSelectOptions}
                   getPreviewSrc={assetOptionToPreviewSrc}
@@ -77,21 +78,26 @@ export function FactionFormSectionIdentity({
                     if (value) field.handleChange(value as Faction['logo']);
                   }}
                 />
-              </Input.Wrapper>
-            );
-          }}
+              }
+            />
+          )}
         </form.Field>
 
         <form.Field name="themeColor">
           {(field) => (
-            <ColorInput
-              id="faction-theme-color"
-              label="Faction sheet theme"
+            <ControlBlock
+              title="Faction sheet theme"
               description="Used for headings and accents on the complete faction sheet."
-              format="hex"
-              value={field.state.value}
-              onBlur={field.handleBlur}
-              onChange={field.handleChange}
+              input={
+                <ColorInput
+                  id="faction-theme-color"
+                  aria-label="Faction sheet theme"
+                  format="hex"
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={field.handleChange}
+                />
+              }
             />
           )}
         </form.Field>

--- a/src/app/components/factions/editor/FactionFormSectionLeaders.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionLeaders.tsx
@@ -1,24 +1,11 @@
 import { arrayMove } from '@dnd-kit/sortable';
-import {
-  ActionIcon,
-  Alert,
-  Badge,
-  Box,
-  Button,
-  Grid,
-  Group,
-  Input,
-  Paper,
-  Stack,
-  Text,
-  TextInput,
-  Tooltip,
-} from '@mantine/core';
-import { Plus, Trash2 } from 'lucide-react';
+import { Alert, Badge, Box, Grid, Group, Paper, Stack, Text, TextInput } from '@mantine/core';
 import { useLayoutEffect, useState } from 'react';
 
 import type { Faction } from '@db/factions';
 import { AssetSelect } from '@app/components/content/FormControls/AssetSelect';
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
+import { ListLengthActions } from '@app/components/content/FormControls/ListLengthActions';
 import { LeaderToken } from '@game/assets/faction/leader/Leader';
 import { LEADERS } from '@game/data/generated';
 
@@ -42,57 +29,47 @@ export function canAddSupportingLeader(count: number): boolean {
 function SupportingLeaderCard({
   form,
   index,
-  onRemove,
   showPreview,
 }: {
   form: FactionFormApi;
   index: number;
-  onRemove: () => void;
   showPreview: boolean;
 }) {
   const leader = form.state.values.leaders[index];
   if (!leader) return null;
 
   return (
-    <Paper withBorder radius="md" p="md">
+    <Paper
+      component="section"
+      aria-label={`Edit supporting leader ${index + 1}`}
+      withBorder
+      radius="md"
+      p="md"
+    >
       <Stack gap="md">
-        <Group justify="space-between" align="flex-start" wrap="wrap">
-          <Box>
-            <Text fw={700}>Supporting leader {index + 1}</Text>
-            <Text size="xs" c="dimmed">
-              {leader.name.trim() || 'Unnamed leader'}
-            </Text>
-          </Box>
-          <Tooltip label={`Remove supporting leader ${index + 1}`}>
-            <ActionIcon
-              type="button"
-              variant="light"
-              color="red"
-              aria-label={`Remove supporting leader ${index + 1}`}
-              onClick={onRemove}
-            >
-              <Trash2 size={16} aria-hidden />
-            </ActionIcon>
-          </Tooltip>
-        </Group>
-
         <Grid gap="xl" align="center">
           <Grid.Col span={{ base: 12, sm: showPreview ? 8 : 12 }}>
             <Stack gap="md">
               <form.Field name={`leaders[${index}].name`}>
                 {(field) => {
-                  const blank = field.state.value.trim().length === 0;
+                  const value = field.state.value ?? '';
+                  const blank = value.trim().length === 0;
                   const warningId = `leader-${index}-name-warning`;
                   return (
                     <Stack gap={4}>
-                      <TextInput
-                        id={`leader-${index}-name`}
-                        label="Leader name"
+                      <ControlBlock
+                        title="Leader name"
                         description="Printed around this leader token."
-                        value={field.state.value}
-                        aria-describedby={blank ? warningId : undefined}
-                        onBlur={field.handleBlur}
-                        onChange={(event) => field.handleChange(event.currentTarget.value)}
+                        input={
+                          <TextInput
+                            id={`leader-${index}-name`}
+                            aria-label="Leader name"
+                            value={value}
+                            aria-describedby={blank ? warningId : undefined}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => field.handleChange(event.currentTarget.value)}
+                          />
+                        }
                       />
                       {blank ? (
                         <Text id={warningId} c="yellow.9" size="xs" role="status">
@@ -108,47 +85,47 @@ function SupportingLeaderCard({
                 <Grid.Col span={{ base: 12, xs: 4 }}>
                   <form.Field name={`leaders[${index}].strength`}>
                     {(field) => (
-                      <TextInput
-                        id={`leader-${index}-str`}
-                        label="Strength"
+                      <ControlBlock
+                        title="Strength"
                         description="A whole number or one character. Leave blank to omit."
-                        inputMode="text"
-                        autoComplete="off"
-                        value={
-                          field.state.value === undefined || field.state.value === null
-                            ? ''
-                            : String(field.state.value)
+                        input={
+                          <TextInput
+                            id={`leader-${index}-str`}
+                            aria-label="Strength"
+                            inputMode="text"
+                            autoComplete="off"
+                            value={
+                              field.state.value === undefined || field.state.value === null
+                                ? ''
+                                : String(field.state.value)
+                            }
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              const raw = event.currentTarget.value;
+                              if (raw === '') {
+                                field.handleChange(undefined);
+                              } else if (/^-?\d+$/u.test(raw)) {
+                                field.handleChange(Number.parseInt(raw, 10));
+                              } else if (raw.length === 1) {
+                                field.handleChange(raw);
+                              }
+                            }}
+                          />
                         }
-                        onBlur={field.handleBlur}
-                        onChange={(event) => {
-                          const raw = event.currentTarget.value;
-                          if (raw === '') {
-                            field.handleChange(undefined);
-                          } else if (/^-?\d+$/u.test(raw)) {
-                            field.handleChange(Number.parseInt(raw, 10));
-                          } else if (raw.length === 1) {
-                            field.handleChange(raw);
-                          }
-                        }}
                       />
                     )}
                   </form.Field>
                 </Grid.Col>
                 <Grid.Col span={{ base: 12, xs: 8 }}>
                   <form.Field name={`leaders[${index}].image`}>
-                    {(field) => {
-                      const id = `leader-${index}-img`;
-                      const descriptionId = `${id}-description`;
-                      return (
-                        <Input.Wrapper
-                          id={id}
-                          descriptionProps={{ id: descriptionId }}
-                          label="Leader portrait"
-                          description="Choose the portrait rendered on this token."
-                        >
+                    {(field) => (
+                      <ControlBlock
+                        title="Leader portrait"
+                        description="Choose the portrait rendered on this token."
+                        input={
                           <AssetSelect
-                            id={id}
-                            aria-describedby={descriptionId}
+                            id={`leader-${index}-img`}
+                            aria-label="Leader portrait"
                             allowDeselect={false}
                             limit={24}
                             data={leaderImageOptions}
@@ -160,9 +137,9 @@ function SupportingLeaderCard({
                               }
                             }}
                           />
-                        </Input.Wrapper>
-                      );
-                    }}
+                        }
+                      />
+                    )}
                   </form.Field>
                 </Grid.Col>
               </Grid>
@@ -234,43 +211,53 @@ export function FactionFormSectionLeaders({
   }, [pendingLeaderFocusId]);
 
   return (
-    <Stack component="section" gap="md" aria-labelledby="supporting-leaders-heading">
-      <Group justify="space-between" align="flex-start" wrap="wrap">
-        <Box>
-          <Text id="supporting-leaders-heading" fw={700} size="lg">
-            Supporting leaders
-          </Text>
-          <Text c="dimmed" size="sm">
-            Add zero to ten leaders and arrange the order used on faction artifacts.
-          </Text>
-        </Box>
-        <form.Subscribe selector={(state) => state.values.leaders.length}>
-          {(count) => (
-            <Badge
-              variant="light"
-              color={count === CONVENTIONAL_SUPPORTING_LEADER_COUNT ? 'dune' : 'gray'}
-            >
-              {count} / {SUPPORTING_LEADER_LIMIT}
-            </Badge>
-          )}
-        </form.Subscribe>
-      </Group>
-
+    <Stack component="section" gap="md" aria-label="Supporting leaders">
       <form.Field name="leaders" mode="array">
         {(field) => {
           const sortablePrefix = 'leaders-';
-          const canAdd = canAddSupportingLeader(field.state.value.length);
+          const count = field.state.value.length;
+          const canAdd = canAddSupportingLeader(count);
           const safeSelectedIndex = Math.min(
             Math.max(currentSelectedIndex, 0),
-            Math.max(field.state.value.length - 1, 0)
+            Math.max(count - 1, 0)
           );
           return (
             <Stack gap="md">
-              {field.state.value.length === 0 ? (
+              <Group justify="flex-end" gap={4} wrap="nowrap">
+                <Badge
+                  variant="light"
+                  color={count === CONVENTIONAL_SUPPORTING_LEADER_COUNT ? 'dune' : 'gray'}
+                >
+                  {count} / {SUPPORTING_LEADER_LIMIT}
+                </Badge>
+                <ListLengthActions
+                  removeLabel="Remove last supporting leader"
+                  addLabel="Add supporting leader"
+                  removeDisabled={count === 0}
+                  addDisabled={!canAdd}
+                  onRemove={() => {
+                    const lastIndex = count - 1;
+                    if (lastIndex < 0) return;
+                    if (currentSelectedIndex >= lastIndex) {
+                      selectIndex(Math.max(0, lastIndex - 1));
+                    }
+                    field.removeValue(lastIndex);
+                  }}
+                  onAdd={() => {
+                    if (!canAdd) return;
+                    const newIndex = count;
+                    field.pushValue(nextLeaderFromLast(field.state.value[newIndex - 1]));
+                    selectIndex(newIndex);
+                    setPendingLeaderFocusId(`leader-${newIndex}-name`);
+                  }}
+                />
+              </Group>
+
+              {count === 0 ? (
                 <Alert color="yellow" variant="light" title="No supporting leaders">
                   Zero is valid, but unusual. Most factions use five supporting leaders.
                 </Alert>
-              ) : field.state.value.length !== CONVENTIONAL_SUPPORTING_LEADER_COUNT ? (
+              ) : count !== CONVENTIONAL_SUPPORTING_LEADER_COUNT ? (
                 <Alert color="gray" variant="light">
                   Most factions use five supporting leaders; this roster is still valid.
                 </Alert>
@@ -298,33 +285,10 @@ export function FactionFormSectionLeaders({
                   <SupportingLeaderCard
                     form={form}
                     index={safeSelectedIndex}
-                    onRemove={() => {
-                      field.removeValue(safeSelectedIndex);
-                      selectIndex(
-                        Math.max(0, Math.min(safeSelectedIndex, field.state.value.length - 2))
-                      );
-                    }}
                     showPreview={showPreview}
                   />
                 </>
               ) : null}
-
-              <Button
-                type="button"
-                variant="light"
-                color="dune"
-                leftSection={<Plus size={16} aria-hidden />}
-                disabled={!canAdd}
-                onClick={() => {
-                  if (!canAdd) return;
-                  const newIndex = field.state.value.length;
-                  field.pushValue(nextLeaderFromLast(field.state.value[newIndex - 1]));
-                  selectIndex(newIndex);
-                  setPendingLeaderFocusId(`leader-${newIndex}-name`);
-                }}
-              >
-                {canAdd ? 'Add supporting leader' : 'Maximum of 10 leaders reached'}
-              </Button>
             </Stack>
           );
         }}

--- a/src/app/components/factions/editor/FactionFormSectionLeadersAlliance.stories.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionLeadersAlliance.stories.tsx
@@ -1,6 +1,7 @@
 import { Box, Stack } from '@mantine/core';
 import preview from '@sb/preview';
 import { useForm } from '@tanstack/react-form';
+import { expect, userEvent, within } from 'storybook/test';
 
 import type { Faction } from '@db/factions';
 import { defaultFaction } from '@data/defaultFaction';
@@ -78,6 +79,20 @@ const meta = preview.meta({
 export const ConventionalFive = meta.story({
   args: {
     faction: withLeadersAndDecals(5, 2),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Add supporting leader' }));
+    await expect(canvas.getByText('6 / 10')).toBeVisible();
+    await expect(canvas.getByRole('region', { name: 'Edit supporting leader 6' })).toBeVisible();
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Remove last supporting leader' }));
+    await expect(canvas.getByText('5 / 10')).toBeVisible();
+    await expect(
+      canvas.queryByRole('region', { name: 'Edit supporting leader 6' })
+    ).not.toBeInTheDocument();
+    await expect(canvas.getByRole('region', { name: 'Edit supporting leader 5' })).toBeVisible();
   },
 });
 

--- a/src/app/components/factions/editor/FactionFormSectionPlanets.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionPlanets.tsx
@@ -5,7 +5,6 @@ import {
   AspectRatio,
   Badge,
   Box,
-  Button,
   Group,
   Image,
   Paper,
@@ -14,13 +13,14 @@ import {
   Text,
   Textarea,
   TextInput,
-  Tooltip,
   UnstyledButton,
 } from '@mantine/core';
-import { Check, Plus, Trash2 } from 'lucide-react';
+import { Check } from 'lucide-react';
 import { useState } from 'react';
 
 import type { Faction } from '@db/factions';
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
+import { ListLengthActions } from '@app/components/content/FormControls/ListLengthActions';
 import { CURATED_PLANET_IMAGES } from '@game/data/planetCatalogue';
 
 import { FactionCollectionShelf } from './FactionCollectionShelf';
@@ -119,40 +119,19 @@ function PlanetImageLibrary({
   );
 }
 
-function PlanetCard({
-  form,
-  index,
-  onRemove,
-}: {
-  form: FactionFormApi;
-  index: number;
-  onRemove: () => void;
-}) {
+function PlanetCard({ form, index }: { form: FactionFormApi; index: number }) {
   const planet = form.state.values.planet?.[index];
   if (!planet) return null;
 
   return (
     <Paper withBorder radius="md" p="md">
       <Stack gap="md">
-        <Group justify="space-between" align="flex-start" wrap="wrap">
-          <Box>
-            <Text fw={700}>Planet {index + 1}</Text>
-            <Text size="xs" c="dimmed">
-              {planet.name.trim() || 'Unnamed world'}
-            </Text>
-          </Box>
-          <Tooltip label={`Remove planet ${index + 1}`}>
-            <ActionIcon
-              type="button"
-              variant="light"
-              color="red"
-              aria-label={`Remove planet ${index + 1}`}
-              onClick={onRemove}
-            >
-              <Trash2 size={16} aria-hidden />
-            </ActionIcon>
-          </Tooltip>
-        </Group>
+        <Box>
+          <Text fw={700}>Planet {index + 1}</Text>
+          <Text size="xs" c="dimmed">
+            {planet.name.trim() || 'Unnamed world'}
+          </Text>
+        </Box>
 
         <form.Field name={`planet[${index}].image`}>
           {(field) => (
@@ -167,27 +146,37 @@ function PlanetCard({
         <SimpleGrid cols={{ base: 1, sm: 2 }}>
           <form.Field name={`planet[${index}].name`}>
             {(field) => (
-              <TextInput
-                id={`planet-${index}-name`}
-                label="Planet name"
+              <ControlBlock
+                title="Planet name"
                 description="The authored name of this faction world."
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(event) => field.handleChange(event.currentTarget.value)}
+                input={
+                  <TextInput
+                    id={`planet-${index}-name`}
+                    aria-label="Planet name"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => field.handleChange(event.currentTarget.value)}
+                  />
+                }
               />
             )}
           </form.Field>
           <form.Field name={`planet[${index}].description`}>
             {(field) => (
-              <Textarea
-                id={`planet-${index}-description`}
-                label="Planet description"
+              <ControlBlock
+                title="Planet description"
                 description="Stored with the world for future artifact use."
-                autosize
-                minRows={2}
-                value={field.state.value}
-                onBlur={field.handleBlur}
-                onChange={(event) => field.handleChange(event.currentTarget.value)}
+                input={
+                  <Textarea
+                    id={`planet-${index}-description`}
+                    aria-label="Planet description"
+                    autosize
+                    minRows={2}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => field.handleChange(event.currentTarget.value)}
+                  />
+                }
               />
             )}
           </form.Field>
@@ -228,6 +217,7 @@ export function FactionFormSectionPlanets({
       <form.Field name="planet">
         {(field) => {
           const planets = field.state.value ?? [];
+          const count = planets.length;
           const sortablePrefix = 'planets-';
           const safeSelectedIndex = Math.min(
             Math.max(currentSelectedIndex, 0),
@@ -235,14 +225,34 @@ export function FactionFormSectionPlanets({
           );
           return (
             <Stack gap="md">
-              {planets.length === 0 ? (
+              <Group justify="flex-end">
+                <ListLengthActions
+                  removeLabel="Remove last faction world"
+                  addLabel="Add faction world"
+                  removeDisabled={count === 0}
+                  onRemove={() => {
+                    const lastIndex = count - 1;
+                    if (lastIndex < 0) return;
+                    if (currentSelectedIndex >= lastIndex) {
+                      selectIndex(Math.max(0, lastIndex - 1));
+                    }
+                    field.handleChange(planets.slice(0, -1));
+                  }}
+                  onAdd={() => {
+                    field.handleChange([...planets, defaultPlanet()]);
+                    selectIndex(count);
+                  }}
+                />
+              </Group>
+
+              {count === 0 ? (
                 <Alert color="gray" variant="light" title="No faction worlds">
                   Worlds are optional. Add one when a planet is part of this faction&apos;s
                   identity.
                 </Alert>
               ) : null}
 
-              {planets.length > 0 ? (
+              {count > 0 ? (
                 <>
                   <FactionCollectionShelf
                     label="Ordered faction worlds"
@@ -256,31 +266,9 @@ export function FactionFormSectionPlanets({
                     }))}
                     onMove={(from, to) => field.handleChange(arrayMove(planets, from, to))}
                   />
-                  <PlanetCard
-                    form={form}
-                    index={safeSelectedIndex}
-                    onRemove={() => {
-                      field.handleChange(
-                        planets.filter((__, itemIndex) => itemIndex !== safeSelectedIndex)
-                      );
-                      selectIndex(Math.max(0, Math.min(safeSelectedIndex, planets.length - 2)));
-                    }}
-                  />
+                  <PlanetCard form={form} index={safeSelectedIndex} />
                 </>
               ) : null}
-
-              <Button
-                type="button"
-                variant="light"
-                color="dune"
-                leftSection={<Plus size={16} aria-hidden />}
-                onClick={() => {
-                  field.handleChange([...planets, defaultPlanet()]);
-                  selectIndex(planets.length);
-                }}
-              >
-                Add faction world
-              </Button>
             </Stack>
           );
         }}

--- a/src/app/components/factions/editor/FactionFormSectionRules.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionRules.tsx
@@ -1,14 +1,6 @@
-import {
-  Alert,
-  Box,
-  NumberInput,
-  Paper,
-  SimpleGrid,
-  Stack,
-  Text,
-  Textarea,
-  TextInput,
-} from '@mantine/core';
+import { Divider, NumberInput, SimpleGrid, Stack, Text, Textarea, TextInput } from '@mantine/core';
+
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
 
 import type { FactionFormApi } from './factionFormTypes';
 
@@ -26,16 +18,7 @@ function Advisory({ children, id }: { children: string; id: string }) {
 
 function SetupFields({ form }: { form: FactionFormApi }) {
   return (
-    <Stack component="section" gap="md" aria-labelledby="setup-fields-heading">
-      <Stack gap={2}>
-        <Text id="setup-fields-heading" fw={700} size="lg">
-          Setup and revival
-        </Text>
-        <Text c="dimmed" size="sm">
-          Keep free-form instructions separate from the structured Starting spice value.
-        </Text>
-      </Stack>
-
+    <Stack component="section" gap="md" aria-label="Setup and revival">
       <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
         <Stack gap="md">
           <form.Field name="rules.startText">
@@ -43,16 +26,21 @@ function SetupFields({ form }: { form: FactionFormApi }) {
               const warningId = 'rules-start-warning';
               return (
                 <Stack gap={4}>
-                  <Textarea
-                    id="rules-start"
-                    label="Starting instructions"
+                  <ControlBlock
+                    title="Starting instructions"
                     description="Free-form setup instructions shown in the faction rules output. Do not repeat the structured spice amount here unless the prose genuinely needs it."
-                    autosize
-                    minRows={4}
-                    value={field.state.value}
-                    aria-describedby={isBlank(field.state.value) ? warningId : undefined}
-                    onBlur={field.handleBlur}
-                    onChange={(event) => field.handleChange(event.currentTarget.value)}
+                    input={
+                      <Textarea
+                        id="rules-start"
+                        aria-label="Starting instructions"
+                        autosize
+                        minRows={4}
+                        value={field.state.value}
+                        aria-describedby={isBlank(field.state.value) ? warningId : undefined}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => field.handleChange(event.currentTarget.value)}
+                      />
+                    }
                   />
                   {isBlank(field.state.value) ? (
                     <Advisory id={warningId}>Starting instructions are empty.</Advisory>
@@ -67,16 +55,21 @@ function SetupFields({ form }: { form: FactionFormApi }) {
               const warningId = 'rules-revival-warning';
               return (
                 <Stack gap={4}>
-                  <Textarea
-                    id="rules-revival"
-                    label="Revival instructions"
+                  <ControlBlock
+                    title="Revival instructions"
                     description="Explains this faction's revival rule in the faction rules output."
-                    autosize
-                    minRows={3}
-                    value={field.state.value}
-                    aria-describedby={isBlank(field.state.value) ? warningId : undefined}
-                    onBlur={field.handleBlur}
-                    onChange={(event) => field.handleChange(event.currentTarget.value)}
+                    input={
+                      <Textarea
+                        id="rules-revival"
+                        aria-label="Revival instructions"
+                        autosize
+                        minRows={3}
+                        value={field.state.value}
+                        aria-describedby={isBlank(field.state.value) ? warningId : undefined}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => field.handleChange(event.currentTarget.value)}
+                      />
+                    }
                   />
                   {isBlank(field.state.value) ? (
                     <Advisory id={warningId}>Revival instructions are empty.</Advisory>
@@ -87,20 +80,15 @@ function SetupFields({ form }: { form: FactionFormApi }) {
           </form.Field>
         </Stack>
 
-        <Paper withBorder radius="md" p="md" bg="dune.0">
-          <Stack gap="md">
-            <Box>
-              <Text fw={700}>Structured setup fact</Text>
-              <Text c="dimmed" size="sm">
-                The faction sheet renders this separately in At start as “Starting spice: N”.
-              </Text>
-            </Box>
-            <form.Field name="rules.spiceCount">
-              {(field) => (
+        <form.Field name="rules.spiceCount">
+          {(field) => (
+            <ControlBlock
+              title="Starting spice"
+              description="Rendered in At start as “Starting spice: N”; use a positive whole number."
+              input={
                 <NumberInput
                   id="rules-spice"
-                  label="Starting spice"
-                  description="A positive whole-number component count, not prose."
+                  aria-label="Starting spice"
                   min={1}
                   step={1}
                   allowDecimal={false}
@@ -112,13 +100,10 @@ function SetupFields({ form }: { form: FactionFormApi }) {
                     )
                   }
                 />
-              )}
-            </form.Field>
-            <Alert color="dune" variant="light">
-              Starting instructions and Starting spice are intentionally independent fields.
-            </Alert>
-          </Stack>
-        </Paper>
+              }
+            />
+          )}
+        </form.Field>
       </SimpleGrid>
     </Stack>
   );
@@ -136,44 +121,47 @@ function FateFields({ form }: { form: FactionFormApi }) {
           editable independently.
         </Text>
       </Stack>
-      <Paper withBorder radius="md" p="md">
-        <Stack gap="md">
-          <form.Field name="rules.fate.title">
-            {(field) => (
-              <TextInput
-                id="rules-fate-title"
-                label="Fate title (optional)"
-                description="Leave blank when this Fate rule does not need a separate heading."
-                value={field.state.value ?? ''}
-                onBlur={field.handleBlur}
-                onChange={(event) => field.handleChange(event.currentTarget.value || undefined)}
-              />
-            )}
-          </form.Field>
-          <form.Field name="rules.fate.text">
-            {(field) => {
-              const warningId = 'rules-fate-text-warning';
-              return (
-                <Stack gap={4}>
-                  <Textarea
-                    id="rules-fate-text"
-                    label="Fate rule"
-                    autosize
-                    minRows={3}
-                    value={field.state.value}
-                    aria-describedby={isBlank(field.state.value) ? warningId : undefined}
-                    onBlur={field.handleBlur}
-                    onChange={(event) => field.handleChange(event.currentTarget.value)}
-                  />
-                  {isBlank(field.state.value) ? (
-                    <Advisory id={warningId}>Fate text is empty.</Advisory>
-                  ) : null}
-                </Stack>
-              );
-            }}
-          </form.Field>
-        </Stack>
-      </Paper>
+      <Stack gap="md">
+        <form.Field name="rules.fate.title">
+          {(field) => (
+            <ControlBlock
+              title="Fate title (optional)"
+              description="Leave blank when this Fate rule does not need a separate heading."
+              input={
+                <TextInput
+                  id="rules-fate-title"
+                  aria-label="Fate title (optional)"
+                  value={field.state.value ?? ''}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(event.currentTarget.value || undefined)}
+                />
+              }
+            />
+          )}
+        </form.Field>
+        <form.Field name="rules.fate.text">
+          {(field) => {
+            const warningId = 'rules-fate-text-warning';
+            return (
+              <Stack gap={4}>
+                <Textarea
+                  id="rules-fate-text"
+                  label="Fate rule"
+                  autosize
+                  minRows={3}
+                  value={field.state.value}
+                  aria-describedby={isBlank(field.state.value) ? warningId : undefined}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(event.currentTarget.value)}
+                />
+                {isBlank(field.state.value) ? (
+                  <Advisory id={warningId}>Fate text is empty.</Advisory>
+                ) : null}
+              </Stack>
+            );
+          }}
+        </form.Field>
+      </Stack>
     </Stack>
   );
 }
@@ -188,6 +176,8 @@ export function FactionFormSectionRules({
   return (
     <>
       {part === 'all' || part === 'setup' ? <SetupFields form={form} /> : null}
+
+      {part === 'all' ? <Divider my="lg" /> : null}
 
       {part === 'all' || part === 'fate' ? <FateFields form={form} /> : null}
     </>

--- a/src/app/components/factions/editor/FactionFormSectionTroops.tsx
+++ b/src/app/components/factions/editor/FactionFormSectionTroops.tsx
@@ -1,6 +1,5 @@
 import { arrayMove } from '@dnd-kit/sortable';
 import {
-  ActionIcon,
   Alert,
   Badge,
   Box,
@@ -14,11 +13,12 @@ import {
   Stack,
   Text,
   TextInput,
-  Tooltip,
 } from '@mantine/core';
-import { Plus, Rotate3d, Trash2 } from 'lucide-react';
+import { Rotate3d } from 'lucide-react';
 import { useState } from 'react';
 
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
+import { ListLengthActions } from '@app/components/content/FormControls/ListLengthActions';
 import { TroopToken } from '@game/assets/faction/troop/Troop';
 
 import { FactionCollectionShelf } from './FactionCollectionShelf';
@@ -31,7 +31,6 @@ function TroopCard({
   index,
   activeSide,
   onActiveSideChange,
-  onRemove,
   onToggleBack,
   showPreview,
 }: {
@@ -39,7 +38,6 @@ function TroopCard({
   index: number;
   activeSide: 'front' | 'back';
   onActiveSideChange: (side: 'front' | 'back') => void;
-  onRemove: () => void;
   onToggleBack: () => void;
   showPreview: boolean;
 }) {
@@ -65,29 +63,16 @@ function TroopCard({
             </Text>
           </Box>
 
-          <Group gap="xs">
-            <Button
-              type="button"
-              variant="light"
-              color={hasBack ? 'gray' : 'dune'}
-              size="compact-sm"
-              leftSection={<Rotate3d size={15} aria-hidden />}
-              onClick={onToggleBack}
-            >
-              {hasBack ? 'Remove flip side' : 'Add flip side'}
-            </Button>
-            <Tooltip label={`Remove troop ${index + 1}`}>
-              <ActionIcon
-                type="button"
-                variant="light"
-                color="red"
-                aria-label={`Remove troop ${index + 1}`}
-                onClick={onRemove}
-              >
-                <Trash2 size={16} aria-hidden />
-              </ActionIcon>
-            </Tooltip>
-          </Group>
+          <Button
+            type="button"
+            variant="light"
+            color={hasBack ? 'gray' : 'dune'}
+            size="compact-sm"
+            leftSection={<Rotate3d size={15} aria-hidden />}
+            onClick={onToggleBack}
+          >
+            {hasBack ? 'Remove flip side' : 'Add flip side'}
+          </Button>
         </Group>
 
         {hasBack ? (
@@ -114,21 +99,26 @@ function TroopCard({
               <SimpleGrid cols={{ base: 1, sm: 2 }}>
                 <form.Field name={`troops[${index}].count`}>
                   {(field) => (
-                    <NumberInput
-                      id={`troop-${index}-count`}
-                      label="Physical supply"
+                    <ControlBlock
+                      title="Physical supply"
                       description="The sheet lists this once as ×N, including two-sided troops."
-                      min={1}
-                      step={1}
-                      allowDecimal={false}
-                      value={field.state.value}
-                      onBlur={field.handleBlur}
-                      onChange={(value) =>
-                        field.handleChange(
-                          typeof value === 'number' && Number.isInteger(value) && value > 0
-                            ? value
-                            : 1
-                        )
+                      input={
+                        <NumberInput
+                          id={`troop-${index}-count`}
+                          aria-label="Physical supply"
+                          min={1}
+                          step={1}
+                          allowDecimal={false}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(value) =>
+                            field.handleChange(
+                              typeof value === 'number' && Number.isInteger(value) && value > 0
+                                ? value
+                                : 1
+                            )
+                          }
+                        />
                       }
                     />
                   )}
@@ -136,15 +126,20 @@ function TroopCard({
 
                 <form.Field name={`troops[${index}].planet`}>
                   {(field) => (
-                    <TextInput
-                      id={`troop-${index}-planet`}
-                      label="Planet reference (optional)"
+                    <ControlBlock
+                      title="Planet reference (optional)"
                       description="Data-only association; it has no current rendered consumer."
-                      placeholder="e.g. Meridian Prime"
-                      value={field.state.value ?? ''}
-                      onBlur={field.handleBlur}
-                      onChange={(event) =>
-                        field.handleChange(event.currentTarget.value || undefined)
+                      input={
+                        <TextInput
+                          id={`troop-${index}-planet`}
+                          aria-label="Planet reference (optional)"
+                          placeholder="e.g. Meridian Prime"
+                          value={field.state.value ?? ''}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.currentTarget.value || undefined)
+                          }
+                        />
                       }
                     />
                   )}
@@ -228,36 +223,45 @@ export function FactionFormSectionTroops({
   );
 
   return (
-    <Stack component="section" gap="md" aria-labelledby="troop-inventory-heading">
-      <Stack gap={2}>
-        <Group justify="space-between" align="flex-end">
-          <Box>
-            <Text id="troop-inventory-heading" fw={700} size="lg">
-              Troop inventory
-            </Text>
-            <Text c="dimmed" size="sm">
-              Troops are rendered as tokens and listed on the faction sheet in this order.
-            </Text>
-          </Box>
-        </Group>
-      </Stack>
-
+    <Stack component="section" gap="md" aria-label="Troop inventory">
       <form.Field name="troops" mode="array">
         {(field) => {
           const sortablePrefix = 'troops-';
+          const count = field.state.value.length;
           const safeSelectedIndex = Math.min(
             Math.max(currentSelectedIndex, 0),
-            Math.max(field.state.value.length - 1, 0)
+            Math.max(count - 1, 0)
           );
           return (
             <Stack gap="md">
-              {field.state.value.length === 0 ? (
+              <Group justify="flex-end">
+                <ListLengthActions
+                  removeLabel="Remove last troop type"
+                  addLabel="Add troop type"
+                  removeDisabled={count === 0}
+                  onRemove={() => {
+                    const lastIndex = count - 1;
+                    if (lastIndex < 0) return;
+                    if (currentSelectedIndex >= lastIndex) {
+                      selectIndex(Math.max(0, lastIndex - 1));
+                    }
+                    field.removeValue(lastIndex);
+                  }}
+                  onAdd={() => {
+                    const newIndex = count;
+                    field.pushValue(defaultTroop());
+                    selectIndex(newIndex);
+                  }}
+                />
+              </Group>
+
+              {count === 0 ? (
                 <Alert color="gray" variant="light" title="No troop types">
                   This faction currently has no physical troop inventory.
                 </Alert>
               ) : null}
 
-              {field.state.value.length > 0 ? (
+              {count > 0 ? (
                 <>
                   <FactionCollectionShelf
                     label="Ordered troop types"
@@ -291,12 +295,6 @@ export function FactionFormSectionTroops({
                         [safeSelectedIndex]: side,
                       }))
                     }
-                    onRemove={() => {
-                      field.removeValue(safeSelectedIndex);
-                      selectIndex(
-                        Math.max(0, Math.min(safeSelectedIndex, field.state.value.length - 2))
-                      );
-                    }}
                     onToggleBack={() => {
                       const next = [...field.state.value];
                       const current = next[safeSelectedIndex];
@@ -315,20 +313,6 @@ export function FactionFormSectionTroops({
                   />
                 </>
               ) : null}
-
-              <Button
-                type="button"
-                variant="light"
-                color="dune"
-                leftSection={<Plus size={16} aria-hidden />}
-                onClick={() => {
-                  const newIndex = field.state.value.length;
-                  field.pushValue(defaultTroop());
-                  selectIndex(newIndex);
-                }}
-              >
-                Add troop type
-              </Button>
             </Stack>
           );
         }}

--- a/src/app/components/factions/editor/FactionIdentityBackground.architecture.test.ts
+++ b/src/app/components/factions/editor/FactionIdentityBackground.architecture.test.ts
@@ -87,7 +87,13 @@ describe('Identity and Appearance chapter architecture', () => {
     expect(fieldsSource).toContain('BackgroundRenderer');
     expect(fieldsSource).toContain('<Token');
     expect(fieldsSource).toContain('data-faction-token-proof');
-    expect(fieldsSource).toContain('visibleFrom="sm"');
+    expect(fieldsSource).toContain('component="section"');
+    expect(fieldsSource).toContain('live preview');
+    expect(fieldsSource).not.toContain('className={styles.artifactColumn} visibleFrom="sm"');
+    expect(fieldsSource.indexOf('{artifact}')).toBeLessThan(
+      fieldsSource.indexOf('className={styles.sheetColorReference}')
+    );
+    expect(editorStyles).toContain('.identityProof .squareProof');
     expect(editorStyles).toContain('aspect-ratio: 1');
     expect(rendererSource).not.toContain('@mantine');
   });
@@ -99,10 +105,10 @@ describe('Identity and Appearance chapter architecture', () => {
     expect(ttsColorsSource).toContain('renderOption=');
     expect(ttsColorsSource).toContain('availableTtsColors');
     expect(ttsColorsSource).toContain('nextUnusedTtsColor');
-    expect(ttsColorsSource).toContain('<ActionIcon.Group>');
-    expect(ttsColorsSource).toContain('aria-label="Remove last TTS color"');
-    expect(ttsColorsSource).toContain('aria-label="Add TTS color"');
-    expect(ttsColorsSource).toContain('color="green"');
+    expect(ttsColorsSource).toContain('<ListLengthActions');
+    expect(ttsColorsSource).toContain('removeLabel="Remove last TTS color"');
+    expect(ttsColorsSource).toContain('addLabel="Add TTS color"');
+    expect(ttsColorsSource).not.toContain('<ActionIcon.Group>');
     expect(ttsColorsSource).toContain('PointerSensor');
     expect(ttsColorsSource).toContain('KeyboardSensor');
     expect(ttsColorsSource).toContain('sortableKeyboardCoordinates');
@@ -126,5 +132,10 @@ describe('Identity and Appearance chapter architecture', () => {
     expect(backgroundStyles).toContain('@container connected-tabs-panel');
     expect(identityStyles).not.toContain('@media');
     expect(backgroundStyles).not.toContain('@media');
+  });
+
+  it('uses one outer separator around the open pattern catalogue', () => {
+    expect(backgroundSource).toContain('<Divider />');
+    expect(backgroundStyles).not.toContain('border-block:');
   });
 });

--- a/src/app/components/factions/editor/FactionLeadersAlliance.architecture.test.ts
+++ b/src/app/components/factions/editor/FactionLeadersAlliance.architecture.test.ts
@@ -44,8 +44,26 @@ describe('Leaders and Alliance authoring architecture', () => {
     expect(collectionShelfSource).toContain('KeyboardSensor');
     expect(collectionShelfSource).toContain('sortableKeyboardCoordinates');
     expect(leadersSource).toContain('SUPPORTING_LEADER_LIMIT = 10');
-    expect(leadersSource).toContain('disabled={!canAdd}');
+    expect(leadersSource).toContain('addDisabled={!canAdd}');
+    expect(leadersSource).toContain('<ListLengthActions');
+    expect(leadersSource).toContain('addLabel="Add supporting leader"');
+    expect(leadersSource).toContain('removeLabel="Remove last supporting leader"');
+    expect(leadersSource).toContain('field.removeValue(lastIndex)');
+    expect(leadersSource).not.toContain('Remove supporting leader');
     expect(leadersSource).toContain('Most factions use five supporting leaders');
+  });
+
+  it('uses tab and field labels instead of repeated chapter introductions', () => {
+    expect(heroSource).toContain('aria-label="Faction leader"');
+    expect(heroSource).not.toContain('Every faction has one required hero');
+    expect(leadersSource).toContain('aria-label="Supporting leaders"');
+    expect(leadersSource).toContain('Edit supporting leader');
+    expect(leadersSource).not.toContain('Add zero to ten leaders');
+    expect(leadersSource).not.toContain('<Text fw={700}>Supporting leader');
+    expect(leadersSource).toContain('title="Strength"');
+    expect(leadersSource).toContain(
+      'description="A whole number or one character. Leave blank to omit."'
+    );
   });
 
   it('owns alliance ability and every decal field beside the real alliance card', () => {
@@ -63,6 +81,11 @@ describe('Leaders and Alliance authoring architecture', () => {
     expect(fieldsSource).toContain('<AllianceCard');
     expect(allianceSource).toContain('visibleFrom="sm"');
     expect(allianceSource).toContain('<FactionCollectionShelf');
+    expect(allianceSource).toContain('<ListLengthActions');
+    expect(allianceSource).toContain('removeLabel="Remove last alliance decal"');
+    expect(allianceSource).toContain('addLabel="Add alliance decal"');
+    expect(allianceSource).not.toMatch(/Remove alliance decal \$\{index/);
+    expect(allianceSource).not.toContain('leftSection={<Plus');
   });
 
   it('keeps application presentation in Mantine and renderers isolated', () => {

--- a/src/app/components/factions/editor/TroopSideFields.tsx
+++ b/src/app/components/factions/editor/TroopSideFields.tsx
@@ -1,7 +1,8 @@
-import { Box, Input, SimpleGrid, Stack, Switch, Textarea, TextInput } from '@mantine/core';
+import { Box, SimpleGrid, Stack, Switch, Textarea, TextInput } from '@mantine/core';
 
 import type { Faction } from '@db/factions';
 import { AssetSelect } from '@app/components/content/FormControls/AssetSelect';
+import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
 import { TROOP, TROOP_MODIFIER } from '@game/data/generated';
 
 import {
@@ -49,112 +50,132 @@ export function TroopSideFields({
     <Stack gap="md">
       <SimpleGrid cols={{ base: 1, sm: 2 }}>
         <form.Field name={nameField}>
-          {(field) => (
-            <TextInput
-              id={`${idBase}-name`}
-              label={isBack ? 'Back-side name' : 'Troop name'}
-              description={
-                isBack
-                  ? 'Name printed for the reverse side of this physical troop.'
-                  : 'Used on the troop token and faction sheet.'
-              }
-              value={field.state.value}
-              onBlur={field.handleBlur}
-              onChange={(event) => field.handleChange(event.currentTarget.value)}
-            />
-          )}
+          {(field) => {
+            const title = isBack ? 'Back-side name' : 'Troop name';
+            return (
+              <ControlBlock
+                title={title}
+                description={
+                  isBack
+                    ? 'Name printed for the reverse side of this physical troop.'
+                    : 'Used on the troop token and faction sheet.'
+                }
+                input={
+                  <TextInput
+                    id={`${idBase}-name`}
+                    aria-label={title}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => field.handleChange(event.currentTarget.value)}
+                  />
+                }
+              />
+            );
+          }}
         </form.Field>
 
         <form.Field name={imageField}>
           {(field) => {
-            const id = `${idBase}-img`;
-            const descriptionId = `${id}-description`;
+            const title = isBack ? 'Back-side symbol' : 'Troop symbol';
             return (
-              <Input.Wrapper
-                id={id}
-                descriptionProps={{ id: descriptionId }}
-                label={isBack ? 'Back-side symbol' : 'Troop symbol'}
+              <ControlBlock
+                title={title}
                 description="Select the symbol rendered inside the troop token."
-              >
-                <AssetSelect
-                  id={id}
-                  aria-describedby={descriptionId}
-                  allowDeselect={false}
-                  data={troopImageOptions}
-                  getPreviewSrc={assetOptionToPreviewSrc}
-                  value={field.state.value ?? null}
-                  onChange={(value) => {
-                    if (value) {
-                      field.handleChange(value as Faction['troops'][number]['image']);
-                    }
-                  }}
-                />
-              </Input.Wrapper>
+                input={
+                  <AssetSelect
+                    id={`${idBase}-img`}
+                    aria-label={title}
+                    allowDeselect={false}
+                    data={troopImageOptions}
+                    getPreviewSrc={assetOptionToPreviewSrc}
+                    value={field.state.value ?? null}
+                    onChange={(value) => {
+                      if (value) {
+                        field.handleChange(value as Faction['troops'][number]['image']);
+                      }
+                    }}
+                  />
+                }
+              />
             );
           }}
         </form.Field>
       </SimpleGrid>
 
       <form.Field name={descField}>
-        {(field) => (
-          <Textarea
-            id={`${idBase}-desc`}
-            label={isBack ? 'Back-side description' : 'Troop description'}
-            description="Used as the troop rules description on the faction sheet."
-            autosize
-            minRows={2}
-            value={field.state.value}
-            onBlur={field.handleBlur}
-            onChange={(event) => field.handleChange(event.currentTarget.value)}
-          />
-        )}
+        {(field) => {
+          const title = isBack ? 'Back-side description' : 'Troop description';
+          return (
+            <ControlBlock
+              title={title}
+              description="Used as the troop rules description on the faction sheet."
+              input={
+                <Textarea
+                  id={`${idBase}-desc`}
+                  aria-label={title}
+                  autosize
+                  minRows={2}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={(event) => field.handleChange(event.currentTarget.value)}
+                />
+              }
+            />
+          );
+        }}
       </form.Field>
 
       <SimpleGrid cols={{ base: 1, sm: 2 }}>
         <form.Field name={starField}>
           {(field) => {
-            const id = `${idBase}-star`;
-            const descriptionId = `${id}-description`;
+            const title = isBack ? 'Back-side star modifier' : 'Star modifier';
             return (
-              <Input.Wrapper
-                id={id}
-                descriptionProps={{ id: descriptionId }}
-                label={isBack ? 'Back-side star modifier' : 'Star modifier'}
+              <ControlBlock
+                title={title}
                 description="Optional marker rendered on the troop token."
-              >
-                <AssetSelect
-                  id={id}
-                  aria-describedby={descriptionId}
-                  placeholder="No star modifier"
-                  clearable
-                  data={troopStarOptions}
-                  getPreviewSrc={assetOptionToPreviewSrc}
-                  value={field.state.value ?? null}
-                  onChange={(value) =>
-                    field.handleChange(
-                      value ? (value as Faction['troops'][number]['star']) : undefined
-                    )
-                  }
-                />
-              </Input.Wrapper>
+                input={
+                  <AssetSelect
+                    id={`${idBase}-star`}
+                    aria-label={title}
+                    placeholder="No star modifier"
+                    clearable
+                    data={troopStarOptions}
+                    getPreviewSrc={assetOptionToPreviewSrc}
+                    value={field.state.value ?? null}
+                    onChange={(value) =>
+                      field.handleChange(
+                        value ? (value as Faction['troops'][number]['star']) : undefined
+                      )
+                    }
+                  />
+                }
+              />
             );
           }}
         </form.Field>
 
         <Box pt={{ base: 0, sm: 'xl' }}>
           <form.Field name={stripedField}>
-            {(field) => (
-              <Switch
-                id={`${idBase}-striped`}
-                label={isBack ? 'Striped reverse token' : 'Striped troop token'}
-                description="Adds the striped treatment to this side only."
-                checked={field.state.value === true}
-                onBlur={field.handleBlur}
-                onChange={(event) =>
-                  field.handleChange(event.currentTarget.checked ? true : undefined)
-                }
-              />
-            )}
+            {(field) => {
+              const title = isBack ? 'Striped reverse token' : 'Striped troop token';
+              return (
+                <ControlBlock
+                  title={title}
+                  description="Adds the striped treatment to this side only."
+                  input={
+                    <Switch
+                      id={`${idBase}-striped`}
+                      aria-label={title}
+                      checked={field.state.value === true}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.currentTarget.checked ? true : undefined)
+                      }
+                    />
+                  }
+                />
+              );
+            }}
           </form.Field>
         </Box>
       </SimpleGrid>

--- a/src/app/components/factions/editor/TtsColorsEditor.tsx
+++ b/src/app/components/factions/editor/TtsColorsEditor.tsx
@@ -14,10 +14,11 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { ActionIcon, Box, Group, Select, Stack, Text, Tooltip } from '@mantine/core';
-import { GripVertical, Minus, Plus } from 'lucide-react';
+import { GripVertical } from 'lucide-react';
 
 import type { Faction } from '@db/factions';
 import { ControlBlock } from '@app/components/content/FormControls/ControlBlock';
+import { ListLengthActions } from '@app/components/content/FormControls/ListLengthActions';
 import { getSortableIds, indexFromSortableId } from '@app/lib/dnd-sortable-ids';
 import { TTS_COLOR_SWATCHES } from '@game/data/ttsColors';
 import { TTSColor } from '@game/schema/faction';
@@ -157,36 +158,16 @@ export function TtsColorsEditor({
       title="Tabletop Simulator colors"
       description="Choose unique colors; drag to set their priority."
       tool={
-        <ActionIcon.Group>
-          <Tooltip label="Remove last color">
-            <ActionIcon
-              type="button"
-              variant="light"
-              color="red"
-              size="sm"
-              disabled={value.length === 0}
-              aria-label="Remove last TTS color"
-              onClick={() => onChange(removeLastTtsColor(value))}
-            >
-              <Minus size={16} aria-hidden />
-            </ActionIcon>
-          </Tooltip>
-          <Tooltip label="Add color">
-            <ActionIcon
-              type="button"
-              variant="filled"
-              color="green"
-              size="sm"
-              disabled={nextAvailableColor == null}
-              aria-label="Add TTS color"
-              onClick={() => {
-                if (nextAvailableColor) onChange([...value, nextAvailableColor]);
-              }}
-            >
-              <Plus size={16} aria-hidden />
-            </ActionIcon>
-          </Tooltip>
-        </ActionIcon.Group>
+        <ListLengthActions
+          removeLabel="Remove last TTS color"
+          addLabel="Add TTS color"
+          removeDisabled={value.length === 0}
+          addDisabled={nextAvailableColor == null}
+          onRemove={() => onChange(removeLastTtsColor(value))}
+          onAdd={() => {
+            if (nextAvailableColor) onChange([...value, nextAvailableColor]);
+          }}
+        />
       }
       input={
         <Stack gap={6}>


### PR DESCRIPTION
## Summary

- improve the mobile faction-authoring layout with a compact connected section picker and section-specific live previews
- standardize descriptive editor fields on the shared `ControlBlock` composition
- introduce reusable end-of-list minus/plus actions and apply them consistently to TTS colors, leaders, decals, worlds, troops, and advantages
- simplify redundant headings, helper copy, nested panels, per-card delete actions, and duplicate separators
- refine the desktop artifact workbench, including toolbar ordering and an attached sheet-color reference beneath the background preview

## Why

The editor had accumulated inconsistent field treatments, collection controls, repeated introductory text, and desktop-only preview assumptions. These changes make the authoring flow denser and more predictable while preserving the existing form state, ordering, renderer output, and save behavior.

## User impact

Authors now get a usable live preview on mobile, consistent controls across every ordered collection, clearer field descriptions, and less vertical and visual clutter. Add actions append to collections and minus actions remove the final entry consistently.

## Root cause

Related editor sections had evolved independently and relied on a mix of direct Mantine input wrappers, bespoke add/delete placements, and repeated framing content. The shared `ControlBlock` and `ListLengthActions` compositions provide one consistent contract for those repeated semantics.

## Validation

- `bun run typecheck`
- `bun run test` — 57 files, 385 tests
- `bun run biome:check`
- `git diff --check`
- `bun run build-storybook`
- `bun run publisher:release:verify`
- browser interaction and visual checks of the Wide Contract and Mobile authoring stories
