### PR TITLE
Migrate faction and ruleset callers to projected access

### DIFF
--- a/convex/collaborativeAccess.test.ts
+++ b/convex/collaborativeAccess.test.ts
@@ -97,6 +97,10 @@ async function groupAccessFixture() {
       is_deleted: false,
       image_cover: null,
     });
+    await ctx.db.insert('ruleset_factions', {
+      ruleset_id: rulesetId,
+      faction_id: factionId,
+    });
     return {
       ownerId,
       assetOwnerId,
@@ -216,6 +220,9 @@ describe('collaborative access public projections', () => {
       { id: ids.groupId, name: 'Dune Designers', slug: 'dune-designers' },
     ]);
     expect(rulesetPage?.assignableGroups).toEqual(factionPage.assignableGroups);
+    expect(factionPage.rulesets).toEqual([
+      { id: ids.rulesetId, name: 'Collaborative Ruleset', slug: 'collaborative-ruleset' },
+    ]);
 
     expect(factionPage.memberships).toHaveLength(1);
     expect(factionPage.groupAccess?.members).toHaveLength(4);

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -50,6 +50,19 @@ function factionRowForClient(row: Doc<'factions'>) {
   };
 }
 
+async function listFactionRulesets(ctx: QueryCtx, factionId: Id<'factions'>) {
+  const links = await ctx.db
+    .query('ruleset_factions')
+    .withIndex('by_faction', (q) => q.eq('faction_id', factionId))
+    .take(500);
+  const rulesets = await Promise.all(links.map((link) => ctx.db.get('rulesets', link.ruleset_id)));
+  return rulesets.flatMap((ruleset) =>
+    ruleset && !ruleset.is_deleted
+      ? [{ id: ruleset._id, name: ruleset.name, slug: ruleset.slug }]
+      : []
+  );
+}
+
 /** Faction detail page bundle (view, edit, and sheet preview). */
 async function loadFactionDetailPageBySlug(ctx: QueryCtx, slug: string) {
   const locatedRow = await ctx.db
@@ -109,6 +122,7 @@ async function loadFactionDetailPageBySlug(ctx: QueryCtx, slug: string) {
     assetPublishing: await factionSheetPublishingStatus(ctx, row._id),
     viewerAccess: access.viewerAccess,
     assignableGroups: access.assignableGroups,
+    rulesets: await listFactionRulesets(ctx, row._id),
   };
 }
 

--- a/convex/lib/collaborativeAccess.ts
+++ b/convex/lib/collaborativeAccess.ts
@@ -4,36 +4,16 @@ import type { Doc, Id } from '../_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '../_generated/server';
 
 export type MembershipState = 'none' | 'pending' | 'active';
-export type StoredMembershipState = MembershipState | 'removed';
 
 export type PublicViewer =
   | { kind: 'anonymous' }
   | { kind: 'authenticated'; membership: MembershipState };
-
-type ViewerFacts =
-  | { kind: 'anonymous' }
-  | { kind: 'authenticated'; membership: StoredMembershipState; ownsSubject: boolean };
 
 export type AssignedGroupSummary = {
   id: Id<'groups'>;
   name: string;
   slug: string;
 };
-
-export type GroupAccessFacts = {
-  kind: 'group';
-  group: { eligible: boolean };
-  viewer: ViewerFacts;
-};
-
-export type AssetAccessFacts = {
-  kind: 'faction' | 'ruleset';
-  resource: { available: boolean };
-  group: { eligible: boolean; summary: AssignedGroupSummary | null };
-  viewer: ViewerFacts;
-};
-
-export type CollaborativeAccessFacts = GroupAccessFacts | AssetAccessFacts;
 
 export type CollaborativeAccess =
   | {
@@ -70,6 +50,27 @@ export type CollaborativeAccess =
         delete: boolean;
       };
     };
+
+export type StoredMembershipState = MembershipState | 'removed';
+
+type ViewerFacts =
+  | { kind: 'anonymous' }
+  | { kind: 'authenticated'; membership: StoredMembershipState; ownsSubject: boolean };
+
+export type GroupAccessFacts = {
+  kind: 'group';
+  group: { eligible: boolean };
+  viewer: ViewerFacts;
+};
+
+export type AssetAccessFacts = {
+  kind: 'faction' | 'ruleset';
+  resource: { available: boolean };
+  group: { eligible: boolean; summary: AssignedGroupSummary | null };
+  viewer: ViewerFacts;
+};
+
+export type CollaborativeAccessFacts = GroupAccessFacts | AssetAccessFacts;
 
 type CollaborativeSubject =
   | { kind: 'group'; id: Id<'groups'> }

--- a/convex/lib/collaborativeAccessValidators.ts
+++ b/convex/lib/collaborativeAccessValidators.ts
@@ -75,6 +75,12 @@ const assignedGroupSummaryValidator = v.object({
   slug: v.string(),
 });
 
