### PR TITLE
Migrate profile Group summaries off raw membership transport

### DIFF
--- a/convex/collaborativeAccess.test.ts
+++ b/convex/collaborativeAccess.test.ts
@@ -439,6 +439,22 @@ describe('collaborative access public projections', () => {
     });
   });
 
+  test('profile Group summaries safely omit active memberships whose Group is missing', async () => {
+    const { t, ids } = await groupAccessFixture();
+    await t.run((ctx) => ctx.db.delete(ids.groupId));
+
+    const profilePage = await t.query(api.profiles.getBySlug, { slug: 'active-member' });
+
+    expect(profilePage.groupSummaries).toEqual([]);
+    expect(profilePage.groups).toEqual([]);
+    expect(profilePage.memberships).toHaveLength(1);
+    expect(profilePage.memberships[0]).toMatchObject({
+      group_id: ids.groupId,
+      user_id: ids.activeId,
+      status: 'active',
+    });
+  });
+
   test('ownership and active membership remain distinct trusted facts', async () => {
     const { t, ids } = await groupAccessFixture();
     await t.run(async (ctx) => {

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -119,6 +119,8 @@ export const getBySlug = query({
     const groups = groupsWithNulls.filter(
       (group): group is NonNullable<(typeof groupsWithNulls)[number]> => group !== null
     );
+    // Public profile callers count and render only resolvable active Groups. A dangling legacy
+    // membership remains available during widening but cannot become a safe identity summary.
     const groupSummaries = groups.map((group) => ({
       id: group._id,
       name: group.name,

--- a/src/app/collaborativeAccessCallers.architecture.test.ts
+++ b/src/app/collaborativeAccessCallers.architecture.test.ts
@@ -30,6 +30,11 @@ const sources = {
     'utf8'
   ),
   membersDb: readFileSync(new URL('./members/db.ts', import.meta.url), 'utf8'),
+  profileDb: readFileSync(new URL('./profile/db.ts', import.meta.url), 'utf8'),
+  profileDetail: readFileSync(
+    new URL('./routes/_app/profiles/$profileSlug/index.tsx', import.meta.url),
+    'utf8'
+  ),
   rulesetDb: readFileSync(new URL('./rulesets/db.ts', import.meta.url), 'utf8'),
   rulesetDetail: readFileSync(
     new URL('./routes/_app/rulesets/$rulesetSlug/index.tsx', import.meta.url),
@@ -146,5 +151,20 @@ describe('faction and ruleset collaborative-access caller contract', () => {
     expect(sources.membersDb).not.toContain('useApproveGroupMember');
     expect(sources.membersDb).not.toContain('useRejectGroupMember');
     expect(sources.membersDb).not.toContain('useRemoveGroupMember');
+  });
+
+  test('profile detail consumes safe Group summaries without raw membership reconstruction', () => {
+    expect(sources.profileDb).toContain('groupSummaries: AssignedGroupSummary[]');
+    expect(sources.profileDb).not.toMatch(/^\s+memberships:/m);
+    expect(sources.profileDb).not.toMatch(/^\s+groups:/m);
+
+    expect(sources.profileDetail).toContain('profileData.groupSummaries?.length');
+    expect(sources.profileDetail).toContain(
+      '<ProfileGroupMemberships groups={profileData.groupSummaries ?? []} />'
+    );
+    expect(sources.profileDetail).not.toContain('profileData.memberships');
+    expect(sources.profileDetail).not.toContain('groupsById');
+    expect(sources.profileDetail).not.toContain('group_id');
+    expect(sources.profileDetail).not.toContain('Unknown group');
   });
 });

--- a/src/app/components/profile/ProfileGroupMemberships.stories.tsx
+++ b/src/app/components/profile/ProfileGroupMemberships.stories.tsx
@@ -1,0 +1,31 @@
+import preview from '@sb/preview';
+
+import type { Id } from '../../../../convex/_generated/dataModel';
+import { ProfileGroupMemberships } from './ProfileGroupMemberships';
+
+const meta = preview.meta({
+  component: ProfileGroupMemberships,
+});
+
+export const ActiveGroups = meta.story({
+  args: {
+    groups: [
+      {
+        id: 'group-sietch-tabr' as Id<'groups'>,
+        name: 'Sietch Tabr',
+        slug: 'sietch-tabr',
+      },
+      {
+        id: 'group-fremen-council' as Id<'groups'>,
+        name: 'Fremen Council',
+        slug: 'fremen-council',
+      },
+    ],
+  },
+});
+
+export const NoActiveGroups = meta.story({
+  args: {
+    groups: [],
+  },
+});

--- a/src/app/components/profile/ProfileGroupMemberships.test.tsx
+++ b/src/app/components/profile/ProfileGroupMemberships.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+
+import { MantineProvider } from '@mantine/core';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { appContentTheme } from '@app/theme';
+
+import type { Id } from '../../../../convex/_generated/dataModel';
+
+window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, params }: { children: React.ReactNode; params: { groupSlug: string } }) => (
+    <a href={`/groups/${params.groupSlug}`}>{children}</a>
+  ),
+}));
+
+import { ProfileGroupMemberships } from './ProfileGroupMemberships';
+
+afterEach(cleanup);
+
+describe('Profile Group memberships', () => {
+  test('renders ordered Group names as canonical slug links', () => {
+    render(
+      <MantineProvider theme={appContentTheme} forceColorScheme="light">
+        <ProfileGroupMemberships
+          groups={[
+            {
+              id: 'group-2' as Id<'groups'>,
+              name: 'Sietch Tabr',
+              slug: 'sietch-tabr',
+            },
+            {
+              id: 'group-1' as Id<'groups'>,
+              name: 'Fremen Council',
+              slug: 'fremen-council',
+            },
+          ]}
+        />
+      </MantineProvider>
+    );
+
+    const links = screen.getAllByRole('link');
+    expect(links.map((link) => link.textContent)).toEqual(['Sietch Tabr', 'Fremen Council']);
+    expect(links.map((link) => link.getAttribute('href'))).toEqual([
+      '/groups/sietch-tabr',
+      '/groups/fremen-council',
+    ]);
+  });
+
+  test('renders the existing empty state when no resolvable active Groups remain', () => {
+    render(
+      <MantineProvider theme={appContentTheme} forceColorScheme="light">
+        <ProfileGroupMemberships groups={[]} />
+      </MantineProvider>
+    );
+
+    expect(screen.getByText('Not a member of any groups.')).toBeTruthy();
+    expect(screen.queryByRole('link')).toBeNull();
+  });
+});

--- a/src/app/components/profile/ProfileGroupMemberships.tsx
+++ b/src/app/components/profile/ProfileGroupMemberships.tsx
@@ -1,0 +1,26 @@
+import { List, Text } from '@mantine/core';
+import { Link } from '@tanstack/react-router';
+
+import type { AssignedGroupSummary } from '../../../../convex/lib/collaborativeAccess';
+
+export function ProfileGroupMemberships({ groups }: { groups: AssignedGroupSummary[] }) {
+  if (groups.length === 0) {
+    return (
+      <Text c="dimmed" m={0} size="sm">
+        Not a member of any groups.
+      </Text>
+    );
+  }
+
+  return (
+    <List m={0} pl="md" spacing="xs">
+      {groups.map((group) => (
+        <List.Item key={group.id}>
+          <Link to="/groups/$groupSlug" params={{ groupSlug: group.slug }}>
+            {group.name}
+          </Link>
+        </List.Item>
+      ))}
+    </List>
+  );
+}

--- a/src/app/profile/db.test.tsx
+++ b/src/app/profile/db.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { api } from '../../../convex/_generated/api';
+
+const mocks = vi.hoisted(() => ({
+  dbQuery: vi.fn(),
+  useQuery: vi.fn(),
+}));
+
+vi.mock('@db/core', () => ({ db: { query: mocks.dbQuery, mutation: vi.fn() } }));
+vi.mock('convex/react', () => ({
+  useQuery: mocks.useQuery,
+  useMutation: vi.fn(),
+}));
+
+import { loadProfileBySlug, useProfileBySlug } from './db';
+
+const profile = {
+  _id: 'profile-1',
+  _creationTime: 1,
+  user_id: 'user-1',
+  username: 'Chani',
+  avatar_url: null,
+  slug: 'chani',
+  created_at: '2026-08-05T00:00:00.000Z',
+  updated_at: '2026-08-05T00:00:00.000Z',
+};
+
+const groupSummaries = [
+  { id: 'group-2', name: 'Sietch Tabr', slug: 'sietch-tabr' },
+  { id: 'group-1', name: 'Fremen Council', slug: 'fremen-council' },
+];
+
+const serverPage = {
+  profile,
+  memberships: [{ _id: 'legacy-membership' }],
+  groups: [{ _id: 'legacy-group' }],
+  groupSummaries,
+  faqAsked: [],
+  faqAnswers: [],
+  factions: [],
+};
+
+const canonicalPage = {
+  profile,
+  groupSummaries,
+  faqAsked: [],
+  faqAnswers: [],
+  factions: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('profile page interface', () => {
+  test('normalizes loader and live data to ordered Group summaries without raw membership transport', async () => {
+    mocks.dbQuery.mockResolvedValue(serverPage);
+
+    const loaded = await loadProfileBySlug('chani');
+
+    expect(loaded).toEqual(canonicalPage);
+    expect(loaded).not.toHaveProperty('memberships');
+    expect(loaded).not.toHaveProperty('groups');
+    expect(mocks.dbQuery).toHaveBeenCalledWith(api.profiles.getBySlug, { slug: 'chani' });
+
+    mocks.useQuery.mockReturnValue(undefined);
+    const loaderHandoff = renderHook(() =>
+      useProfileBySlug('chani', { initialData: canonicalPage as never })
+    );
+    expect(loaderHandoff.result.current.data).toEqual(canonicalPage);
+    loaderHandoff.unmount();
+
+    mocks.useQuery.mockReturnValue(serverPage);
+    const live = renderHook(() => useProfileBySlug('chani'));
+    expect(live.result.current.data).toEqual(canonicalPage);
+    expect(live.result.current.groupSummaries).toEqual(groupSummaries);
+    expect(live.result.current).not.toHaveProperty('memberships');
+    expect(live.result.current).not.toHaveProperty('groups');
+    live.unmount();
+  });
+});

--- a/src/app/profile/db.ts
+++ b/src/app/profile/db.ts
@@ -10,6 +10,7 @@ import type { ProfileUserEditInput } from '@app/profile/validation';
 
 import { api } from '../../../convex/_generated/api';
 import type { Doc } from '../../../convex/_generated/dataModel';
+import type { AssignedGroupSummary } from '../../../convex/lib/collaborativeAccess';
 import type { FaqAnswerWithParent, FaqItemAskedByWithRuleset } from '../faq/db';
 
 export type ProfileRow = Doc<'profiles'>;
@@ -25,27 +26,33 @@ export type ProfileListEntry = ProfileRow & {
 
 export type ProfilePageData = {
   profile: ProfileEntry;
-  memberships: Doc<'group_members'>[];
-  groups: Doc<'groups'>[];
+  groupSummaries: AssignedGroupSummary[];
   faqAsked: FaqItemAskedByWithRuleset[];
   faqAnswers: FaqAnswerWithParent[];
   factions: FactionCatalogueEntry[];
 };
 
-export async function loadProfileBySlug(slug: string): Promise<ProfilePageData> {
-  const result = await db.query<{
-    profile: ProfileRow;
-    memberships: Doc<'group_members'>[];
-    groups: Doc<'groups'>[];
-    faqAsked: FaqItemAskedByWithRuleset[];
-    faqAnswers: FaqAnswerWithParent[];
-    factions: FactionCatalogueRow[];
-  }>(api.profiles.getBySlug, { slug });
+type ProfilePageTransport = {
+  profile: ProfileRow;
+  groupSummaries: AssignedGroupSummary[];
+  faqAsked: FaqItemAskedByWithRuleset[];
+  faqAnswers: FaqAnswerWithParent[];
+  factions: FactionCatalogueRow[];
+};
 
+function normalizeProfilePage(result: ProfilePageTransport): ProfilePageData {
   return {
-    ...result,
+    profile: result.profile,
+    groupSummaries: result.groupSummaries,
+    faqAsked: result.faqAsked,
+    faqAnswers: result.faqAnswers,
     factions: factionCatalogueRowsToEntries(result.factions),
   };
+}
+
+export async function loadProfileBySlug(slug: string): Promise<ProfilePageData> {
+  const result = await db.query<ProfilePageTransport>(api.profiles.getBySlug, { slug });
+  return normalizeProfilePage(result);
 }
 
 export async function loadProfilesAll(): Promise<ProfileListEntry[]> {
@@ -94,18 +101,12 @@ export function useProfileBySlug(
   }
 ) {
   const liveData = useQuery(api.profiles.getBySlug, { slug });
-  const normalized: ProfilePageData | undefined = liveData
-    ? {
-        ...liveData,
-        factions: factionCatalogueRowsToEntries(liveData.factions),
-      }
-    : undefined;
+  const normalized = liveData ? normalizeProfilePage(liveData) : undefined;
   const result = toLiveQueryResult(normalized, true, () => options?.initialData);
   return {
     ...result,
     profile: result.data ? result.data.profile : undefined,
-    memberships: result.data?.memberships,
-    groups: result.data?.groups,
+    groupSummaries: result.data?.groupSummaries,
     faqAsked: result.data?.faqAsked,
     faqAnswers: result.data?.faqAnswers,
     factions: result.data?.factions,

--- a/src/app/routes/_app/profiles/$profileSlug/index.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/index.tsx
@@ -23,6 +23,7 @@ import {
   ProfileFaqAnswersGiven,
   ProfileFaqQuestionsAsked,
 } from '@app/components/profile/ProfileFaqActivity';
+import { ProfileGroupMemberships } from '@app/components/profile/ProfileGroupMemberships';
 import { PageLayout } from '@app/components/shell';
 import { TopicIcon } from '@app/components/topics/TopicIcon';
 
@@ -69,7 +70,6 @@ function ProfileDetailPage() {
     await navigate({ to: '/auth/login' });
   };
 
-  const groupsById = new Map((profileData.groups ?? []).map((g) => [String(g._id), g] as const));
   const acceptedAnswerCount = (profileData.faqAnswers ?? []).filter(
     (answer) => answer.faq_item.accepted_answer_id === answer._id
   ).length;
@@ -224,7 +224,7 @@ function ProfileDetailPage() {
                 </p>
                 <p>
                   <UsersRound size={18} aria-hidden />
-                  <strong>{profileData.memberships?.length ?? 0}</strong>
+                  <strong>{profileData.groupSummaries?.length ?? 0}</strong>
                   <span>Groups</span>
                 </p>
                 <p>
@@ -276,28 +276,7 @@ function ProfileDetailPage() {
                 </h2>
               }
             >
-              {profileData.memberships && profileData.memberships.length > 0 ? (
-                <ul className={styles.list}>
-                  {profileData.memberships.map((m) => {
-                    const group = groupsById.get(String(m.group_id));
-                    return (
-                      <li key={m._id}>
-                        {group?.slug ? (
-                          <Link to="/groups/$groupSlug" params={{ groupSlug: group.slug }}>
-                            {group.name}
-                          </Link>
-                        ) : group ? (
-                          <span>{group.name}</span>
-                        ) : (
-                          <span title={m.group_id}>Unknown group</span>
-                        )}
-                      </li>
-                    );
-                  })}
-                </ul>
-              ) : (
-                <p className={styles.empty}>Not a member of any groups.</p>
-              )}
+              <ProfileGroupMemberships groups={profileData.groupSummaries ?? []} />
             </Card>
           </Stack>
         </aside>

--- a/src/app/routes/_app/profiles/ProfileDetail.module.css
+++ b/src/app/routes/_app/profiles/ProfileDetail.module.css
@@ -49,15 +49,6 @@
   margin: 0;
 }
 
-.list {
-  margin: 0;
-  padding-left: 1.25rem;
-}
-
-.list li + li {
-  padding-top: var(--space-1);
-}
-
 .empty {
   margin: 0;
   font-size: 0.9rem;


### PR DESCRIPTION
Closes #224

## Summary

- expose canonical `groupSummaries` from the profile client adapter and use them for profile counts and Group links
- safely omit missing or dangling active Group memberships without inventing placeholders
- retain the widened server-side legacy transport for the later cleanup tracked by #221
- add architecture guards plus focused adapter and presentation coverage

## Validation

- `bun run test` (63 files, 420 tests)
- `bun run typecheck`
- `bun run check`
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:release:verify`
- `git diff --check`

The final cold architecture review is SAFE: the profile route has no raw membership reconstruction, routine UI styling is Mantine-owned, and themed tests cover ordered links and the empty state.

## Deployment boundary

Merging this PR is intentionally left to the protected workflow. Issue resolution still requires exact-head CI, automated-review triage, deployment, and live verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile pages now show assigned groups as links to their group pages.
  * Added a clear empty state when no groups are assigned.
  * Group listings use consistent ordering and canonical links.

* **Bug Fixes**
  * Removed deleted or unresolvable groups from profile summaries while preserving valid membership information.
  * Eliminated confusing unknown-group entries from profile details.

* **Tests**
  * Added coverage for populated, empty, ordered, and deleted-group scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->