### PR TITLE
Widen the collaborative-access contract

### DIFF
--- a/convex/collaborativeAccess.test.ts
+++ b/convex/collaborativeAccess.test.ts
@@ -1,0 +1,741 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import aggregateTest from '@convex-dev/aggregate/test';
+import { convexTest } from 'convex-test';
+import { describe, expect, test } from 'vitest';
+
+import { assetPublishingFaction } from '../src/game/fixtures/assetPublishingFaction';
+import { api } from './_generated/api';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+const now = '2026-08-05T00:00:00.000Z';
+
+async function groupAccessFixture() {
+  const t = convexTest(schema, modules);
+  aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileDiscovery');
+  const ids = await t.run(async (ctx) => {
+    const ownerId = await ctx.db.insert('users', { name: 'Group owner' });
+    const assetOwnerId = await ctx.db.insert('users', { name: 'Asset owner' });
+    const activeId = await ctx.db.insert('users', { name: 'Active member' });
+    const pendingId = await ctx.db.insert('users', { name: 'Pending member' });
+    const removedId = await ctx.db.insert('users', { name: 'Removed member' });
+    const groupId = await ctx.db.insert('groups', {
+      name: 'Dune Designers',
+      slug: 'dune-designers',
+      created_at: now,
+      created_by: ownerId,
+    });
+    for (const [userId, username, slug] of [
+      [ownerId, 'Group owner', 'group-owner'],
+      [assetOwnerId, 'Asset owner', 'asset-owner'],
+      [activeId, 'Active member', 'active-member'],
+      [pendingId, 'Pending member', 'pending-member'],
+      [removedId, 'Removed member', 'removed-member'],
+    ] as const) {
+      await ctx.db.insert('profiles', {
+        user_id: userId,
+        username,
+        avatar_url: null,
+        slug,
+        created_at: now,
+        updated_at: now,
+      });
+    }
+    const membershipIds = {
+      owner: await ctx.db.insert('group_members', {
+        group_id: groupId,
+        user_id: ownerId,
+        status: 'active',
+        requested_at: now,
+        approved_at: now,
+        approved_by: ownerId,
+      }),
+      active: await ctx.db.insert('group_members', {
+        group_id: groupId,
+        user_id: activeId,
+        status: 'active',
+        requested_at: now,
+        approved_at: now,
+        approved_by: ownerId,
+      }),
+      pending: await ctx.db.insert('group_members', {
+        group_id: groupId,
+        user_id: pendingId,
+        status: 'pending',
+        requested_at: now,
+        approved_at: null,
+        approved_by: null,
+      }),
+      removed: await ctx.db.insert('group_members', {
+        group_id: groupId,
+        user_id: removedId,
+        status: 'removed',
+        requested_at: now,
+        approved_at: null,
+        approved_by: null,
+      }),
+    };
+    const factionId = await ctx.db.insert('factions', {
+      owner_id: assetOwnerId,
+      data: { ...structuredClone(assetPublishingFaction), name: 'Collaborative Faction' },
+      slug: 'collaborative-faction',
+      created_at: now,
+      updated_at: now,
+      is_deleted: false,
+      group_id: groupId,
+    });
+    const rulesetId = await ctx.db.insert('rulesets', {
+      name: 'Collaborative Ruleset',
+      slug: 'collaborative-ruleset',
+      created_at: now,
+      updated_at: now,
+      owner_id: assetOwnerId,
+      group_id: groupId,
+      is_deleted: false,
+      image_cover: null,
+    });
+    return {
+      ownerId,
+      assetOwnerId,
+      activeId,
+      pendingId,
+      removedId,
+      groupId,
+      membershipIds,
+      factionId,
+      rulesetId,
+    };
+  });
+  return { t, ids };
+}
+
+describe('collaborative access public projections', () => {
+  test('public Group access distinguishes anonymous, none, pending, active, and removed', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const outsiderId = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert('users', { name: 'Outsider' });
+      await ctx.db.insert('profiles', {
+        user_id: userId,
+        username: 'Outsider',
+        avatar_url: null,
+        slug: 'outsider',
+        created_at: now,
+        updated_at: now,
+      });
+      return userId;
+    });
+
+    const queryAs = async (userId?: typeof outsiderId) =>
+      userId
+        ? await t
+            .withIdentity({ subject: userId })
+            .query(api.groups.detailBySlug, { slug: 'dune-designers' })
+        : await t.query(api.groups.detailBySlug, { slug: 'dune-designers' });
+
+    expect((await queryAs()).viewerAccess.viewer).toEqual({ kind: 'anonymous' });
+    expect((await queryAs(outsiderId)).viewerAccess.viewer).toEqual({
+      kind: 'authenticated',
+      membership: 'none',
+    });
+    expect((await queryAs(ids.pendingId)).viewerAccess.viewer).toEqual({
+      kind: 'authenticated',
+      membership: 'pending',
+    });
+    expect((await queryAs(ids.activeId)).viewerAccess.viewer).toEqual({
+      kind: 'authenticated',
+      membership: 'active',
+    });
+    expect((await queryAs(ids.removedId)).viewerAccess.viewer).toEqual({
+      kind: 'authenticated',
+      membership: 'none',
+    });
+  });
+
+  test('Group detail adds trusted viewer access and roster without changing legacy rows', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const owner = t.withIdentity({ subject: ids.ownerId });
+
+    const page = await owner.query(api.groups.detailBySlug, { slug: 'dune-designers' });
+
+    expect(page.viewerAccess).toEqual({
+      kind: 'group',
+      viewer: { kind: 'authenticated', membership: 'active' },
+      capabilities: {
+        requestMembership: false,
+        rename: true,
+        delete: true,
+        addMember: true,
+      },
+    });
+    expect(page.roster).toEqual([
+      expect.objectContaining({
+        membershipId: ids.membershipIds.owner,
+        status: 'active',
+        capabilities: { approve: false, reject: false, remove: false },
+      }),
+      expect.objectContaining({
+        membershipId: ids.membershipIds.active,
+        status: 'active',
+        capabilities: { approve: false, reject: false, remove: true },
+      }),
+      expect.objectContaining({
+        membershipId: ids.membershipIds.pending,
+        status: 'pending',
+        capabilities: { approve: true, reject: true, remove: false },
+      }),
+    ]);
+    expect(page.members).toHaveLength(4);
+    expect(page.profiles).toHaveLength(4);
+  });
+
+  test('faction and ruleset pages project parity with their rename policy difference', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const member = t.withIdentity({ subject: ids.activeId });
+
+    const factionPage = await member.query(api.factions.getBySlug, {
+      slug: 'collaborative-faction',
+    });
+    const rulesetPage = await member.query(api.rulesets.detailPageBySlug, {
+      slug: 'collaborative-ruleset',
+    });
+
+    expect(factionPage.viewerAccess).toMatchObject({
+      kind: 'faction',
+      viewer: { kind: 'authenticated', membership: 'active' },
+      capabilities: { edit: true, rename: true, changeGroup: false, delete: false },
+    });
+    expect(rulesetPage?.viewerAccess).toMatchObject({
+      kind: 'ruleset',
+      viewer: { kind: 'authenticated', membership: 'active' },
+      capabilities: { edit: true, rename: false, changeGroup: false, delete: false },
+    });
+    expect(factionPage.assignableGroups).toEqual([
+      { id: ids.groupId, name: 'Dune Designers', slug: 'dune-designers' },
+    ]);
+    expect(rulesetPage?.assignableGroups).toEqual(factionPage.assignableGroups);
+
+    expect(factionPage.memberships).toHaveLength(1);
+    expect(factionPage.groupAccess?.members).toHaveLength(4);
+    expect(rulesetPage?.canEditRuleset).toBe(true);
+    expect(rulesetPage?.groupAccess?.members).toHaveLength(4);
+    expect(rulesetPage?.viewerAssignableMemberships).toHaveLength(1);
+  });
+
+  test('faction and ruleset public access cover every actor role symmetrically', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const outsiderId = await t.run((ctx) => ctx.db.insert('users', { name: 'Asset outsider' }));
+    const cases = [
+      {
+        label: 'anonymous',
+        userId: null,
+        viewer: { kind: 'anonymous' },
+        faction: {
+          requestMembership: false,
+          edit: false,
+          rename: false,
+          changeGroup: false,
+          delete: false,
+        },
+        ruleset: {
+          requestMembership: false,
+          edit: false,
+          rename: false,
+          changeGroup: false,
+          delete: false,
+        },
+      },
+      {
+        label: 'authenticated none',
+        userId: outsiderId,
+        viewer: { kind: 'authenticated', membership: 'none' },
+        faction: {
+          requestMembership: true,
+          edit: false,
+          rename: false,
+          changeGroup: false,
+          delete: false,
+        },
+        ruleset: {
+          requestMembership: true,
+          edit: false,
+          rename: false,
+          changeGroup: false,
+          delete: false,
+        },
+      },
+      {
+        label: 'pending',
+        userId: ids.pendingId,
+        viewer: { kind: 'authenticated', membership: 'pending' },
+        faction: {
+          requestMembership: false,
+          edit: false,
+          rename: false,
+          changeGroup: false,
+          delete: false,
+        },
+        ruleset: {
+          requestMembership: false,
+          edit: false,
+          rename: false,
+          changeGroup: false,
+          delete: false,
+        },
+      },
+      {
+        label: 'removed',
+        userId: ids.removedId,
+        viewer: { kind: 'authenticated', membership: 'none' },
+        faction: {
+          requestMembership: true,
+          edit: false,
+          rename: false,
+          changeGroup: false,
+          delete: false,
+        },
+        ruleset: {
+          requestMembership: true,
+          edit: false,
+          rename: false,
+          changeGroup: false,
+          delete: false,
+        },
+      },
+      {
+        label: 'Group owner',
+        userId: ids.ownerId,
+        viewer: { kind: 'authenticated', membership: 'active' },
+        faction: {
+          requestMembership: false,
+          edit: true,
+          rename: true,
+          changeGroup: false,
+          delete: false,
+        },
+        ruleset: {
+          requestMembership: false,
+          edit: true,
+          rename: false,
+          changeGroup: false,
+          delete: false,
+        },
+      },
+      {
+        label: 'distinct asset owner',
+        userId: ids.assetOwnerId,
+        viewer: { kind: 'authenticated', membership: 'none' },
+        faction: {
+          requestMembership: true,
+          edit: true,
+          rename: true,
+          changeGroup: true,
+          delete: true,
+        },
+        ruleset: {
+          requestMembership: true,
+          edit: true,
+          rename: true,
+          changeGroup: true,
+          delete: true,
+        },
+      },
+    ] as const;
+
+    for (const actor of cases) {
+      const client = actor.userId ? t.withIdentity({ subject: actor.userId }) : t;
+      const faction = await client.query(api.factions.getBySlug, {
+        slug: 'collaborative-faction',
+      });
+      const ruleset = await client.query(api.rulesets.getBySlug, {
+        slug: 'collaborative-ruleset',
+      });
+      expect(faction.viewerAccess.viewer, actor.label).toEqual(actor.viewer);
+      expect(ruleset.viewerAccess.viewer, actor.label).toEqual(actor.viewer);
+      expect(faction.viewerAccess.capabilities, actor.label).toEqual(actor.faction);
+      expect(ruleset.viewerAccess.capabilities, actor.label).toEqual(actor.ruleset);
+    }
+  });
+
+  test('profile detail adds safe Group summaries without removing legacy membership transport', async () => {
+    const { t, ids } = await groupAccessFixture();
+
+    const profilePage = await t.query(api.profiles.getBySlug, { slug: 'active-member' });
+
+    expect(profilePage.groupSummaries).toEqual([
+      { id: ids.groupId, name: 'Dune Designers', slug: 'dune-designers' },
+    ]);
+    expect(profilePage.memberships).toHaveLength(1);
+    expect(profilePage.groups).toHaveLength(1);
+    expect(profilePage.memberships[0]).toMatchObject({
+      group_id: ids.groupId,
+      user_id: ids.activeId,
+      status: 'active',
+    });
+  });
+
+  test('ownership and active membership remain distinct trusted facts', async () => {
+    const { t, ids } = await groupAccessFixture();
+    await t.run(async (ctx) => {
+      await ctx.db.delete(ids.membershipIds.owner);
+    });
+
+    const page = await t.withIdentity({ subject: ids.ownerId }).query(api.groups.detailBySlug, {
+      slug: 'dune-designers',
+    });
+    expect(page.viewerAccess).toMatchObject({
+      viewer: { kind: 'authenticated', membership: 'none' },
+      capabilities: { rename: true, delete: true, addMember: false },
+    });
+
+    const assetOwnerPage = await t
+      .withIdentity({ subject: ids.assetOwnerId })
+      .query(api.factions.getBySlug, { slug: 'collaborative-faction' });
+    expect(assetOwnerPage.viewerAccess).toMatchObject({
+      viewer: { kind: 'authenticated', membership: 'none' },
+      capabilities: { edit: true, rename: true, changeGroup: true, delete: true },
+    });
+  });
+
+  test('soft-deleted rulesets do not regain owner edit access', async () => {
+    const { t, ids } = await groupAccessFixture();
+    await t.run(async (ctx) => {
+      await ctx.db.patch(ids.rulesetId, { is_deleted: true });
+    });
+
+    await expect(
+      t.withIdentity({ subject: ids.assetOwnerId }).query(api.rulesets.canEdit, {
+        ruleset_id: ids.rulesetId,
+      })
+    ).resolves.toBe(false);
+  });
+
+  test('duplicate membership pairs fail the trusted lookup instead of becoming order-dependent', async () => {
+    const { t, ids } = await groupAccessFixture();
+    await t.run(async (ctx) => {
+      await ctx.db.insert('group_members', {
+        group_id: ids.groupId,
+        user_id: ids.activeId,
+        status: 'active',
+        requested_at: `${now}-duplicate`,
+        approved_at: now,
+        approved_by: ids.ownerId,
+      });
+    });
+
+    const active = t.withIdentity({ subject: ids.activeId });
+    await expect(
+      active.query(api.factions.getBySlug, { slug: 'collaborative-faction' })
+    ).rejects.toThrow();
+    await expect(
+      active.query(api.groups.detailBySlug, { slug: 'dune-designers' })
+    ).rejects.toThrow();
+  });
+
+  test('trusted membership authority is independent of capped presentation collections', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const capped = await t.run(async (ctx) => {
+      const viewerId = await ctx.db.insert('users', { name: 'Late active viewer' });
+      const fillerId = await ctx.db.insert('users', { name: 'Roster filler' });
+      for (const [userId, slug] of [
+        [viewerId, 'late-active-viewer'],
+        [fillerId, 'roster-filler'],
+      ] as const) {
+        await ctx.db.insert('profiles', {
+          user_id: userId,
+          username: slug,
+          avatar_url: null,
+          slug,
+          created_at: now,
+          updated_at: now,
+        });
+      }
+      const distractionGroupId = await ctx.db.insert('groups', {
+        name: 'Membership history',
+        slug: 'membership-history',
+        created_at: now,
+        created_by: ids.ownerId,
+      });
+      for (let index = 0; index < 500; index += 1) {
+        await ctx.db.insert('group_members', {
+          group_id: distractionGroupId,
+          user_id: viewerId,
+          status: 'removed',
+          requested_at: `${now}-${index}`,
+          approved_at: null,
+          approved_by: null,
+        });
+        await ctx.db.insert('group_members', {
+          group_id: ids.groupId,
+          user_id: fillerId,
+          status: 'removed',
+          requested_at: `${now}-${index}`,
+          approved_at: null,
+          approved_by: null,
+        });
+      }
+      for (let index = 0; index < 501; index += 1) {
+        const groupId = await ctx.db.insert('groups', {
+          name: `Active history ${index}`,
+          slug: `active-history-${index}`,
+          created_at: now,
+          created_by: ids.ownerId,
+        });
+        await ctx.db.insert('group_members', {
+          group_id: groupId,
+          user_id: viewerId,
+          status: 'active',
+          requested_at: `${now}-active-${index}`,
+          approved_at: now,
+          approved_by: ids.ownerId,
+        });
+      }
+      const membershipId = await ctx.db.insert('group_members', {
+        group_id: ids.groupId,
+        user_id: viewerId,
+        status: 'active',
+        requested_at: now,
+        approved_at: now,
+        approved_by: ids.ownerId,
+      });
+      return { viewerId, membershipId };
+    });
+
+    const viewer = t.withIdentity({ subject: capped.viewerId });
+    const faction = await viewer.query(api.factions.getBySlug, {
+      slug: 'collaborative-faction',
+    });
+    const ruleset = await viewer.query(api.rulesets.detailPageBySlug, {
+      slug: 'collaborative-ruleset',
+    });
+    const group = await viewer.query(api.groups.detailBySlug, { slug: 'dune-designers' });
+
+    expect(faction.viewerAccess).toMatchObject({
+      viewer: { kind: 'authenticated', membership: 'active' },
+      capabilities: { edit: true, rename: true },
+    });
+    expect(group.viewerAccess).toMatchObject({
+      viewer: { kind: 'authenticated', membership: 'active' },
+      capabilities: { addMember: true },
+    });
+    expect(ruleset?.viewerAccess.viewer).toEqual({
+      kind: 'authenticated',
+      membership: 'active',
+    });
+    expect(faction.memberships).toHaveLength(500);
+    expect(faction.groups).toHaveLength(501);
+    expect(faction.assignableGroups).toHaveLength(200);
+    expect(ruleset?.viewerAssignableMemberships).toHaveLength(200);
+    expect(ruleset?.assignableGroups).toHaveLength(200);
+    expect(group.roster.some((entry) => entry.membershipId === capped.membershipId)).toBe(false);
+  });
+});
+
+describe('collaborative access moderation commands', () => {
+  test('legacy soft-delete commands remain idempotent while deleted projections deny access', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const assetOwner = t.withIdentity({ subject: ids.assetOwnerId });
+
+    await expect(assetOwner.mutation(api.factions.softDelete, { id: ids.factionId })).resolves.toBe(
+      null
+    );
+    await expect(assetOwner.mutation(api.factions.softDelete, { id: ids.factionId })).resolves.toBe(
+      null
+    );
+    await expect(assetOwner.mutation(api.rulesets.softDelete, { id: ids.rulesetId })).resolves.toBe(
+      null
+    );
+    await expect(assetOwner.mutation(api.rulesets.softDelete, { id: ids.rulesetId })).resolves.toBe(
+      null
+    );
+    await expect(
+      assetOwner.query(api.rulesets.canEdit, { ruleset_id: ids.rulesetId })
+    ).resolves.toBe(false);
+  });
+
+  test('request is authoritative, idempotent, and reactivates the same removed row', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const pending = t.withIdentity({ subject: ids.pendingId });
+    const active = t.withIdentity({ subject: ids.activeId });
+    const removed = t.withIdentity({ subject: ids.removedId });
+
+    await expect(
+      pending.mutation(api.members.request, { group_id: ids.groupId })
+    ).resolves.toMatchObject({
+      _id: ids.membershipIds.pending,
+      status: 'pending',
+    });
+    await expect(
+      active.mutation(api.members.request, { group_id: ids.groupId })
+    ).resolves.toMatchObject({
+      _id: ids.membershipIds.active,
+      status: 'active',
+    });
+    await expect(
+      removed.mutation(api.members.request, { group_id: ids.groupId })
+    ).resolves.toMatchObject({
+      _id: ids.membershipIds.removed,
+      status: 'pending',
+    });
+    await expect(
+      removed.mutation(api.members.request, { group_id: ids.groupId })
+    ).resolves.toMatchObject({
+      _id: ids.membershipIds.removed,
+      status: 'pending',
+    });
+  });
+
+  test('canonical membership-id commands and exact legacy pair shims share one policy path', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const owner = t.withIdentity({ subject: ids.ownerId });
+
+    const approved = await owner.mutation(api.members.approveRequest, {
+      membershipId: ids.membershipIds.pending,
+    });
+    expect(approved).toEqual({ membershipId: ids.membershipIds.pending, status: 'active' });
+    await expect(
+      t.run((ctx) => ctx.db.get('group_members', ids.membershipIds.pending))
+    ).resolves.toMatchObject({ status: 'active', approved_by: ids.ownerId });
+
+    const rejectedId = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert('users', { name: 'Second requester' });
+      return await ctx.db.insert('group_members', {
+        group_id: ids.groupId,
+        user_id: userId,
+        status: 'pending',
+        requested_at: now,
+        approved_at: null,
+        approved_by: null,
+      });
+    });
+    const rejected = await owner.mutation(api.members.rejectRequest, {
+      membershipId: rejectedId,
+    });
+    expect(rejected).toEqual({ membershipId: rejectedId, status: 'removed' });
+
+    const removed = await owner.mutation(api.members.removeMember, {
+      membershipId: ids.membershipIds.active,
+    });
+    expect(removed).toEqual({ membershipId: ids.membershipIds.active, status: 'removed' });
+
+    const legacyApproved = await owner
+      .mutation(api.members.approve, {
+        group_id: ids.groupId,
+        user_id: ids.removedId,
+      })
+      .catch((error) => error);
+    expect(String(legacyApproved)).toContain('Membership is not pending approval');
+
+    await expect(
+      t.withIdentity({ subject: ids.removedId }).mutation(api.members.rejectRequest, {
+        membershipId: ids.membershipIds.pending,
+      })
+    ).rejects.toThrow('Not authorized');
+  });
+
+  test('faction command guards preserve collaborator rename but owner-only reassignment and delete', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const member = t.withIdentity({ subject: ids.activeId });
+
+    const updated = await member.mutation(api.factions.update, {
+      id: ids.factionId,
+      data: { ...structuredClone(assetPublishingFaction), name: 'Member Renamed Faction' },
+    });
+    expect(updated).toMatchObject({ slug: 'member-renamed-faction' });
+
+    await expect(
+      member.mutation(api.factions.setGroup, { id: ids.factionId, group_id: null })
+    ).rejects.toThrow('Not authorized');
+    await expect(member.mutation(api.factions.softDelete, { id: ids.factionId })).rejects.toThrow(
+      'Not authorized'
+    );
+  });
+
+  test('add, owner-removal denial, and reassignment target eligibility are authoritative', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const member = t.withIdentity({ subject: ids.activeId });
+    const groupOwner = t.withIdentity({ subject: ids.ownerId });
+    const assetOwner = t.withIdentity({ subject: ids.assetOwnerId });
+
+    await expect(
+      groupOwner.mutation(api.members.removeMember, {
+        membershipId: ids.membershipIds.owner,
+      })
+    ).rejects.toThrow('Cannot remove the group owner');
+
+    await assetOwner.mutation(api.factions.setGroup, { id: ids.factionId, group_id: null });
+    await assetOwner.mutation(api.rulesets.update, {
+      id: ids.rulesetId,
+      name: 'CollaborativeRuleset',
+      group_id: null,
+    });
+    await expect(
+      assetOwner.mutation(api.factions.setGroup, { id: ids.factionId, group_id: ids.groupId })
+    ).rejects.toThrow('Not authorized for group');
+    await expect(
+      assetOwner.mutation(api.rulesets.update, {
+        id: ids.rulesetId,
+        name: 'CollaborativeRuleset',
+        group_id: ids.groupId,
+      })
+    ).rejects.toThrow('Not authorized for group');
+
+    const added = await member.mutation(api.members.addMember, {
+      groupId: ids.groupId,
+      userId: ids.assetOwnerId,
+    });
+    expect(added).toMatchObject({ status: 'active' });
+    await expect(
+      assetOwner.mutation(api.factions.setGroup, { id: ids.factionId, group_id: ids.groupId })
+    ).resolves.toMatchObject({ group_id: ids.groupId });
+    await expect(
+      assetOwner.mutation(api.rulesets.update, {
+        id: ids.rulesetId,
+        name: 'CollaborativeRuleset',
+        group_id: ids.groupId,
+      })
+    ).resolves.toMatchObject({ group_id: ids.groupId });
+  });
+
+  test('legacy pair shims authorize before revealing whether the target pair exists', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const { nonexistentUserId, missingGroupId } = await t.run(async (ctx) => {
+      const userId = await ctx.db.insert('users', { name: 'Nobody' });
+      const groupId = await ctx.db.insert('groups', {
+        name: 'Deleted transport target',
+        slug: 'deleted-transport-target',
+        created_at: now,
+        created_by: ids.ownerId,
+      });
+      await ctx.db.delete(groupId);
+      return { nonexistentUserId: userId, missingGroupId: groupId };
+    });
+
+    await expect(
+      t.mutation(api.members.approve, {
+        group_id: ids.groupId,
+        user_id: nonexistentUserId,
+      })
+    ).rejects.toThrow('Not authenticated');
+    await expect(
+      t.withIdentity({ subject: ids.removedId }).mutation(api.members.approve, {
+        group_id: ids.groupId,
+        user_id: nonexistentUserId,
+      })
+    ).rejects.toThrow('Not authorized');
+    await expect(
+      t.withIdentity({ subject: ids.ownerId }).mutation(api.members.approve, {
+        group_id: missingGroupId,
+        user_id: nonexistentUserId,
+      })
+    ).rejects.toThrow('Not authorized');
+    await expect(
+      t.withIdentity({ subject: ids.ownerId }).mutation(api.members.remove, {
+        group_id: missingGroupId,
+        user_id: nonexistentUserId,
+      })
+    ).rejects.toThrow('Group not found');
+  });
+});

