### PR TITLE
Show group-associated rulesets

### DIFF
--- a/convex/groups.ts
+++ b/convex/groups.ts
@@ -64,8 +64,8 @@ export const getBySlug = query({
 });
 
 /**
- * Group detail page: group, memberships, factions in group, and profiles for owner + every member
- * user_id (each user must have a profile row).
+ * Group detail page: group, memberships, associated factions and rulesets, and profiles for the
+ * owner + every member user_id (each user must have a profile row).
  */
 export const detailBySlug = query({
   args: { slug: v.string() },
@@ -88,6 +88,11 @@ export const detailBySlug = query({
       .withIndex('by_group_deleted', (q) => q.eq('group_id', group._id).eq('is_deleted', false))
       .take(500);
 
+    const rulesets = await ctx.db
+      .query('rulesets')
+      .withIndex('by_group_deleted', (q) => q.eq('group_id', group._id).eq('is_deleted', false))
+      .take(500);
+
     const userIds = new Set<Id<'users'>>([group.created_by]);
     for (const m of members) {
       userIds.add(m.user_id);
@@ -105,7 +110,7 @@ export const detailBySlug = query({
       profiles.push(profile);
     }
 
-    return { group, members, factions, profiles };
+    return { group, members, factions, rulesets, profiles };
   },
 });
 

--- a/src/app/groups/db.ts
+++ b/src/app/groups/db.ts
@@ -3,6 +3,8 @@ import { useQuery } from 'convex/react';
 import { db } from '@db/core';
 import { factionRowsToEntries } from '@db/factions';
 import type { FactionEntry } from '@db/factions';
+import { rulesetRowsToEntries } from '@db/rulesets';
+import type { RulesetEntry, RulesetRow } from '@db/rulesets';
 import { toLiveQueryResult, useLiveMutation } from '@app/db/core/live';
 import { groupInputSchema } from '@app/groups/validation';
 
@@ -25,6 +27,7 @@ export type GroupDetailPageData = {
   group: GroupEntry;
   members: GroupMemberWithId[];
   factions: FactionEntry[];
+  rulesets: RulesetEntry[];
   profiles: Doc<'profiles'>[];
 };
 
@@ -33,12 +36,14 @@ export async function loadGroupDetailBySlug(slug: string): Promise<GroupDetailPa
     group: GroupRow;
     members: Doc<'group_members'>[];
     factions: Doc<'factions'>[];
+    rulesets: RulesetRow[];
     profiles: Doc<'profiles'>[];
   }>(api.groups.detailBySlug, { slug });
   return {
     group: { ...result.group, id: result.group._id },
     members: result.members.map((m) => ({ ...m, id: m._id })),
     factions: factionRowsToEntries(result.factions),
+    rulesets: rulesetRowsToEntries(result.rulesets),
     profiles: result.profiles,
   };
 }
@@ -83,12 +88,14 @@ function normalizeGroupDetailFromConvex(raw: {
   group: GroupRow;
   members: Doc<'group_members'>[];
   factions: Doc<'factions'>[];
+  rulesets: RulesetRow[];
   profiles: Doc<'profiles'>[];
 }): GroupDetailPageData {
   return {
     group: { ...raw.group, id: raw.group._id },
     members: raw.members.map((m) => ({ ...m, id: m._id })),
     factions: factionRowsToEntries(raw.factions),
+    rulesets: rulesetRowsToEntries(raw.rulesets),
     profiles: raw.profiles,
   };
 }
@@ -109,6 +116,7 @@ export function useGroupDetailBySlug(
     group: result.data?.group,
     members: result.data?.members,
     factions: result.data?.factions,
+    rulesets: result.data?.rulesets,
     profiles: result.data?.profiles,
   };
 }

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -64,6 +64,7 @@ function GroupDetailPage() {
   const viewerIsOwner = !!viewerUserId && viewerUserId === group.created_by;
   const viewerCanModeratePending = membershipStatus === 'active';
   const factions = groupData.factions ?? [];
+  const rulesets = groupData.rulesets ?? [];
 
   const membersModerationBusy =
     approveMember.isPending || rejectMember.isPending || removeMember.isPending;
@@ -254,6 +255,23 @@ function GroupDetailPage() {
               <li key={faction._id}>
                 <Link to="/factions/$factionId" params={{ factionId: faction.slug }}>
                   {faction.data.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      <Card>
+        <h3>Rulesets</h3>
+        {rulesets.length === 0 ? (
+          <p>No rulesets in this group yet.</p>
+        ) : (
+          <ul>
+            {rulesets.map((ruleset) => (
+              <li key={ruleset._id}>
+                <Link to="/rulesets/$rulesetSlug" params={{ rulesetSlug: ruleset.slug }}>
+                  {ruleset.name}
                 </Link>
               </li>
             ))}

--- a/src/app/rulesets/db.ts
+++ b/src/app/rulesets/db.ts
@@ -100,9 +100,13 @@ function toRulesetEntry(entry: RulesetRow): RulesetEntry {
   };
 }
 
+export function rulesetRowsToEntries(entries: RulesetRow[]): RulesetEntry[] {
+  return entries.map(toRulesetEntry);
+}
+
 export async function loadRulesetsAll(): Promise<RulesetEntry[]> {
   const entries = await db.query<RulesetRow[]>(api.rulesets.list, {});
-  return entries.map(toRulesetEntry);
+  return rulesetRowsToEntries(entries);
 }
 
 export async function loadRuleset(id: string): Promise<RulesetEntry> {


### PR DESCRIPTION
## What changed

- include active group-associated rulesets in the existing group detail query
- carry rulesets through the group page data boundary as their own typed collection
- show a Rulesets section with typed links on the existing group detail page
- reuse the canonical ruleset row normalization used by the ruleset domain

## Why

Groups are deliberately cross-asset, but their detail pages only exposed associated factions. A ruleset assigned to a group therefore remained invisible from that group's page.

## User impact

Visitors can now discover both factions and rulesets maintained by a group from the existing group detail page. This does not add a group index or change group discovery and permissions.

## Root cause

The group page-data contract modeled associated factions but omitted the parallel ruleset relationship even though rulesets already store a `group_id`.

## Validation

- `bun run check`
- `bun run typecheck`
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:release:verify`
