### PR TITLE
Migrate Group detail to projected collaborative access

### DIFF
--- a/convex/collaborativeAccess.test.ts
+++ b/convex/collaborativeAccess.test.ts
@@ -174,6 +174,12 @@ describe('collaborative access public projections', () => {
         addMember: true,
       },
     });
+    expect(page.owner).toEqual({
+      id: expect.any(String),
+      slug: 'group-owner',
+      username: 'Group owner',
+      avatar_url: null,
+    });
     expect(page.roster).toEqual([
       expect.objectContaining({
         membershipId: ids.membershipIds.owner,
@@ -446,6 +452,11 @@ describe('collaborative access public projections', () => {
       viewer: { kind: 'authenticated', membership: 'none' },
       capabilities: { rename: true, delete: true, addMember: false },
     });
+    expect(page.owner).toMatchObject({
+      slug: 'group-owner',
+      username: 'Group owner',
+    });
+    expect(page.roster.some((entry) => entry.membershipId === ids.membershipIds.owner)).toBe(false);
 
     const assetOwnerPage = await t
       .withIdentity({ subject: ids.assetOwnerId })

--- a/convex/groups.ts
+++ b/convex/groups.ts
@@ -99,6 +99,7 @@ export const detailBySlug = query({
       factions,
       rulesets,
       profiles: accessBundle.profiles,
+      owner: accessBundle.owner,
       viewerAccess: accessBundle.viewerAccess,
       roster: accessBundle.roster,
     };

--- a/convex/lib/collaborativeAccess.ts
+++ b/convex/lib/collaborativeAccess.ts
@@ -646,7 +646,17 @@ export async function loadGroupAccessBundle(ctx: QueryCtx, group: Doc<'groups'>)
     ];
   });
 
-  return { ...access, members, profiles, roster };
+  const ownerProfile = profileByUserId.get(access.subject.created_by);
+  const owner = ownerProfile
+    ? {
+        id: ownerProfile._id,
+        slug: ownerProfile.slug,
+        username: ownerProfile.username,
+        avatar_url: ownerProfile.avatar_url,
+      }
+    : null;
+
+  return { ...access, members, profiles, owner, roster };
 }
 
 export function evaluateCollaborativeAccess(facts: CollaborativeAccessFacts): CollaborativeAccess {

--- a/convex/lib/collaborativeAccessValidators.ts
+++ b/convex/lib/collaborativeAccessValidators.ts
@@ -263,6 +263,7 @@ export const groupDetailPageValidator = v.object({
   factions: v.array(factionValidator),
   rulesets: v.array(rulesetValidator),
   profiles: v.array(profileValidator),
+  owner: v.union(profileSummaryValidator, v.null()),
   viewerAccess: groupViewerAccessValidator,
   roster: v.array(rosterEntryValidator),
 });

--- a/docs/membership.md
+++ b/docs/membership.md
@@ -4,11 +4,11 @@
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Pending: Request Membership<br/>useRequestGroupMembership
-    Pending --> Active: Approve<br/>useApproveGroupMember<br/>Trigger sets approved_by/approved_at
-    Pending --> Removed: Reject<br/>useRejectGroupMember
-    Active --> Removed: Remove<br/>useRemoveGroupMember
-    Removed --> [*]
+    [*] --> Pending: Request Membership<br/>workflow.request(groupId)
+    Pending --> Active: Approve<br/>workflow.approve(membershipId)<br/>Sets approved_by/approved_at
+    Pending --> Removed: Reject<br/>workflow.reject(membershipId)
+    Active --> Removed: Remove<br/>workflow.remove(membershipId)
+    Removed --> Pending: Request again<br/>workflow.request(groupId)
 ```
 
 Status transitions: `pending` → `active` (approved) or `removed` (rejected/removed).
@@ -25,24 +25,31 @@ Status transitions: `pending` → `active` (approved) or `removed` (rejected/rem
 
 `approved_by` and `approved_at` are set in Convex membership mutations when status becomes `active`.
 
-## Hooks
+## Client workflow
 
-**Mutations**: `useRequestGroupMembership`, `useApproveGroupMember`, `useRejectGroupMember`, `useRemoveGroupMember`
+`useGroupMembershipWorkflow` exposes the named `request`, `approve`, `reject`, `remove`, and `add`
+commands with normalized pending and error state. Group detail consumes the canonical Group page
+projection: `viewerAccess` controls viewer actions, while each `roster` row controls approve, reject,
+and remove actions. Callers pass `membershipId` for moderation and never reconstruct authorization
+from raw membership rows.
 
-**Queries**: `useGroupMembers`, `useGroupMembersByStatus`, and `useGroupMember`. Asset page queries provide server-derived `assignableGroups`; assignment controls do not query or filter raw membership rows.
+Asset page queries provide server-derived `assignableGroups`; assignment controls do not query or
+filter raw membership rows.
 
 **Example**: [`src/app/members/db.ts`](../src/app/members/db.ts)
 
 ## Authorization
 
-Convex handlers in `convex/members.ts` enforce:
+Convex handlers in `convex/members.ts` enforce authorization through the trusted collaborative-access
+module:
 
-- **`approve` / `reject`**: Caller must be an **active** member of the group (`isActiveGroupMember`). Target row must be **`pending`**.
-- **`remove`**: Only the **group creator** (`groups.created_by`) may remove someone else. Cannot remove the creator. Target must be **`active`** (pending requests are handled with `reject`).
+- **`approveRequest` / `rejectRequest`**: Caller must be an **active** member of the Group. Target row must be **`pending`**.
+- **`removeMember`**: Only the **Group owner** may remove someone else. The owner cannot be removed. Target must be **`active`** (pending requests are handled with `rejectRequest`).
 - **`request`**: Any authenticated user may request membership.
-- **`add`**: Any active member may directly add another user without a prior request.
+- **`addMember`**: Any active member may directly add another user without a prior request.
 
-Shared helpers live in `convex/lib/policy.ts` (`requireAuthUserId`, `isActiveGroupMember`).
+The legacy pair-argument moderation functions remain registered only for the widened deployment
+compatibility interval and are removed by the separate transport-narrowing release.
 
 ## Group-associated content
 

--- a/docs/membership.md
+++ b/docs/membership.md
@@ -4,14 +4,16 @@
 
 ```mermaid
 stateDiagram-v2
-    [*] --> Pending: Request Membership<br/>workflow.request(groupId)
-    Pending --> Active: Approve<br/>workflow.approve(membershipId)<br/>Sets approved_by/approved_at
-    Pending --> Removed: Reject<br/>workflow.reject(membershipId)
-    Active --> Removed: Remove<br/>workflow.remove(membershipId)
-    Removed --> Pending: Request again<br/>workflow.request(groupId)
+    [*] --> Pending: Request Membership<br/>workflow.request.run(groupId)
+    Pending --> Active: Approve<br/>workflow.approve.run(membershipId)<br/>Sets approved_by/approved_at
+    Pending --> Removed: Reject<br/>workflow.reject.run(membershipId)
+    Active --> Removed: Remove<br/>workflow.remove.run(membershipId)
+    Removed --> Pending: Request again<br/>workflow.request.run(groupId)
 ```
 
-Status transitions: `pending` → `active` (approved) or `removed` (rejected/removed).
+Status transitions: requests create `pending` memberships, approval moves `pending` → `active`, and
+rejection or removal moves a membership to `removed`. Calling `members.request` for a removed
+membership reactivates it as `pending`.
 
 ## Status Enum
 

--- a/src/app/collaborativeAccessCallers.architecture.test.ts
+++ b/src/app/collaborativeAccessCallers.architecture.test.ts
@@ -20,6 +20,15 @@ const sources = {
     new URL('./components/groups/GroupAssignPopover.tsx', import.meta.url),
     'utf8'
   ),
+  groupDb: readFileSync(new URL('./groups/db.ts', import.meta.url), 'utf8'),
+  groupDetail: readFileSync(
+    new URL('./routes/_app/groups/$groupSlug/index.tsx', import.meta.url),
+    'utf8'
+  ),
+  groupEdit: readFileSync(
+    new URL('./routes/_app/groups/$groupSlug/edit.tsx', import.meta.url),
+    'utf8'
+  ),
   membersDb: readFileSync(new URL('./members/db.ts', import.meta.url), 'utf8'),
   rulesetDb: readFileSync(new URL('./rulesets/db.ts', import.meta.url), 'utf8'),
   rulesetDetail: readFileSync(
@@ -97,5 +106,45 @@ describe('faction and ruleset collaborative-access caller contract', () => {
     expect(sources.rulesetDetail).not.toContain('viewerAssignableMemberships');
     expect(sources.rulesetDb).not.toContain('viewerAssignableMemberships');
     expect(sources.membersDb).not.toContain('listByUserActiveWithGroups');
+  });
+
+  test('Group callers consume viewer access, owner summary, roster capabilities, and one workflow', () => {
+    expect(sources.groupDb).toContain('viewerAccess');
+    expect(sources.groupDb).toContain('owner: GroupOwnerSummary | null');
+    expect(sources.groupDb).toContain('roster: GroupRosterEntry[]');
+    expect(sources.groupDb).not.toMatch(/^\s+members:/m);
+    expect(sources.groupDb).not.toMatch(/^\s+profiles:/m);
+
+    expect(sources.groupDetail).toContain('groupData.viewerAccess');
+    expect(sources.groupDetail).toContain('groupData.owner');
+    expect(sources.groupDetail).toContain('groupData.roster');
+    expect(sources.groupDetail).toContain('useGroupMembershipWorkflow');
+    expect(sources.groupDetail).toContain('entry.capabilities.approve');
+    expect(sources.groupDetail).toContain('entry.capabilities.reject');
+    expect(sources.groupDetail).toContain('entry.capabilities.remove');
+    expect(sources.groupDetail).toMatch(/approve\s*\.run\(entry\.membershipId\)/);
+    expect(sources.groupDetail).toMatch(/reject\s*\.run\(entry\.membershipId\)/);
+    expect(sources.groupDetail).toContain('remove.run(membershipId)');
+    expect(sources.groupDetail).toContain('handleRemoveMember(entry.membershipId)');
+    expect(sources.groupDetail).not.toContain('useCurrentProfile');
+    expect(sources.groupDetail).not.toContain('useApproveGroupMember');
+    expect(sources.groupDetail).not.toContain('useRejectGroupMember');
+    expect(sources.groupDetail).not.toContain('useRemoveGroupMember');
+    expect(sources.groupDetail).not.toContain('useRequestGroupMembership');
+
+    expect(sources.groupEdit).toContain('useGroupEditBySlug');
+    expect(sources.groupEdit).toContain('viewerAccess.capabilities.rename');
+    expect(sources.groupEdit).not.toContain('useCurrentProfile');
+    expect(sources.groupEdit).not.toContain('group.created_by');
+
+    expect(sources.groupDb).not.toContain('api.groups.getBySlug');
+    expect(sources.groupDb).not.toContain('loadGroupBySlug');
+    expect(sources.groupDb).not.toContain('useGroupBySlug');
+    expect(sources.membersDb).not.toContain('api.members.listByGroup');
+    expect(sources.membersDb).not.toContain('api.members.get');
+    expect(sources.membersDb).not.toContain('useRequestGroupMembership');
+    expect(sources.membersDb).not.toContain('useApproveGroupMember');
+    expect(sources.membersDb).not.toContain('useRejectGroupMember');
+    expect(sources.membersDb).not.toContain('useRemoveGroupMember');
   });
 });

--- a/src/app/groups/db.test.tsx
+++ b/src/app/groups/db.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { api } from '../../../convex/_generated/api';
+
+const mocks = vi.hoisted(() => ({
+  dbQuery: vi.fn(),
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@db/core', () => ({ db: { query: mocks.dbQuery } }));
+vi.mock('convex/react', () => ({
+  useQuery: mocks.useQuery,
+  useMutation: vi.fn(),
+}));
+
+import {
+  loadGroupDetailBySlug,
+  loadGroupEditBySlug,
+  useGroupDetailBySlug,
+  useGroupEditBySlug,
+} from './db';
+
+const group = {
+  _id: 'group-1',
+  _creationTime: 1,
+  name: 'Dune Designers',
+  slug: 'dune-designers',
+  created_at: '2026-08-05T00:00:00.000Z',
+  created_by: 'user-owner',
+};
+
+const owner = {
+  id: 'profile-owner',
+  slug: 'group-owner',
+  username: 'Group owner',
+  avatar_url: null,
+};
+
+const viewerAccess = {
+  kind: 'group' as const,
+  viewer: { kind: 'authenticated' as const, membership: 'active' as const },
+  capabilities: {
+    requestMembership: false,
+    rename: true,
+    delete: true,
+    addMember: true,
+  },
+};
+
+const roster = [
+  {
+    membershipId: 'membership-owner',
+    user: owner,
+    status: 'active' as const,
+    requestedAt: '2026-08-05T00:00:00.000Z',
+    capabilities: { approve: false, reject: false, remove: false },
+  },
+];
+
+const serverPage = {
+  group,
+  factions: [],
+  rulesets: [],
+  owner,
+  viewerAccess,
+  roster,
+  members: [{ _id: 'legacy-membership' }],
+  profiles: [{ _id: 'legacy-profile' }],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Group page interface', () => {
+  test('normalizes the canonical detail projection without exposing legacy authorization rows', async () => {
+    mocks.dbQuery.mockResolvedValue(serverPage);
+
+    const loaded = await loadGroupDetailBySlug('dune-designers');
+
+    expect(loaded).toEqual({
+      group: { ...group, id: 'group-1' },
+      factions: [],
+      rulesets: [],
+      owner,
+      viewerAccess,
+      roster,
+    });
+    expect(mocks.dbQuery).toHaveBeenCalledWith(api.groups.detailBySlug, {
+      slug: 'dune-designers',
+    });
+
+    mocks.useQuery.mockReturnValue(undefined);
+    const loaderHandoff = renderHook(() =>
+      useGroupDetailBySlug('dune-designers', { initialData: loaded })
+    );
+    expect(loaderHandoff.result.current.data).toEqual(loaded);
+    loaderHandoff.unmount();
+
+    mocks.useQuery.mockReturnValue(serverPage);
+    const live = renderHook(() => useGroupDetailBySlug('dune-designers'));
+    expect(live.result.current.data).toEqual(loaded);
+    expect(mocks.useQuery).toHaveBeenLastCalledWith(api.groups.detailBySlug, {
+      slug: 'dune-designers',
+    });
+    live.unmount();
+  });
+
+  test('gives Group edit only its Group and owner capability projection', async () => {
+    mocks.dbQuery.mockResolvedValue(serverPage);
+
+    const loaded = await loadGroupEditBySlug('dune-designers');
+
+    expect(loaded).toEqual({
+      group: { ...group, id: 'group-1' },
+      viewerAccess,
+    });
+
+    mocks.useQuery.mockReturnValue(serverPage);
+    const live = renderHook(() => useGroupEditBySlug('dune-designers'));
+    expect(live.result.current.data).toEqual(loaded);
+    live.unmount();
+  });
+});

--- a/src/app/groups/db.ts
+++ b/src/app/groups/db.ts
@@ -10,53 +10,51 @@ import { groupInputSchema } from '@app/groups/validation';
 
 import { api } from '../../../convex/_generated/api';
 import type { Doc } from '../../../convex/_generated/dataModel';
+import type {
+  CollaborativeAccess,
+  GroupRosterEntry,
+} from '../../../convex/lib/collaborativeAccess';
 
 export type GroupRow = Doc<'groups'>;
 export type GroupEntry = GroupRow & { id: GroupRow['_id'] };
 export type GroupInsert = GroupEntry;
 export type GroupUpdate = Partial<GroupEntry>;
 
-export type GroupPageData = {
-  group: GroupEntry;
-  members: Doc<'group_members'>[];
+export type GroupOwnerSummary = {
+  id: Doc<'profiles'>['_id'];
+  slug: string;
+  username: string | null;
+  avatar_url: string | null;
 };
-
-export type GroupMemberWithId = Doc<'group_members'> & { id: Doc<'group_members'>['_id'] };
 
 export type GroupDetailPageData = {
   group: GroupEntry;
-  members: GroupMemberWithId[];
   factions: FactionEntry[];
   rulesets: RulesetEntry[];
-  profiles: Doc<'profiles'>[];
+  owner: GroupOwnerSummary | null;
+  viewerAccess: Extract<CollaborativeAccess, { kind: 'group' }>;
+  roster: GroupRosterEntry[];
+};
+
+export type GroupEditPageData = Pick<GroupDetailPageData, 'group' | 'viewerAccess'>;
+
+type GroupDetailPageRaw = {
+  group: GroupRow;
+  factions: Doc<'factions'>[];
+  rulesets: RulesetRow[];
+  owner: GroupOwnerSummary | null;
+  viewerAccess: GroupDetailPageData['viewerAccess'];
+  roster: GroupRosterEntry[];
 };
 
 export async function loadGroupDetailBySlug(slug: string): Promise<GroupDetailPageData> {
-  const result = await db.query<{
-    group: GroupRow;
-    members: Doc<'group_members'>[];
-    factions: Doc<'factions'>[];
-    rulesets: RulesetRow[];
-    profiles: Doc<'profiles'>[];
-  }>(api.groups.detailBySlug, { slug });
-  return {
-    group: { ...result.group, id: result.group._id },
-    members: result.members.map((m) => ({ ...m, id: m._id })),
-    factions: factionRowsToEntries(result.factions),
-    rulesets: rulesetRowsToEntries(result.rulesets),
-    profiles: result.profiles,
-  };
+  const result = await db.query<GroupDetailPageRaw>(api.groups.detailBySlug, { slug });
+  return normalizeGroupDetailFromConvex(result);
 }
 
-export async function loadGroupBySlug(slug: string): Promise<GroupPageData> {
-  const result = await db.query<{
-    group: GroupRow;
-    members: Doc<'group_members'>[];
-  }>(api.groups.getBySlug, { slug });
-  return {
-    ...result,
-    group: { ...result.group, id: result.group._id },
-  };
+export async function loadGroupEditBySlug(slug: string): Promise<GroupEditPageData> {
+  const result = await loadGroupDetailBySlug(slug);
+  return { group: result.group, viewerAccess: result.viewerAccess };
 }
 
 /** Call only when `id` is a real group id (mount a child component if the id is optional). */
@@ -69,34 +67,14 @@ export function useGroup(id: string) {
   };
 }
 
-export function useGroupBySlug(slug: string, options?: { initialData?: GroupPageData }) {
-  const liveData = useQuery(api.groups.getBySlug, { slug });
-  const result = toLiveQueryResult<{
-    group: GroupRow;
-    members: Doc<'group_members'>[];
-  } | null>(liveData, true, () => (options?.initialData as never) ?? undefined);
-  return {
-    ...result,
-    group: result.data
-      ? ({ ...result.data.group, id: result.data.group._id } as GroupEntry)
-      : undefined,
-    members: result.data?.members,
-  };
-}
-
-function normalizeGroupDetailFromConvex(raw: {
-  group: GroupRow;
-  members: Doc<'group_members'>[];
-  factions: Doc<'factions'>[];
-  rulesets: RulesetRow[];
-  profiles: Doc<'profiles'>[];
-}): GroupDetailPageData {
+function normalizeGroupDetailFromConvex(raw: GroupDetailPageRaw): GroupDetailPageData {
   return {
     group: { ...raw.group, id: raw.group._id },
-    members: raw.members.map((m) => ({ ...m, id: m._id })),
     factions: factionRowsToEntries(raw.factions),
     rulesets: rulesetRowsToEntries(raw.rulesets),
-    profiles: raw.profiles,
+    owner: raw.owner,
+    viewerAccess: raw.viewerAccess,
+    roster: raw.roster,
   };
 }
 
@@ -114,10 +92,29 @@ export function useGroupDetailBySlug(
   return {
     ...result,
     group: result.data?.group,
-    members: result.data?.members,
     factions: result.data?.factions,
     rulesets: result.data?.rulesets,
-    profiles: result.data?.profiles,
+    owner: result.data?.owner ?? null,
+    viewerAccess: result.data?.viewerAccess,
+    roster: result.data?.roster,
+  };
+}
+
+export function useGroupEditBySlug(slug: string, options?: { initialData?: GroupEditPageData }) {
+  const liveData = useQuery(api.groups.detailBySlug, { slug });
+  const normalizedLive = liveData ? normalizeGroupDetailFromConvex(liveData) : undefined;
+  const editData = normalizedLive
+    ? { group: normalizedLive.group, viewerAccess: normalizedLive.viewerAccess }
+    : undefined;
+  const result = toLiveQueryResult<GroupEditPageData | undefined>(
+    editData,
+    true,
+    () => options?.initialData
+  );
+  return {
+    ...result,
+    group: result.data?.group,
+    viewerAccess: result.data?.viewerAccess,
   };
 }
 

--- a/src/app/members/db.test.tsx
+++ b/src/app/members/db.test.tsx
@@ -57,4 +57,43 @@ describe('Group membership workflow', () => {
     expect(mocks.remove).toHaveBeenCalledWith({ membershipId: 'membership-3' });
     expect(mocks.add).toHaveBeenCalledWith({ groupId: 'group-1', userId: 'user-1' });
   });
+
+  test('clears an earlier moderation failure when a different command succeeds', async () => {
+    mocks.approve.mockRejectedValueOnce(new Error('Approve failed'));
+    const hook = renderHook(() => useGroupMembershipWorkflow());
+
+    await act(async () => {
+      await expect(hook.result.current.approve.run('membership-1')).rejects.toThrow(
+        'Approve failed'
+      );
+    });
+    expect(hook.result.current.approve.error?.message).toBe('Approve failed');
+
+    await act(async () => {
+      await hook.result.current.reject.run('membership-1');
+    });
+
+    expect(hook.result.current.approve.error).toBeNull();
+    expect(hook.result.current.reject.error).toBeNull();
+    expect(hook.result.current.remove.error).toBeNull();
+  });
+
+  test('replaces an earlier moderation failure with the latest command failure', async () => {
+    mocks.approve.mockRejectedValueOnce(new Error('Approve failed'));
+    mocks.reject.mockRejectedValueOnce(new Error('Reject failed'));
+    const hook = renderHook(() => useGroupMembershipWorkflow());
+
+    await act(async () => {
+      await expect(hook.result.current.approve.run('membership-1')).rejects.toThrow(
+        'Approve failed'
+      );
+    });
+    await act(async () => {
+      await expect(hook.result.current.reject.run('membership-1')).rejects.toThrow('Reject failed');
+    });
+
+    expect(hook.result.current.approve.error).toBeNull();
+    expect(hook.result.current.reject.error?.message).toBe('Reject failed');
+    expect(hook.result.current.remove.error).toBeNull();
+  });
 });

--- a/src/app/members/db.ts
+++ b/src/app/members/db.ts
@@ -1,16 +1,10 @@
-import { useQuery } from 'convex/react';
-
-import { db } from '@db/core';
-import { toLiveQueryResult, useLiveMutation } from '@app/db/core/live';
+import { useLiveMutation } from '@app/db/core/live';
 import type { LiveMutationResult } from '@app/db/core/live';
 
 import { api } from '../../../convex/_generated/api';
 import type { Doc } from '../../../convex/_generated/dataModel';
 
 export type GroupMemberRow = Doc<'group_members'>;
-export type GroupMemberEntry = GroupMemberRow & { id: string };
-export type GroupMemberInsert = GroupMemberEntry;
-export type GroupMemberUpdate = Partial<GroupMemberEntry>;
 export type GroupMemberStatus = GroupMemberRow['status'];
 
 type MembershipCommandAcknowledgement = {
@@ -28,74 +22,18 @@ type GroupMembershipCommand<TInput> = {
 
 function membershipCommand<TInput, TVariables, TResult>(
   mutation: LiveMutationResult<TVariables, TResult>,
-  variables: (input: TInput) => TVariables
+  variables: (input: TInput) => TVariables,
+  beforeRun?: () => void
 ): GroupMembershipCommand<TInput> {
   return {
     run: async (input) => {
+      beforeRun?.();
       await mutation.mutateAsync(variables(input));
     },
     isPending: mutation.isPending,
     isError: mutation.isError,
     error: mutation.error,
     reset: mutation.reset,
-  };
-}
-
-export async function loadGroupMembersByStatus(
-  groupId: string,
-  status: GroupMemberStatus
-): Promise<GroupMemberEntry[]> {
-  const entries = await db.query<GroupMemberRow[]>(api.members.listByGroupAndStatus, {
-    group_id: groupId,
-    status,
-  });
-  return entries.map((entry) => ({ ...entry, id: entry._id }));
-}
-
-export async function loadGroupMembers(groupId: string): Promise<GroupMemberEntry[]> {
-  const entries = await db.query<GroupMemberRow[]>(api.members.listByGroup, {
-    group_id: groupId,
-  });
-  return entries.map((entry) => ({ ...entry, id: entry._id }));
-}
-
-/** Mount only when `groupId` is a real group id. */
-export function useGroupMembers(groupId: string, options?: { initialData?: GroupMemberEntry[] }) {
-  const liveData = useQuery(api.members.listByGroup, { group_id: groupId } as never) as
-    | GroupMemberRow[]
-    | undefined;
-  const result = toLiveQueryResult(liveData, true, () => options?.initialData ?? undefined);
-  return {
-    ...result,
-    data: result.data?.map((entry) => ({ ...entry, id: entry._id })),
-  };
-}
-
-export function useGroupMembersByStatus(
-  groupId: string,
-  status: GroupMemberStatus,
-  options?: { initialData?: GroupMemberEntry[] }
-) {
-  const liveData = useQuery(api.members.listByGroupAndStatus, {
-    group_id: groupId,
-    status,
-  } as never) as GroupMemberRow[] | undefined;
-  const result = toLiveQueryResult(liveData, true, () => options?.initialData ?? undefined);
-  return {
-    ...result,
-    data: result.data?.map((entry) => ({ ...entry, id: entry._id })),
-  };
-}
-
-export function useGroupMember(groupId: string, userId: string) {
-  const liveData = useQuery(api.members.get, {
-    group_id: groupId,
-    user_id: userId,
-  } as never) as GroupMemberRow | undefined;
-  const result = toLiveQueryResult(liveData, true);
-  return {
-    ...result,
-    data: result.data ? { ...result.data, id: result.data._id } : undefined,
   };
 }
 
@@ -122,129 +60,30 @@ export function useGroupMembershipWorkflow() {
 
   return {
     request: membershipCommand(requestMutation, (groupId: string) => ({ group_id: groupId })),
-    approve: membershipCommand(approveMutation, (membershipId: string) => ({ membershipId })),
-    reject: membershipCommand(rejectMutation, (membershipId: string) => ({ membershipId })),
-    remove: membershipCommand(removeMutation, (membershipId: string) => ({ membershipId })),
-    add: membershipCommand(addMutation, (input: { groupId: string; userId: string }) => input),
-  };
-}
-
-export function useRequestGroupMembership() {
-  const mutation = useLiveMutation<{ group_id: string }, GroupMemberRow>(api.members.request);
-  return {
-    ...mutation,
-    mutate: (
-      groupId: string,
-      options?: { onSuccess?: (entry: GroupMemberEntry) => void; onError?: (error: Error) => void }
-    ) =>
-      mutation.mutate(
-        { group_id: groupId },
-        {
-          onSuccess: (entry) => options?.onSuccess?.({ ...entry, id: entry._id }),
-          onError: (error) => options?.onError?.(error),
-        }
-      ),
-    mutateAsync: async (groupId: string) => {
-      const entry = await mutation.mutateAsync({ group_id: groupId });
-      return { ...entry, id: entry._id };
-    },
-  };
-}
-
-export function useApproveGroupMember() {
-  const mutation = useLiveMutation<{ group_id: string; user_id: string }, GroupMemberRow>(
-    api.members.approve
-  );
-  return {
-    ...mutation,
-    mutate: (
-      variables: { groupId: string; userId: string },
-      options?: { onSuccess?: (entry: GroupMemberEntry) => void; onError?: (error: Error) => void }
-    ) =>
-      mutation.mutate(
-        { group_id: variables.groupId, user_id: variables.userId },
-        {
-          onSuccess: (entry) => options?.onSuccess?.({ ...entry, id: entry._id }),
-          onError: (error) => options?.onError?.(error),
-        }
-      ),
-    mutateAsync: async ({ groupId, userId }: { groupId: string; userId: string }) => {
-      const entry = await mutation.mutateAsync({ group_id: groupId, user_id: userId });
-      return { ...entry, id: entry._id };
-    },
-  };
-}
-
-export function useRejectGroupMember() {
-  const mutation = useLiveMutation<{ group_id: string; user_id: string }, GroupMemberRow>(
-    api.members.reject
-  );
-  return {
-    ...mutation,
-    mutate: (
-      variables: { groupId: string; userId: string },
-      options?: { onSuccess?: (entry: GroupMemberEntry) => void; onError?: (error: Error) => void }
-    ) =>
-      mutation.mutate(
-        { group_id: variables.groupId, user_id: variables.userId },
-        {
-          onSuccess: (entry) => options?.onSuccess?.({ ...entry, id: entry._id }),
-          onError: (error) => options?.onError?.(error),
-        }
-      ),
-    mutateAsync: async ({ groupId, userId }: { groupId: string; userId: string }) => {
-      const entry = await mutation.mutateAsync({ group_id: groupId, user_id: userId });
-      return { ...entry, id: entry._id };
-    },
-  };
-}
-
-export function useRemoveGroupMember() {
-  const mutation = useLiveMutation<
-    { group_id: string; user_id: string },
-    { groupId: string; userId: string }
-  >(api.members.remove);
-  return {
-    ...mutation,
-    mutate: (
-      variables: { groupId: string; userId: string },
-      options?: {
-        onSuccess?: (entry: { groupId: string; userId: string }) => void;
-        onError?: (error: Error) => void;
+    approve: membershipCommand(
+      approveMutation,
+      (membershipId: string) => ({ membershipId }),
+      () => {
+        rejectMutation.reset();
+        removeMutation.reset();
       }
-    ) =>
-      mutation.mutate(
-        { group_id: variables.groupId, user_id: variables.userId },
-        {
-          onSuccess: (entry) => options?.onSuccess?.(entry),
-          onError: (error) => options?.onError?.(error),
-        }
-      ),
-    mutateAsync: async ({ groupId, userId }: { groupId: string; userId: string }) =>
-      await mutation.mutateAsync({ group_id: groupId, user_id: userId }),
-  };
-}
-
-export function useAddGroupMember() {
-  const mutation = useLiveMutation<{ group_id: string; user_id: string }, GroupMemberRow>(
-    api.members.add
-  );
-  return {
-    ...mutation,
-    mutate: (
-      variables: { groupId: string; userId: string },
-      options?: { onSuccess?: (entry: GroupMemberEntry) => void; onError?: (error: Error) => void }
-    ) =>
-      mutation.mutate(
-        { group_id: variables.groupId, user_id: variables.userId },
-        {
-          onSuccess: (entry) => options?.onSuccess?.({ ...entry, id: entry._id }),
-          onError: (error) => options?.onError?.(error),
-        }
-      ),
-    mutateAsync: async ({ groupId, userId }: { groupId: string; userId: string }) => {
-      const entry = await mutation.mutateAsync({ group_id: groupId, user_id: userId });
-      return { ...entry, id: entry._id };
-    },
+    ),
+    reject: membershipCommand(
+      rejectMutation,
+      (membershipId: string) => ({ membershipId }),
+      () => {
+        approveMutation.reset();
+        removeMutation.reset();
+      }
+    ),
+    remove: membershipCommand(
+      removeMutation,
+      (membershipId: string) => ({ membershipId }),
+      () => {
+        approveMutation.reset();
+        rejectMutation.reset();
+      }
+    ),
+    add: membershipCommand(addMutation, (input: { groupId: string; userId: string }) => input),
   };
 }

--- a/src/app/routes/_app/groups/$groupSlug/edit.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/edit.tsx
@@ -1,8 +1,7 @@
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { ArrowLeft, Users } from 'lucide-react';
 
-import { loadGroupDetailBySlug, useGroupDetailBySlug } from '@db/groups';
-import { useCurrentProfile } from '@db/profiles';
+import { loadGroupEditBySlug, useGroupEditBySlug } from '@db/groups';
 import { FormTooltip } from '@app/components/form/FormTooltip';
 import { ButtonGroup, Toolbar } from '@app/components/generic/layout';
 import { Card } from '@app/components/generic/surfaces/Card';
@@ -12,8 +11,8 @@ import { PageLayout } from '@app/components/shell';
 
 export const Route = createFileRoute('/_app/groups/$groupSlug/edit')({
   loader: async ({ params }) => {
-    const groupDetail = await loadGroupDetailBySlug(params.groupSlug);
-    return { groupDetail };
+    const groupEdit = await loadGroupEditBySlug(params.groupSlug);
+    return { groupEdit };
   },
   component: GroupEditPage,
 });
@@ -21,10 +20,9 @@ export const Route = createFileRoute('/_app/groups/$groupSlug/edit')({
 function GroupEditPage() {
   const { groupSlug } = Route.useParams();
   const loaderData = Route.useLoaderData();
-  const groupData = useGroupDetailBySlug(groupSlug, { initialData: loaderData.groupDetail });
-  const profile = useCurrentProfile();
+  const groupData = useGroupEditBySlug(groupSlug, { initialData: loaderData.groupEdit });
 
-  if (groupData.isError || !groupData.group) {
+  if (groupData.isError || !groupData.group || !groupData.viewerAccess) {
     return (
       <PageLayout header={<h1>Edit group</h1>}>
         <Card>
@@ -38,7 +36,7 @@ function GroupEditPage() {
   }
 
   const group = groupData.group;
-  const viewerUserId = profile.data?.user_id;
+  const viewerAccess = groupData.viewerAccess;
   const header = <h1>{`Edit ${group.name}`}</h1>;
   const toolbar = (
     <Toolbar>
@@ -64,15 +62,7 @@ function GroupEditPage() {
     </Toolbar>
   );
 
-  if (profile.isPending) {
-    return (
-      <PageLayout header={header} toolbar={toolbar}>
-        Loading profile…
-      </PageLayout>
-    );
-  }
-
-  if (!viewerUserId) {
+  if (viewerAccess.viewer.kind === 'anonymous') {
     return (
       <PageLayout header={header} toolbar={toolbar}>
         <Card>
@@ -89,7 +79,7 @@ function GroupEditPage() {
     );
   }
 
-  if (viewerUserId !== group.created_by) {
+  if (!viewerAccess.capabilities.rename) {
     return (
       <PageLayout header={header} toolbar={toolbar}>
         <Card>

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -2,13 +2,7 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { ArrowLeft, Check, Pencil, UserPlus, UserRoundMinus, X } from 'lucide-react';
 
 import { loadGroupDetailBySlug, useGroupDetailBySlug } from '@db/groups';
-import {
-  useApproveGroupMember,
-  useRejectGroupMember,
-  useRemoveGroupMember,
-  useRequestGroupMembership,
-} from '@db/members';
-import { useCurrentProfile } from '@db/profiles';
+import { useGroupMembershipWorkflow } from '@db/members';
 import { FormTooltip } from '@app/components/form/FormTooltip';
 import { ButtonGroup, Toolbar } from '@app/components/generic/layout';
 import { Card } from '@app/components/generic/surfaces/Card';
@@ -31,12 +25,7 @@ function GroupDetailPage() {
   const { groupSlug } = Route.useParams();
   const loaderData = Route.useLoaderData();
   const groupData = useGroupDetailBySlug(groupSlug, { initialData: loaderData.groupDetail });
-  const requestMembership = useRequestGroupMembership();
-  const approveMember = useApproveGroupMember();
-  const rejectMember = useRejectGroupMember();
-  const removeMember = useRemoveGroupMember();
-  const profile = useCurrentProfile();
-  const viewerUserId = profile.data?.user_id;
+  const membershipWorkflow = useGroupMembershipWorkflow();
 
   if (groupData.isError) {
     return (
@@ -48,41 +37,39 @@ function GroupDetailPage() {
     );
   }
 
-  if (!groupData.group) {
+  if (!groupData.group || !groupData.viewerAccess) {
     return <PageLayout header={<h1>Group</h1>}>Loading group…</PageLayout>;
   }
 
   const group = groupData.group;
   const groupId = group._id;
-  const members = groupData.members ?? [];
-  const profileByUserId = new Map((groupData.profiles ?? []).map((p) => [p.user_id, p]));
-  const ownerProfile = profileByUserId.get(group.created_by);
-  const viewerMembership = members.find((entry) => entry.user_id === viewerUserId);
+  const viewerAccess = groupData.viewerAccess;
+  const ownerProfile = groupData.owner;
   const membershipStatus =
-    viewerMembership && viewerMembership.status !== 'removed' ? viewerMembership.status : 'none';
-  const canRequestMembership = membershipStatus === 'none' && !!viewerUserId;
-  const viewerIsOwner = !!viewerUserId && viewerUserId === group.created_by;
-  const viewerCanModeratePending = membershipStatus === 'active';
+    viewerAccess.viewer.kind === 'authenticated' ? viewerAccess.viewer.membership : 'none';
   const factions = groupData.factions ?? [];
   const rulesets = groupData.rulesets ?? [];
+  const roster = groupData.roster ?? [];
 
   const membersModerationBusy =
-    approveMember.isPending || rejectMember.isPending || removeMember.isPending;
+    membershipWorkflow.approve.isPending ||
+    membershipWorkflow.reject.isPending ||
+    membershipWorkflow.remove.isPending;
   const membersModerationError =
-    approveMember.error?.message ??
-    rejectMember.error?.message ??
-    removeMember.error?.message ??
+    membershipWorkflow.approve.error?.message ??
+    membershipWorkflow.reject.error?.message ??
+    membershipWorkflow.remove.error?.message ??
     null;
 
-  const handleRemoveMember = (memberUserId: string) => {
+  const handleRemoveMember = (membershipId: string) => {
     if (!window.confirm('Remove this member from the group?')) {
       return;
     }
-    removeMember.mutate({ groupId, userId: memberUserId });
+    void membershipWorkflow.remove.run(membershipId).catch(() => undefined);
   };
 
-  const activeMembers = members.filter((member) => member.status === 'active');
-  const pendingMembers = members.filter((member) => member.status === 'pending');
+  const activeMembers = roster.filter((member) => member.status === 'active');
+  const pendingMembers = roster.filter((member) => member.status === 'pending');
   const memberRows = [...activeMembers, ...pendingMembers];
 
   const header = <h1>{group.name}</h1>;
@@ -99,7 +86,7 @@ function GroupDetailPage() {
                   <ArrowLeft size={16} aria-hidden />
                 </UIButton>
               </FormTooltip>
-              {viewerIsOwner ? (
+              {viewerAccess.capabilities.rename ? (
                 <FormTooltip content="Edit group settings">
                   <UIButton
                     variant="secondary"
@@ -138,25 +125,27 @@ function GroupDetailPage() {
               : 'Not a member'}
         </p>
         {membershipStatus === 'pending' && <p>Your request is awaiting approval.</p>}
-        {!profile.isPending && !viewerUserId && (
+        {viewerAccess.viewer.kind === 'anonymous' && (
           <p>
             <Link to="/auth/login">Log in</Link> to request membership.
           </p>
         )}
-        {canRequestMembership && (
+        {viewerAccess.capabilities.requestMembership && (
           <FormTooltip content="Request membership">
             <UIButton
               type="button"
               iconOnly
               aria-label="Request membership"
-              disabled={requestMembership.isPending}
-              onClick={() => requestMembership.mutate(groupId)}
+              disabled={membershipWorkflow.request.isPending}
+              onClick={() => void membershipWorkflow.request.run(groupId).catch(() => undefined)}
             >
               <UserPlus size={16} aria-hidden />
             </UIButton>
           </FormTooltip>
         )}
-        {requestMembership.isError && <p role="alert">{requestMembership.error?.message}</p>}
+        {membershipWorkflow.request.isError && (
+          <p role="alert">{membershipWorkflow.request.error?.message}</p>
+        )}
       </Card>
 
       <Card>
@@ -166,61 +155,71 @@ function GroupDetailPage() {
         ) : (
           <ul>
             {memberRows.map((entry) => {
-              const memberProfile = profileByUserId.get(entry.user_id);
               const isPending = entry.status === 'pending';
-              const isOwnerRow = entry.user_id === group.created_by;
 
               return (
-                <li key={entry.id}>
+                <li key={entry.membershipId}>
                   <div className={pageStyles.memberRow}>
                     <div className={pageStyles.memberRowMain}>
-                      {memberProfile?.slug ? (
+                      {entry.user.slug ? (
                         <ProfileLink
-                          slug={memberProfile.slug}
-                          username={memberProfile.username}
-                          avatar_url={memberProfile.avatar_url}
+                          slug={entry.user.slug}
+                          username={entry.user.username}
+                          avatar_url={entry.user.avatar_url}
                         />
                       ) : (
-                        <span>{memberProfile?.username ?? entry.user_id}</span>
+                        <span>{entry.user.username ?? entry.user.id}</span>
                       )}
                       {isPending ? (
                         <>
                           <span className={pageStyles.pendingMeta}>(pending)</span>
                           <span className={pageStyles.pendingMeta}>
-                            {formatRelativeDate(entry.requested_at)}
+                            {formatRelativeDate(entry.requestedAt)}
                           </span>
                         </>
                       ) : null}
                     </div>
-                    {isPending && viewerCanModeratePending ? (
+                    {entry.capabilities.approve || entry.capabilities.reject ? (
                       <ButtonGroup>
-                        <FormTooltip content="Approve">
-                          <UIButton
-                            type="button"
-                            variant="confirm"
-                            iconOnly
-                            aria-label="Approve membership"
-                            disabled={membersModerationBusy}
-                            onClick={() => approveMember.mutate({ groupId, userId: entry.user_id })}
-                          >
-                            <Check size={16} aria-hidden />
-                          </UIButton>
-                        </FormTooltip>
-                        <FormTooltip content="Decline">
-                          <UIButton
-                            type="button"
-                            variant="critical"
-                            iconOnly
-                            aria-label="Decline membership"
-                            disabled={membersModerationBusy}
-                            onClick={() => rejectMember.mutate({ groupId, userId: entry.user_id })}
-                          >
-                            <X size={16} aria-hidden />
-                          </UIButton>
-                        </FormTooltip>
+                        {entry.capabilities.approve ? (
+                          <FormTooltip content="Approve">
+                            <UIButton
+                              type="button"
+                              variant="confirm"
+                              iconOnly
+                              aria-label="Approve membership"
+                              disabled={membersModerationBusy}
+                              onClick={() =>
+                                void membershipWorkflow.approve
+                                  .run(entry.membershipId)
+                                  .catch(() => undefined)
+                              }
+                            >
+                              <Check size={16} aria-hidden />
+                            </UIButton>
+                          </FormTooltip>
+                        ) : null}
+                        {entry.capabilities.reject ? (
+                          <FormTooltip content="Decline">
+                            <UIButton
+                              type="button"
+                              variant="critical"
+                              iconOnly
+                              aria-label="Decline membership"
+                              disabled={membersModerationBusy}
+                              onClick={() =>
+                                void membershipWorkflow.reject
+                                  .run(entry.membershipId)
+                                  .catch(() => undefined)
+                              }
+                            >
+                              <X size={16} aria-hidden />
+                            </UIButton>
+                          </FormTooltip>
+                        ) : null}
                       </ButtonGroup>
                     ) : null}
-                    {!isPending && viewerIsOwner && !isOwnerRow ? (
+                    {entry.capabilities.remove ? (
                       <ButtonGroup>
                         <FormTooltip content="Remove member">
                           <UIButton
@@ -229,7 +228,7 @@ function GroupDetailPage() {
                             iconOnly
                             aria-label="Remove member"
                             disabled={membersModerationBusy}
-                            onClick={() => handleRemoveMember(entry.user_id)}
+                            onClick={() => handleRemoveMember(entry.membershipId)}
                           >
                             <UserRoundMinus size={16} aria-hidden />
                           </UIButton>


### PR DESCRIPTION
## Summary

- add a canonical owner summary to the widened Group detail projection while retaining legacy server-side compatibility
- migrate Group detail and Group edit to projected viewer access, roster capabilities, and the unified membership workflow
- remove proven-unused raw Group/member client wrappers without narrowing the deployed Convex compatibility surface
- make moderation failures single-owner across approve, reject, and remove commands

## Why

Group detail and edit were still reconstructing authorization from raw profiles and membership rows after the collaborative-access projection shipped. This change makes projected capabilities the only client-side gating input while preserving the existing presentation and authoritative Convex checks.

The architecture cold review found that independent sticky moderation errors could preserve an older failure after a newer command. Each moderation command now clears sibling command state before running, so the displayed error always represents the latest attempt.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run test` — 61 files, 415 tests
- focused collaborative-access suite — 4 files, 30 tests
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:release:verify`
- publisher renderer manifest unchanged at `5132c7f42432d0766effc6b4d42a47c8916d979286efb57b832b400a0a14f9de`
- replacement architecture re-review: SAFE, no remaining actionable finding

Closes #220


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group pages now display the owner, member roster, viewer access, and available actions.
  * Group editing uses permission-based access and provides streamlined edit data.
  * Membership requests and moderation actions now follow a unified workflow with clearer status and error handling.
* **Bug Fixes**
  * Re-requesting membership after removal now returns the request to Pending.
  * Deleted owner memberships are excluded from group rosters.
* **Documentation**
  * Updated membership workflow, authorization, and moderation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->