--- a/convex/collaborativeAccess.test.ts
+++ b/convex/collaborativeAccess.test.ts
@@ -635,6 +635,41 @@ describe('collaborative access moderation commands', () => {
     ).rejects.toThrow('Not authorized');
   });
 
+  test('canonical membership-id commands authenticate before existing or missing row lookup', async () => {
+    const { t, ids } = await groupAccessFixture();
+    const missingMembershipId = await t.run(async (ctx) => {
+      const membershipId = await ctx.db.insert('group_members', {
+        group_id: ids.groupId,
+        user_id: ids.assetOwnerId,
+        status: 'pending',
+        requested_at: now,
+        approved_at: null,
+        approved_by: null,
+      });
+      await ctx.db.delete(membershipId);
+      return membershipId;
+    });
+
+    await expect(
+      t.mutation(api.members.approveRequest, { membershipId: ids.membershipIds.pending })
+    ).rejects.toThrow('Not authenticated');
+    await expect(
+      t.mutation(api.members.approveRequest, { membershipId: missingMembershipId })
+    ).rejects.toThrow('Not authenticated');
+    await expect(
+      t.mutation(api.members.rejectRequest, { membershipId: ids.membershipIds.pending })
+    ).rejects.toThrow('Not authenticated');
+    await expect(
+      t.mutation(api.members.rejectRequest, { membershipId: missingMembershipId })
+    ).rejects.toThrow('Not authenticated');
+    await expect(
+      t.mutation(api.members.removeMember, { membershipId: ids.membershipIds.active })
+    ).rejects.toThrow('Not authenticated');
+    await expect(
+      t.mutation(api.members.removeMember, { membershipId: missingMembershipId })
+    ).rejects.toThrow('Not authenticated');
+  });
+
   test('faction command guards preserve collaborator rename but owner-only reassignment and delete', async () => {
     const { t, ids } = await groupAccessFixture();
     const member = t.withIdentity({ subject: ids.activeId });
@@ -735,6 +770,11 @@ describe('collaborative access moderation commands', () => {
       t.withIdentity({ subject: ids.ownerId }).mutation(api.members.remove, {
         group_id: missingGroupId,
         user_id: nonexistentUserId,
+      })
+    ).rejects.toThrow('Group not found');
+    await expect(
+      t.withIdentity({ subject: ids.ownerId }).mutation(api.members.request, {
+        group_id: missingGroupId,
       })
     ).rejects.toThrow('Group not found');
   });

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -1,4 +1,3 @@
-import { getAuthUserId } from '@convex-dev/auth/server';
 import { v } from 'convex/values';
 
 import { CanonicalFactionStoredSchema } from '../src/game/schema/faction';
@@ -7,12 +6,20 @@ import { query } from './_generated/server';
 import { factionSheetPublishingStatus } from './assetPublishingStatus';
 import { mutation } from './functions';
 import {
+  loadAssetAccessBundle,
+  requireAssignableGroup,
+  requireFactionSoftDelete,
+  requireFactionUpdate,
+  requireGroupReassignment,
+} from './lib/collaborativeAccess';
+import { factionDetailPageValidator } from './lib/collaborativeAccessValidators';
+import {
   enrichFactionsWithRulesets,
   listActiveRulesetSummaries,
   selectFactionCatalogueSpotlights,
 } from './lib/factionCatalogue';
 import { parseFactionInput } from './lib/factionInput';
-import { isActiveGroupMember, requireAuthUserId } from './lib/policy';
+import { requireAuthUserId } from './lib/policy';
 import { profileSummary } from './lib/profileSummary';
 import { enqueueFactionSheetPublication } from './lib/publication';
 import { nowIso, slugify } from './lib/utils';
@@ -43,39 +50,18 @@ function factionRowForClient(row: Doc<'factions'>) {
   };
 }
 
