### PR TITLE
Refresh collaborative-access Convex bindings

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -18,6 +18,8 @@ import type * as groups from "../groups.js";
 import type * as homepage from "../homepage.js";
 import type * as http from "../http.js";
 import type * as lib_applicationTriggers from "../lib/applicationTriggers.js";
+import type * as lib_collaborativeAccess from "../lib/collaborativeAccess.js";
+import type * as lib_collaborativeAccessValidators from "../lib/collaborativeAccessValidators.js";
 import type * as lib_factionCatalogue from "../lib/factionCatalogue.js";
 import type * as lib_factionInput from "../lib/factionInput.js";
 import type * as lib_faqProfileActivity from "../lib/faqProfileActivity.js";
@@ -61,6 +63,8 @@ declare const fullApi: ApiFromModules<{
   homepage: typeof homepage;
   http: typeof http;
   "lib/applicationTriggers": typeof lib_applicationTriggers;
+  "lib/collaborativeAccess": typeof lib_collaborativeAccess;
+  "lib/collaborativeAccessValidators": typeof lib_collaborativeAccessValidators;
   "lib/factionCatalogue": typeof lib_factionCatalogue;
   "lib/factionInput": typeof lib_factionInput;
   "lib/faqProfileActivity": typeof lib_faqProfileActivity;


### PR DESCRIPTION
## What changed

- regenerate `convex/_generated/api.d.ts`
- register the new `lib/collaborativeAccess` and `lib/collaborativeAccessValidators` modules in the generated API map
- keep test modules excluded from generated public bindings

## Why

The protected production workflow for #225 deployed widened Convex functions and migrations, then correctly stopped before the Worker release because `convex deploy` regenerated this tracked binding and the exact-checkout preflight detected a dirty tree. The widened Convex deployment remains compatible with the previously deployed Worker. This generated-only follow-up lets a new protected `main` workflow complete the Worker release without bypassing the safety gate.

## Validation

- generated twice with `CONVEX_DEPLOYMENT=prod:exuberant-finch-263 bunx convex codegen --typecheck disable`; byte-for-byte idempotent
- `bun run check`
- `bun run typecheck`
- `bun run test` (398 tests)
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:release:verify`
- `git diff --check`
- exact diff: four additions in `convex/_generated/api.d.ts` only

Resolves the release preflight failure in https://github.com/ndelangen/dunezone/actions/runs/31054082690. This PR does not roll back Convex and must deploy only through the protected `main` workflow.
