### PR TITLE
Address collaboration review findings

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,7 +5,7 @@ Dune Zone is a community catalogue for Dune board-game factions, rulesets, and t
 ## Language
 
 **Group**:
-A collaboration boundary shared by factions, rulesets, and future community assets. Active members may maintain associated content and manage membership intake, while the Group owner alone may remove active members.
+A collaboration boundary shared by factions, rulesets, and future community assets. Active members may maintain associated content and manage membership intake, while the Group owner alone may rename the Group or remove active members.
 
 **Group-associated asset**:
 A faction, ruleset, or future community asset that its owner has assigned to a Group for collaborative maintenance. Active members may edit it, while its owner alone may delete it or change its Group association; ruleset renames are owner-only, while faction renames are collaborative.

--- a/convex/lib/policy.ts
+++ b/convex/lib/policy.ts
@@ -30,7 +30,7 @@ export async function isActiveGroupMember(ctx: AnyCtx, groupId: Id<'groups'>, us
   return membership?.status === 'active';
 }
 
-export async function canAccessRuleset(
+export async function canEditRuleset(
   ctx: AnyCtx,
   ruleset: {
     owner_id: Id<'users'>;

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -8,7 +8,7 @@ import { query } from './_generated/server';
 import { mutation } from './functions';
 import { loadFaqItemsForRuleset } from './lib/faqRulesetList';
 import { listByUserActiveWithGroupsData } from './lib/memberGroups';
-import { canAccessRuleset, isActiveGroupMember, requireAuthUserId } from './lib/policy';
+import { canEditRuleset, isActiveGroupMember, requireAuthUserId } from './lib/policy';
 import { profileSummary } from './lib/profileSummary';
 import { ensureObject, nowIso, slugify } from './lib/utils';
 import type { MutationCtx, QueryCtx } from './types';
@@ -91,8 +91,8 @@ async function rulesetPublicBundleBySlugMaybe(ctx: QueryCtx, slug: string) {
   const factionRows = await Promise.all(links.map((link) => getFactionById(ctx, link.faction_id)));
 
   const userId = await getAuthUserId(ctx);
-  const canAccess =
-    userId != null && (await canAccessRuleset(ctx, row, userId as unknown as Id<'users'>));
+  const canEditRulesetForViewer =
+    userId != null && (await canEditRuleset(ctx, row, userId as unknown as Id<'users'>));
 
   return {
     ruleset: row,
@@ -109,7 +109,7 @@ async function rulesetPublicBundleBySlugMaybe(ctx: QueryCtx, slug: string) {
         identity: factionIdentityForClient(data),
       };
     }),
-    canAccess,
+    canEditRuleset: canEditRulesetForViewer,
   };
 }
 
@@ -208,7 +208,7 @@ export const factionDetails = query({
   },
 });
 