-/** Groups relevant to the faction row + viewer memberships only (no full-table scan). */
-async function groupsForFactionAndMemberships(
-  ctx: QueryCtx,
-  factionGroupId: Id<'groups'> | null | undefined,
-  memberships: { group_id: Id<'groups'> }[]
-) {
-  const groupIds = new Set<Id<'groups'>>();
-  if (factionGroupId) {
-    groupIds.add(factionGroupId);
-  }
-  for (const m of memberships) {
-    groupIds.add(m.group_id);
-  }
-  const groups = [];
-  for (const gid of groupIds) {
-    const g = await ctx.db.get('groups', gid);
-    if (g) {
-      groups.push(g);
-    }
-  }
-  return groups;
-}
-
 /** Faction detail page bundle (view, edit, and sheet preview). */
 async function loadFactionDetailPageBySlug(ctx: QueryCtx, slug: string) {
-  const row = await ctx.db
+  const locatedRow = await ctx.db
     .query('factions')
     .withIndex('by_slug', (q) => q.eq('slug', slug))
     .unique();
-  if (!row || row.is_deleted) {
+  if (!locatedRow || locatedRow.is_deleted) {
     throw new Error(`Faction with slug ${slug} not found`);
   }
 
+  const access = await loadAssetAccessBundle(ctx, { kind: 'faction', row: locatedRow });
+  const row = access.subject;
   const ownerProfile = await ctx.db
     .query('profiles')
     .withIndex('by_user_id', (q) => q.eq('user_id', row.owner_id))
@@ -84,18 +70,8 @@ async function loadFactionDetailPageBySlug(ctx: QueryCtx, slug: string) {
     throw new Error(`Profile with user id ${row.owner_id} not found`);
   }
 
-  const group = row.group_id ? await ctx.db.get('groups', row.group_id) : null;
-
-  const authUserId = await getAuthUserId(ctx);
-  const memberships =
-    authUserId != null
-      ? await ctx.db
-          .query('group_members')
-          .withIndex('by_user_status', (q) => q.eq('user_id', authUserId).eq('status', 'active'))
-          .take(500)
-      : [];
-
-  const groups = await groupsForFactionAndMemberships(ctx, row.group_id, memberships);
+  const memberships = access.memberships;
+  const groups = access.groups;
 
   let groupAccess: {
     group: Doc<'groups'>;
@@ -106,7 +82,7 @@ async function loadFactionDetailPageBySlug(ctx: QueryCtx, slug: string) {
   } | null = null;
 
   const linkedGroupId = row.group_id;
-  if (linkedGroupId && group) {
+  if (linkedGroupId && access.assignedGroup) {
     const groupMemberships = await ctx.db
       .query('group_members')
       .withIndex('by_group', (q) => q.eq('group_id', linkedGroupId))
@@ -117,7 +93,7 @@ async function loadFactionDetailPageBySlug(ctx: QueryCtx, slug: string) {
         profile: await profileSummary(ctx, m.user_id),
       }))
     );
-    groupAccess = { group, members };
+    groupAccess = { group: access.assignedGroup, members };
   }
 
   return {
@@ -126,16 +102,19 @@ async function loadFactionDetailPageBySlug(ctx: QueryCtx, slug: string) {
       data: factionDataForClient(row.data),
     },
     owner: ownerProfile,
-    group,
+    group: access.assignedGroup,
     memberships,
     groups,
     groupAccess,
     assetPublishing: await factionSheetPublishingStatus(ctx, row._id),
+    viewerAccess: access.viewerAccess,
+    assignableGroups: access.assignableGroups,
   };
 }
 
 export const getBySlug = query({
   args: { slug: v.string() },
+  returns: factionDetailPageValidator,
   handler: async (ctx, args) => loadFactionDetailPageBySlug(ctx, args.slug),
 });
 
