### PR TITLE
Retire the source-text collaborative-access contract

### DIFF
--- a/src/app/collaborativeAccessCallers.architecture.test.ts
+++ b/src/app/collaborativeAccessCallers.architecture.test.ts
@@ -7,51 +7,11 @@ import * as groupsApi from '../../convex/groups';
 import * as membersApi from '../../convex/members';
 import * as rulesetsApi from '../../convex/rulesets';
 
-const sources = {
-  collaborativeAccess: readFileSync(
-    new URL('../../convex/lib/collaborativeAccess.ts', import.meta.url),
-    'utf8'
-  ),
-  factionDb: readFileSync(new URL('./factions/db.ts', import.meta.url), 'utf8'),
-  factionDetail: readFileSync(
-    new URL('./routes/_app/factions/$factionId/index.tsx', import.meta.url),
-    'utf8'
-  ),
-  factionEdit: readFileSync(
-    new URL('./routes/_app/factions/$factionId/edit.tsx', import.meta.url),
-    'utf8'
-  ),
-  groupAssignPopover: readFileSync(
-    new URL('./components/groups/GroupAssignPopover.tsx', import.meta.url),
-    'utf8'
-  ),
-  groupDb: readFileSync(new URL('./groups/db.ts', import.meta.url), 'utf8'),
-  groupDetail: readFileSync(
-    new URL('./routes/_app/groups/$groupSlug/index.tsx', import.meta.url),
-    'utf8'
-  ),
-  groupEdit: readFileSync(
-    new URL('./routes/_app/groups/$groupSlug/edit.tsx', import.meta.url),
-    'utf8'
-  ),
-  membersDb: readFileSync(new URL('./members/db.ts', import.meta.url), 'utf8'),
-  profileDb: readFileSync(new URL('./profile/db.ts', import.meta.url), 'utf8'),
-  profileDetail: readFileSync(
-    new URL('./routes/_app/profiles/$profileSlug/index.tsx', import.meta.url),
-    'utf8'
-  ),
-  rulesetDb: readFileSync(new URL('./rulesets/db.ts', import.meta.url), 'utf8'),
-  rulesetDetail: readFileSync(
-    new URL('./routes/_app/rulesets/$rulesetSlug/index.tsx', import.meta.url),
-    'utf8'
-  ),
-  rulesetEdit: readFileSync(
-    new URL('./routes/_app/rulesets/$rulesetSlug/edit.tsx', import.meta.url),
-    'utf8'
-  ),
-};
-
-describe('faction and ruleset collaborative-access caller contract', () => {
+// ADR-0001: tests assert contracts through public interfaces, never source text. The former
+// source-text assertions in this file were retired in #233; the guarantees they expressed live in
+// the narrowed `returns` validators (convex/lib/collaborativeAccessValidators.ts), the narrowed
+// registry below, and the client types derived from the server contract.
+describe('collaborative-access caller contract', () => {
   test('the narrowed Convex registry exposes only canonical collaborative-access transport', () => {
     expect(Object.keys(membersApi).sort()).toEqual(
       ['addMember', 'approveRequest', 'rejectRequest', 'removeMember', 'request'].sort()
@@ -61,125 +21,13 @@ describe('faction and ruleset collaborative-access caller contract', () => {
     expect(factionsApi).not.toHaveProperty('getCreatePageContext');
   });
 
-  test('domain page adapters expose the canonical viewer projection', () => {
-    expect(sources.factionDb).toContain('viewerAccess');
-    expect(sources.rulesetDb).toContain('viewerAccess');
-    expect(sources.factionDb).not.toContain('FactionPageGroupAccess');
-    expect(sources.factionDb).not.toMatch(/^\s+memberships:/m);
-    expect(sources.factionDb).not.toMatch(/^\s+groupAccess:/m);
-    expect(sources.rulesetDb).not.toContain('canEditRuleset');
-    expect(sources.rulesetDb).not.toMatch(/^\s+memberships:/m);
-    expect(sources.rulesetDb).not.toMatch(/^\s+groupAccess:/m);
-  });
-
-  test('the server policy module owns its public contract', () => {
-    expect(sources.collaborativeAccess).not.toContain('../../src/app');
-    expect(sources.collaborativeAccess).toContain('export type CollaborativeAccess =');
-    expect(sources.factionDb).toContain("from '../../../convex/lib/collaborativeAccess'");
-    expect(sources.rulesetDb).toContain("from '../../../convex/lib/collaborativeAccess'");
-  });
-
-  test('detail and edit routes render authorization from viewerAccess capabilities', () => {
-    for (const source of [
-      sources.factionDetail,
-      sources.factionEdit,
-      sources.rulesetDetail,
-      sources.rulesetEdit,
-    ]) {
-      expect(source).toContain('viewerAccess');
-    }
-
-    expect(sources.factionDetail).not.toContain('canEditFaction(');
-    expect(sources.factionDetail).not.toContain('groupAccess');
-    expect(sources.factionDetail).not.toContain('memberships');
-    expect(sources.rulesetDetail).not.toContain('canEditRuleset');
-    expect(sources.rulesetDetail).not.toContain('groupAccess');
-    expect(sources.rulesetEdit).not.toContain('canEditRuleset');
-  });
-
-  test('ruleset owner actions do not depend on profile projection availability', () => {
-    expect(sources.rulesetDetail).not.toMatch(
-      /\{profile\.data\?\._id \? \(\s*<Group[^>]+aria-label="Ruleset actions"/
+  test('the server policy module does not import client code', () => {
+    // Allowlisted source-text assertion (see #233): a dependency-direction rule the compiler does
+    // not enforce. Its proper long-term home is a no-restricted-imports lint rule.
+    const collaborativeAccess = readFileSync(
+      new URL('../../convex/lib/collaborativeAccess.ts', import.meta.url),
+      'utf8'
     );
-  });
-
-  test('membership request handlers consume command rejections after state records the error', () => {
-    for (const source of [sources.factionDetail, sources.rulesetDetail]) {
-      expect(source).not.toMatch(
-        /onClick=\{\(\) => void membershipWorkflow\.request\.run\(assignedGroup\.id\)\}/
-      );
-      expect(source).toMatch(
-        /void membershipWorkflow\.request\s*\.run\(assignedGroup\.id\)\s*\.catch\(\(\) => undefined\)/
-      );
-    }
-  });
-
-  test('assignment callers consume server-derived group summaries without raw membership fallbacks', () => {
-    expect(sources.groupAssignPopover).toContain('assignableGroups');
-    expect(sources.groupAssignPopover).not.toContain('prefetchedMemberships');
-    expect(sources.groupAssignPopover).not.toContain('useUserGroupMemberships');
-    expect(sources.groupAssignPopover).not.toContain('userId');
-
-    expect(sources.factionEdit).toContain('assignableGroups={assignableGroups}');
-    expect(sources.rulesetDetail).toContain('assignableGroups={page.assignableGroups}');
-    expect(sources.rulesetDetail).not.toContain('viewerAssignableMemberships');
-    expect(sources.rulesetDb).not.toContain('viewerAssignableMemberships');
-    expect(sources.membersDb).not.toContain('listByUserActiveWithGroups');
-  });
-
-  test('Group callers consume viewer access, owner summary, roster capabilities, and one workflow', () => {
-    expect(sources.groupDb).toContain('viewerAccess');
-    expect(sources.groupDb).toContain('owner: GroupOwnerSummary | null');
-    expect(sources.groupDb).toContain('roster: GroupRosterEntry[]');
-    expect(sources.groupDb).not.toMatch(/^\s+members:/m);
-    expect(sources.groupDb).not.toMatch(/^\s+profiles:/m);
-
-    expect(sources.groupDetail).toContain('groupData.viewerAccess');
-    expect(sources.groupDetail).toContain('groupData.owner');
-    expect(sources.groupDetail).toContain('groupData.roster');
-    expect(sources.groupDetail).toContain('useGroupMembershipWorkflow');
-    expect(sources.groupDetail).toContain('entry.capabilities.approve');
-    expect(sources.groupDetail).toContain('entry.capabilities.reject');
-    expect(sources.groupDetail).toContain('entry.capabilities.remove');
-    expect(sources.groupDetail).toMatch(/approve\s*\.run\(entry\.membershipId\)/);
-    expect(sources.groupDetail).toMatch(/reject\s*\.run\(entry\.membershipId\)/);
-    expect(sources.groupDetail).toContain('remove.run(membershipId)');
-    expect(sources.groupDetail).toContain('handleRemoveMember(entry.membershipId)');
-    expect(sources.groupDetail).not.toContain('useCurrentProfile');
-    expect(sources.groupDetail).not.toContain('useApproveGroupMember');
-    expect(sources.groupDetail).not.toContain('useRejectGroupMember');
-    expect(sources.groupDetail).not.toContain('useRemoveGroupMember');
-    expect(sources.groupDetail).not.toContain('useRequestGroupMembership');
-
-    expect(sources.groupEdit).toContain('useGroupEditBySlug');
-    expect(sources.groupEdit).toContain('viewerAccess.capabilities.rename');
-    expect(sources.groupEdit).not.toContain('useCurrentProfile');
-    expect(sources.groupEdit).not.toContain('group.created_by');
-
-    expect(sources.groupDb).not.toContain('api.groups.getBySlug');
-    expect(sources.groupDb).not.toContain('loadGroupBySlug');
-    expect(sources.groupDb).not.toContain('useGroupBySlug');
-    expect(sources.membersDb).not.toContain('api.members.listByGroup');
-    expect(sources.membersDb).not.toContain('api.members.get');
-    expect(sources.membersDb).not.toContain('useRequestGroupMembership');
-    expect(sources.membersDb).not.toContain('useApproveGroupMember');
-    expect(sources.membersDb).not.toContain('useRejectGroupMember');
-    expect(sources.membersDb).not.toContain('useRemoveGroupMember');
-  });
-
-  test('profile detail consumes safe Group summaries without raw membership reconstruction', () => {
-    // ProfilePageData derives from the server contract (FunctionReturnType); the summaries-only
-    // guarantee lives in profileDetailPageValidator, not in this file's spelling. See ADR-0001.
-    expect(sources.profileDb).not.toMatch(/^\s+memberships:/m);
-    expect(sources.profileDb).not.toMatch(/^\s+groups:/m);
-
-    expect(sources.profileDetail).toContain('profileData.groupSummaries?.length');
-    expect(sources.profileDetail).toContain(
-      '<ProfileGroupMemberships groups={profileData.groupSummaries ?? []} />'
-    );
-    expect(sources.profileDetail).not.toContain('profileData.memberships');
-    expect(sources.profileDetail).not.toContain('groupsById');
-    expect(sources.profileDetail).not.toContain('group_id');
-    expect(sources.profileDetail).not.toContain('Unknown group');
+    expect(collaborativeAccess).not.toContain('../../src/app');
   });
 });

--- a/src/app/groups/db.test.tsx
+++ b/src/app/groups/db.test.tsx
@@ -79,14 +79,11 @@ describe('Group page interface', () => {
 
     const loaded = await loadGroupDetailBySlug('dune-designers');
 
-    expect(loaded).toEqual({
-      group: { ...group, id: 'group-1' },
-      factions: [],
-      rulesets: [],
-      owner,
-      viewerAccess,
-      roster,
-    });
+    expect(loaded.group.id).toBe('group-1');
+    expect(loaded.viewerAccess).toEqual(viewerAccess);
+    expect(loaded.roster).toEqual(roster);
+    expect(loaded).not.toHaveProperty('members');
+    expect(loaded).not.toHaveProperty('profiles');
     expect(mocks.dbQuery).toHaveBeenCalledWith(api.groups.detailBySlug, {
       slug: 'dune-designers',
     });
@@ -112,10 +109,8 @@ describe('Group page interface', () => {
 
     const loaded = await loadGroupEditBySlug('dune-designers');
 
-    expect(loaded).toEqual({
-      group: { ...group, id: 'group-1' },
-      viewerAccess,
-    });
+    expect(Object.keys(loaded).sort()).toEqual(['group', 'viewerAccess']);
+    expect(loaded.group.id).toBe('group-1');
 
     mocks.useQuery.mockReturnValue(serverPage);
     const live = renderHook(() => useGroupEditBySlug('dune-designers'));

--- a/src/app/profile/db.test.tsx
+++ b/src/app/profile/db.test.tsx
@@ -42,43 +42,29 @@ const serverPage = {
   factions: [],
 };
 
-const canonicalPage = {
-  profile,
-  groupSummaries,
-  faqAsked: [],
-  faqAnswers: [],
-  factions: [],
-  acceptedAnswerCount: 0,
-};
-
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
 describe('profile page interface', () => {
-  test('normalizes loader and live data to ordered Group summaries without raw membership transport', async () => {
+  test('loader and live paths produce one canonical page with ordered Group summaries', async () => {
     mocks.dbQuery.mockResolvedValue(serverPage);
 
     const loaded = await loadProfileBySlug('chani');
 
-    expect(loaded).toEqual(canonicalPage);
+    expect(loaded.groupSummaries).toEqual(groupSummaries);
     expect(loaded).not.toHaveProperty('memberships');
     expect(loaded).not.toHaveProperty('groups');
     expect(mocks.dbQuery).toHaveBeenCalledWith(api.profiles.getBySlug, { slug: 'chani' });
 
     mocks.useQuery.mockReturnValue(undefined);
-    const loaderHandoff = renderHook(() =>
-      useProfileBySlug('chani', { initialData: canonicalPage as never })
-    );
-    expect(loaderHandoff.result.current.data).toEqual(canonicalPage);
+    const loaderHandoff = renderHook(() => useProfileBySlug('chani', { initialData: loaded }));
+    expect(loaderHandoff.result.current.data).toEqual(loaded);
     loaderHandoff.unmount();
 
     mocks.useQuery.mockReturnValue(serverPage);
     const live = renderHook(() => useProfileBySlug('chani'));
-    expect(live.result.current.data).toEqual(canonicalPage);
-    expect(live.result.current.groupSummaries).toEqual(groupSummaries);
-    expect(live.result.current).not.toHaveProperty('memberships');
-    expect(live.result.current).not.toHaveProperty('groups');
+    expect(live.result.current.data).toEqual(loaded);
     live.unmount();
   });
 


### PR DESCRIPTION
Closes #233. Stacked on #232 (base branch); retarget to `main` after #232 merges.

Per ADR-0001, the architecture test drops from 184 lines / 8 tests to 2 tests: the module key-set test (the one that was always real) and a single allowlisted layering assertion. Net −171 lines. The seam tests in `profile/db.test.tsx` and `groups/db.test.tsx` replace hand-fixture full-page `toEqual` with loader-vs-live path equality plus targeted behavior assertions, so additive page-model changes no longer fail tests.

## Inventory — every retired assertion and what carries its guarantee now

| Former test | Assertions | Disposition | Guarantee now carried by |
|---|---|---|---|
| registry key-set | `membersApi` keys; `not.toHaveProperty` ×3 | **KEPT unchanged** | itself — interface-level |
| server policy module owns its contract | `collaborativeAccess not.toContain('../../src/app')` | **KEPT (allowlisted)** | nothing else enforces this dependency direction; proper long-term home is a `no-restricted-imports` lint rule (noted in-file) |
| ″ | `toContain('export type CollaborativeAccess =')`; import-path greps ×2 | deleted | compiler — the type is imported by consumers; a missing export fails typecheck. Path spelling is not a contract |
| domain page adapters | `toContain('viewerAccess')` ×2; `not.toContain FactionPageGroupAccess`/`canEditRuleset`; `not.toMatch memberships:/groupAccess:` ×4 | deleted | `factionDetailPageValidator` / `rulesetDetailPageValidator` carry `viewerAccess` and cannot produce the legacy fields; #234 finishes client-type honesty by derivation |
| routes render authorization from viewerAccess | `toContain('viewerAccess')` ×4; `not.toContain canEditFaction(/groupAccess/memberships/canEditRuleset` ×5 | deleted | narrowed registry (deleted helpers can't be imported — compile error) + validators: capabilities are the only authorization data the wire offers since #231 |
| ruleset owner-actions gating regex | 1 regex | deleted | behavioral home already exists: `src/app/rulesets/rulesetActionVisibility.test.ts` |
| membership request `.catch` wiring | 2 regexes ×2 files | deleted | the state-recording contract is tested at the workflow seam (`src/app/members/db.test.tsx`: error isolation, failure replacement, clearing); the `.catch` chain is expression, not contract |
| assignment callers | popover `toContain assignableGroups` + `not.toContain` ×3; JSX attribute greps ×2; `viewerAssignableMemberships` ×2; `listByUserActiveWithGroups` | deleted | `GroupAssignPopover.test.tsx` (rendered behavior); validators carry `assignableGroups`; the legacy hooks/queries no longer exist (registry + compiler) |
| Group callers | `groupDb` type-annotation literals ×2 (`owner: GroupOwnerSummary \| null`, `roster: GroupRosterEntry[]`); `not.toMatch members:/profiles:`; `groupDetail`/`groupEdit` usage + capability greps ×12; legacy-hook negatives ×9 | deleted | `groupDetailPageValidator` (roster entries carry `capabilities`; no raw members/profiles on the wire); registry test (legacy hooks gone); seam tests. The two annotation literals were pinning exactly the hand-written types #234 deletes — same blocker ADR-0001 removed for profile |
| profile detail | `not.toMatch memberships:/groups:`; route JSX greps ×2; `not.toContain` ×4 | deleted | `profileDetailPageValidator` + fully derived `ProfilePageData` (cannot lie about the wire); `ProfileGroupMemberships.test.tsx` (rendered behavior, incl. empty state) |

## Accepted coverage change (declared, per the deletion-first mandate)

The Group **roster moderation button wiring** (capability → button → `approve/reject/remove.run`) now has no direct test: the command layer is seam-tested in `members/db.test.tsx` and the wire shape is validator-guaranteed, but no rendered-output or e2e test exercises the buttons (e2e covers faction/ruleset lifecycles only). Declared rather than papered over with a new grep; if this UI proves fragile, the right instrument is one rendered-output test or a `group-lifecycle` e2e spec — not source text.

## Seam-test changes

- `profile/db.test.tsx`: the canonical-page hand fixture is gone; the test asserts ordered `groupSummaries`, absence of raw transport, and **loader ≡ live** equality (the actual contract). The targeted `acceptedAnswerCount` test is unchanged.
- `groups/db.test.tsx`: detail test asserts the normalize behavior (`group.id` aliasing), pass-through of `viewerAccess`/`roster`, absence of legacy rows, and loader ≡ live; the edit test asserts its deliberately narrow surface via key-set (`['group', 'viewerAccess']`) — narrowness *is* that page's contract.
- `faq/db.test.tsx` untouched: its loader/live comparisons already express pass-through; it changes shape under #235 anyway.

## Acceptance criteria (from #233)

- [x] No test asserts on raw source text except the one allowlisted layering rule
- [x] Module key-set test retained unchanged
- [x] Every deleted assertion appears above with its disposition
- [x] No new `expectTypeOf` duplicates a validator/derivation guarantee (none added)
- [x] Seam tests tolerate additive page-model changes
- [x] `bun run test` (425), `bun run typecheck`, `bun run lint`, `bun run format:check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined access-policy checks to focus on supported public behavior and prevent server code from importing client code.
  * Updated group tests to validate canonical fields, normalized IDs, and rejection of legacy properties.
  * Simplified profile tests to verify consistent loader and live-response data, including ordered group summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->