-export const canAccess = query({
+export const canEdit = query({
   args: { ruleset_id: v.id('rulesets') },
   handler: async (ctx, args) => {
     const userId = await getAuthUserId(ctx);
@@ -219,7 +219,7 @@ export const canAccess = query({
     if (!ruleset) {
       return false;
     }
-    return await canAccessRuleset(ctx, ruleset, userId);
+    return await canEditRuleset(ctx, ruleset, userId);
   },
 });
 
@@ -306,7 +306,7 @@ export const update = mutation({
     }
 
     const isOwner = ruleset.owner_id === userId;
-    const canEdit = await canAccessRuleset(ctx, ruleset, userId);
+    const canEdit = await canEditRuleset(ctx, ruleset, userId);
     if (!canEdit) {
       throw new Error('Not authorized');
     }
@@ -393,7 +393,7 @@ export const addFaction = mutation({
       throw new Error('Ruleset not found');
     }
 
-    const allowed = await canAccessRuleset(ctx, ruleset, userId);
+    const allowed = await canEditRuleset(ctx, ruleset, userId);
     if (!allowed) {
       throw new Error('Not authorized');
     }
@@ -431,7 +431,7 @@ export const removeFaction = mutation({
       throw new Error('Ruleset not found');
     }
 
-    const allowed = await canAccessRuleset(ctx, ruleset, userId);
+    const allowed = await canEditRuleset(ctx, ruleset, userId);
     if (!allowed) {
       throw new Error('Not authorized');
     }

--- a/docs/membership.md
+++ b/docs/membership.md
@@ -48,6 +48,7 @@ Shared helpers live in `convex/lib/policy.ts` (`requireAuthUserId`, `isActiveGro
 
 Groups are collaboration boundaries shared by factions, rulesets, and future community assets.
 
+- Only the group owner may rename the group.
 - Active members may edit content associated with their group.
 - Only the asset owner may delete it or assign, unassign, or move it between groups.
 - Active members may rename factions.

--- a/src/app/components/rulesets/RulesetSettingsForm.tsx
+++ b/src/app/components/rulesets/RulesetSettingsForm.tsx
@@ -1,12 +1,9 @@
+import { Alert, Button, Group, Stack, TextInput } from '@mantine/core';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 
 import { useUpdateRuleset } from '@db/rulesets';
 import type { RulesetEntry } from '@db/rulesets';
-import { FormField } from '@app/components/form/FormField';
-import { TextField } from '@app/components/form/TextField';
-import { ButtonGroup, Stack } from '@app/components/generic/layout';
-import { UIButton } from '@app/components/generic/ui/UIButton';
 
 export function RulesetSettingsForm({
   initial,
@@ -53,11 +50,12 @@ export function RulesetSettingsForm({
       : null;
 
   return (
-    <Stack as="form" gap={3} onSubmit={handleSubmit}>
-      <FormField
+    <Stack component="form" gap="md" onSubmit={handleSubmit}>
+      <TextInput
+        id="ruleset-settings-name"
+        name="name"
         label="Name"
-        htmlFor="ruleset-settings-name"
-        hint={
+        description={
           canRename ? (
             <>
               Changing the name updates the URL slug (e.g. <code>…/rulesets/{initial.slug}</code>{' '}
@@ -67,48 +65,39 @@ export function RulesetSettingsForm({
             'Only the ruleset owner can rename it.'
           )
         }
-      >
-        <TextField
-          id="ruleset-settings-name"
-          name="name"
-          required
-          minLength={1}
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-          disabled={!canRename}
-        />
-      </FormField>
+        required
+        minLength={1}
+        value={name}
+        onChange={(event) => setName(event.currentTarget.value)}
+        disabled={!canRename}
+      />
 
-      <FormField
+      <TextInput
+        id="ruleset-settings-cover"
+        type="url"
         label="Cover image URL"
-        htmlFor="ruleset-settings-cover"
-        hint={
+        description={
           <>
             Optional. Use a full <code>https://</code> URL. Leave empty to clear the cover.
           </>
         }
-      >
-        <TextField
-          id="ruleset-settings-cover"
-          type="url"
-          value={coverUrl}
-          onChange={(event) => setCoverUrl(event.target.value)}
-          placeholder="https://…"
-          autoComplete="off"
-        />
-      </FormField>
+        value={coverUrl}
+        onChange={(event) => setCoverUrl(event.currentTarget.value)}
+        placeholder="https://…"
+        autoComplete="off"
+      />
 
-      {mutationError && <p role="alert">{mutationError}</p>}
+      {mutationError ? (
+        <Alert color="red" title="Ruleset could not be saved" role="alert">
+          {mutationError}
+        </Alert>
+      ) : null}
 
-      <ButtonGroup>
-        <UIButton
-          type="submit"
-          iconOnly={false}
-          disabled={updateRuleset.isPending || name.trim().length === 0}
-        >
+      <Group justify="flex-end">
+        <Button type="submit" loading={updateRuleset.isPending} disabled={name.trim().length === 0}>
           {updateRuleset.isPending ? 'Saving…' : 'Save changes'}
-        </UIButton>
-      </ButtonGroup>
+        </Button>
+      </Group>
     </Stack>
   );
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.module.css
@@ -1,16 +1,23 @@
 .pageHead {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
   min-width: 0;
   width: 100%;
   max-width: 42rem;
   margin: 0 auto;
+  padding-inline: var(--mantine-spacing-sm);
 }
 
 .rulesetHeadCover {
   width: 5.5rem;
-  flex-shrink: 0;
+  height: 5.5rem;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--mantine-color-dune-1) 72%, transparent);
+  flex: 0 0 5.5rem;
+}
+
+.coverImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .pageHeadText {
@@ -19,9 +26,6 @@
 }
 
 .rulesetTitle {
-  margin: 0;
-  font-size: 1.35rem;
-  font-weight: 700;
-  line-height: 1.2;
-  color: var(--color-text, #2e2927);
+  overflow-wrap: anywhere;
+  color: var(--color-text, var(--mantine-color-dark-8));
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
@@ -1,13 +1,20 @@
+import {
+  ActionIcon,
+  Anchor,
+  Center,
+  Group,
+  Image,
+  Paper,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { ArrowLeft, BookOpen } from 'lucide-react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { loadRulesetDetailPage, useRulesetDetailPage } from '@db/rulesets';
-import { FormTooltip } from '@app/components/form/FormTooltip';
-import { ButtonGroup, Toolbar } from '@app/components/generic/layout';
-import { BlockCover } from '@app/components/generic/surfaces';
-import { Card } from '@app/components/generic/surfaces/Card';
-import { UIButton } from '@app/components/generic/ui/UIButton';
 import { RulesetSettingsForm } from '@app/components/rulesets/RulesetSettingsForm';
 import { PageLayout } from '@app/components/shell';
 
@@ -33,49 +40,75 @@ function RulesetEditPage() {
   const profile = useCurrentProfile();
 
   const header = page.ruleset ? (
-    <div className={styles.pageHead}>
-      <div className={styles.rulesetHeadCover}>
-        <BlockCover src={page.ruleset.image_cover} alt={`Cover for ${page.ruleset.name}`} />
-      </div>
-      <div className={styles.pageHeadText}>
-        <h1 className={styles.rulesetTitle}>Edit {page.ruleset.name}</h1>
-      </div>
-    </div>
+    <Group wrap="nowrap" align="center" gap="lg" className={styles.pageHead}>
+      <Paper className={styles.rulesetHeadCover} radius="md" withBorder>
+        {page.ruleset.image_cover ? (
+          <Image
+            src={page.ruleset.image_cover}
+            fallbackSrc="/image/background/card.jpg"
+            alt={`Cover for ${page.ruleset.name}`}
+            className={styles.coverImage}
+          />
+        ) : (
+          <Center h="100%">
+            <Text size="xs" c="dimmed" ta="center">
+              No cover
+            </Text>
+          </Center>
+        )}
+      </Paper>
+      <Stack gap={6} className={styles.pageHeadText}>
+        <Title order={1} className={styles.rulesetTitle}>
+          Edit {page.ruleset.name}
+        </Title>
+      </Stack>
+    </Group>
   ) : (
-    <h1>Edit ruleset</h1>
+    <Title order={1}>Edit ruleset</Title>
   );
   const toolbar = (
-    <Toolbar>
-      <Toolbar.Left>
-        <ButtonGroup>
-          <FormTooltip content="Back to rulesets">
-            <UIButton variant="nav" to="/rulesets" aria-label="Back to rulesets">
-              <ArrowLeft size={16} aria-hidden />
-            </UIButton>
-          </FormTooltip>
-          {page.ruleset ? (
-            <FormTooltip content="View ruleset">
-              <UIButton
-                variant="secondary"
-                to="/rulesets/$rulesetSlug"
-                params={{ rulesetSlug: page.ruleset.slug }}
-                aria-label="View ruleset"
-              >
-                <BookOpen size={16} aria-hidden />
-              </UIButton>
-            </FormTooltip>
-          ) : null}
-        </ButtonGroup>
-      </Toolbar.Left>
-    </Toolbar>
+    <Paper withBorder p="sm" radius="md">
+      <Group gap="xs" wrap="wrap" role="group" aria-label="Ruleset navigation">
+        <Tooltip label="Back to rulesets">
+          <ActionIcon
+            variant="light"
+            color="gray"
+            size="lg"
+            aria-label="Back to rulesets"
+            renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}
+          >
+            <ArrowLeft size={17} aria-hidden />
+          </ActionIcon>
+        </Tooltip>
+        {page.ruleset ? (
+          <Tooltip label="View ruleset">
+            <ActionIcon
+              variant="light"
+              color="dune"
+              size="lg"
+              aria-label="View ruleset"
+              renderRoot={(rootProps) => (
+                <Link
+                  {...rootProps}
+                  to="/rulesets/$rulesetSlug"
+                  params={{ rulesetSlug: page.ruleset?.slug ?? rulesetSlug }}
+                />
+              )}
+            >
+              <BookOpen size={17} aria-hidden />
+            </ActionIcon>
+          </Tooltip>
+        ) : null}
+      </Group>
+    </Paper>
   );
 
   if (loaderData.notFound) {
     return (
       <PageLayout header={header} toolbar={toolbar}>
-        <Card>
-          <p>Ruleset not found.</p>
-        </Card>
+        <Paper withBorder p="xl" radius="md">
+          <Text>Ruleset not found.</Text>
+        </Paper>
       </PageLayout>
     );
   }
@@ -83,9 +116,9 @@ function RulesetEditPage() {
   if (!page.ruleset) {
     return (
       <PageLayout header={header} toolbar={toolbar}>
-        <Card>
-          <p>Ruleset not found.</p>
-        </Card>
+        <Paper withBorder p="xl" radius="md">
+          <Text>Ruleset not found.</Text>
+        </Paper>
       </PageLayout>
     );
   }
@@ -96,7 +129,9 @@ function RulesetEditPage() {
   if (profile.isPending) {
     return (
       <PageLayout header={header} toolbar={toolbar}>
-        Loading profile…
+        <Paper withBorder p="xl" radius="md" aria-live="polite">
+          <Text>Loading profile…</Text>
+        </Paper>
       </PageLayout>
     );
   }
@@ -104,34 +139,37 @@ function RulesetEditPage() {
   if (!viewerUserId) {
     return (
       <PageLayout header={header} toolbar={toolbar}>
-        <Card>
-          <p>
-            <Link to="/auth/login">Log in</Link> to edit this ruleset.
-          </p>
-        </Card>
+        <Paper withBorder p="xl" radius="md">
+          <Text>
+            <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>
+              Log in
+            </Anchor>{' '}
+            to edit this ruleset.
+          </Text>
+        </Paper>
       </PageLayout>
     );
   }
 
-  if (!page.canAccess) {
+  if (!page.canEditRuleset) {
     return (
       <PageLayout header={header} toolbar={toolbar}>
-        <Card>
-          <p>
+        <Paper withBorder p="xl" radius="md">
+          <Text>
             {r.group_id
               ? 'Only the ruleset owner or an active member of its group can edit this ruleset.'
               : 'Only the ruleset owner can edit this ruleset.'}
-          </p>
-        </Card>
+          </Text>
+        </Paper>
       </PageLayout>
     );
   }
 
   return (
     <PageLayout header={header} toolbar={toolbar}>
-      <Card>
+      <Paper withBorder p="lg" radius="md">
         <RulesetSettingsForm key={r.slug} initial={r} canRename={r.owner_id === viewerUserId} />
-      </Card>
+      </Paper>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -262,7 +262,7 @@ function RulesetDetailPage() {
                   <ArrowLeft size={17} aria-hidden />
                 </ActionIcon>
               </Tooltip>
-              {page.canAccess ? (
+              {page.canEditRuleset ? (
                 <Tooltip label="Edit ruleset">
                   <ActionIcon
                     variant="light"

--- a/src/app/rulesets/db.ts
+++ b/src/app/rulesets/db.ts
@@ -50,7 +50,7 @@ function normalizeRulesetFactionSummary(faction: RulesetFactionSummaryRaw): Rule
 export type RulesetPageData = {
   ruleset: RulesetEntry;
   factions: RulesetFactionSummary[];
-  canAccess: boolean;
+  canEditRuleset: boolean;
 };
 
 export type RulesetDetailPageData = RulesetPageData & {
@@ -118,7 +118,7 @@ export async function loadRulesetBySlug(slug: string): Promise<RulesetPageData> 
   const result = await db.query<{
     ruleset: RulesetRow;
     factions: RulesetFactionSummaryRaw[];
-    canAccess: boolean;
+    canEditRuleset: boolean;
   }>(api.rulesets.getBySlug, { slug });
   return {
     ...result,
@@ -131,7 +131,7 @@ export async function loadRulesetDetailPage(slug: string): Promise<RulesetDetail
   const raw = await db.query<{
     ruleset: RulesetRow;
     factions: RulesetFactionSummaryRaw[];
-    canAccess: boolean;
+    canEditRuleset: boolean;
     owner: RulesetDetailPageData['owner'];
     viewerAssignableMemberships: AssignableMembershipConvexRow[] | null;
     groupAccess: RulesetDetailPageData['groupAccess'];
@@ -143,7 +143,7 @@ export async function loadRulesetDetailPage(slug: string): Promise<RulesetDetail
   return {
     ruleset: toRulesetEntry(raw.ruleset),
     factions: raw.factions.map(normalizeRulesetFactionSummary),
-    canAccess: raw.canAccess,
+    canEditRuleset: raw.canEditRuleset,
     owner: raw.owner,
     viewerAssignableMemberships: mapViewerAssignableMembershipsFromConvex(
       raw.viewerAssignableMemberships
@@ -166,12 +166,12 @@ export async function loadRulesetFactionsWithDetails(
   return factions.map(normalizeRulesetFactionSummary);
 }
 
-export async function loadCanAccessRuleset(rulesetId: string): Promise<boolean> {
-  return await db.query<boolean>(api.rulesets.canAccess, { ruleset_id: rulesetId });
+export async function loadCanEditRuleset(rulesetId: string): Promise<boolean> {
+  return await db.query<boolean>(api.rulesets.canEdit, { ruleset_id: rulesetId });
 }
 
-export function useCanAccessRuleset(rulesetId: string) {
-  const liveData = useQuery(api.rulesets.canAccess, { ruleset_id: rulesetId } as never) as
+export function useCanEditRuleset(rulesetId: string) {
+  const liveData = useQuery(api.rulesets.canEdit, { ruleset_id: rulesetId } as never) as
     | boolean
     | undefined;
   return toLiveQueryResult(liveData, true);
@@ -213,13 +213,13 @@ export function useRulesetBySlug(slug: string, options?: { initialData?: Ruleset
   const result = toLiveQueryResult<{
     ruleset: RulesetRow;
     factions: RulesetFactionSummaryRaw[];
-    canAccess: boolean;
+    canEditRuleset: boolean;
   } | null>(liveData, true, () => (options?.initialData as never) ?? undefined);
   return {
     ...result,
     ruleset: result.data ? toRulesetEntry(result.data.ruleset) : undefined,
     factions: result.data?.factions.map(normalizeRulesetFactionSummary),
-    canAccess: result.data?.canAccess ?? false,
+    canEditRuleset: result.data?.canEditRuleset ?? false,
   };
 }
 
@@ -238,7 +238,7 @@ export function useRulesetDetailPage(
         : {
             ruleset: toRulesetEntry(liveData.ruleset),
             factions: liveData.factions.map(normalizeRulesetFactionSummary),
-            canAccess: liveData.canAccess,
+            canEditRuleset: liveData.canEditRuleset,
             owner: liveData.owner,
             viewerAssignableMemberships: mapViewerAssignableMembershipsFromConvex(
               liveData.viewerAssignableMemberships as AssignableMembershipConvexRow[] | null
@@ -251,7 +251,7 @@ export function useRulesetDetailPage(
     ...result,
     ruleset: result.data?.ruleset,
     factions: result.data?.factions,
-    canAccess: result.data?.canAccess ?? false,
+    canEditRuleset: result.data?.canEditRuleset ?? false,
     owner: result.data?.owner ?? null,
     viewerAssignableMemberships: result.data?.viewerAssignableMemberships ?? null,
     groupAccess: result.data?.groupAccess ?? null,


### PR DESCRIPTION
## What changed

- rename the broad ruleset `canAccess` permission to the specific `canEditRuleset` contract across Convex and the application
- document that only the group owner may rename a group
- migrate the ruleset edit route and settings form from retired generic UI wrappers to direct Mantine composition

## Why

This follows up on the two-axis review of #165. The permission name obscured what capability it represented, the ownership documentation omitted group renaming, and the touched edit route still used migration-only presentation primitives.

## User impact

Ruleset collaboration behavior is unchanged. The edit screen now follows the current UI architecture while preserving owner-only renaming and member editing of ordinary ruleset fields.

Group deletion strategy is intentionally excluded because it is being handled separately. Additional Storybook coverage is also intentionally excluded from this follow-up.

## Validation

- `bun run typecheck`
- `bun run check`
- `bun run test convex/collaborationPermissions.test.ts`
- `bun run app:build`
- desktop and 390px browser checks for the ruleset edit authorization state
- `bun run publisher:release:verify`
