### PR TITLE
Remove retired homepage statistics fields

### DIFF
--- a/convex/homepage.test.ts
+++ b/convex/homepage.test.ts
@@ -15,33 +15,6 @@ import schema from './schema';
 const modules = import.meta.glob('./**/*.ts');
 
 describe('homepage page data', () => {
-  test('removes retired homepage counters from existing rulesets', async () => {
-    const t = convexTest(schema, modules);
-    aggregateTest.register(t, 'statistics');
-    migrationsTest.register(t);
-    const rulesetId = await t.run(async (ctx) => {
-      const userId = await ctx.db.insert('users', { name: 'Legacy homepage owner' });
-      return await ctx.db.insert('rulesets', {
-        name: 'Legacy homepage ruleset',
-        slug: 'legacy-homepage-ruleset',
-        created_at: '2026-08-04T10:00:00.000Z',
-        updated_at: '2026-08-04T10:00:00.000Z',
-        owner_id: userId,
-        group_id: null,
-        is_deleted: false,
-        image_cover: null,
-        homepage_question_count: 3,
-        homepage_answer_count: 5,
-      });
-    });
-
-    await t.mutation(internal.migrations.rulesets_remove_homepage_counts_v1, {});
-
-    const ruleset = await t.run((ctx) => ctx.db.get(rulesetId));
-    expect(ruleset).not.toHaveProperty('homepage_question_count');
-    expect(ruleset).not.toHaveProperty('homepage_answer_count');
-  });
-
   test('deletes large FAQ answer sets in bounded aggregate-safe batches', async () => {
     const t = convexTest({ schema, modules, transactionLimits: true });
     aggregateTest.register(t, 'statistics');

--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -86,6 +86,11 @@
       "requires": ["faq_item_slug_v1"]
     },
     {
+      "id": "rulesets_homepage_counts_narrow",
+      "phase": "narrow",
+      "requires": ["rulesets_remove_homepage_counts_v1"]
+    },
+    {
       "id": "statistics_ready",
       "phase": "narrow",
       "requires": [

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -267,19 +267,11 @@ export const faction_slug_reservations_verify_v1 = migrations.define({
   },
 });
 
-/** Clears the retired homepage-specific FAQ counters before their schema fields are removed. */
+/** Retains the completed cleanup migration identity through the schema-narrowing release. */
 export const rulesets_remove_homepage_counts_v1 = migrations.define({
   table: 'rulesets',
   batchSize: 50,
-  migrateOne: async (_ctx, row) => {
-    if (row.homepage_question_count === undefined && row.homepage_answer_count === undefined) {
-      return;
-    }
-    return {
-      homepage_question_count: undefined,
-      homepage_answer_count: undefined,
-    };
-  },
+  migrateOne: async () => undefined,
 });
 
 /** Populates reusable Profile discovery while live profile writes maintain it automatically. */

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -114,8 +114,6 @@ export default defineSchema({
     group_id: v.union(v.id('groups'), v.null()),
     is_deleted: v.boolean(),
     image_cover: v.union(v.string(), v.null()),
-    homepage_question_count: v.optional(v.number()),
-    homepage_answer_count: v.optional(v.number()),
   })
     .index('by_name', ['name'])
     .index('by_slug', ['slug'])


### PR DESCRIPTION
Part of #171

## What changed
- remove `homepage_question_count` and `homepage_answer_count` from the ruleset schema
- add the `rulesets_homepage_counts_narrow` deployment guard
- retain the completed cleanup migration identity as a no-op during narrowing
- remove the now-obsolete cleanup-migration unit fixture

## Production prerequisite
`rulesets_remove_homepage_counts_v1` completed successfully in production before this PR:
- state: `success`
- isDone: `true`
- processed: `1`

`bun run migrations:narrow-check` passes against production and includes that migration in the required set.

## Verification
- `bun run typecheck`
- `bun run check`
- `bun run check:convex-skip`
- `bun run test` (60 files, 399 tests)
- `bun run migrations:narrow-check`
- `bun run publisher:release:verify`
- `git diff --check`