### PR TITLE
Regenerate Convex bindings for lib/profileDetail

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -27,6 +27,7 @@ import type * as lib_faqRulesetList from "../lib/faqRulesetList.js";
 import type * as lib_ids from "../lib/ids.js";
 import type * as lib_policy from "../lib/policy.js";
 import type * as lib_profileBootstrap from "../lib/profileBootstrap.js";
+import type * as lib_profileDetail from "../lib/profileDetail.js";
 import type * as lib_profileDiscovery from "../lib/profileDiscovery.js";
 import type * as lib_profileSummary from "../lib/profileSummary.js";
 import type * as lib_publication from "../lib/publication.js";
@@ -71,6 +72,7 @@ declare const fullApi: ApiFromModules<{
   "lib/ids": typeof lib_ids;
   "lib/policy": typeof lib_policy;
   "lib/profileBootstrap": typeof lib_profileBootstrap;
+  "lib/profileDetail": typeof lib_profileDetail;
   "lib/profileDiscovery": typeof lib_profileDiscovery;
   "lib/profileSummary": typeof lib_profileSummary;
   "lib/publication": typeof lib_publication;


### PR DESCRIPTION
The deploy-main run for #232 failed at "Preflight exact scheduled Worker release": PR #232 added `convex/lib/profileDetail.ts` without regenerating `convex/_generated/api.d.ts`, so the `convex deploy` step's codegen dirtied the checkout and `assertExactCheckout` correctly refused the Worker release.

State when this lands: the Convex backend for #232 is already deployed (that step succeeded); production is serving the previous Worker bundle against the new backend, which is safe because #232 kept the wire shape unchanged. Merging this completes the interrupted release — the next deploy-main run ships the Worker.

Diff is exactly the two generated lines for the new module (test files are excluded from codegen, so nothing else moves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)