### PR TITLE
Lock the FAQ client seam tests

### DIFF
--- a/src/app/faq/db.test.tsx
+++ b/src/app/faq/db.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { getFunctionName } from 'convex/server';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { api } from '../../../convex/_generated/api';
@@ -56,6 +57,16 @@ const serverPage = {
   ],
 };
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   for (const mutation of [
@@ -68,17 +79,23 @@ beforeEach(() => {
   ]) {
     mutation.mockResolvedValue(null);
   }
-  const mutations = [
-    mocks.editQuestion,
-    mocks.deleteQuestion,
-    mocks.createAnswer,
-    mocks.editAnswer,
-    mocks.deleteAnswer,
-    mocks.setAcceptedAnswer,
-  ];
-  mocks.useMutation.mockImplementation(
-    () => mutations[(mocks.useMutation.mock.calls.length - 1) % mutations.length]
-  );
+  const mutationsByReference = new Map([
+    [getFunctionName(api.faq.editQuestion), mocks.editQuestion],
+    [getFunctionName(api.faq.deleteQuestion), mocks.deleteQuestion],
+    [getFunctionName(api.faq.createAnswer), mocks.createAnswer],
+    [getFunctionName(api.faq.editAnswer), mocks.editAnswer],
+    [getFunctionName(api.faq.deleteAnswer), mocks.deleteAnswer],
+    [getFunctionName(api.faq.setAcceptedAnswer), mocks.setAcceptedAnswer],
+    [getFunctionName(api.faq.createQuestion), mocks.askQuestion],
+  ]);
+  mocks.useMutation.mockImplementation((mutationReference) => {
+    const functionName = getFunctionName(mutationReference);
+    const mutation = mutationsByReference.get(functionName);
+    if (!mutation) {
+      throw new Error(`Unexpected FAQ mutation reference: ${functionName}`);
+    }
+    return mutation;
+  });
 });
 
 describe('FAQ question page interface', () => {
@@ -160,13 +177,81 @@ describe('FAQ question page interface', () => {
     });
   });
 
+  test('keeps pending and error state isolated between commands', async () => {
+    mocks.useQuery.mockReturnValue(serverPage);
+    const pendingEdit = deferred<null>();
+    const deleteError = new Error('Delete failed');
+    mocks.editQuestion.mockReturnValueOnce(pendingEdit.promise);
+    mocks.deleteQuestion.mockRejectedValueOnce(deleteError);
+    const hook = renderHook(() =>
+      useFaqQuestionPage({ rulesetSlug: 'test-ruleset', questionSlug: '1' })
+    );
+
+    let editPromise!: Promise<void>;
+    act(() => {
+      editPromise = hook.result.current.editQuestion.run({
+        question: 'Edited question?',
+        tags: ['errata'],
+      });
+    });
+
+    await waitFor(() => expect(hook.result.current.editQuestion.isPending).toBe(true));
+    expect(hook.result.current.deleteQuestion).toMatchObject({
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+
+    await act(async () => {
+      await expect(hook.result.current.deleteQuestion.run()).rejects.toThrow('Delete failed');
+    });
+
+    expect(hook.result.current.editQuestion).toMatchObject({
+      isPending: true,
+      isError: false,
+      error: null,
+    });
+    expect(hook.result.current.deleteQuestion).toMatchObject({
+      isPending: false,
+      isError: true,
+      error: deleteError,
+    });
+
+    await act(async () => {
+      pendingEdit.resolve(null);
+      await editPromise;
+    });
+
+    expect(hook.result.current.editQuestion).toMatchObject({
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+    expect(hook.result.current.deleteQuestion).toMatchObject({
+      isPending: false,
+      isError: true,
+      error: deleteError,
+    });
+
+    act(() => hook.result.current.deleteQuestion.reset());
+    expect(hook.result.current.deleteQuestion).toMatchObject({
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+    expect(hook.result.current.editQuestion).toMatchObject({
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+  });
+
   test('asks a question through the canonical operation and returns its locator', async () => {
     mocks.askQuestion.mockResolvedValue({
       questionId: 'question-2',
       rulesetSlug: 'test-ruleset',
       questionSlug: '2',
     });
-    mocks.useMutation.mockReturnValue(mocks.askQuestion);
     const hook = renderHook(() => useAskFaqQuestion());
 
     let locator: { rulesetSlug: string; questionSlug: string } | undefined;

--- a/src/app/faq/db.test.tsx
+++ b/src/app/faq/db.test.tsx
@@ -217,6 +217,18 @@ describe('FAQ question page interface', () => {
       error: deleteError,
     });
 
+    act(() => hook.result.current.deleteQuestion.reset());
+    expect(hook.result.current.deleteQuestion).toMatchObject({
+      isPending: false,
+      isError: false,
+      error: null,
+    });
+    expect(hook.result.current.editQuestion).toMatchObject({
+      isPending: true,
+      isError: false,
+      error: null,
+    });
+
     await act(async () => {
       pendingEdit.resolve(null);
       await editPromise;
@@ -228,18 +240,6 @@ describe('FAQ question page interface', () => {
       error: null,
     });
     expect(hook.result.current.deleteQuestion).toMatchObject({
-      isPending: false,
-      isError: true,
-      error: deleteError,
-    });
-
-    act(() => hook.result.current.deleteQuestion.reset());
-    expect(hook.result.current.deleteQuestion).toMatchObject({
-      isPending: false,
-      isError: false,
-      error: null,
-    });
-    expect(hook.result.current.editQuestion).toMatchObject({
       isPending: false,
       isError: false,
       error: null,


### PR DESCRIPTION
## Summary

- key FAQ mutation doubles by the exact canonical `api.faq.*` function reference instead of hook call order
- fail immediately when the client seam requests an unexpected FAQ mutation
- verify pending, rejected, completed, and reset state remain isolated between independent question commands

## Mutation proof

Before this change, deliberately binding `editQuestion` to `api.faq.deleteQuestion` still left all 3 client-seam tests passing. With the reference-keyed mocks, the same deliberate mutation fails 2 tests, including the canonical binding and state-isolation cases. The production binding was restored before commit.

## Validation

- `bun run test src/app/faq/db.test.tsx` — 4 tests passed
- `bun run test` — 55 files, 369 tests passed
- `bun run check`
- `bun run typecheck`
- `git diff --check`
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:release:verify` — passed; Renderer manifest unchanged

This addresses the P2 client-seam test gap found in the post-implementation architecture review of the completed FAQ lifecycle refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded FAQ test coverage for in-flight actions.
  * Verified that loading and error states remain isolated between commands.
  * Confirmed that resetting one command clears only its own state.
  * Improved test reliability by matching mocked responses to the intended action rather than execution order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->