### PR TITLE
Pin the local Convex runtime images

### DIFF
--- a/docker-compose.convex-local.yml
+++ b/docker-compose.convex-local.yml
@@ -1,6 +1,7 @@
 services:
   backend:
-    image: ghcr.io/get-convex/convex-backend:latest
+    # Keep this digest compatible with the Convex packages in package.json.
+    image: ghcr.io/get-convex/convex-backend:latest@sha256:467964cc6af57ba3e757e3e6cb1fa09a1c577803a19f03f0f42c9c4b134b070c
     stop_grace_period: 10s
     stop_signal: SIGINT
     ports:
@@ -49,7 +50,8 @@ services:
       start_period: 10s
 
   dashboard:
-    image: ghcr.io/get-convex/convex-dashboard:latest
+    # Update the dashboard and backend digests together.
+    image: ghcr.io/get-convex/convex-dashboard:latest@sha256:5f4620ca0640ed863a8c5109123b9831157e889c6294e28c5e96ea0a62375efb
     stop_grace_period: 10s
     stop_signal: SIGINT
     ports:

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,11 @@ It requires Docker and the existing `.env.e2e.local` credentials (copy
 the two configured local password users, and copies active production factions plus their
 directly referenced groups through a read-only production query.
 
+The backend and dashboard images are pinned to multi-platform digests in
+`docker-compose.convex-local.yml`, so an existing Docker cache cannot silently select an
+older runtime. When upgrading the Convex packages, update both image digests together and
+verify a clean `bun run app:dev --local` start.
+
 The local mapping is intentionally simple: user A owns every copied faction and group,
 while user B is an active member of every copied group. Production users, profiles,
 sessions, publisher state, rulesets, and operational tables are not copied. Use the two


### PR DESCRIPTION
## Summary

- pin the local Convex backend and dashboard images to verified multi-architecture digests
- document why the pins exist and how to update them
- prevent stale cached local images from breaking required migrations with unknown async operations

## Verification

- bun run test
- bun run check
- bun run typecheck
- bun run app:build
- bun run publisher:release:verify
- bun run e2e:local
- full bun run app:dev --local bootstrap, including required migrations and production-faction import

Supports the final verification and shipping work tracked by #148.