### PR TITLE
Prototype iconized footer and add privacy policy

### DIFF
--- a/src/app/components/shell/AppShell.module.css
+++ b/src/app/components/shell/AppShell.module.css
@@ -67,6 +67,12 @@
   height: 11.5vw;
 }
 
+.footer.prototypeFooter {
+  height: auto;
+  min-height: 8rem;
+  padding-bottom: 4.5rem;
+}
+
 @media (max-width: 900px) {
   .hero {
     aspect-ratio: unset;

--- a/src/app/components/shell/AppShell.tsx
+++ b/src/app/components/shell/AppShell.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import { type ReactNode, useEffect, useState } from 'react';
 
 import styles from './AppShell.module.css';
+import { FooterLinksPrototype } from './FooterLinksPrototype';
 import { SiteNavigation } from './SiteNavigation';
 
 const SCROLL_VAR = '--scroll-pct';
@@ -26,6 +27,10 @@ export interface AppShellProps {
 /** Persistent application chrome and document-level page effects. */
 export function AppShell({ children, pathname }: AppShellProps) {
   const [imageLoaded, setImageLoaded] = useState(heroImageLoaded);
+  const showFooterPrototype =
+    import.meta.env.DEV &&
+    typeof window !== 'undefined' &&
+    new URLSearchParams(window.location.search).has('variant');
 
   useEffect(() => {
     if (heroImageLoaded) return;
@@ -91,10 +96,14 @@ export function AppShell({ children, pathname }: AppShellProps) {
           {children}
         </div>
       </div>
-      <footer className={styles.footer}>
-        <p>
-          <Link to="/privacy">Privacy Policy</Link>
-        </p>
+      <footer className={clsx(styles.footer, showFooterPrototype && styles.prototypeFooter)}>
+        {showFooterPrototype ? (
+          <FooterLinksPrototype />
+        ) : (
+          <p>
+            <Link to="/privacy">Privacy Policy</Link>
+          </p>
+        )}
       </footer>
     </div>
   );

--- a/src/app/components/shell/FooterLinksPrototype.module.css
+++ b/src/app/components/shell/FooterLinksPrototype.module.css
@@ -1,0 +1,312 @@
+.waypoints,
+.archive,
+.ribbon {
+  font-family: inherit;
+}
+
+.eyebrow {
+  margin: 0;
+  color: var(--color-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.icon {
+  display: grid;
+  flex: 0 0 auto;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid rgba(132, 34, 12, 0.22);
+  border-radius: 50%;
+  color: var(--color-link);
+  place-items: center;
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.linkCopy {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.linkCopy strong {
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.linkCopy small {
+  color: var(--color-muted);
+  font-size: 0.68rem;
+}
+
+.waypoints {
+  padding: 1.5rem clamp(1rem, 3vw, 2.5rem) 2rem;
+  border: 1px solid rgba(248, 175, 64, 0.18);
+  border-radius: 8px 8px 0 0;
+  background:
+    radial-gradient(circle at 50% 0%, rgba(199, 131, 70, 0.2), transparent 52%),
+    rgba(35, 27, 23, 0.82);
+  box-shadow: 0 -14px 38px rgba(17, 11, 8, 0.16);
+  color: #fff9ef;
+  text-align: center;
+  backdrop-filter: blur(9px);
+}
+
+.waypoints .eyebrow,
+.waypoints .linkCopy small {
+  color: rgba(255, 249, 239, 0.7);
+}
+
+.waypoints .icon {
+  border-color: rgba(248, 175, 64, 0.42);
+  color: var(--color-accent);
+}
+
+.waypoints nav {
+  display: grid;
+  max-width: 42rem;
+  margin: 1rem auto 0;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.waypointLink {
+  display: grid;
+  position: relative;
+  gap: 0.7rem;
+  padding: 0.4rem 1rem;
+  color: inherit;
+  text-decoration: none;
+  justify-items: center;
+}
+
+.waypointLink:not(:last-child)::after {
+  position: absolute;
+  top: 1.55rem;
+  right: -25%;
+  width: 50%;
+  border-top: 1px dashed rgba(115, 92, 71, 0.28);
+  content: "";
+}
+
+.waypointLink:hover .icon {
+  background: var(--color-link);
+  color: #fff9ef;
+  transform: translateY(-3px);
+}
+
+.archive {
+  display: grid;
+  gap: clamp(1.5rem, 5vw, 4rem);
+  padding: 1.5rem clamp(1.2rem, 4vw, 3rem);
+  border: 1px solid rgba(115, 92, 71, 0.2);
+  border-radius: 8px 8px 0 0;
+  background:
+    linear-gradient(115deg, rgba(248, 175, 64, 0.12), transparent 42%), rgba(255, 253, 248, 0.45);
+  grid-template-columns: minmax(14rem, 0.85fr) minmax(20rem, 1.15fr);
+}
+
+.archiveIntro {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.archiveIntro p:last-child {
+  max-width: 25rem;
+  margin: 0.35rem 0 0;
+  color: var(--color-muted);
+  font-family: Caladea, Georgia, serif;
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+
+.archiveMark {
+  display: grid;
+  flex: 0 0 auto;
+  width: 3.4rem;
+  height: 3.4rem;
+  border: 1px solid rgba(132, 34, 12, 0.4);
+  border-radius: 50%;
+  color: var(--color-link);
+  font-family: Caladea, Georgia, serif;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+  place-items: center;
+}
+
+.archive nav {
+  display: grid;
+  gap: 0.25rem;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.archiveLink {
+  display: flex;
+  gap: 0.65rem;
+  padding: 0.75rem;
+  border-radius: 6px;
+  color: inherit;
+  text-decoration: none;
+  align-items: center;
+}
+
+.archiveLink:hover {
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.archiveLink:hover .icon {
+  transform: rotate(-6deg);
+}
+
+.ribbon {
+  display: flex;
+  gap: 1.25rem;
+  padding: 0.8rem 1rem 1.8rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.ribbonLabel {
+  color: rgba(255, 249, 239, 0.86);
+  font-family: Caladea, Georgia, serif;
+  font-size: 0.82rem;
+  font-style: italic;
+  white-space: nowrap;
+}
+
+.ribbon nav {
+  display: flex;
+  overflow: hidden;
+  border: 1px solid rgba(115, 92, 71, 0.28);
+  border-radius: var(--radius-pill);
+  background: rgba(255, 253, 248, 0.54);
+  box-shadow: 0 10px 28px rgba(46, 41, 39, 0.08);
+}
+
+.ribbonLink {
+  display: flex;
+  gap: 0.55rem;
+  padding: 0.52rem 1rem;
+  color: inherit;
+  text-decoration: none;
+  align-items: center;
+}
+
+.ribbonLink:not(:last-child) {
+  border-right: 1px solid rgba(115, 92, 71, 0.18);
+}
+
+.ribbonLink .icon {
+  width: 1.75rem;
+  height: 1.75rem;
+  border: 0;
+}
+
+.ribbonLink .linkCopy small {
+  display: none;
+}
+
+.ribbonLink:hover {
+  background: rgba(248, 175, 64, 0.14);
+}
+
+.ribbonLink:hover .icon {
+  transform: scale(1.08);
+}
+
+.switcher {
+  display: flex;
+  position: fixed;
+  z-index: 1000;
+  right: 50%;
+  bottom: 1rem;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: var(--radius-pill);
+  background: #2e2927;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.28);
+  color: #fff9ef;
+  font:
+    600 0.78rem / 1 "C_Candara",
+    Candara,
+    sans-serif;
+  align-items: center;
+  transform: translateX(50%);
+}
+
+.switcher button {
+  display: grid;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  place-items: center;
+}
+
+.switcher button:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.switcher button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -3px;
+}
+
+.switcher span {
+  min-width: 11.5rem;
+  text-align: center;
+}
+
+@media (max-width: 700px) {
+  .waypoints nav,
+  .archive,
+  .archive nav {
+    grid-template-columns: 1fr;
+  }
+
+  .waypointLink {
+    grid-template-columns: auto 1fr;
+    text-align: left;
+    align-items: center;
+    justify-items: start;
+  }
+
+  .waypointLink::after {
+    display: none;
+  }
+
+  .archive {
+    gap: 1rem;
+  }
+
+  .archive nav {
+    gap: 0;
+  }
+
+  .ribbon {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .ribbonLabel {
+    text-align: center;
+  }
+
+  .ribbon nav {
+    border-radius: 8px;
+    flex-direction: column;
+  }
+
+  .ribbonLink:not(:last-child) {
+    border-right: 0;
+    border-bottom: 1px solid rgba(115, 92, 71, 0.18);
+  }
+}

--- a/src/app/components/shell/FooterLinksPrototype.tsx
+++ b/src/app/components/shell/FooterLinksPrototype.tsx
@@ -1,0 +1,155 @@
+import { useRouter, useRouterState } from '@tanstack/react-router';
+import { BookOpen, ChevronLeft, ChevronRight, GitFork, ShieldCheck } from 'lucide-react';
+import { type ComponentType, useEffect } from 'react';
+
+import styles from './FooterLinksPrototype.module.css';
+
+type VariantKey = 'A' | 'B' | 'C';
+
+type FooterLink = {
+  href: string;
+  icon: ComponentType<{ 'aria-hidden'?: boolean; size?: number; strokeWidth?: number }>;
+  label: string;
+  note: string;
+};
+
+const variants: Array<{ key: VariantKey; name: string }> = [
+  { key: 'A', name: 'Desert waypoints' },
+  { key: 'B', name: 'Open archive' },
+  { key: 'C', name: 'Brass ribbon' },
+];
+
+const footerLinks: FooterLink[] = [
+  {
+    href: '/__storybook/',
+    icon: BookOpen,
+    label: 'Component library',
+    note: 'Explore the interface',
+  },
+  {
+    href: 'https://github.com/ndelangen/dunezone',
+    icon: GitFork,
+    label: 'Source code',
+    note: 'Built in the open',
+  },
+  {
+    href: '/privacy',
+    icon: ShieldCheck,
+    label: 'Privacy policy',
+    note: 'How data is handled',
+  },
+];
+
+function iconLinks(className: string) {
+  return footerLinks.map(({ href, icon: Icon, label, note }) => (
+    <a className={className} href={href} key={href}>
+      <span className={styles.icon}>
+        <Icon aria-hidden size={20} strokeWidth={1.8} />
+      </span>
+      <span className={styles.linkCopy}>
+        <strong>{label}</strong>
+        <small>{note}</small>
+      </span>
+    </a>
+  ));
+}
+
+function VariantA() {
+  return (
+    <div className={styles.waypoints}>
+      <p className={styles.eyebrow}>Continue exploring</p>
+      <nav aria-label="Footer">{iconLinks(styles.waypointLink)}</nav>
+    </div>
+  );
+}
+
+function VariantB() {
+  return (
+    <div className={styles.archive}>
+      <div className={styles.archiveIntro}>
+        <span className={styles.archiveMark} aria-hidden>
+          DZ
+        </span>
+        <div>
+          <p className={styles.eyebrow}>Dune Zone</p>
+          <p>Tools and stories for the factions beyond the Shield Wall.</p>
+        </div>
+      </div>
+      <nav aria-label="Footer">{iconLinks(styles.archiveLink)}</nav>
+    </div>
+  );
+}
+
+function VariantC() {
+  return (
+    <div className={styles.ribbon}>
+      <span className={styles.ribbonLabel}>Follow the trail</span>
+      <nav aria-label="Footer">{iconLinks(styles.ribbonLink)}</nav>
+    </div>
+  );
+}
+
+function selectedVariant(value: unknown): VariantKey {
+  return value === 'B' || value === 'C' ? value : 'A';
+}
+
+export function FooterLinksPrototype() {
+  const router = useRouter();
+  const href = useRouterState({ select: (state) => state.location.href });
+  const variant = selectedVariant(
+    new URL(href, 'https://prototype.invalid').searchParams.get('variant')
+  );
+  const currentIndex = variants.findIndex(({ key }) => key === variant);
+
+  const changeVariant = (direction: -1 | 1) => {
+    const nextIndex = (currentIndex + direction + variants.length) % variants.length;
+    const next = variants[nextIndex];
+    const nextUrl = new URL(href, 'https://prototype.invalid');
+    nextUrl.searchParams.set('variant', next.key);
+    void router.navigate({
+      href: `${nextUrl.pathname}${nextUrl.search}${nextUrl.hash}`,
+      replace: true,
+    });
+  };
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        (target instanceof HTMLElement && target.isContentEditable)
+      ) {
+        return;
+      }
+      if (event.key === 'ArrowLeft') changeVariant(-1);
+      if (event.key === 'ArrowRight') changeVariant(1);
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  });
+
+  return (
+    <>
+      {/* PROTOTYPE: three footer directions, switchable via ?variant=, in the existing app shell. */}
+      {variant === 'A' && <VariantA />}
+      {variant === 'B' && <VariantB />}
+      {variant === 'C' && <VariantC />}
+      <aside className={styles.switcher} aria-label="Footer prototype variants">
+        <button
+          aria-label="Previous footer variant"
+          onClick={() => changeVariant(-1)}
+          type="button"
+        >
+          <ChevronLeft aria-hidden size={18} />
+        </button>
+        <span>
+          {variant} — {variants[currentIndex].name}
+        </span>
+        <button aria-label="Next footer variant" onClick={() => changeVariant(1)} type="button">
+          <ChevronRight aria-hidden size={18} />
+        </button>
+      </aside>
+    </>
+  );
+}

--- a/src/app/routes/_app/privacy/index.tsx
+++ b/src/app/routes/_app/privacy/index.tsx
@@ -1,3 +1,4 @@
+import { List, Paper, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import { createFileRoute } from '@tanstack/react-router';
 
 import { PageLayout } from '@app/components/shell';
@@ -8,8 +9,214 @@ export const Route = createFileRoute('/_app/privacy/')({
 
 function PrivacyPage() {
   return (
-    <PageLayout header={<h1>Privacy policy</h1>}>
-      <div>Hello &quot;/privacy/&quot;!3</div>
+    <PageLayout
+      header={
+        <SimpleGrid cols={{ base: 1, sm: 2 }} maw="58rem" spacing="xl" w="100%">
+          <Stack gap="sm" justify="center">
+            <Text fw={700} size="xs" tt="uppercase">
+              Public and private
+            </Text>
+            <h1>Privacy</h1>
+            <Text size="lg">
+              Signing in creates a public profile. Anything you publish can be seen and shared by
+              anyone.
+            </Text>
+          </Stack>
+          <Paper bg="rgba(255, 255, 255, 0.82)" p="lg" radius="md" shadow="sm">
+            <Stack gap="sm">
+              <Title order={2} size="h3">
+                Two firm promises
+              </Title>
+              <List spacing="xs">
+                <List.Item>We never show your email address.</List.Item>
+                <List.Item>We never sell your data.</List.Item>
+              </List>
+              <Text c="dimmed" size="sm">
+                There is no private-profile setting.
+              </Text>
+            </Stack>
+          </Paper>
+        </SimpleGrid>
+      }
+    >
+      <Stack gap="xl">
+        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
+          <Paper component="section" withBorder radius="md" p="xl">
+            <Stack gap="md">
+              <Title order={2}>What we keep private</Title>
+              <Text>We need a small amount of private information to run your account:</Text>
+              <List spacing="sm">
+                <List.Item>
+                  Your email address, if Google or Discord gives it to us when you sign in.
+                </List.Item>
+                <List.Item>
+                  Whether you signed in with Google or Discord, and the account ID they give us.
+                </List.Item>
+                <List.Item>
+                  The sign-in records needed to keep you logged in and protect your account.
+                </List.Item>
+                <List.Item>
+                  Basic technical details such as your IP address, browser, when you visited, and
+                  errors that happened.
+                </List.Item>
+              </List>
+              <Text>
+                Your email address is only used for your account and sign-in. It will not appear on
+                your profile or anywhere else on the public website.
+              </Text>
+            </Stack>
+          </Paper>
+
+          <Paper component="section" withBorder radius="md" p="xl">
+            <Stack gap="md">
+              <Title order={2}>What everyone can see</Title>
+              <Text>Your public profile can show:</Text>
+              <List spacing="sm">
+                <List.Item>Your screen name, profile picture, and profile link.</List.Item>
+                <List.Item>
+                  When you joined and when your public work was created or changed.
+                </List.Item>
+                <List.Item>Your active group memberships.</List.Item>
+                <List.Item>
+                  The factions, groups, and rulesets you create, own, or help maintain.
+                </List.Item>
+                <List.Item>
+                  The questions you ask, the answers you give, and whether an answer was picked.
+                </List.Item>
+                <List.Item>
+                  Activity totals and the links between you and the things you contribute.
+                </List.Item>
+              </List>
+              <Text>
+                The first time you sign in, we use the name and picture from Google or Discord to
+                set up your public profile.
+              </Text>
+            </Stack>
+          </Paper>
+        </SimpleGrid>
+
+        <Paper component="section" withBorder radius="md" p="xl">
+          <Stack gap="md">
+            <Title order={2}>Your choices</Title>
+            <List spacing="sm">
+              <List.Item>
+                You can change your screen name and profile picture in your profile settings.
+              </List.Item>
+              <List.Item>
+                Changing your screen name may also change the link to your profile.
+              </List.Item>
+              <List.Item>Do not share anything here that you want to keep private.</List.Item>
+            </List>
+          </Stack>
+        </Paper>
+
+        <Paper component="section" withBorder radius="md" p="xl">
+          <Stack gap="md">
+            <Title order={2}>Your data rights</Title>
+            <Text>We follow the GDPR rules that protect your personal data.</Text>
+            <Text>
+              You can ask us what personal data we have about you. You can also ask us to correct
+              it, give you a copy, or delete it.
+            </Text>
+            <Text fw={700}>
+              If you ask us to delete your data, we will remove your account, profile,
+              contributions, memberships, sign-in details, and any other personal data we control.
+            </Text>
+            <Text>
+              We may first ask you to prove that the account is yours. It can take a little longer
+              for deleted data to disappear from backups and security logs. We cannot delete copies
+              that other people made while your work was public.
+            </Text>
+            <Text>
+              To make a request, contact the Dune Zone site owner. Do not include your password or
+              other private sign-in details in your message.
+            </Text>
+          </Stack>
+        </Paper>
+
+        <Paper component="section" withBorder radius="md" p="xl">
+          <Stack gap="md">
+            <Title order={2}>What we do with the data</Title>
+            <Text>
+              We only use the data to let you sign in, run the website, show who made each
+              contribution, keep the website safe, and fix problems.
+            </Text>
+            <Text>
+              Google or Discord handles sign-in. Convex stores the data. Cloudflare helps deliver
+              the website. They receive the information they need to do those jobs.
+            </Text>
+            <Text>
+              We do not sell your data. Your profile and contributions are free for people to view,
+              but we do not sell access to them.
+            </Text>
+          </Stack>
+        </Paper>
+
+        <Paper component="section" withBorder radius="md" p="xl">
+          <Stack gap="md">
+            <Title order={2}>Code of conduct</Title>
+            <Text>Be kind and treat other people with respect.</Text>
+            <Text>We do not allow:</Text>
+            <List spacing="sm">
+              <List.Item>Harassment, bullying, threats, or hateful behaviour.</List.Item>
+              <List.Item>
+                Attacks on people because of who they are, where they come from, or what they
+                believe.
+              </List.Item>
+              <List.Item>Sharing someone else&apos;s private information.</List.Item>
+              <List.Item>Spam, scams, impersonation, or attempts to damage the website.</List.Item>
+              <List.Item>Illegal content or anything that puts another person at risk.</List.Item>
+            </List>
+            <Text fw={700}>These rules are not optional.</Text>
+            <Text>
+              We may remove content and suspend or delete accounts when these rules are broken. We
+              will not knowingly allow a violation to remain on Dune Zone.
+            </Text>
+          </Stack>
+        </Paper>
+
+        <Paper component="section" withBorder radius="md" p="xl">
+          <Stack gap="md">
+            <Title order={2}>Copyright</Title>
+            <Text>
+              Do not upload or publish something if doing so would infringe another person&apos;s
+              copyright.
+            </Text>
+            <Text>
+              Only share work that you made, have permission to use, or are allowed to use by law.
+              We may remove work that breaks this rule.
+            </Text>
+            <Text>
+              We view original, non-commercial fan-made game assets that transform existing material
+              into something new as fair use. That is our view, not a promise that every derivative
+              work is legally fair use. Each work and each use is different.
+            </Text>
+            <Text>
+              Uploading an official image, scan, book, rules text, or other person&apos;s work
+              without meaningful changes is not allowed unless you have permission or another clear
+              legal right to use it.
+            </Text>
+          </Stack>
+        </Paper>
+
+        <Paper component="section" withBorder radius="md" p="xl">
+          <Stack gap="md">
+            <Title order={2}>A free hobby project</Title>
+            <Text>Dune Zone is a hobby project. You can use it free of charge.</Text>
+            <Text>
+              We will do our best to keep it working, but there is no uptime guarantee. The website
+              may be slow, unavailable, or stop running without notice.
+            </Text>
+            <Text>
+              Please do not use Dune Zone as the only place where you keep something important.
+            </Text>
+          </Stack>
+        </Paper>
+
+        <Text c="dimmed" size="sm">
+          Last updated 27 July 2026. If anything changes, we will update this page.
+        </Text>
+      </Stack>
     </PageLayout>
   );
 }


### PR DESCRIPTION
## What changed

- adds three iconized application-footer directions for review, with links to the component library, source code, and privacy page
- replaces the placeholder privacy route with a plain-language privacy and community policy
- clearly separates public profile data from private sign-in data
- documents GDPR data requests, conduct enforcement, copyright expectations, the project's fair-use position, and the hobby-project uptime disclaimer
- uses the selected split hero treatment for the privacy page

## Why

Dune Zone needs a useful application footer and an honest, human-readable explanation of what is public, what stays private, and which community rules apply.

## Validation

- `bun run typecheck`
- `bun run test` — 57 files and 385 tests passed
- `bun run app:build`
- `bun run publisher:release:verify` — application/publisher builds, generated renderer manifest check, and Cloudflare dry run passed
- desktop and mobile browser smoke of `/privacy`