+const rulesetSummaryValidator = v.object({
+  id: v.id('rulesets'),
+  name: v.string(),
+  slug: v.string(),
+});
+
 const profileSummaryValidator = v.object({
   id: v.id('profiles'),
   slug: v.string(),
@@ -152,6 +158,7 @@ export const factionDetailPageValidator = v.object({
   assetPublishing: assetPublishingValidator,
   viewerAccess: assetViewerAccessValidator('faction'),
   assignableGroups: v.array(assignedGroupSummaryValidator),
+  rulesets: v.array(rulesetSummaryValidator),
 });
 
 const rulesetFactionSummaryValidator = v.object({
@@ -202,12 +209,6 @@ const faqItemValidator = v.object({
 const faqListItemValidator = faqItemValidator.extend({
   faq_answers: v.array(faqAnswerValidator),
   asker_profile: v.union(profileSummaryValidator, v.null()),
-});
-
-const rulesetSummaryValidator = v.object({
-  id: v.id('rulesets'),
-  name: v.string(),
-  slug: v.string(),
 });
 
 const profileFaqQuestionValidator = faqItemValidator.extend({

--- a/src/app/collaborativeAccessCallers.architecture.test.ts
+++ b/src/app/collaborativeAccessCallers.architecture.test.ts
@@ -35,6 +35,7 @@ describe('faction and ruleset collaborative-access caller contract', () => {
     expect(sources.factionDb).not.toMatch(/^\s+memberships:/m);
     expect(sources.factionDb).not.toMatch(/^\s+groupAccess:/m);
     expect(sources.rulesetDb).not.toContain('canEditRuleset');
+    expect(sources.rulesetDb).not.toMatch(/^\s+memberships:/m);
     expect(sources.rulesetDb).not.toMatch(/^\s+groupAccess:/m);
   });
 

--- a/src/app/collaborativeAccessCallers.architecture.test.ts
+++ b/src/app/collaborativeAccessCallers.architecture.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, test } from 'vitest';
+
+const sources = {
+  collaborativeAccess: readFileSync(
+    new URL('../../convex/lib/collaborativeAccess.ts', import.meta.url),
+    'utf8'
+  ),
+  factionDb: readFileSync(new URL('./factions/db.ts', import.meta.url), 'utf8'),
+  factionDetail: readFileSync(
+    new URL('./routes/_app/factions/$factionId/index.tsx', import.meta.url),
+    'utf8'
+  ),
+  factionEdit: readFileSync(
+    new URL('./routes/_app/factions/$factionId/edit.tsx', import.meta.url),
+    'utf8'
+  ),
+  rulesetDb: readFileSync(new URL('./rulesets/db.ts', import.meta.url), 'utf8'),
+  rulesetDetail: readFileSync(
+    new URL('./routes/_app/rulesets/$rulesetSlug/index.tsx', import.meta.url),
+    'utf8'
+  ),
+  rulesetEdit: readFileSync(
+    new URL('./routes/_app/rulesets/$rulesetSlug/edit.tsx', import.meta.url),
+    'utf8'
+  ),
+};
+
+describe('faction and ruleset collaborative-access caller contract', () => {
+  test('domain page adapters expose the canonical viewer projection', () => {
+    expect(sources.factionDb).toContain('viewerAccess');
+    expect(sources.rulesetDb).toContain('viewerAccess');
+    expect(sources.factionDb).not.toContain('FactionPageGroupAccess');
+    expect(sources.factionDb).not.toMatch(/^\s+memberships:/m);
+    expect(sources.factionDb).not.toMatch(/^\s+groupAccess:/m);
+    expect(sources.rulesetDb).not.toContain('canEditRuleset');
+    expect(sources.rulesetDb).not.toMatch(/^\s+groupAccess:/m);
+  });
+
+  test('the server policy module owns its public contract', () => {
+    expect(sources.collaborativeAccess).not.toContain('../../src/app');
+    expect(sources.collaborativeAccess).toContain('export type CollaborativeAccess =');
+    expect(sources.factionDb).toContain("from '../../../convex/lib/collaborativeAccess'");
+    expect(sources.rulesetDb).toContain("from '../../../convex/lib/collaborativeAccess'");
+  });
+
+  test('detail and edit routes render authorization from viewerAccess capabilities', () => {
+    for (const source of [
+      sources.factionDetail,
+      sources.factionEdit,
+      sources.rulesetDetail,
+      sources.rulesetEdit,
+    ]) {
+      expect(source).toContain('viewerAccess');
+    }
+
+    expect(sources.factionDetail).not.toContain('canEditFaction(');
+    expect(sources.factionDetail).not.toContain('groupAccess');
+    expect(sources.factionDetail).not.toContain('memberships');
+    expect(sources.rulesetDetail).not.toContain('canEditRuleset');
+    expect(sources.rulesetDetail).not.toContain('groupAccess');
+    expect(sources.rulesetEdit).not.toContain('canEditRuleset');
+  });
+
+  test('ruleset owner actions do not depend on profile projection availability', () => {
+    expect(sources.rulesetDetail).not.toMatch(
+      /\{profile\.data\?\._id \? \(\s*<Group[^>]+aria-label="Ruleset actions"/
+    );
+  });
+
+  test('membership request handlers consume command rejections after state records the error', () => {
+    for (const source of [sources.factionDetail, sources.rulesetDetail]) {
+      expect(source).not.toMatch(
+        /onClick=\{\(\) => void membershipWorkflow\.request\.run\(assignedGroup\.id\)\}/
+      );
+      expect(source).toMatch(
+        /void membershipWorkflow\.request\s*\.run\(assignedGroup\.id\)\s*\.catch\(\(\) => undefined\)/
+      );
+    }
+  });
+});

--- a/src/app/factions/db.ts
+++ b/src/app/factions/db.ts
@@ -9,6 +9,10 @@ import type { FactionInput } from '@game/schema/faction';
 import { api } from '../../../convex/_generated/api';
 import type { Doc } from '../../../convex/_generated/dataModel';
 import type { PublicAssetPublishingStatusProjection } from '../../../convex/assetPublishingStatus';
+import type {
+  AssignedGroupSummary,
+  CollaborativeAccess,
+} from '../../../convex/lib/collaborativeAccess';
 
 export type Faction = FactionInput;
 export type FactionData = FactionInput;
@@ -100,29 +104,25 @@ export function factionRowsToEntries(rows: FactionRow[]): FactionEntry[] {
   return rows.map(toFactionEntry);
 }
 
-/** Assigned group + members (profile summaries) for faction detail; mirrors ruleset `groupAccess`. */
-export type FactionPageGroupAccess = {
-  group: Doc<'groups'>;
-  members: Array<{
-    membership: Doc<'group_members'>;
-    profile: {
-      id: string;
-      slug: string;
-      username: string | null;
-      avatar_url: string | null;
-    } | null;
-  }>;
-};
-
 export type FactionDetailPageData = {
   faction: FactionEntry;
   owner: Doc<'profiles'>;
-  group: Doc<'groups'> | null;
-  memberships: Doc<'group_members'>[];
-  groups: Doc<'groups'>[];
-  groupAccess: FactionPageGroupAccess | null;
   assetPublishing: PublicAssetPublishingStatusProjection;
+  viewerAccess: Extract<CollaborativeAccess, { kind: 'faction' }>;
+  assignableGroups: AssignedGroupSummary[];
+  rulesets: FactionRulesetSummary[];
 };
+
+function toFactionDetailPageData(raw: FactionDetailPageData): FactionDetailPageData {
+  return {
+    faction: toFactionEntry(raw.faction),
+    owner: raw.owner,
+    assetPublishing: raw.assetPublishing,
+    viewerAccess: raw.viewerAccess,
+    assignableGroups: raw.assignableGroups,
+    rulesets: raw.rulesets,
+  };
+}
 
 export async function loadFactionBySlug(slug: string): Promise<FactionDetailPageData> {
   return await loadFaction(slug);
@@ -166,21 +166,15 @@ export function useFaction(
   }
 ) {
   const liveData = useQuery(api.factions.getBySlug, { slug });
-  const normalized = liveData
-    ? {
-        ...liveData,
-        faction: toFactionEntry(liveData.faction),
-      }
-    : undefined;
+  const normalized = liveData ? toFactionDetailPageData(liveData) : undefined;
   const result = toLiveQueryResult(normalized, true, () => options?.initialData ?? undefined);
   return {
     ...result,
     faction: result.data?.faction,
     owner: result.data?.owner,
-    group: result.data?.group,
-    memberships: result.data?.memberships,
-    groups: result.data?.groups,
-    groupAccess: result.data?.groupAccess ?? null,
+    viewerAccess: result.data?.viewerAccess,
+    assignableGroups: result.data?.assignableGroups ?? [],
+    rulesets: result.data?.rulesets ?? [],
     assetPublishing: result.data?.assetPublishing ?? {
       status: null,
       captureStatus: null,
@@ -370,7 +364,8 @@ export function useSetFactionGroup() {
 }
 
 export async function loadFaction(slug: string): Promise<FactionDetailPageData> {
-  return await db.query<FactionDetailPageData>(api.factions.getBySlug, {
+  const raw = await db.query<FactionDetailPageData>(api.factions.getBySlug, {
     slug,
   });
+  return toFactionDetailPageData(raw);
 }

--- a/src/app/factions/db.ts
+++ b/src/app/factions/db.ts
@@ -113,9 +113,16 @@ export type FactionDetailPageData = {
   rulesets: FactionRulesetSummary[];
 };
 
-function toFactionDetailPageData(raw: FactionDetailPageData): FactionDetailPageData {
+type FactionDetailPageDataRaw = Omit<FactionDetailPageData, 'faction'> & {
+  faction: Omit<FactionRow, 'data'> & { data: unknown };
+};
+
+function toFactionDetailPageData(raw: FactionDetailPageDataRaw): FactionDetailPageData {
   return {
-    faction: toFactionEntry(raw.faction),
+    faction: {
+      ...raw.faction,
+      data: CanonicalFactionStoredSchema.parse(raw.faction.data),
+    },
     owner: raw.owner,
     assetPublishing: raw.assetPublishing,
     viewerAccess: raw.viewerAccess,
@@ -364,7 +371,7 @@ export function useSetFactionGroup() {
 }
 
 export async function loadFaction(slug: string): Promise<FactionDetailPageData> {
-  const raw = await db.query<FactionDetailPageData>(api.factions.getBySlug, {
+  const raw = await db.query<FactionDetailPageDataRaw>(api.factions.getBySlug, {
     slug,
   });
   return toFactionDetailPageData(raw);

--- a/src/app/routes/_app/factions/$factionId/edit.tsx
+++ b/src/app/routes/_app/factions/$factionId/edit.tsx
@@ -40,7 +40,9 @@ function FactionEditPage() {
   const profile = useCurrentProfile();
   const [confirmDelete, setConfirmDelete] = useState(false);
 
-  const { faction, group, assetPublishing } = useFaction(factionId, { initialData: loaderData });
+  const { faction, viewerAccess, assetPublishing } = useFaction(factionId, {
+    initialData: loaderData,
+  });
   const authoringFaction = faction ?? loaderData.faction;
   const authoring = useFactionAuthoring({
     sessionKey: authoringFaction._id,
@@ -78,7 +80,7 @@ function FactionEditPage() {
     </Stack>
   );
 
-  if (!profile.data?.user_id) {
+  if (viewerAccess?.viewer.kind === 'anonymous') {
     return (
       <PageLayout header={header} headerSize="compact">
         <Paper withBorder radius="md" p="xl">
@@ -110,8 +112,23 @@ function FactionEditPage() {
     );
   }
 
-  const canDelete = faction.owner_id === profile.data.user_id;
-  const canAssignGroup = canDelete;
+  if (!viewerAccess?.capabilities.edit) {
+    return (
+      <PageLayout header={header} headerSize="compact">
+        <Paper withBorder radius="md" p="xl">
+          <Text>
+            {faction.group_id
+              ? 'Only the faction owner or an active member of its group can edit this faction.'
+              : 'Only the faction owner can edit this faction.'}
+          </Text>
+        </Paper>
+      </PageLayout>
+    );
+  }
+
+  const assignedGroup = viewerAccess.assignedGroup;
+  const canDelete = viewerAccess.capabilities.delete;
+  const canAssignGroup = viewerAccess.capabilities.changeGroup;
 
   return (
     <PageLayout
@@ -141,7 +158,7 @@ function FactionEditPage() {
                 currentPublicSlug={faction.slug}
                 onLoaded={authoring.actions.loadDraft}
               />
-              {canAssignGroup && !group ? (
+              {canAssignGroup && !assignedGroup && profile.data?.user_id ? (
                 <FactionGroupPopover
                   disabled={setFactionGroup.isPending}
                   userId={profile.data.user_id}
@@ -154,7 +171,7 @@ function FactionEditPage() {
                   }}
                 />
               ) : null}
-              {canAssignGroup && group ? (
+              {canAssignGroup && assignedGroup ? (
                 <Tooltip label="Remove group">
                   <ActionIcon
                     type="button"
@@ -174,9 +191,9 @@ function FactionEditPage() {
             </>
           }
           context={
-            group ? (
+            assignedGroup ? (
               <Text size="xs" c="dimmed">
-                Group access: <strong>{group.name ?? group._id}</strong>
+                Group access: <strong>{assignedGroup.name}</strong>
               </Text>
             ) : null
           }

--- a/src/app/routes/_app/factions/$factionId/index.tsx
+++ b/src/app/routes/_app/factions/$factionId/index.tsx
@@ -32,9 +32,7 @@ import {
 import type { ComponentProps, ReactNode } from 'react';
 
 import { loadFaction, useFaction } from '@db/factions';
-import { useRequestGroupMembership } from '@db/members';
-import { useCurrentProfile } from '@db/profiles';
-import { loadRulesetsByFaction, useRulesetsByFaction } from '@db/rulesets';
+import { useGroupMembershipWorkflow } from '@db/members';
 import { IconStat } from '@app/components/content/IconStat';
 import { ProfileLink } from '@app/components/profile/ProfileLink';
 import { PageLayout } from '@app/components/shell';
@@ -49,11 +47,7 @@ import styles from '../FactionDetail.module.css';
 
 export const Route = createFileRoute('/_app/factions/$factionId/')({
   codeSplitGroupings: [['component', 'pendingComponent', 'errorComponent']],
-  loader: async ({ params }) => {
-    const faction = await loadFaction(params.factionId);
-    const rulesets = await loadRulesetsByFaction(faction.faction._id);
-    return { faction, rulesets };
-  },
+  loader: async ({ params }) => await loadFaction(params.factionId),
   pendingComponent: FactionDetailPending,
   errorComponent: FactionDetailError,
   component: FactionDetailPage,
@@ -100,37 +94,15 @@ function FactionDetailError({ error }: ErrorComponentProps) {
   );
 }
 
-function canEditFaction(
-  profileId: string | undefined,
-  ownerId: string | undefined,
-  groupId: string | null | undefined,
-  memberships: { group_id: string }[] | undefined
-) {
-  if (!profileId) {
-    return false;
-  }
-  if (profileId === ownerId) {
-    return true;
-  }
-  if (!groupId) {
-    return false;
-  }
-  return (memberships ?? []).some((membership) => membership.group_id === groupId);
-}
-
 function FactionDetailPage() {
   const { factionId } = Route.useParams();
   const loaderData = Route.useLoaderData();
-  const factionSeed = loaderData.faction;
+  const factionSeed = loaderData;
 
-  const { faction, memberships, groupAccess, owner, assetPublishing } = useFaction(factionId, {
+  const { faction, viewerAccess, owner, assetPublishing, rulesets } = useFaction(factionId, {
     initialData: factionSeed,
   });
-  const rulesets = useRulesetsByFaction(factionSeed.faction._id, {
-    initialData: loaderData.rulesets,
-  });
-  const profile = useCurrentProfile();
-  const requestMembership = useRequestGroupMembership();
+  const membershipWorkflow = useGroupMembershipWorkflow();
 
   if (!faction) {
     return (
@@ -154,16 +126,11 @@ function FactionDetailPage() {
     );
   }
 
-  const canEdit = canEditFaction(profile.data?._id, owner?._id, faction.group_id, memberships);
-  const profileUserId = profile.data?.user_id;
-  const assignedGroup = groupAccess?.group;
-  const groupMembersList = groupAccess?.members ?? [];
-  const viewerMembership = groupMembersList.find(
-    (entry) => entry.membership.user_id === profileUserId
-  )?.membership;
+  const canEdit = viewerAccess?.capabilities.edit ?? false;
+  const assignedGroup = viewerAccess?.assignedGroup ?? null;
   const membershipStatus =
-    viewerMembership && viewerMembership.status !== 'removed' ? viewerMembership.status : 'none';
-  const canRequestMembership = !!profileUserId && !!assignedGroup && membershipStatus === 'none';
+    viewerAccess?.viewer.kind === 'authenticated' ? viewerAccess.viewer.membership : 'none';
+  const canRequestMembership = viewerAccess?.capabilities.requestMembership ?? false;
 
   const data = faction.data;
   const planets = data.planet ?? [];
@@ -580,7 +547,7 @@ function FactionDetailPage() {
                           : 'Not a member'}
                     </Badge>
                   </Group>
-                  {!profile.isPending && !profileUserId ? (
+                  {viewerAccess?.viewer.kind === 'anonymous' ? (
                     <Text size="sm">
                       <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>
                         Log in
@@ -593,17 +560,19 @@ function FactionDetailPage() {
                       type="button"
                       variant="light"
                       leftSection={<UserPlus size={16} aria-hidden />}
-                      loading={requestMembership.isPending}
-                      onClick={() => requestMembership.mutate(assignedGroup._id)}
+                      loading={membershipWorkflow.request.isPending}
+                      onClick={() =>
+                        void membershipWorkflow.request.run(assignedGroup.id).catch(() => undefined)
+                      }
                     >
                       Request membership
                     </Button>
                   ) : null}
                 </Stack>
               )}
-              {requestMembership.isError ? (
+              {membershipWorkflow.request.isError ? (
                 <Alert color="red" title="Membership request failed" role="alert">
-                  {requestMembership.error?.message}
+                  {membershipWorkflow.request.error?.message}
                 </Alert>
               ) : null}
             </Stack>
@@ -664,13 +633,9 @@ function FactionDetailPage() {
               <SectionHeading icon={<TopicIcon topic="rulesets" size={20} />}>
                 Rulesets
               </SectionHeading>
-              {rulesets.data === undefined ? (
-                <Text size="sm" c="dimmed">
-                  Loading rulesets…
-                </Text>
-              ) : rulesets.data.length > 0 ? (
+              {rulesets.length > 0 ? (
                 <Stack component="ul" gap="xs" m={0} pl="lg">
-                  {rulesets.data.map((ruleset) => (
+                  {rulesets.map((ruleset) => (
                     <li key={ruleset.id}>
                       <Anchor
                         renderRoot={(rootProps) => (

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
@@ -13,7 +13,6 @@ import {
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { ArrowLeft, BookOpen } from 'lucide-react';
 
-import { useCurrentProfile } from '@db/profiles';
 import { loadRulesetDetailPage, useRulesetDetailPage } from '@db/rulesets';
 import { RulesetSettingsForm } from '@app/components/rulesets/RulesetSettingsForm';
 import { PageLayout } from '@app/components/shell';
@@ -37,7 +36,6 @@ function RulesetEditPage() {
   const detailSeed =
     !loaderData.notFound && loaderData.detailPage ? loaderData.detailPage : undefined;
   const page = useRulesetDetailPage(rulesetSlug, { initialData: detailSeed });
-  const profile = useCurrentProfile();
 
   const header = page.ruleset ? (
     <Group wrap="nowrap" align="center" gap="lg" className={styles.pageHead}>
@@ -124,9 +122,9 @@ function RulesetEditPage() {
   }
 
   const r = page.ruleset;
-  const viewerUserId = profile.data?.user_id;
+  const viewerAccess = page.viewerAccess;
 
-  if (profile.isPending) {
+  if (!viewerAccess) {
     return (
       <PageLayout header={header} toolbar={toolbar}>
         <Paper withBorder p="xl" radius="md" aria-live="polite">
@@ -136,7 +134,7 @@ function RulesetEditPage() {
     );
   }
 
-  if (!viewerUserId) {
+  if (viewerAccess.viewer.kind === 'anonymous') {
     return (
       <PageLayout header={header} toolbar={toolbar}>
         <Paper withBorder p="xl" radius="md">
@@ -151,7 +149,7 @@ function RulesetEditPage() {
     );
   }
 
-  if (!page.canEditRuleset) {
+  if (!viewerAccess.capabilities.edit) {
     return (
       <PageLayout header={header} toolbar={toolbar}>
         <Paper withBorder p="xl" radius="md">
@@ -168,7 +166,11 @@ function RulesetEditPage() {
   return (
     <PageLayout header={header} toolbar={toolbar}>
       <Paper withBorder p="lg" radius="md">
-        <RulesetSettingsForm key={r.slug} initial={r} canRename={r.owner_id === viewerUserId} />
+        <RulesetSettingsForm
+          key={r.slug}
+          initial={r}
+          canRename={viewerAccess.capabilities.rename}
+        />
       </Paper>
     </PageLayout>
   );

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -37,7 +37,7 @@ import {
   UsersRound,
 } from 'lucide-react';
 
-import { useRequestGroupMembership } from '@db/members';
+import { useGroupMembershipWorkflow } from '@db/members';
 import { useCurrentProfile } from '@db/profiles';
 import {
   loadRulesetDetailPage,
@@ -53,6 +53,7 @@ import { PageLayout } from '@app/components/shell';
 import { TopicIcon } from '@app/components/topics/TopicIcon';
 import { FAQ_TAG_LABELS, FAQ_TAG_VALUES } from '@app/faq/tags';
 import type { FaqTag } from '@app/faq/tags';
+import { rulesetActionVisibility } from '@app/rulesets/rulesetActionVisibility';
 import { Token as FactionToken } from '@game/assets/faction/token/Token';
 
 import styles from '../RulesetDetail.module.css';
@@ -132,7 +133,7 @@ function RulesetDetailPage() {
   const profile = useCurrentProfile();
   const deleteRuleset = useDeleteRuleset();
   const updateRuleset = useUpdateRuleset();
-  const requestMembership = useRequestGroupMembership();
+  const membershipWorkflow = useGroupMembershipWorkflow();
 
   if (loaderData.notFound || !page.ruleset) {
     return (
@@ -156,22 +157,28 @@ function RulesetDetailPage() {
     );
   }
 
+  const viewerAccess = page.viewerAccess;
+  if (!viewerAccess) {
+    return <RulesetDetailPending />;
+  }
+
   const r = page.ruleset;
-  const isOwner = profile.data?.user_id === r.owner_id;
   const profileUserId = profile.data?.user_id;
-  const assignedGroup = page.groupAccess?.group;
-  const groupMembersList = page.groupAccess?.members ?? [];
-  const viewerMembership = groupMembersList.find(
-    (entry) => entry.membership.user_id === profileUserId
-  )?.membership;
+  const assignedGroup = viewerAccess.assignedGroup;
   const membershipStatus =
-    viewerMembership && viewerMembership.status !== 'removed' ? viewerMembership.status : 'none';
-  const canRequestMembership = !!profileUserId && !!assignedGroup && membershipStatus === 'none';
+    viewerAccess.viewer.kind === 'authenticated' ? viewerAccess.viewer.membership : 'none';
+  const canRequestMembership = viewerAccess.capabilities.requestMembership;
   const answeredFaqCount = page.faqItems.filter((item) => item.accepted_answer_id != null).length;
   const mutationError =
     deleteRuleset.error?.message ??
-    requestMembership.error?.message ??
+    membershipWorkflow.request.error?.message ??
     updateRuleset.error?.message;
+  const actionVisibility = rulesetActionVisibility({
+    hasProfile: Boolean(profile.data?._id),
+    canChangeGroup: viewerAccess.capabilities.changeGroup,
+    canDelete: viewerAccess.capabilities.delete,
+    hasAssignedGroup: r.group_id != null,
+  });
 
   const handleDelete = () => {
     if (!window.confirm(`Delete ruleset "${r.name}"? This cannot be undone.`)) {
@@ -262,7 +269,7 @@ function RulesetDetailPage() {
                   <ArrowLeft size={17} aria-hidden />
                 </ActionIcon>
               </Tooltip>
-              {page.canEditRuleset ? (
+              {viewerAccess.capabilities.edit ? (
                 <Tooltip label="Edit ruleset">
                   <ActionIcon
                     variant="light"
@@ -283,83 +290,89 @@ function RulesetDetailPage() {
               ) : null}
             </Group>
 
-            {profile.data?._id ? (
+            {actionVisibility.askQuestion ||
+            actionVisibility.assignGroup ||
+            actionVisibility.removeGroup ||
+            actionVisibility.deleteRuleset ? (
               <Group gap="xs" wrap="wrap" role="group" aria-label="Ruleset actions">
-                <Tooltip label="Ask a question">
-                  <ActionIcon
-                    type="button"
-                    variant="filled"
-                    color="confirm"
-                    size="lg"
-                    aria-label="Ask a question"
-                    onClick={() =>
-                      navigate({
-                        to: '/rulesets/$rulesetSlug/faq/create',
-                        params: { rulesetSlug: r.slug },
-                      })
-                    }
-                  >
-                    <MessageCircleQuestionMark size={17} aria-hidden />
-                  </ActionIcon>
-                </Tooltip>
-                {isOwner ? (
-                  <>
-                    {r.group_id == null ? (
-                      <GroupAssignPopover
-                        disabled={!isOwner || updateRuleset.isPending}
-                        userId={profileUserId}
-                        isUserPending={profile.isPending}
-                        prefetchedMemberships={page.viewerAssignableMemberships}
-                        onChangeGroup={async (nextGroupId) => {
-                          await updateRuleset.mutateAsync({
+                {actionVisibility.askQuestion ? (
+                  <Tooltip label="Ask a question">
+                    <ActionIcon
+                      type="button"
+                      variant="filled"
+                      color="confirm"
+                      size="lg"
+                      aria-label="Ask a question"
+                      onClick={() =>
+                        navigate({
+                          to: '/rulesets/$rulesetSlug/faq/create',
+                          params: { rulesetSlug: r.slug },
+                        })
+                      }
+                    >
+                      <MessageCircleQuestionMark size={17} aria-hidden />
+                    </ActionIcon>
+                  </Tooltip>
+                ) : null}
+                {actionVisibility.assignGroup ? (
+                  <GroupAssignPopover
+                    disabled={updateRuleset.isPending}
+                    userId={profileUserId}
+                    isUserPending={profile.isPending}
+                    prefetchedMemberships={page.viewerAssignableMemberships}
+                    onChangeGroup={async (nextGroupId) => {
+                      await updateRuleset.mutateAsync({
+                        id: r._id,
+                        input: { name: r.name },
+                        groupId: nextGroupId,
+                        imageCover: r.image_cover ?? null,
+                      });
+                    }}
+                    title="Assign Group"
+                    descriptionLines={[
+                      `Assign a group that can help maintain "${r.name}".`,
+                      'You can create and join groups from your profile.',
+                    ]}
+                  />
+                ) : null}
+                {actionVisibility.removeGroup ? (
+                  <Tooltip label="Remove group">
+                    <ActionIcon
+                      type="button"
+                      aria-label="Remove group"
+                      color="red"
+                      variant="light"
+                      size="lg"
+                      disabled={updateRuleset.isPending}
+                      onClick={() =>
+                        void updateRuleset
+                          .mutateAsync({
                             id: r._id,
                             input: { name: r.name },
-                            groupId: nextGroupId,
+                            groupId: null,
                             imageCover: r.image_cover ?? null,
-                          });
-                        }}
-                        title="Assign Group"
-                        descriptionLines={[
-                          `Assign a group that can help maintain "${r.name}".`,
-                          'You can create and join groups from your profile.',
-                        ]}
-                      />
-                    ) : (
-                      <Tooltip label="Remove group">
-                        <ActionIcon
-                          type="button"
-                          aria-label="Remove group"
-                          color="red"
-                          variant="light"
-                          size="lg"
-                          disabled={updateRuleset.isPending}
-                          onClick={() =>
-                            void updateRuleset.mutateAsync({
-                              id: r._id,
-                              input: { name: r.name },
-                              groupId: null,
-                              imageCover: r.image_cover ?? null,
-                            })
-                          }
-                        >
-                          <UserRoundMinus size={17} aria-hidden />
-                        </ActionIcon>
-                      </Tooltip>
-                    )}
-                    <Tooltip label="Delete ruleset">
-                      <ActionIcon
-                        color="red"
-                        variant="light"
-                        type="button"
-                        size="lg"
-                        aria-label="Delete ruleset"
-                        onClick={handleDelete}
-                        disabled={deleteRuleset.isPending}
-                      >
-                        <Trash2 size={17} aria-hidden />
-                      </ActionIcon>
-                    </Tooltip>
-                  </>
+                          })
+                          .catch(() => undefined)
+                      }
+                    >
+                      <UserRoundMinus size={17} aria-hidden />
+                    </ActionIcon>
+                  </Tooltip>
+                ) : null}
+                {actionVisibility.deleteRuleset ? (
+                  <Tooltip label="Delete ruleset">
+                    <ActionIcon
+                      color="red"
+                      variant="light"
+                      type="button"
+                      size="lg"
+                      aria-label="Delete ruleset"
+                      onClick={handleDelete}
+                      disabled={deleteRuleset.isPending}
+                    >
+                      <Trash2 size={17} aria-hidden />
+                    </ActionIcon>
+                  </Tooltip>
                 ) : null}
               </Group>
             ) : null}
@@ -660,8 +673,12 @@ function RulesetDetailPage() {
                         type="button"
                         variant="light"
                         leftSection={<UserPlus size={16} aria-hidden />}
-                        loading={requestMembership.isPending}
-                        onClick={() => requestMembership.mutate(assignedGroup._id)}
+                        loading={membershipWorkflow.request.isPending}
+                        onClick={() =>
+                          void membershipWorkflow.request
+                            .run(assignedGroup.id)
+                            .catch(() => undefined)
+                        }
                       >
                         Request membership
                       </Button>

--- a/src/app/rulesets/db.ts
+++ b/src/app/rulesets/db.ts
@@ -10,6 +10,10 @@ import type { FactionData } from '@game/schema/faction';
 
 import { api } from '../../../convex/_generated/api';
 import type { Doc } from '../../../convex/_generated/dataModel';
+import type {
+  AssignedGroupSummary,
+  CollaborativeAccess,
+} from '../../../convex/lib/collaborativeAccess';
 
 export type Ruleset = { name: string };
 export type RulesetRow = Doc<'rulesets'>;
@@ -50,22 +54,28 @@ function normalizeRulesetFactionSummary(faction: RulesetFactionSummaryRaw): Rule
 export type RulesetPageData = {
   ruleset: RulesetEntry;
   factions: RulesetFactionSummary[];
-  canEditRuleset: boolean;
+  viewerAccess: Extract<CollaborativeAccess, { kind: 'ruleset' }>;
 };
 
 export type RulesetDetailPageData = RulesetPageData & {
   owner: FaqItemWithDetails['asker_profile'];
   /** Active memberships + groups for assign-group UI; null when viewer is not logged in. */
   viewerAssignableMemberships: UserGroupMembershipWithGroup[] | null;
-  groupAccess: {
-    group: Doc<'groups'>;
-    members: Array<{
-      membership: Doc<'group_members'>;
-      profile: FaqItemWithDetails['asker_profile'];
-    }>;
-  } | null;
+  assignableGroups: AssignedGroupSummary[];
   faqItems: FaqItemWithDetails[];
 };
+
+function toRulesetPageData(raw: {
+  ruleset: RulesetRow;
+  factions: RulesetFactionSummaryRaw[];
+  viewerAccess: RulesetPageData['viewerAccess'];
+}): RulesetPageData {
+  return {
+    ruleset: toRulesetEntry(raw.ruleset),
+    factions: raw.factions.map(normalizeRulesetFactionSummary),
+    viewerAccess: raw.viewerAccess,
+  };
+}
 
 type FaqItemConvexRow = Omit<FaqItemWithDetails, 'id' | 'faq_answers'> & {
   faq_answers: Omit<FaqAnswerEntry, 'id'>[];
@@ -118,23 +128,19 @@ export async function loadRulesetBySlug(slug: string): Promise<RulesetPageData> 
   const result = await db.query<{
     ruleset: RulesetRow;
     factions: RulesetFactionSummaryRaw[];
-    canEditRuleset: boolean;
+    viewerAccess: RulesetPageData['viewerAccess'];
   }>(api.rulesets.getBySlug, { slug });
-  return {
-    ...result,
-    factions: result.factions.map(normalizeRulesetFactionSummary),
-    ruleset: toRulesetEntry(result.ruleset),
-  };
+  return toRulesetPageData(result);
 }
 
 export async function loadRulesetDetailPage(slug: string): Promise<RulesetDetailPageData | null> {
   const raw = await db.query<{
     ruleset: RulesetRow;
     factions: RulesetFactionSummaryRaw[];
-    canEditRuleset: boolean;
+    viewerAccess: RulesetPageData['viewerAccess'];
     owner: RulesetDetailPageData['owner'];
     viewerAssignableMemberships: AssignableMembershipConvexRow[] | null;
-    groupAccess: RulesetDetailPageData['groupAccess'];
+    assignableGroups: AssignedGroupSummary[];
     faqItems: FaqItemConvexRow[];
   } | null>(api.rulesets.detailPageBySlug, { slug });
   if (!raw) {
@@ -143,12 +149,12 @@ export async function loadRulesetDetailPage(slug: string): Promise<RulesetDetail
   return {
     ruleset: toRulesetEntry(raw.ruleset),
     factions: raw.factions.map(normalizeRulesetFactionSummary),
-    canEditRuleset: raw.canEditRuleset,
+    viewerAccess: raw.viewerAccess,
     owner: raw.owner,
     viewerAssignableMemberships: mapViewerAssignableMembershipsFromConvex(
       raw.viewerAssignableMemberships
     ),
-    groupAccess: raw.groupAccess,
+    assignableGroups: raw.assignableGroups,
     faqItems: mapFaqItemsFromConvex(raw.faqItems),
   };
 }
@@ -164,17 +170,6 @@ export async function loadRulesetFactionsWithDetails(
     ruleset_id: rulesetId,
   });
   return factions.map(normalizeRulesetFactionSummary);
-}
-
-export async function loadCanEditRuleset(rulesetId: string): Promise<boolean> {
-  return await db.query<boolean>(api.rulesets.canEdit, { ruleset_id: rulesetId });
-}
-
-export function useCanEditRuleset(rulesetId: string) {
-  const liveData = useQuery(api.rulesets.canEdit, { ruleset_id: rulesetId } as never) as
-    | boolean
-    | undefined;
-  return toLiveQueryResult(liveData, true);
 }
 
 export async function loadRulesetsByFaction(factionId: string): Promise<RulesetEntry[]> {
@@ -210,16 +205,13 @@ export function useRuleset(id: string) {
 
 export function useRulesetBySlug(slug: string, options?: { initialData?: RulesetPageData }) {
   const liveData = useQuery(api.rulesets.getBySlug, { slug });
-  const result = toLiveQueryResult<{
-    ruleset: RulesetRow;
-    factions: RulesetFactionSummaryRaw[];
-    canEditRuleset: boolean;
-  } | null>(liveData, true, () => (options?.initialData as never) ?? undefined);
+  const normalized = liveData ? toRulesetPageData(liveData) : undefined;
+  const result = toLiveQueryResult(normalized, true, () => options?.initialData);
   return {
     ...result,
     ruleset: result.data ? toRulesetEntry(result.data.ruleset) : undefined,
     factions: result.data?.factions.map(normalizeRulesetFactionSummary),
-    canEditRuleset: result.data?.canEditRuleset ?? false,
+    viewerAccess: result.data?.viewerAccess,
   };
 }
 
@@ -238,12 +230,12 @@ export function useRulesetDetailPage(
         : {
             ruleset: toRulesetEntry(liveData.ruleset),
             factions: liveData.factions.map(normalizeRulesetFactionSummary),
-            canEditRuleset: liveData.canEditRuleset,
+            viewerAccess: liveData.viewerAccess,
             owner: liveData.owner,
             viewerAssignableMemberships: mapViewerAssignableMembershipsFromConvex(
               liveData.viewerAssignableMemberships as AssignableMembershipConvexRow[] | null
             ),
-            groupAccess: liveData.groupAccess,
+            assignableGroups: liveData.assignableGroups,
             faqItems: mapFaqItemsFromConvex(liveData.faqItems as FaqItemConvexRow[]),
           };
   const result = toLiveQueryResult(normalized, true, () => options?.initialData);
@@ -251,10 +243,10 @@ export function useRulesetDetailPage(
     ...result,
     ruleset: result.data?.ruleset,
     factions: result.data?.factions,
-    canEditRuleset: result.data?.canEditRuleset ?? false,
+    viewerAccess: result.data?.viewerAccess,
     owner: result.data?.owner ?? null,
     viewerAssignableMemberships: result.data?.viewerAssignableMemberships ?? null,
-    groupAccess: result.data?.groupAccess ?? null,
+    assignableGroups: result.data?.assignableGroups ?? [],
     faqItems: result.data?.faqItems ?? [],
   };
 }

--- a/src/app/rulesets/rulesetActionVisibility.test.ts
+++ b/src/app/rulesets/rulesetActionVisibility.test.ts
@@ -31,11 +31,20 @@ describe('rulesetActionVisibility', () => {
 
     expect(
       rulesetActionVisibility({
-        hasProfile: false,
+        hasProfile: true,
         canChangeGroup: true,
         canDelete: false,
         hasAssignedGroup: true,
       })
     ).toMatchObject({ assignGroup: false, removeGroup: true });
+
+    expect(
+      rulesetActionVisibility({
+        hasProfile: true,
+        canChangeGroup: false,
+        canDelete: false,
+        hasAssignedGroup: true,
+      })
+    ).toMatchObject({ assignGroup: false, removeGroup: false });
   });
 });

--- a/src/app/rulesets/rulesetActionVisibility.test.ts
+++ b/src/app/rulesets/rulesetActionVisibility.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from 'vitest';
+
+import { rulesetActionVisibility } from './rulesetActionVisibility';
+
+describe('rulesetActionVisibility', () => {
+  test('keeps deletion available without a bogus group action while profile resolves', () => {
+    expect(
+      rulesetActionVisibility({
+        hasProfile: false,
+        canChangeGroup: true,
+        canDelete: true,
+        hasAssignedGroup: false,
+      })
+    ).toEqual({
+      askQuestion: false,
+      assignGroup: false,
+      removeGroup: false,
+      deleteRuleset: true,
+    });
+  });
+
+  test('selects assignment for unassigned rulesets and removal for assigned rulesets', () => {
+    expect(
+      rulesetActionVisibility({
+        hasProfile: true,
+        canChangeGroup: true,
+        canDelete: false,
+        hasAssignedGroup: false,
+      })
+    ).toMatchObject({ assignGroup: true, removeGroup: false });
+
+    expect(
+      rulesetActionVisibility({
+        hasProfile: false,
+        canChangeGroup: true,
+        canDelete: false,
+        hasAssignedGroup: true,
+      })
+    ).toMatchObject({ assignGroup: false, removeGroup: true });
+  });
+});

--- a/src/app/rulesets/rulesetActionVisibility.ts
+++ b/src/app/rulesets/rulesetActionVisibility.ts
@@ -1,0 +1,20 @@
+type RulesetActionVisibilityInput = {
+  hasProfile: boolean;
+  canChangeGroup: boolean;
+  canDelete: boolean;
+  hasAssignedGroup: boolean;
+};
+
+export function rulesetActionVisibility({
+  hasProfile,
+  canChangeGroup,
+  canDelete,
+  hasAssignedGroup,
+}: RulesetActionVisibilityInput) {
+  return {
+    askQuestion: hasProfile,
+    assignGroup: canChangeGroup && !hasAssignedGroup && hasProfile,
+    removeGroup: canChangeGroup && hasAssignedGroup,
+    deleteRuleset: canDelete,
+  };
+}


### PR DESCRIPTION
## Summary
- move faction and ruleset detail/edit routes to canonical viewerAccess capabilities
- expose faction ruleset summaries in the page projection and remove redundant page subscriptions
- preserve widened legacy backend fields/functions for the remaining migration tickets
- cover the caller boundary, policy matrix, transient profile state, and membership rejection handling

## Validation
- focused: 4 files, 35 tests
- full: 60 files, 405 tests
- bun run check
- bun run typecheck
- git diff --check
- publisher release verification: 1378 assets, 226 stories, renderer manifest unchanged at 5132c7f42432d0766effc6b4d42a47c8916d979286efb57b832b400a0a14f9de, Wrangler dry-run green
- cold architecture review: SAFE for spec and standards

## Compatibility and rollback
The Convex backend remains widened: legacy fields and functions are intentionally retained for issues #219, #220, and #224. The new Worker may rely on viewerAccess for faction and ruleset callers after this deploy. A Worker rollback remains safe while the backend is widened; after later narrowing, re-widen Convex before rolling back to an older Worker.

Closes #218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faction pages now display associated rulesets with names and links.
  * Faction and ruleset pages provide access-aware controls for editing, deleting, assigning groups, and managing content.
  * Membership requests and group assignment workflows now show loading and error feedback.
* **Bug Fixes**
  * Improved handling for anonymous visitors with login prompts and redirects.
  * Deleted rulesets no longer appear in faction details.
  * Permissions and available actions are now applied more consistently across faction and ruleset pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->