@@ -290,10 +269,7 @@ export const create = mutation({
   handler: async (ctx, args) => {
     const userId = await requireAuthUserId(ctx);
     if (args.group_id) {
-      const canUseGroup = await isActiveGroupMember(ctx, args.group_id, userId);
-      if (!canUseGroup) {
-        throw new Error('Not authorized for group');
-      }
+      await requireAssignableGroup(ctx, args.group_id);
     }
 
     const data = parseFactionInput(args.data, {
@@ -327,30 +303,19 @@ export const update = mutation({
     data: v.any(),
   },
   handler: async (ctx, args) => {
-    const userId = await requireAuthUserId(ctx);
-    const row = await ctx.db.get(args.id);
-    if (!row || row.is_deleted) {
-      throw new Error(`Faction with id ${args.id} not found`);
-    }
-    const isOwner = row.owner_id === userId;
-    const isGroupEditor =
-      row.group_id == null ? false : await isActiveGroupMember(ctx, row.group_id, userId);
-    if (!isOwner && !isGroupEditor) {
-      throw new Error('Not authorized');
-    }
-
     const data = parseFactionInput(args.data, {
       requireAuthoringSemantics: true,
     });
+    const access = await requireFactionUpdate(ctx, args.id, data);
     const slug = slugify(data.name);
     await assertFactionSlugAvailable(ctx, slug, args.id);
 
-    await ctx.db.patch(args.id, {
+    await ctx.db.patch(access.subject._id, {
       data,
       slug,
       updated_at: nowIso(),
     });
-    const updated = await ctx.db.get(args.id);
+    const updated = await ctx.db.get(access.subject._id);
     if (!updated) {
       throw new Error('Failed to update faction');
     }
@@ -365,26 +330,17 @@ export const setGroup = mutation({
     group_id: v.union(v.id('groups'), v.null()),
   },
   handler: async (ctx, args) => {
-    const userId = await requireAuthUserId(ctx);
-    const row = await ctx.db.get(args.id);
-    if (!row || row.is_deleted) {
-      throw new Error(`Faction with id ${args.id} not found`);
-    }
-    if (row.owner_id !== userId) {
-      throw new Error('Not authorized');
-    }
-    if (args.group_id) {
-      const canUseGroup = await isActiveGroupMember(ctx, args.group_id, userId);
-      if (!canUseGroup) {
-        throw new Error('Not authorized for group');
-      }
-    }
+    const access = await requireGroupReassignment(
+      ctx,
+      { kind: 'faction', id: args.id },
+      args.group_id
+    );
 
     await ctx.db.patch(args.id, {
       group_id: args.group_id,
       updated_at: nowIso(),
     });
-    const updated = await ctx.db.get(args.id);
+    const updated = await ctx.db.get(access.subject._id);
     if (!updated) {
       throw new Error('Failed to update faction group');
     }
@@ -395,16 +351,9 @@ export const setGroup = mutation({
 export const softDelete = mutation({
   args: { id: v.id('factions') },
   handler: async (ctx, args) => {
-    const userId = await requireAuthUserId(ctx);
-    const row = await ctx.db.get(args.id);
-    if (!row) {
-      throw new Error(`Faction with id ${args.id} not found`);
-    }
-    if (row.owner_id !== userId) {
-      throw new Error('Not authorized');
-    }
+    const access = await requireFactionSoftDelete(ctx, args.id);
 
-    await ctx.db.patch(args.id, {
+    await ctx.db.patch(access.subject._id, {
       is_deleted: true,
       updated_at: nowIso(),
     });

--- a/convex/groups.ts
+++ b/convex/groups.ts
@@ -1,10 +1,12 @@
 import { v } from 'convex/values';
 
 import { groupInputSchema } from '../src/app/groups/validation';
-import type { Doc, Id } from './_generated/dataModel';
+import type { Id } from './_generated/dataModel';
 import type { MutationCtx, QueryCtx } from './_generated/server';
 import { query } from './_generated/server';
 import { mutation } from './functions';
+import { loadGroupAccessBundle, requireGroupCapability } from './lib/collaborativeAccess';
+import { groupDetailPageValidator } from './lib/collaborativeAccessValidators';
 import { requireAuthUserId } from './lib/policy';
 import { nowIso, slugify } from './lib/utils';
 
@@ -69,6 +71,7 @@ export const getBySlug = query({
  */
 export const detailBySlug = query({
   args: { slug: v.string() },
+  returns: groupDetailPageValidator,
   handler: async (ctx, args) => {
     const group = await ctx.db
       .query('groups')
@@ -78,10 +81,7 @@ export const detailBySlug = query({
       throw new Error(`Group with slug ${args.slug} not found`);
     }
 
-    const members = await ctx.db
-      .query('group_members')
-      .withIndex('by_group', (q) => q.eq('group_id', group._id))
-      .take(500);
+    const accessBundle = await loadGroupAccessBundle(ctx, group);
 
     const factions = await ctx.db
       .query('factions')
@@ -93,24 +93,15 @@ export const detailBySlug = query({
       .withIndex('by_group_deleted', (q) => q.eq('group_id', group._id).eq('is_deleted', false))
       .take(500);
 
-    const userIds = new Set<Id<'users'>>([group.created_by]);
-    for (const m of members) {
-      userIds.add(m.user_id);
-    }
-
-    const profiles: Doc<'profiles'>[] = [];
-    for (const uid of userIds) {
-      const profile = await ctx.db
-        .query('profiles')
-        .withIndex('by_user_id', (q) => q.eq('user_id', uid))
-        .unique();
-      if (!profile) {
-        throw new Error(`Invariant: every user must have a profile (missing for ${uid})`);
-      }
-      profiles.push(profile);
-    }
-
-    return { group, members, factions, rulesets, profiles };
+    return {
+      group: accessBundle.subject,
+      members: accessBundle.members,
+      factions,
+      rulesets,
+      profiles: accessBundle.profiles,
+      viewerAccess: accessBundle.viewerAccess,
+      roster: accessBundle.roster,
+    };
   },
 });
 
@@ -180,20 +171,13 @@ export const update = mutation({
     name: v.string(),
   },
   handler: async (ctx, args) => {
-    const userId = await requireAuthUserId(ctx);
     const parsed = groupInputSchema.safeParse({ name: args.name });
     if (!parsed.success) {
       const msg = parsed.error.issues.map((i) => i.message).join(' ');
       throw new Error(msg || 'Invalid group input');
     }
     const normalizedName = parsed.data.name;
-    const group = await ctx.db.get(args.id);
-    if (!group) {
-      throw new Error(`Group with id ${args.id} not found`);
-    }
-    if (group.created_by !== userId) {
-      throw new Error('Not authorized');
-    }
+    const { subject: group } = await requireGroupCapability(ctx, args.id, 'rename');
 
     const nameOwner = await ctx.db
       .query('groups')
@@ -216,19 +200,12 @@ export const update = mutation({
 export const remove = mutation({
   args: { id: v.id('groups') },
   handler: async (ctx, args) => {
-    const userId = await requireAuthUserId(ctx);
-    const group = await ctx.db.get(args.id);
-    if (!group) {
-      throw new Error(`Group with id ${args.id} not found`);
-    }
-    if (group.created_by !== userId) {
-      throw new Error('Not authorized');
-    }
-    await ctx.db.delete(args.id);
+    const { subject: group } = await requireGroupCapability(ctx, args.id, 'delete');
+    await ctx.db.delete(group._id);
 
     const rulesetsWithGroup = await ctx.db
       .query('rulesets')
-      .withIndex('by_group_deleted', (q) => q.eq('group_id', args.id).eq('is_deleted', false))
+      .withIndex('by_group_deleted', (q) => q.eq('group_id', group._id).eq('is_deleted', false))
       .take(100);
     for (const ruleset of rulesetsWithGroup) {
       await ctx.db.patch(ruleset._id, { group_id: null });
@@ -236,7 +213,7 @@ export const remove = mutation({
 
     const memberships = await ctx.db
       .query('group_members')
-      .withIndex('by_group', (q) => q.eq('group_id', args.id))
+      .withIndex('by_group', (q) => q.eq('group_id', group._id))
       .take(100);
     for (const membership of memberships) {
       await ctx.db.delete(membership._id);

--- a/convex/lib/collaborativeAccess.test.ts
+++ b/convex/lib/collaborativeAccess.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from 'vitest';
+
+import type { Id } from '../_generated/dataModel';
+import { evaluateCollaborativeAccess } from './collaborativeAccess';
+
+describe('collaborative access evaluator', () => {
+  test.each([
+    {
+      label: 'Group none',
+      facts: {
+        kind: 'group' as const,
+        group: { eligible: true },
+        viewer: { kind: 'authenticated' as const, membership: 'none' as const, ownsSubject: false },
+      },
+      expected: { requestMembership: true, rename: false, delete: false, addMember: false },
+    },
+    {
+      label: 'Group pending',
+      facts: {
+        kind: 'group' as const,
+        group: { eligible: true },
+        viewer: {
+          kind: 'authenticated' as const,
+          membership: 'pending' as const,
+          ownsSubject: false,
+        },
+      },
+      expected: { requestMembership: false, rename: false, delete: false, addMember: false },
+    },
+    {
+      label: 'Group active',
+      facts: {
+        kind: 'group' as const,
+        group: { eligible: true },
+        viewer: {
+          kind: 'authenticated' as const,
+          membership: 'active' as const,
+          ownsSubject: false,
+        },
+      },
+      expected: { requestMembership: false, rename: false, delete: false, addMember: true },
+    },
+    {
+      label: 'Group owner without membership',
+      facts: {
+        kind: 'group' as const,
+        group: { eligible: true },
+        viewer: { kind: 'authenticated' as const, membership: 'none' as const, ownsSubject: true },
+      },
+      expected: { requestMembership: true, rename: true, delete: true, addMember: false },
+    },
+    {
+      label: 'Faction active collaborator',
+      facts: {
+        kind: 'faction' as const,
+        resource: { available: true },
+        group: { eligible: true, summary: null },
+        viewer: {
+          kind: 'authenticated' as const,
+          membership: 'active' as const,
+          ownsSubject: false,
+        },
+      },
+      expected: {
+        requestMembership: false,
+        edit: true,
+        rename: true,
+        changeGroup: false,
+        delete: false,
+      },
+    },
+    {
+      label: 'Ruleset active collaborator',
+      facts: {
+        kind: 'ruleset' as const,
+        resource: { available: true },
+        group: { eligible: true, summary: null },
+        viewer: {
+          kind: 'authenticated' as const,
+          membership: 'active' as const,
+          ownsSubject: false,
+        },
+      },
+      expected: {
+        requestMembership: false,
+        edit: true,
+        rename: false,
+        changeGroup: false,
+        delete: false,
+      },
+    },
+    {
+      label: 'Unassigned asset owner',
+      facts: {
+        kind: 'ruleset' as const,
+        resource: { available: true },
+        group: { eligible: false, summary: null },
+        viewer: { kind: 'authenticated' as const, membership: 'none' as const, ownsSubject: true },
+      },
+      expected: {
+        requestMembership: false,
+        edit: true,
+        rename: true,
+        changeGroup: true,
+        delete: true,
+      },
+    },
+  ])('$label capabilities are explicit', ({ facts, expected }) => {
+    expect(evaluateCollaborativeAccess(facts).capabilities).toEqual(expected);
+  });
+
+  test('an anonymous Group viewer receives no collaborative actions', () => {
+    expect(
+      evaluateCollaborativeAccess({
+        kind: 'group',
+        group: { eligible: true },
+        viewer: { kind: 'anonymous' },
+      })
+    ).toEqual({
+      kind: 'group',
+      viewer: { kind: 'anonymous' },
+      capabilities: {
+        requestMembership: false,
+        rename: false,
+        delete: false,
+        addMember: false,
+      },
+    });
+  });
+
+  test('a removed Group membership is public none and may request again', () => {
+    expect(
+      evaluateCollaborativeAccess({
+        kind: 'group',
+        group: { eligible: true },
+        viewer: { kind: 'authenticated', membership: 'removed', ownsSubject: false },
+      })
+    ).toEqual({
+      kind: 'group',
+      viewer: { kind: 'authenticated', membership: 'none' },
+      capabilities: {
+        requestMembership: true,
+        rename: false,
+        delete: false,
+        addMember: false,
+      },
+    });
+  });
+
+  test('an active collaborator may rename a faction but not a ruleset', () => {
+    const assignedGroup = {
+      id: 'group-1' as Id<'groups'>,
+      name: 'Dune Designers',
+      slug: 'dune-designers',
+    };
+    const viewer = {
+      kind: 'authenticated' as const,
+      membership: 'active' as const,
+      ownsSubject: false,
+    };
+
+    expect(
+      evaluateCollaborativeAccess({
+        kind: 'faction',
+        resource: { available: true },
+        group: { eligible: true, summary: assignedGroup },
+        viewer,
+      }).capabilities
+    ).toEqual({
+      requestMembership: false,
+      edit: true,
+      rename: true,
+      changeGroup: false,
+      delete: false,
+    });
+    expect(
+      evaluateCollaborativeAccess({
+        kind: 'ruleset',
+        resource: { available: true },
+        group: { eligible: true, summary: assignedGroup },
+        viewer,
+      }).capabilities
+    ).toEqual({
+      requestMembership: false,
+      edit: true,
+      rename: false,
+      changeGroup: false,
+      delete: false,
+    });
+  });
+
+  test('an unavailable Group grants no effective Group capabilities', () => {
+    expect(
+      evaluateCollaborativeAccess({
+        kind: 'group',
+        group: { eligible: false },
+        viewer: { kind: 'authenticated', membership: 'active', ownsSubject: true },
+      }).capabilities
+    ).toEqual({
+      requestMembership: false,
+      rename: false,
+      delete: false,
+      addMember: false,
+    });
+  });
+
+  test('a deleted asset grants no effective capabilities even to its owner', () => {
+    expect(
+      evaluateCollaborativeAccess({
+        kind: 'ruleset',
+        resource: { available: false },
+        group: { eligible: true, summary: null },
+        viewer: { kind: 'authenticated', membership: 'active', ownsSubject: true },
+      }).capabilities
+    ).toEqual({
+      requestMembership: false,
+      edit: false,
+      rename: false,
+      changeGroup: false,
+      delete: false,
+    });
+  });
+});

--- a/convex/lib/collaborativeAccess.ts
+++ b/convex/lib/collaborativeAccess.ts
@@ -1,0 +1,689 @@
+import { getAuthUserId } from '@convex-dev/auth/server';
+
+import type { Doc, Id } from '../_generated/dataModel';
+import type { MutationCtx, QueryCtx } from '../_generated/server';
+
+export type MembershipState = 'none' | 'pending' | 'active';
+export type StoredMembershipState = MembershipState | 'removed';
+
+export type PublicViewer =
+  | { kind: 'anonymous' }
+  | { kind: 'authenticated'; membership: MembershipState };
+
+type ViewerFacts =
+  | { kind: 'anonymous' }
+  | { kind: 'authenticated'; membership: StoredMembershipState; ownsSubject: boolean };
+
+export type AssignedGroupSummary = {
+  id: Id<'groups'>;
+  name: string;
+  slug: string;
+};
+
+export type GroupAccessFacts = {
+  kind: 'group';
+  group: { eligible: boolean };
+  viewer: ViewerFacts;
+};
+
+export type AssetAccessFacts = {
+  kind: 'faction' | 'ruleset';
+  resource: { available: boolean };
+  group: { eligible: boolean; summary: AssignedGroupSummary | null };
+  viewer: ViewerFacts;
+};
+
+export type CollaborativeAccessFacts = GroupAccessFacts | AssetAccessFacts;
+
+export type CollaborativeAccess =
+  | {
+      kind: 'group';
+      viewer: PublicViewer;
+      capabilities: {
+        requestMembership: boolean;
+        rename: boolean;
+        delete: boolean;
+        addMember: boolean;
+      };
+    }
+  | {
+      kind: 'faction';
+      assignedGroup: AssignedGroupSummary | null;
+      viewer: PublicViewer;
+      capabilities: {
+        requestMembership: boolean;
+        edit: boolean;
+        rename: boolean;
+        changeGroup: boolean;
+        delete: boolean;
+      };
+    }
+  | {
+      kind: 'ruleset';
+      assignedGroup: AssignedGroupSummary | null;
+      viewer: PublicViewer;
+      capabilities: {
+        requestMembership: boolean;
+        edit: boolean;
+        rename: boolean;
+        changeGroup: boolean;
+        delete: boolean;
+      };
+    };
+
+type CollaborativeSubject =
+  | { kind: 'group'; id: Id<'groups'> }
+  | { kind: 'faction'; id: Id<'factions'> }
+  | { kind: 'ruleset'; id: Id<'rulesets'> };
+
+type LoadedGroupAccess = {
+  subject: Doc<'groups'>;
+  assignedGroup: Doc<'groups'>;
+  viewerMembership: Doc<'group_members'> | null;
+  viewerAccess: Extract<CollaborativeAccess, { kind: 'group' }>;
+  viewerId: Id<'users'> | null;
+};
+
+type LoadedFactionAccess = {
+  subject: Doc<'factions'>;
+  assignedGroup: Doc<'groups'> | null;
+  viewerMembership: Doc<'group_members'> | null;
+  viewerAccess: Extract<CollaborativeAccess, { kind: 'faction' }>;
+  viewerId: Id<'users'> | null;
+};
+
+type LoadedRulesetAccess = {
+  subject: Doc<'rulesets'>;
+  assignedGroup: Doc<'groups'> | null;
+  viewerMembership: Doc<'group_members'> | null;
+  viewerAccess: Extract<CollaborativeAccess, { kind: 'ruleset' }>;
+  viewerId: Id<'users'> | null;
+};
+
+type LoadedCollaborativeAccess = LoadedGroupAccess | LoadedFactionAccess | LoadedRulesetAccess;
+
+type AnyCtx = QueryCtx | MutationCtx;
+
+async function requireAuthenticatedViewerId(ctx: AnyCtx) {
+  const viewerId = (await getAuthUserId(ctx)) as Id<'users'> | null;
+  if (!viewerId) {
+    throw new Error('Not authenticated');
+  }
+  return viewerId;
+}
+
+async function membershipFor(
+  ctx: AnyCtx,
+  groupId: Id<'groups'> | null,
+  viewerId: Id<'users'> | null
+) {
+  if (!groupId || !viewerId) {
+    return null;
+  }
+  return await ctx.db
+    .query('group_members')
+    .withIndex('by_group_user', (q) => q.eq('group_id', groupId).eq('user_id', viewerId))
+    .unique();
+}
+
+function viewerFacts(
+  viewerId: Id<'users'> | null,
+  ownerId: Id<'users'>,
+  membership: Doc<'group_members'> | null
+): ViewerFacts {
+  if (!viewerId) {
+    return { kind: 'anonymous' };
+  }
+  return {
+    kind: 'authenticated',
+    membership: membership?.status ?? 'none',
+    ownsSubject: viewerId === ownerId,
+  };
+}
+
+function groupAccessFromLoaded(
+  subject: Doc<'groups'>,
+  viewerId: Id<'users'> | null,
+  viewerMembership: Doc<'group_members'> | null
+): LoadedGroupAccess {
+  return {
+    subject,
+    assignedGroup: subject,
+    viewerMembership,
+    viewerId,
+    viewerAccess: evaluateCollaborativeAccess({
+      kind: 'group',
+      group: { eligible: true },
+      viewer: viewerFacts(viewerId, subject.created_by, viewerMembership),
+    }) as Extract<CollaborativeAccess, { kind: 'group' }>,
+  };
+}
+
+function factionAccessFromLoaded(
+  subject: Doc<'factions'>,
+  assignedGroup: Doc<'groups'> | null,
+  viewerId: Id<'users'> | null,
+  viewerMembership: Doc<'group_members'> | null
+): LoadedFactionAccess {
+  return {
+    subject,
+    assignedGroup,
+    viewerMembership,
+    viewerId,
+    viewerAccess: evaluateCollaborativeAccess({
+      kind: 'faction',
+      resource: { available: !subject.is_deleted },
+      group: {
+        eligible: assignedGroup !== null,
+        summary: assignedGroup
+          ? { id: assignedGroup._id, name: assignedGroup.name, slug: assignedGroup.slug }
+          : null,
+      },
+      viewer: viewerFacts(viewerId, subject.owner_id, viewerMembership),
+    }) as Extract<CollaborativeAccess, { kind: 'faction' }>,
+  };
+}
+
+function rulesetAccessFromLoaded(
+  subject: Doc<'rulesets'>,
+  assignedGroup: Doc<'groups'> | null,
+  viewerId: Id<'users'> | null,
+  viewerMembership: Doc<'group_members'> | null
+): LoadedRulesetAccess {
+  return {
+    subject,
+    assignedGroup,
+    viewerMembership,
+    viewerId,
+    viewerAccess: evaluateCollaborativeAccess({
+      kind: 'ruleset',
+      resource: { available: !subject.is_deleted },
+      group: {
+        eligible: assignedGroup !== null,
+        summary: assignedGroup
+          ? { id: assignedGroup._id, name: assignedGroup.name, slug: assignedGroup.slug }
+          : null,
+      },
+      viewer: viewerFacts(viewerId, subject.owner_id, viewerMembership),
+    }) as Extract<CollaborativeAccess, { kind: 'ruleset' }>,
+  };
+}
+
+export function loadCollaborativeAccess(
+  ctx: AnyCtx,
+  subject: Extract<CollaborativeSubject, { kind: 'group' }>
+): Promise<LoadedGroupAccess>;
+export function loadCollaborativeAccess(
+  ctx: AnyCtx,
+  subject: Extract<CollaborativeSubject, { kind: 'faction' }>
+): Promise<LoadedFactionAccess>;
+export function loadCollaborativeAccess(
+  ctx: AnyCtx,
+  subject: Extract<CollaborativeSubject, { kind: 'ruleset' }>
+): Promise<LoadedRulesetAccess>;
+export async function loadCollaborativeAccess(
+  ctx: AnyCtx,
+  subject: CollaborativeSubject
+): Promise<LoadedCollaborativeAccess> {
+  const viewerId = (await getAuthUserId(ctx)) as Id<'users'> | null;
+
+  if (subject.kind === 'group') {
+    const row = await ctx.db.get('groups', subject.id);
+    if (!row) {
+      throw new Error(`Group with id ${subject.id} not found`);
+    }
+    const viewerMembership = await membershipFor(ctx, row._id, viewerId);
+    return groupAccessFromLoaded(row, viewerId, viewerMembership);
+  }
+
+  if (subject.kind === 'faction') {
+    const row = await ctx.db.get('factions', subject.id);
+    if (!row) {
+      throw new Error(`Faction with id ${subject.id} not found`);
+    }
+    const assignedGroup = row.group_id ? await ctx.db.get('groups', row.group_id) : null;
+    const viewerMembership = await membershipFor(ctx, assignedGroup?._id ?? null, viewerId);
+    return factionAccessFromLoaded(row, assignedGroup, viewerId, viewerMembership);
+  }
+
+  const row = await ctx.db.get('rulesets', subject.id);
+  if (!row) {
+    throw new Error(`Ruleset with id ${subject.id} not found`);
+  }
+  const assignedGroup = row.group_id ? await ctx.db.get(row.group_id) : null;
+  const viewerMembership = await membershipFor(ctx, assignedGroup?._id ?? null, viewerId);
+  return rulesetAccessFromLoaded(row, assignedGroup, viewerId, viewerMembership);
+}
+
+export async function collaborativeAccessFor(
+  ctx: AnyCtx,
+  subject: CollaborativeSubject
+): Promise<CollaborativeAccess> {
+  if (subject.kind === 'group') {
+    return (await loadCollaborativeAccess(ctx, subject)).viewerAccess;
+  }
+  if (subject.kind === 'faction') {
+    return (await loadCollaborativeAccess(ctx, subject)).viewerAccess;
+  }
+  return (await loadCollaborativeAccess(ctx, subject)).viewerAccess;
+}
+
+export async function loadRulesetAccessForLoadedSubject(ctx: AnyCtx, ruleset: Doc<'rulesets'>) {
+  const viewerId = (await getAuthUserId(ctx)) as Id<'users'> | null;
+  const assignedGroup = ruleset.group_id ? await ctx.db.get('groups', ruleset.group_id) : null;
+  const viewerMembership = await membershipFor(ctx, assignedGroup?._id ?? null, viewerId);
+  return rulesetAccessFromLoaded(ruleset, assignedGroup, viewerId, viewerMembership);
+}
+
+export async function requireGroupCapability(
+  ctx: MutationCtx,
+  groupId: Id<'groups'>,
+  capability: keyof Extract<CollaborativeAccess, { kind: 'group' }>['capabilities'],
+  message = 'Not authorized'
+) {
+  await requireAuthenticatedViewerId(ctx);
+  const access = await loadCollaborativeAccess(ctx, { kind: 'group', id: groupId });
+  if (!access.viewerAccess.capabilities[capability]) {
+    throw new Error(message);
+  }
+  return access;
+}
+
+export async function requireFactionCapability(
+  ctx: MutationCtx,
+  factionId: Id<'factions'>,
+  capability: keyof Extract<CollaborativeAccess, { kind: 'faction' }>['capabilities'],
+  message = 'Not authorized'
+) {
+  await requireAuthenticatedViewerId(ctx);
+  const access = await loadCollaborativeAccess(ctx, { kind: 'faction', id: factionId });
+  if (!access.viewerAccess.capabilities[capability]) {
+    throw new Error(message);
+  }
+  return access;
+}
+
+export async function requireRulesetCapability(
+  ctx: MutationCtx,
+  rulesetId: Id<'rulesets'>,
+  capability: keyof Extract<CollaborativeAccess, { kind: 'ruleset' }>['capabilities'],
+  message = 'Not authorized'
+) {
+  await requireAuthenticatedViewerId(ctx);
+  const access = await loadCollaborativeAccess(ctx, { kind: 'ruleset', id: rulesetId });
+  if (!access.viewerAccess.capabilities[capability]) {
+    throw new Error(message);
+  }
+  return access;
+}
+
+export async function requireAssignableGroup(ctx: MutationCtx, groupId: Id<'groups'>) {
+  return await requireGroupCapability(ctx, groupId, 'addMember', 'Not authorized for group');
+}
+
+export async function requireMembershipRequest(ctx: MutationCtx, groupId: Id<'groups'>) {
+  await requireAuthenticatedViewerId(ctx);
+  const access = await loadCollaborativeAccess(ctx, { kind: 'group', id: groupId });
+  if (
+    access.viewerMembership?.status !== 'pending' &&
+    access.viewerMembership?.status !== 'active' &&
+    !access.viewerAccess.capabilities.requestMembership
+  ) {
+    throw new Error('Not authorized');
+  }
+  return access;
+}
+
+export async function requireLegacyMembershipManager(ctx: MutationCtx, groupId: Id<'groups'>) {
+  const viewerId = (await getAuthUserId(ctx)) as Id<'users'> | null;
+  if (!viewerId) {
+    throw new Error('Not authenticated');
+  }
+  const group = await ctx.db.get('groups', groupId);
+  if (!group) {
+    throw new Error('Not authorized');
+  }
+  const viewerMembership = await membershipFor(ctx, groupId, viewerId);
+  const access = groupAccessFromLoaded(group, viewerId, viewerMembership);
+  if (!access.viewerAccess.capabilities.addMember) {
+    throw new Error('Not authorized');
+  }
+  return access;
+}
+
+export async function requireLegacyGroupOwner(ctx: MutationCtx, groupId: Id<'groups'>) {
+  const viewerId = (await getAuthUserId(ctx)) as Id<'users'> | null;
+  if (!viewerId) {
+    throw new Error('Not authenticated');
+  }
+  const group = await ctx.db.get('groups', groupId);
+  if (!group) {
+    throw new Error('Group not found');
+  }
+  const viewerMembership = await membershipFor(ctx, groupId, viewerId);
+  const access = groupAccessFromLoaded(group, viewerId, viewerMembership);
+  if (!access.viewerAccess.capabilities.delete) {
+    throw new Error('Not authorized');
+  }
+  return access;
+}
+
+export async function requireFactionUpdate(
+  ctx: MutationCtx,
+  factionId: Id<'factions'>,
+  proposedData: { name: string }
+) {
+  await requireAuthenticatedViewerId(ctx);
+  const access = await loadCollaborativeAccess(ctx, { kind: 'faction', id: factionId });
+  if (access.subject.is_deleted) {
+    throw new Error(`Faction with id ${factionId} not found`);
+  }
+  if (!access.viewerAccess.capabilities.edit) {
+    throw new Error('Not authorized');
+  }
+  if (proposedData.name !== access.subject.data.name && !access.viewerAccess.capabilities.rename) {
+    throw new Error('Not authorized');
+  }
+  return access;
+}
+
+export async function requireRulesetUpdate(
+  ctx: MutationCtx,
+  rulesetId: Id<'rulesets'>,
+  proposedChange: { name: string; groupId?: Id<'groups'> | null }
+) {
+  await requireAuthenticatedViewerId(ctx);
+  const access = await loadCollaborativeAccess(ctx, { kind: 'ruleset', id: rulesetId });
+  if (access.subject.is_deleted) {
+    throw new Error(`Ruleset with id ${rulesetId} not found`);
+  }
+  if (!access.viewerAccess.capabilities.edit) {
+    throw new Error('Not authorized');
+  }
+  if (proposedChange.name !== access.subject.name && !access.viewerAccess.capabilities.rename) {
+    throw new Error('Only the ruleset owner can rename this ruleset');
+  }
+  if (proposedChange.groupId !== undefined && proposedChange.groupId !== access.subject.group_id) {
+    if (!access.viewerAccess.capabilities.changeGroup) {
+      throw new Error('Only the ruleset owner can change its group');
+    }
+    if (proposedChange.groupId !== null) {
+      await requireAssignableGroup(ctx, proposedChange.groupId);
+    }
+  }
+  return access;
+}
+
+export function requireGroupReassignment(
+  ctx: MutationCtx,
+  subject: { kind: 'faction'; id: Id<'factions'> },
+  targetGroupId: Id<'groups'> | null
+): Promise<LoadedFactionAccess>;
+export function requireGroupReassignment(
+  ctx: MutationCtx,
+  subject: { kind: 'ruleset'; id: Id<'rulesets'> },
+  targetGroupId: Id<'groups'> | null
+): Promise<LoadedRulesetAccess>;
+export async function requireGroupReassignment(
+  ctx: MutationCtx,
+  subject: { kind: 'faction'; id: Id<'factions'> } | { kind: 'ruleset'; id: Id<'rulesets'> },
+  targetGroupId: Id<'groups'> | null
+) {
+  await requireAuthenticatedViewerId(ctx);
+  const access =
+    subject.kind === 'faction'
+      ? await loadCollaborativeAccess(ctx, subject)
+      : await loadCollaborativeAccess(ctx, subject);
+  if (access.subject.is_deleted) {
+    const label = subject.kind === 'faction' ? 'Faction' : 'Ruleset';
+    throw new Error(`${label} with id ${subject.id} not found`);
+  }
+  if (!access.viewerAccess.capabilities.changeGroup) {
+    throw new Error('Not authorized');
+  }
+  if (targetGroupId !== null) {
+    await requireAssignableGroup(ctx, targetGroupId);
+  }
+  return access;
+}
+
+export async function requireFactionSoftDelete(ctx: MutationCtx, factionId: Id<'factions'>) {
+  await requireAuthenticatedViewerId(ctx);
+  const access = await loadCollaborativeAccess(ctx, { kind: 'faction', id: factionId });
+  if (access.viewerId !== access.subject.owner_id) {
+    throw new Error('Not authorized');
+  }
+  return access;
+}
+
+export async function requireRulesetSoftDelete(ctx: MutationCtx, rulesetId: Id<'rulesets'>) {
+  await requireAuthenticatedViewerId(ctx);
+  const access = await loadCollaborativeAccess(ctx, { kind: 'ruleset', id: rulesetId });
+  if (access.viewerId !== access.subject.owner_id) {
+    throw new Error('Not authorized');
+  }
+  return access;
+}
+
+export async function requireRulesetMaintenance(ctx: MutationCtx, rulesetId: Id<'rulesets'>) {
+  await requireAuthenticatedViewerId(ctx);
+  const ruleset = await ctx.db.get('rulesets', rulesetId);
+  if (!ruleset || ruleset.is_deleted) {
+    throw new Error('Ruleset not found');
+  }
+  const access = await loadRulesetAccessForLoadedSubject(ctx, ruleset);
+  if (!access.viewerAccess.capabilities.edit) {
+    throw new Error('Not authorized');
+  }
+  return access;
+}
+
+type ActiveMembershipWithGroup = Doc<'group_members'> & {
+  groups: AssignedGroupSummary | null;
+};
+
+type LoadedFactionAccessBundle = LoadedFactionAccess & {
+  memberships: Doc<'group_members'>[];
+  groups: Doc<'groups'>[];
+  assignableGroups: AssignedGroupSummary[];
+  viewerAssignableMemberships: ActiveMembershipWithGroup[] | null;
+};
+
+type LoadedRulesetAccessBundle = LoadedRulesetAccess & {
+  memberships: Doc<'group_members'>[];
+  groups: Doc<'groups'>[];
+  assignableGroups: AssignedGroupSummary[];
+  viewerAssignableMemberships: ActiveMembershipWithGroup[] | null;
+};
+
+export function loadAssetAccessBundle(
+  ctx: QueryCtx,
+  subject: { kind: 'faction'; row: Doc<'factions'> }
+): Promise<LoadedFactionAccessBundle>;
+export function loadAssetAccessBundle(
+  ctx: QueryCtx,
+  subject: { kind: 'ruleset'; row: Doc<'rulesets'> }
+): Promise<LoadedRulesetAccessBundle>;
+export async function loadAssetAccessBundle(
+  ctx: QueryCtx,
+  subject: { kind: 'faction'; row: Doc<'factions'> } | { kind: 'ruleset'; row: Doc<'rulesets'> }
+): Promise<LoadedFactionAccessBundle | LoadedRulesetAccessBundle> {
+  const viewerId = (await getAuthUserId(ctx)) as Id<'users'> | null;
+  const legacyMembershipLimit = subject.kind === 'faction' ? 500 : 200;
+  const memberships = viewerId
+    ? await ctx.db
+        .query('group_members')
+        .withIndex('by_user_status', (q) => q.eq('user_id', viewerId).eq('status', 'active'))
+        .take(legacyMembershipLimit)
+    : [];
+  const assignmentMemberships = memberships.slice(0, 200);
+  const groupIds = new Set<Id<'groups'>>();
+  if (subject.row.group_id) {
+    groupIds.add(subject.row.group_id);
+  }
+  for (const membership of memberships) {
+    groupIds.add(membership.group_id);
+  }
+
+  const groups: Doc<'groups'>[] = [];
+  const groupById = new Map<Id<'groups'>, Doc<'groups'>>();
+  for (const groupId of groupIds) {
+    const group = await ctx.db.get('groups', groupId);
+    if (group) {
+      groups.push(group);
+      groupById.set(group._id, group);
+    }
+  }
+  const assignedGroup = subject.row.group_id ? (groupById.get(subject.row.group_id) ?? null) : null;
+  const viewerMembership = await membershipFor(ctx, subject.row.group_id, viewerId);
+  const viewerAssignableMemberships = viewerId
+    ? assignmentMemberships.map((membership) => {
+        const group = groupById.get(membership.group_id);
+        return {
+          ...membership,
+          groups: group ? { id: group._id, name: group.name, slug: group.slug } : null,
+        };
+      })
+    : null;
+  const assignableGroups = (viewerAssignableMemberships ?? []).flatMap((membership) =>
+    membership.groups ? [membership.groups] : []
+  );
+  const collection = {
+    memberships,
+    groups,
+    assignableGroups,
+    viewerAssignableMemberships,
+  };
+
+  return subject.kind === 'faction'
+    ? {
+        ...factionAccessFromLoaded(subject.row, assignedGroup, viewerId, viewerMembership),
+        ...collection,
+      }
+    : {
+        ...rulesetAccessFromLoaded(subject.row, assignedGroup, viewerId, viewerMembership),
+        ...collection,
+      };
+}
+
+export type GroupRosterEntry = {
+  membershipId: Id<'group_members'>;
+  user: {
+    id: Id<'profiles'>;
+    slug: string;
+    username: string | null;
+    avatar_url: string | null;
+  };
+  status: 'pending' | 'active';
+  requestedAt: string;
+  capabilities: { approve: boolean; reject: boolean; remove: boolean };
+};
+
+export async function loadGroupAccessBundle(ctx: QueryCtx, group: Doc<'groups'>) {
+  const viewerId = (await getAuthUserId(ctx)) as Id<'users'> | null;
+  const members = await ctx.db
+    .query('group_members')
+    .withIndex('by_group', (q) => q.eq('group_id', group._id))
+    .take(500);
+  const viewerMembership = await membershipFor(ctx, group._id, viewerId);
+  const access = groupAccessFromLoaded(group, viewerId, viewerMembership);
+  const profiles: Doc<'profiles'>[] = [];
+  const profileByUserId = new Map<Id<'users'>, Doc<'profiles'>>();
+  const userIds = new Set<Id<'users'>>([access.subject.created_by]);
+  for (const membership of members) {
+    userIds.add(membership.user_id);
+  }
+  for (const userId of userIds) {
+    const profile = await ctx.db
+      .query('profiles')
+      .withIndex('by_user_id', (q) => q.eq('user_id', userId))
+      .unique();
+    if (!profile) {
+      throw new Error(`Invariant: every user must have a profile (missing for ${userId})`);
+    }
+    profiles.push(profile);
+    profileByUserId.set(userId, profile);
+  }
+
+  const actorIsActive =
+    access.viewerAccess.viewer.kind === 'authenticated' &&
+    access.viewerAccess.viewer.membership === 'active';
+  const actorIsOwner = access.viewerAccess.capabilities.rename;
+  const roster: GroupRosterEntry[] = members.flatMap((membership) => {
+    if (membership.status === 'removed') {
+      return [];
+    }
+    const profile = profileByUserId.get(membership.user_id);
+    if (!profile) {
+      throw new Error(
+        `Invariant: every member must have a profile (missing for ${membership.user_id})`
+      );
+    }
+    const pending = membership.status === 'pending';
+    return [
+      {
+        membershipId: membership._id,
+        user: {
+          id: profile._id,
+          slug: profile.slug,
+          username: profile.username,
+          avatar_url: profile.avatar_url,
+        },
+        status: membership.status,
+        requestedAt: membership.requested_at,
+        capabilities: {
+          approve: actorIsActive && pending,
+          reject: actorIsActive && pending,
+          remove: actorIsOwner && !pending && membership.user_id !== access.subject.created_by,
+        },
+      },
+    ];
+  });
+
+  return { ...access, members, profiles, roster };
+}
+
+export function evaluateCollaborativeAccess(facts: CollaborativeAccessFacts): CollaborativeAccess {
+  const authenticated = facts.viewer.kind === 'authenticated';
+  const membership: MembershipState | null =
+    facts.viewer.kind === 'authenticated'
+      ? facts.viewer.membership === 'removed'
+        ? 'none'
+        : facts.viewer.membership
+      : null;
+  const activeMember = authenticated && membership === 'active';
+  const owner = facts.viewer.kind === 'authenticated' && facts.viewer.ownsSubject;
+  const viewer: PublicViewer =
+    facts.viewer.kind === 'anonymous'
+      ? facts.viewer
+      : { kind: 'authenticated', membership: membership ?? 'none' };
+  const requestMembership = authenticated && membership === 'none' && facts.group.eligible;
+
+  if (facts.kind === 'group') {
+    return {
+      kind: 'group',
+      viewer,
+      capabilities: {
+        requestMembership,
+        rename: owner && facts.group.eligible,
+        delete: owner && facts.group.eligible,
+        addMember: activeMember && facts.group.eligible,
+      },
+    };
+  }
+
+  return {
+    kind: facts.kind,
+    assignedGroup: facts.group.summary,
+    viewer,
+    capabilities: {
+      requestMembership: requestMembership && facts.resource.available,
+      edit: facts.resource.available && (owner || (activeMember && facts.group.eligible)),
+      rename:
+        facts.resource.available &&
+        (owner || (facts.kind === 'faction' && activeMember && facts.group.eligible)),
+      changeGroup: facts.resource.available && owner,
+      delete: facts.resource.available && owner,
+    },
+  };
+}

--- a/convex/lib/collaborativeAccess.ts
+++ b/convex/lib/collaborativeAccess.ts
@@ -322,8 +322,13 @@ export async function requireAssignableGroup(ctx: MutationCtx, groupId: Id<'grou
 }
 
 export async function requireMembershipRequest(ctx: MutationCtx, groupId: Id<'groups'>) {
-  await requireAuthenticatedViewerId(ctx);
-  const access = await loadCollaborativeAccess(ctx, { kind: 'group', id: groupId });
+  const viewerId = await requireAuthenticatedViewerId(ctx);
+  const group = await ctx.db.get('groups', groupId);
+  if (!group) {
+    throw new Error('Group not found');
+  }
+  const viewerMembership = await membershipFor(ctx, groupId, viewerId);
+  const access = groupAccessFromLoaded(group, viewerId, viewerMembership);
   if (
     access.viewerMembership?.status !== 'pending' &&
     access.viewerMembership?.status !== 'active' &&

--- a/convex/lib/collaborativeAccessValidators.ts
+++ b/convex/lib/collaborativeAccessValidators.ts
@@ -1,0 +1,280 @@
+import { v } from 'convex/values';
+
+const groupValidator = v.object({
+  _id: v.id('groups'),
+  _creationTime: v.number(),
+  name: v.string(),
+  slug: v.string(),
+  created_at: v.string(),
+  created_by: v.id('users'),
+});
+
+export const groupMemberValidator = v.object({
+  _id: v.id('group_members'),
+  _creationTime: v.number(),
+  group_id: v.id('groups'),
+  user_id: v.id('users'),
+  status: v.union(v.literal('pending'), v.literal('active'), v.literal('removed')),
+  requested_at: v.string(),
+  approved_at: v.union(v.string(), v.null()),
+  approved_by: v.union(v.id('users'), v.null()),
+});
+
+export const membershipCommandAcknowledgementValidator = v.object({
+  membershipId: v.id('group_members'),
+  status: v.union(v.literal('pending'), v.literal('active'), v.literal('removed')),
+});
+
+const profileValidator = v.object({
+  _id: v.id('profiles'),
+  _creationTime: v.number(),
+  user_id: v.id('users'),
+  username: v.union(v.string(), v.null()),
+  avatar_url: v.union(v.string(), v.null()),
+  slug: v.string(),
+  created_at: v.string(),
+  updated_at: v.string(),
+});
+
+const factionValidator = v.object({
+  _id: v.id('factions'),
+  _creationTime: v.number(),
+  owner_id: v.id('users'),
+  data: v.any(),
+  slug: v.string(),
+  created_at: v.string(),
+  updated_at: v.string(),
+  is_deleted: v.boolean(),
+  group_id: v.union(v.id('groups'), v.null()),
+});
+
+const rulesetValidator = v.object({
+  _id: v.id('rulesets'),
+  _creationTime: v.number(),
+  name: v.string(),
+  slug: v.string(),
+  created_at: v.string(),
+  updated_at: v.string(),
+  owner_id: v.id('users'),
+  group_id: v.union(v.id('groups'), v.null()),
+  is_deleted: v.boolean(),
+  image_cover: v.union(v.string(), v.null()),
+});
+
+const publicViewerValidator = v.union(
+  v.object({ kind: v.literal('anonymous') }),
+  v.object({
+    kind: v.literal('authenticated'),
+    membership: v.union(v.literal('none'), v.literal('pending'), v.literal('active')),
+  })
+);
+
+const assignedGroupSummaryValidator = v.object({
+  id: v.id('groups'),
+  name: v.string(),
+  slug: v.string(),
+});
+
+const profileSummaryValidator = v.object({
+  id: v.id('profiles'),
+  slug: v.string(),
+  username: v.union(v.string(), v.null()),
+  avatar_url: v.union(v.string(), v.null()),
+});
+
+const groupViewerAccessValidator = v.object({
+  kind: v.literal('group'),
+  viewer: publicViewerValidator,
+  capabilities: v.object({
+    requestMembership: v.boolean(),
+    rename: v.boolean(),
+    delete: v.boolean(),
+    addMember: v.boolean(),
+  }),
+});
+
+const rosterEntryValidator = v.object({
+  membershipId: v.id('group_members'),
+  user: v.object({
+    id: v.id('profiles'),
+    slug: v.string(),
+    username: v.union(v.string(), v.null()),
+    avatar_url: v.union(v.string(), v.null()),
+  }),
+  status: v.union(v.literal('pending'), v.literal('active')),
+  requestedAt: v.string(),
+  capabilities: v.object({
+    approve: v.boolean(),
+    reject: v.boolean(),
+    remove: v.boolean(),
+  }),
+});
+
+function assetViewerAccessValidator(kind: 'faction' | 'ruleset') {
+  return v.object({
+    kind: v.literal(kind),
+    assignedGroup: v.union(assignedGroupSummaryValidator, v.null()),
+    viewer: publicViewerValidator,
+    capabilities: v.object({
+      requestMembership: v.boolean(),
+      edit: v.boolean(),
+      rename: v.boolean(),
+      changeGroup: v.boolean(),
+      delete: v.boolean(),
+    }),
+  });
+}
+
+const groupAccessValidator = v.object({
+  group: groupValidator,
+  members: v.array(
+    v.object({
+      membership: groupMemberValidator,
+      profile: v.union(profileSummaryValidator, v.null()),
+    })
+  ),
+});
+
+const assetPublishingValidator = v.object({
+  status: v.union(v.literal('current'), v.null()),
+  captureStatus: v.union(v.literal('scheduled'), v.literal('in_progress'), v.null()),
+  publicationHref: v.union(v.string(), v.null()),
+  lastPublishedAt: v.union(v.number(), v.null()),
+});
+
+export const factionDetailPageValidator = v.object({
+  faction: factionValidator,
+  owner: profileValidator,
+  group: v.union(groupValidator, v.null()),
+  memberships: v.array(groupMemberValidator),
+  groups: v.array(groupValidator),
+  groupAccess: v.union(groupAccessValidator, v.null()),
+  assetPublishing: assetPublishingValidator,
+  viewerAccess: assetViewerAccessValidator('faction'),
+  assignableGroups: v.array(assignedGroupSummaryValidator),
+});
+
+const rulesetFactionSummaryValidator = v.object({
+  factionId: v.id('factions'),
+  name: v.string(),
+  urlSlug: v.string(),
+  identity: v.union(v.object({ logo: v.string(), background: v.any() }), v.null()),
+});
+
+export const rulesetPublicBundleValidator = v.object({
+  ruleset: rulesetValidator,
+  factions: v.array(rulesetFactionSummaryValidator),
+  canEditRuleset: v.boolean(),
+  viewerAccess: assetViewerAccessValidator('ruleset'),
+});
+
+const faqTagValidator = v.union(
+  v.literal('rules'),
+  v.literal('army_list'),
+  v.literal('strategy'),
+  v.literal('balance'),
+  v.literal('errata'),
+  v.literal('other')
+);
+
+const faqAnswerValidator = v.object({
+  _id: v.id('faq_answers'),
+  _creationTime: v.number(),
+  faq_item_id: v.id('faq_items'),
+  answer: v.string(),
+  answered_by: v.id('users'),
+  created_at: v.string(),
+});
+
+const faqItemValidator = v.object({
+  _id: v.id('faq_items'),
+  _creationTime: v.number(),
+  ruleset_id: v.id('rulesets'),
+  slug: v.string(),
+  question: v.string(),
+  tags: v.optional(v.array(faqTagValidator)),
+  asked_by: v.id('users'),
+  created_at: v.string(),
+  updated_at: v.string(),
+  accepted_answer_id: v.union(v.id('faq_answers'), v.null()),
+});
+
+const faqListItemValidator = faqItemValidator.extend({
+  faq_answers: v.array(faqAnswerValidator),
+  asker_profile: v.union(profileSummaryValidator, v.null()),
+});
+
+const rulesetSummaryValidator = v.object({
+  id: v.id('rulesets'),
+  name: v.string(),
+  slug: v.string(),
+});
+
+const profileFaqQuestionValidator = faqItemValidator.extend({
+  ruleset: rulesetSummaryValidator,
+});
+
+const profileFaqAnswerValidator = faqAnswerValidator.extend({
+  faq_item: v.object({
+    id: v.id('faq_items'),
+    slug: v.string(),
+    question: v.string(),
+    ruleset_id: v.id('rulesets'),
+    asked_by: v.id('users'),
+    accepted_answer_id: v.union(v.id('faq_answers'), v.null()),
+  }),
+  asker_profile: v.union(profileSummaryValidator, v.null()),
+  ruleset: rulesetSummaryValidator,
+});
+
+const profileFactionValidator = factionValidator.extend({
+  rulesets: v.array(rulesetSummaryValidator),
+});
+
+export const profileDetailPageValidator = v.object({
+  profile: profileValidator,
+  memberships: v.array(groupMemberValidator),
+  groups: v.array(groupValidator),
+  faqAsked: v.array(profileFaqQuestionValidator),
+  faqAnswers: v.array(profileFaqAnswerValidator),
+  factions: v.array(profileFactionValidator),
+  groupSummaries: v.array(assignedGroupSummaryValidator),
+});
+
+const membershipWithGroupValidator = groupMemberValidator.extend({
+  groups: v.union(assignedGroupSummaryValidator, v.null()),
+});
+
+export const rulesetDetailPageValidator = v.union(
+  rulesetPublicBundleValidator.extend({
+    groupAccess: v.union(groupAccessValidator, v.null()),
+    faqItems: v.array(faqListItemValidator),
+    owner: v.union(profileSummaryValidator, v.null()),
+    viewerAssignableMemberships: v.union(v.array(membershipWithGroupValidator), v.null()),
+    assignableGroups: v.array(assignedGroupSummaryValidator),
+  }),
+  v.null()
+);
+
+export const groupDetailPageValidator = v.object({
+  group: groupValidator,
+  members: v.array(groupMemberValidator),
+  factions: v.array(factionValidator),
+  rulesets: v.array(rulesetValidator),
+  profiles: v.array(profileValidator),
+  viewerAccess: groupViewerAccessValidator,
+  roster: v.array(rosterEntryValidator),
+});
+
+export {
+  factionValidator,
+  assignedGroupSummaryValidator,
+  assetViewerAccessValidator,
+  groupValidator,
+  groupViewerAccessValidator,
+  profileValidator,
+  profileSummaryValidator,
+  publicViewerValidator,
+  rosterEntryValidator,
+  rulesetValidator,
+};

--- a/convex/members.ts
+++ b/convex/members.ts
@@ -4,11 +4,25 @@ import type { Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 import type { MutationCtx, QueryCtx } from './_generated/server';
 import { mutation } from './functions';
+import {
+  requireGroupCapability,
+  requireLegacyGroupOwner,
+  requireLegacyMembershipManager,
+  requireMembershipRequest,
+} from './lib/collaborativeAccess';
+import {
+  groupMemberValidator,
+  membershipCommandAcknowledgementValidator,
+} from './lib/collaborativeAccessValidators';
 import { listByUserActiveWithGroupsData } from './lib/memberGroups';
-import { isActiveGroupMember, requireAuthUserId } from './lib/policy';
+import { requireAuthUserId } from './lib/policy';
 import { nowIso } from './lib/utils';
 
 const statusValidator = v.union(v.literal('pending'), v.literal('active'), v.literal('removed'));
+
+function commandAcknowledgement(membership: Awaited<ReturnType<typeof requireMembership>>) {
+  return { membershipId: membership._id, status: membership.status };
+}
 
 async function getMembership(
   ctx: QueryCtx | MutationCtx,
@@ -21,8 +35,108 @@ async function getMembership(
     .unique();
 }
 
-async function loadGroup(ctx: QueryCtx | MutationCtx, groupId: Id<'groups'>) {
-  return await ctx.db.get(groupId);
+async function requireMembership(ctx: MutationCtx, membershipId: Id<'group_members'>) {
+  const membership = await ctx.db.get('group_members', membershipId);
+  if (!membership) {
+    throw new Error('Group member not found');
+  }
+  return membership;
+}
+
+async function approveRequestHandler(ctx: MutationCtx, membershipId: Id<'group_members'>) {
+  const membership = await requireMembership(ctx, membershipId);
+  const access = await requireGroupCapability(ctx, membership.group_id, 'addMember');
+  return await approveMembership(ctx, membership, access.viewerId as Id<'users'>);
+}
+
+async function approveMembership(
+  ctx: MutationCtx,
+  membership: Awaited<ReturnType<typeof requireMembership>>,
+  actorId: Id<'users'>
+) {
+  if (membership.status !== 'pending') {
+    throw new Error('Membership is not pending approval');
+  }
+  await ctx.db.patch(membership._id, {
+    status: 'active',
+    approved_by: actorId,
+    approved_at: nowIso(),
+  });
+  return await requireMembership(ctx, membership._id);
+}
+
+async function rejectRequestHandler(ctx: MutationCtx, membershipId: Id<'group_members'>) {
+  const membership = await requireMembership(ctx, membershipId);
+  await requireGroupCapability(ctx, membership.group_id, 'addMember');
+  return await rejectMembership(ctx, membership);
+}
+
+async function rejectMembership(
+  ctx: MutationCtx,
+  membership: Awaited<ReturnType<typeof requireMembership>>
+) {
+  if (membership.status !== 'pending') {
+    throw new Error('Membership is not pending approval');
+  }
+  await ctx.db.patch(membership._id, {
+    status: 'removed',
+    approved_by: null,
+    approved_at: null,
+  });
+  return await requireMembership(ctx, membership._id);
+}
+
+async function removeMemberHandler(ctx: MutationCtx, membershipId: Id<'group_members'>) {
+  const membership = await requireMembership(ctx, membershipId);
+  const access = await requireGroupCapability(ctx, membership.group_id, 'delete');
+  return await removeMembership(ctx, membership, access.subject.created_by);
+}
+
+async function removeMembership(
+  ctx: MutationCtx,
+  membership: Awaited<ReturnType<typeof requireMembership>>,
+  ownerId: Id<'users'>
+) {
+  if (membership.user_id === ownerId) {
+    throw new Error('Cannot remove the group owner');
+  }
+  if (membership.status !== 'active') {
+    throw new Error('Can only remove active members');
+  }
+  await ctx.db.patch(membership._id, {
+    status: 'removed',
+    approved_by: null,
+    approved_at: null,
+  });
+  return await requireMembership(ctx, membership._id);
+}
+
+async function addMemberHandler(
+  ctx: MutationCtx,
+  args: { groupId: Id<'groups'>; userId: Id<'users'> }
+) {
+  const actorId = await requireAuthUserId(ctx);
+  await requireGroupCapability(ctx, args.groupId, 'addMember');
+
+  const existing = await getMembership(ctx, args.groupId, args.userId);
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      status: 'active',
+      approved_by: actorId,
+      approved_at: nowIso(),
+    });
+    return await requireMembership(ctx, existing._id);
+  }
+
+  const membershipId = await ctx.db.insert('group_members', {
+    group_id: args.groupId,
+    user_id: args.userId,
+    status: 'active',
+    requested_at: nowIso(),
+    approved_by: actorId,
+    approved_at: nowIso(),
+  });
+  return await requireMembership(ctx, membershipId);
 }
 
 export const listByUserActiveWithGroups = query({
@@ -65,14 +179,11 @@ export const get = query({
 
 export const request = mutation({
   args: { group_id: v.id('groups') },
+  returns: groupMemberValidator,
   handler: async (ctx, args) => {
-    const userId = await requireAuthUserId(ctx);
-    const group = await loadGroup(ctx, args.group_id);
-    if (!group) {
-      throw new Error('Group not found');
-    }
-
-    const existing = await getMembership(ctx, args.group_id, userId);
+    const access = await requireMembershipRequest(ctx, args.group_id);
+    const userId = access.viewerId as Id<'users'>;
+    const existing = access.viewerMembership;
     if (existing) {
       if (existing.status === 'pending' || existing.status === 'active') {
         return existing;
@@ -105,36 +216,34 @@ export const request = mutation({
   },
 });
 
+export const approveRequest = mutation({
+  args: { membershipId: v.id('group_members') },
+  returns: membershipCommandAcknowledgementValidator,
+  handler: async (ctx, args) =>
+    commandAcknowledgement(await approveRequestHandler(ctx, args.membershipId)),
+});
+
 export const approve = mutation({
   args: {
     group_id: v.id('groups'),
     user_id: v.id('users'),
   },
+  returns: groupMemberValidator,
   handler: async (ctx, args) => {
-    const actorId = await requireAuthUserId(ctx);
-    const canManage = await isActiveGroupMember(ctx, args.group_id, actorId);
-    if (!canManage) {
-      throw new Error('Not authorized');
-    }
-
+    const access = await requireLegacyMembershipManager(ctx, args.group_id);
     const row = await getMembership(ctx, args.group_id, args.user_id);
     if (!row) {
       throw new Error('Failed to approve group member');
     }
-    if (row.status !== 'pending') {
-      throw new Error('Membership is not pending approval');
-    }
-    await ctx.db.patch(row._id, {
-      status: 'active',
-      approved_by: actorId,
-      approved_at: nowIso(),
-    });
-    const updated = await ctx.db.get(row._id);
-    if (!updated) {
-      throw new Error('Failed to approve group member');
-    }
-    return updated;
+    return await approveMembership(ctx, row, access.viewerId as Id<'users'>);
   },
+});
+
+export const rejectRequest = mutation({
+  args: { membershipId: v.id('group_members') },
+  returns: membershipCommandAcknowledgementValidator,
+  handler: async (ctx, args) =>
+    commandAcknowledgement(await rejectRequestHandler(ctx, args.membershipId)),
 });
 
 export const reject = mutation({
@@ -142,31 +251,22 @@ export const reject = mutation({
     group_id: v.id('groups'),
     user_id: v.id('users'),
   },
+  returns: groupMemberValidator,
   handler: async (ctx, args) => {
-    const actorId = await requireAuthUserId(ctx);
-    const canManage = await isActiveGroupMember(ctx, args.group_id, actorId);
-    if (!canManage) {
-      throw new Error('Not authorized');
-    }
-
+    await requireLegacyMembershipManager(ctx, args.group_id);
     const row = await getMembership(ctx, args.group_id, args.user_id);
     if (!row) {
       throw new Error('Failed to reject group member');
     }
-    if (row.status !== 'pending') {
-      throw new Error('Membership is not pending approval');
-    }
-    await ctx.db.patch(row._id, {
-      status: 'removed',
-      approved_by: null,
-      approved_at: null,
-    });
-    const updated = await ctx.db.get(row._id);
-    if (!updated) {
-      throw new Error('Failed to reject group member');
-    }
-    return updated;
+    return await rejectMembership(ctx, row);
   },
+});
+
+export const removeMember = mutation({
+  args: { membershipId: v.id('group_members') },
+  returns: membershipCommandAcknowledgementValidator,
+  handler: async (ctx, args) =>
+    commandAcknowledgement(await removeMemberHandler(ctx, args.membershipId)),
 });
 
 export const remove = mutation({
@@ -174,33 +274,25 @@ export const remove = mutation({
     group_id: v.id('groups'),
     user_id: v.id('users'),
   },
+  returns: v.object({ groupId: v.id('groups'), userId: v.id('users') }),
   handler: async (ctx, args) => {
-    const actorId = await requireAuthUserId(ctx);
-    const group = await loadGroup(ctx, args.group_id);
-    if (!group) {
-      throw new Error('Group not found');
-    }
-    if (group.created_by !== actorId) {
-      throw new Error('Not authorized');
-    }
-    if (args.user_id === group.created_by) {
-      throw new Error('Cannot remove the group owner');
-    }
-
+    const access = await requireLegacyGroupOwner(ctx, args.group_id);
     const row = await getMembership(ctx, args.group_id, args.user_id);
     if (!row) {
       throw new Error('Failed to remove group member');
     }
-    if (row.status !== 'active') {
-      throw new Error('Can only remove active members');
-    }
-    await ctx.db.patch(row._id, {
-      status: 'removed',
-      approved_by: null,
-      approved_at: null,
-    });
+    await removeMembership(ctx, row, access.subject.created_by);
     return { groupId: args.group_id, userId: args.user_id };
   },
+});
+
+export const addMember = mutation({
+  args: {
+    groupId: v.id('groups'),
+    userId: v.id('users'),
+  },
+  returns: membershipCommandAcknowledgementValidator,
+  handler: async (ctx, args) => commandAcknowledgement(await addMemberHandler(ctx, args)),
 });
 
 export const add = mutation({
@@ -208,39 +300,7 @@ export const add = mutation({
     group_id: v.id('groups'),
     user_id: v.id('users'),
   },
-  handler: async (ctx, args) => {
-    const actorId = await requireAuthUserId(ctx);
-    const canManage = await isActiveGroupMember(ctx, args.group_id, actorId);
-    if (!canManage) {
-      throw new Error('Not authorized');
-    }
-
-    const existing = await getMembership(ctx, args.group_id, args.user_id);
-    if (existing) {
-      await ctx.db.patch(existing._id, {
-        status: 'active',
-        approved_by: actorId,
-        approved_at: nowIso(),
-      });
-      const updated = await ctx.db.get(existing._id);
-      if (!updated) {
-        throw new Error('Failed to add group member');
-      }
-      return updated;
-    }
-
-    const _id = await ctx.db.insert('group_members', {
-      group_id: args.group_id,
-      user_id: args.user_id,
-      status: 'active',
-      requested_at: nowIso(),
-      approved_by: actorId,
-      approved_at: nowIso(),
-    });
-    const created = await ctx.db.get(_id);
-    if (!created) {
-      throw new Error('Failed to add group member');
-    }
-    return created;
-  },
+  returns: groupMemberValidator,
+  handler: async (ctx, args) =>
+    await addMemberHandler(ctx, { groupId: args.group_id, userId: args.user_id }),
 });

--- a/convex/members.ts
+++ b/convex/members.ts
@@ -44,6 +44,7 @@ async function requireMembership(ctx: MutationCtx, membershipId: Id<'group_membe
 }
 
 async function approveRequestHandler(ctx: MutationCtx, membershipId: Id<'group_members'>) {
+  await requireAuthUserId(ctx);
   const membership = await requireMembership(ctx, membershipId);
   const access = await requireGroupCapability(ctx, membership.group_id, 'addMember');
   return await approveMembership(ctx, membership, access.viewerId as Id<'users'>);
@@ -66,6 +67,7 @@ async function approveMembership(
 }
 
 async function rejectRequestHandler(ctx: MutationCtx, membershipId: Id<'group_members'>) {
+  await requireAuthUserId(ctx);
   const membership = await requireMembership(ctx, membershipId);
   await requireGroupCapability(ctx, membership.group_id, 'addMember');
   return await rejectMembership(ctx, membership);
@@ -87,6 +89,7 @@ async function rejectMembership(
 }
 
 async function removeMemberHandler(ctx: MutationCtx, membershipId: Id<'group_members'>) {
+  await requireAuthUserId(ctx);
   const membership = await requireMembership(ctx, membershipId);
   const access = await requireGroupCapability(ctx, membership.group_id, 'delete');
   return await removeMembership(ctx, membership, access.subject.created_by);

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -6,6 +6,7 @@ import type { Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 import type { MutationCtx } from './_generated/server';
 import { mutation } from './functions';
+import { profileDetailPageValidator } from './lib/collaborativeAccessValidators';
 import { enrichFactionsWithRulesets, listActiveRulesetSummaries } from './lib/factionCatalogue';
 import { loadFaqAnswersGivenBy, loadFaqQuestionsAskedBy } from './lib/faqProfileActivity';
 import { requireAuthUserId } from './lib/policy';
@@ -97,6 +98,7 @@ export const getById = query({
 
 export const getBySlug = query({
   args: { slug: v.string() },
+  returns: profileDetailPageValidator,
   handler: async (ctx, args) => {
     const profile = await ctx.db
       .query('profiles')
@@ -117,6 +119,11 @@ export const getBySlug = query({
     const groups = groupsWithNulls.filter(
       (group): group is NonNullable<(typeof groupsWithNulls)[number]> => group !== null
     );
+    const groupSummaries = groups.map((group) => ({
+      id: group._id,
+      name: group.name,
+      slug: group.slug,
+    }));
 
     const [faqAsked, faqAnswers] = await Promise.all([
       loadFaqQuestionsAskedBy(ctx, profile.user_id),
@@ -139,6 +146,7 @@ export const getBySlug = query({
       faqAsked,
       faqAnswers,
       factions,
+      groupSummaries,
     };
   },
 });

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -1,4 +1,3 @@
-import { getAuthUserId } from '@convex-dev/auth/server';
 import { v } from 'convex/values';
 
 import { rulesetInputSchema } from '../src/app/rulesets/validation';
@@ -6,9 +5,20 @@ import { CanonicalFactionStoredSchema } from '../src/game/schema/faction';
 import type { Doc, Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 import { mutation } from './functions';
+import {
+  loadAssetAccessBundle,
+  loadRulesetAccessForLoadedSubject,
+  requireAssignableGroup,
+  requireRulesetMaintenance,
+  requireRulesetSoftDelete,
+  requireRulesetUpdate,
+} from './lib/collaborativeAccess';
+import {
+  rulesetDetailPageValidator,
+  rulesetPublicBundleValidator,
+} from './lib/collaborativeAccessValidators';
 import { loadFaqItemsForRuleset } from './lib/faqRulesetList';
-import { listByUserActiveWithGroupsData } from './lib/memberGroups';
-import { canEditRuleset, isActiveGroupMember, requireAuthUserId } from './lib/policy';
+import { requireAuthUserId } from './lib/policy';
 import { profileSummary } from './lib/profileSummary';
 import { nowIso, slugify } from './lib/utils';
 import type { MutationCtx, QueryCtx } from './types';
@@ -102,49 +112,57 @@ export const get = query({
   },
 });
 
-async function rulesetPublicBundleBySlugMaybe(ctx: QueryCtx, slug: string) {
-  const row = await ctx.db
+async function rulesetBySlugMaybe(ctx: QueryCtx, slug: string) {
+  const locatedRow = await ctx.db
     .query('rulesets')
     .withIndex('by_slug', (q) => q.eq('slug', slug))
     .unique();
-  if (!row || row.is_deleted) {
+  if (!locatedRow || locatedRow.is_deleted) {
     return null;
   }
+  return locatedRow;
+}
 
+async function rulesetPublicPage(
+  ctx: QueryCtx,
+  row: Doc<'rulesets'>,
+  viewerAccess: Awaited<ReturnType<typeof loadRulesetAccessForLoadedSubject>>['viewerAccess']
+) {
   const factions = await listPublicRulesetFactions(ctx, row._id);
-
-  const userId = await getAuthUserId(ctx);
-  const canEditRulesetForViewer =
-    userId != null && (await canEditRuleset(ctx, row, userId as unknown as Id<'users'>));
-
   return {
     ruleset: row,
     factions,
-    canEditRuleset: canEditRulesetForViewer,
+    canEditRuleset: viewerAccess.capabilities.edit,
+    viewerAccess,
   };
 }
 
 async function rulesetPublicBundleBySlug(ctx: QueryCtx, slug: string) {
-  const bundle = await rulesetPublicBundleBySlugMaybe(ctx, slug);
-  if (!bundle) {
+  const row = await rulesetBySlugMaybe(ctx, slug);
+  if (!row) {
     throw new Error(`Ruleset with slug ${slug} not found`);
   }
-  return bundle;
+  const access = await loadRulesetAccessForLoadedSubject(ctx, row);
+  return await rulesetPublicPage(ctx, row, access.viewerAccess);
 }
 
 export const getBySlug = query({
   args: { slug: v.string() },
+  returns: rulesetPublicBundleValidator,
   handler: async (ctx, args) => rulesetPublicBundleBySlug(ctx, args.slug),
 });
 
 export const detailPageBySlug = query({
   args: { slug: v.string() },
+  returns: rulesetDetailPageValidator,
   handler: async (ctx, args) => {
-    const base = await rulesetPublicBundleBySlugMaybe(ctx, args.slug);
-    if (!base) {
+    const row = await rulesetBySlugMaybe(ctx, args.slug);
+    if (!row) {
       return null;
     }
-    const faqItems = await loadFaqItemsForRuleset(ctx, base.ruleset._id);
+    const access = await loadAssetAccessBundle(ctx, { kind: 'ruleset', row });
+    const page = await rulesetPublicPage(ctx, row, access.viewerAccess);
+    const faqItems = await loadFaqItemsForRuleset(ctx, row._id);
 
     let groupAccess: {
       group: Doc<'groups'>;
@@ -154,33 +172,31 @@ export const detailPageBySlug = query({
       }>;
     } | null = null;
 
-    const linkedGroupId = base.ruleset.group_id;
-    if (linkedGroupId) {
-      const group = await ctx.db.get(linkedGroupId);
-      if (group) {
-        const memberships = await ctx.db
-          .query('group_members')
-          .withIndex('by_group', (q) => q.eq('group_id', linkedGroupId))
-          .take(500);
-        const members = await Promise.all(
-          memberships.map(async (m) => ({
-            membership: m,
-            profile: await profileSummary(ctx, m.user_id),
-          }))
-        );
-        groupAccess = { group, members };
-      }
+    const linkedGroupId = row.group_id;
+    if (linkedGroupId && access.assignedGroup) {
+      const memberships = await ctx.db
+        .query('group_members')
+        .withIndex('by_group', (q) => q.eq('group_id', linkedGroupId))
+        .take(500);
+      const members = await Promise.all(
+        memberships.map(async (m) => ({
+          membership: m,
+          profile: await profileSummary(ctx, m.user_id),
+        }))
+      );
+      groupAccess = { group: access.assignedGroup, members };
     }
 
-    const owner = await profileSummary(ctx, base.ruleset.owner_id);
+    const owner = await profileSummary(ctx, row.owner_id);
 
-    const authUserId = await getAuthUserId(ctx);
-    const viewerAssignableMemberships =
-      authUserId != null
-        ? await listByUserActiveWithGroupsData(ctx, authUserId as unknown as Id<'users'>)
-        : null;
-
-    return { ...base, groupAccess, faqItems, owner, viewerAssignableMemberships };
+    return {
+      ...page,
+      groupAccess,
+      faqItems,
+      owner,
+      viewerAssignableMemberships: access.viewerAssignableMemberships,
+      assignableGroups: access.assignableGroups,
+    };
   },
 });
 
@@ -200,15 +216,11 @@ export const factionDetails = query({
 export const canEdit = query({
   args: { ruleset_id: v.id('rulesets') },
   handler: async (ctx, args) => {
-    const userId = await getAuthUserId(ctx);
-    if (!userId) {
-      return false;
-    }
     const ruleset = await getRulesetById(ctx, args.ruleset_id);
     if (!ruleset) {
       return false;
     }
-    return await canEditRuleset(ctx, ruleset, userId);
+    return (await loadRulesetAccessForLoadedSubject(ctx, ruleset)).viewerAccess.capabilities.edit;
   },
 });
 
@@ -240,10 +252,7 @@ export const create = mutation({
     const normalizedName = parsed.data.name;
 
     if (args.group_id) {
-      const canUseGroup = await isActiveGroupMember(ctx, args.group_id, userId);
-      if (!canUseGroup) {
-        throw new Error('Not authorized for group');
-      }
+      await requireAssignableGroup(ctx, args.group_id);
     }
 
     const duplicate = await ctx.db
@@ -282,38 +291,17 @@ export const update = mutation({
     image_cover: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
-    const userId = await requireAuthUserId(ctx);
     const parsed = rulesetInputSchema.safeParse({ name: args.name });
     if (!parsed.success) {
       const msg = parsed.error.issues.map((i) => i.message).join(' ');
       throw new Error(msg || 'Invalid ruleset input');
     }
     const normalizedName = parsed.data.name;
-    const ruleset = await getRulesetById(ctx, args.id);
-    if (!ruleset || ruleset.is_deleted) {
-      throw new Error(`Ruleset with id ${args.id} not found`);
-    }
-
-    const isOwner = ruleset.owner_id === userId;
-    const canEdit = await canEditRuleset(ctx, ruleset, userId);
-    if (!canEdit) {
-      throw new Error('Not authorized');
-    }
-    if (!isOwner && normalizedName !== ruleset.name) {
-      throw new Error('Only the ruleset owner can rename this ruleset');
-    }
-    if (!isOwner && args.group_id !== undefined && args.group_id !== ruleset.group_id) {
-      throw new Error('Only the ruleset owner can change its group');
-    }
-
-    if (args.group_id !== undefined) {
-      if (args.group_id !== null) {
-        const canUseGroup = await isActiveGroupMember(ctx, args.group_id, userId);
-        if (!canUseGroup) {
-          throw new Error('Not authorized for group');
-        }
-      }
-    }
+    const access = await requireRulesetUpdate(ctx, args.id, {
+      name: normalizedName,
+      groupId: args.group_id,
+    });
+    const ruleset = access.subject;
 
     const duplicate = await ctx.db
       .query('rulesets')
@@ -353,15 +341,7 @@ export const update = mutation({
 export const softDelete = mutation({
   args: { id: v.id('rulesets') },
   handler: async (ctx, args) => {
-    const userId = await requireAuthUserId(ctx);
-    const ruleset = await getRulesetById(ctx, args.id);
-    if (!ruleset) {
-      throw new Error(`Ruleset with id ${args.id} not found`);
-    }
-
-    if (ruleset.owner_id !== userId) {
-      throw new Error('Not authorized');
-    }
+    const { subject: ruleset } = await requireRulesetSoftDelete(ctx, args.id);
 
     await ctx.db.patch(ruleset._id, {
       is_deleted: true,
@@ -376,16 +356,7 @@ export const addFaction = mutation({
     faction_id: v.id('factions'),
   },
   handler: async (ctx, args) => {
-    const userId = await requireAuthUserId(ctx);
-    const ruleset = await getRulesetById(ctx, args.ruleset_id);
-    if (!ruleset || ruleset.is_deleted) {
-      throw new Error('Ruleset not found');
-    }
-
-    const allowed = await canEditRuleset(ctx, ruleset, userId);
-    if (!allowed) {
-      throw new Error('Not authorized');
-    }
+    await requireRulesetMaintenance(ctx, args.ruleset_id);
 
     const faction = await getFactionById(ctx, args.faction_id);
     if (!faction || faction.is_deleted) {
@@ -414,16 +385,7 @@ export const removeFaction = mutation({
     faction_id: v.id('factions'),
   },
   handler: async (ctx, args) => {
-    const userId = await requireAuthUserId(ctx);
-    const ruleset = await getRulesetById(ctx, args.ruleset_id);
-    if (!ruleset || ruleset.is_deleted) {
-      throw new Error('Ruleset not found');
-    }
-
-    const allowed = await canEditRuleset(ctx, ruleset, userId);
-    if (!allowed) {
-      throw new Error('Not authorized');
-    }
+    await requireRulesetMaintenance(ctx, args.ruleset_id);
 
     const existing = await ctx.db
       .query('ruleset_factions')

--- a/src/app/members/db.test.tsx
+++ b/src/app/members/db.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  useMutation: vi.fn(),
+  request: vi.fn(),
+  approve: vi.fn(),
+  reject: vi.fn(),
+  remove: vi.fn(),
+  add: vi.fn(),
+}));
+
+vi.mock('convex/react', () => ({
+  useQuery: vi.fn(),
+  useMutation: mocks.useMutation,
+}));
+vi.mock('@db/core', () => ({ db: { query: vi.fn() } }));
+
+import { useGroupMembershipWorkflow } from './db';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const mutation of [mocks.request, mocks.approve, mocks.reject, mocks.remove, mocks.add]) {
+    mutation.mockResolvedValue({ membershipId: 'membership-1', status: 'active' });
+  }
+  const mutations = [mocks.request, mocks.approve, mocks.reject, mocks.remove, mocks.add];
+  mocks.useMutation.mockImplementation(
+    () => mutations[(mocks.useMutation.mock.calls.length - 1) % mutations.length]
+  );
+});
+
+describe('Group membership workflow', () => {
+  test('exposes normalized commands and keeps Convex transport arguments private', async () => {
+    const hook = renderHook(() => useGroupMembershipWorkflow());
+
+    for (const command of Object.values(hook.result.current)) {
+      expect(Object.keys(command).sort()).toEqual([
+        'error',
+        'isError',
+        'isPending',
+        'reset',
+        'run',
+      ]);
+    }
+
+    await act(() => hook.result.current.request.run('group-1'));
+    await act(() => hook.result.current.approve.run('membership-1'));
+    await act(() => hook.result.current.reject.run('membership-2'));
+    await act(() => hook.result.current.remove.run('membership-3'));
+    await act(() => hook.result.current.add.run({ groupId: 'group-1', userId: 'user-1' }));
+
+    expect(mocks.request).toHaveBeenCalledWith({ group_id: 'group-1' });
+    expect(mocks.approve).toHaveBeenCalledWith({ membershipId: 'membership-1' });
+    expect(mocks.reject).toHaveBeenCalledWith({ membershipId: 'membership-2' });
+    expect(mocks.remove).toHaveBeenCalledWith({ membershipId: 'membership-3' });
+    expect(mocks.add).toHaveBeenCalledWith({ groupId: 'group-1', userId: 'user-1' });
+  });
+});

--- a/src/app/members/db.ts
+++ b/src/app/members/db.ts
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 
 import { db } from '@db/core';
 import { toLiveQueryResult, useLiveMutation } from '@app/db/core/live';
+import type { LiveMutationResult } from '@app/db/core/live';
 
 import { api } from '../../../convex/_generated/api';
 import type { Doc } from '../../../convex/_generated/dataModel';
@@ -12,6 +13,34 @@ export type GroupMemberEntry = GroupMemberRow & { id: string };
 export type GroupMemberInsert = GroupMemberEntry;
 export type GroupMemberUpdate = Partial<GroupMemberEntry>;
 export type GroupMemberStatus = GroupMemberRow['status'];
+
+type MembershipCommandAcknowledgement = {
+  membershipId: string;
+  status: GroupMemberStatus;
+};
+
+type GroupMembershipCommand<TInput> = {
+  run: (input: TInput) => Promise<void>;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+  reset: () => void;
+};
+
+function membershipCommand<TInput, TVariables, TResult>(
+  mutation: LiveMutationResult<TVariables, TResult>,
+  variables: (input: TInput) => TVariables
+): GroupMembershipCommand<TInput> {
+  return {
+    run: async (input) => {
+      await mutation.mutateAsync(variables(input));
+    },
+    isPending: mutation.isPending,
+    isError: mutation.isError,
+    error: mutation.error,
+    reset: mutation.reset,
+  };
+}
 
 export type UserGroupMembershipWithGroup = GroupMemberEntry & {
   groups: { id: string; name: string; slug: string } | null;
@@ -114,6 +143,36 @@ export function useGroupMember(groupId: string, userId: string) {
   return {
     ...result,
     data: result.data ? { ...result.data, id: result.data._id } : undefined,
+  };
+}
+
+export function useGroupMembershipWorkflow() {
+  const requestMutation = useLiveMutation<{ group_id: string }, GroupMemberRow>(
+    api.members.request
+  );
+  const approveMutation = useLiveMutation<
+    { membershipId: string },
+    MembershipCommandAcknowledgement
+  >(api.members.approveRequest);
+  const rejectMutation = useLiveMutation<
+    { membershipId: string },
+    MembershipCommandAcknowledgement
+  >(api.members.rejectRequest);
+  const removeMutation = useLiveMutation<
+    { membershipId: string },
+    MembershipCommandAcknowledgement
+  >(api.members.removeMember);
+  const addMutation = useLiveMutation<
+    { groupId: string; userId: string },
+    MembershipCommandAcknowledgement
+  >(api.members.addMember);
+
+  return {
+    request: membershipCommand(requestMutation, (groupId: string) => ({ group_id: groupId })),
+    approve: membershipCommand(approveMutation, (membershipId: string) => ({ membershipId })),
+    reject: membershipCommand(rejectMutation, (membershipId: string) => ({ membershipId })),
+    remove: membershipCommand(removeMutation, (membershipId: string) => ({ membershipId })),
+    add: membershipCommand(addMutation, (input: { groupId: string; userId: string }) => input),
   };
 }
 


### PR DESCRIPTION
## Summary

- Introduce a trusted collaborative-access module with resource-specific Group, faction, and ruleset capabilities.
- Widen existing Convex page and membership contracts with canonical projections and ID-based commands while preserving exact legacy registrations, fields, bounds, nullability, and error ordering.
- Add a normalized client membership workflow and exhaustive evaluator, public-projection, mutation, compatibility, accessibility, and cap/invariant coverage.

## Compatibility and scope

- Preserves the Convex-first deployment interval selected in [Choose the deployed collaborative-access migration seam](https://github.com/ndelangen/dunezone/issues/216).
- Keeps legacy page fields, raw membership transport, and pair-argument moderation shims available for following caller-cutover tickets.
- Makes every mutation authorize trusted database facts independently of browser projections.
- Does not migrate route/component callers, merge, or deploy. [Deploy and verify the widened collaborative-access release](https://github.com/ndelangen/dunezone/issues/223) owns the production gate.
- Advances [Wayfinder: Centralize collaborative access and Group membership projection](https://github.com/ndelangen/dunezone/issues/198).

## Validation

- `bun run lint`
- `bun run typecheck`
- `bun run test` — 58 files, 396 tests
- `git diff --check`
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:release:verify`
  - renderer manifest unchanged
  - digest `5132c7f42432d0766effc6b4d42a47c8916d979286efb57b832b400a0a14f9de`
  - 915 renderer entries
  - Wrangler dry-run passed
- Architecture review: APPROVED / SAFE for standards and specification after five cold-review cycles.

Closes #217


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added collaborative access controls for groups, factions, and rulesets.
  - Added viewer capabilities, group assignments, rosters, profiles, and membership details to relevant pages.
  - Added standardized workflows for requesting, approving, rejecting, adding, and removing members.
  - Added support for group reassignment and owner-aware editing and deletion permissions.

- **Bug Fixes**
  - Improved handling of removed members, duplicate requests, deleted assets, and invalid targets.

- **Tests**
  - Added comprehensive coverage for access rules, membership workflows, moderation actions, and ownership scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->