### PR TITLE
Derive client transport types through a typed db.query seam

### DIFF
--- a/src/app/db/core/index.ts
+++ b/src/app/db/core/index.ts
@@ -1,6 +1,6 @@
 import { ConvexHttpClient } from 'convex/browser';
 import { ConvexReactClient } from 'convex/react';
-import type { FunctionReference } from 'convex/server';
+import type { FunctionArgs, FunctionReference, FunctionReturnType } from 'convex/server';
 
 import { api } from '../../../../convex/_generated/api';
 
@@ -25,22 +25,25 @@ function convexBackendForDb(): ConvexReactClient | ConvexHttpClient {
 }
 
 export const db = {
-  query: async <T>(fn: FunctionReference<'query'>, args?: Record<string, unknown>): Promise<T> => {
+  query: async <Query extends FunctionReference<'query'>>(
+    fn: Query,
+    args: FunctionArgs<Query>
+  ): Promise<FunctionReturnType<Query>> => {
     const backend = convexBackendForDb();
-    return (await backend.query(fn, args as never)) as T;
+    return await backend.query(fn, args as never);
   },
-  mutation: async <T>(
-    fn: FunctionReference<'mutation'>,
-    args?: Record<string, unknown>
-  ): Promise<T> => {
+  mutation: async <Mutation extends FunctionReference<'mutation'>>(
+    fn: Mutation,
+    args: FunctionArgs<Mutation>
+  ): Promise<FunctionReturnType<Mutation>> => {
     const backend = convexBackendForDb();
-    return (await backend.mutation(fn, args as never)) as T;
+    return await backend.mutation(fn, args as never);
   },
 };
 
 export const auth = {
   getUser: async () => {
-    const userId = await db.query<string | null>(api.profiles.currentUserId, {});
+    const userId = await db.query(api.profiles.currentUserId, {});
     return { data: { user: userId ? { id: userId } : null } };
   },
 };

--- a/src/app/factions/db.ts
+++ b/src/app/factions/db.ts
@@ -1,4 +1,5 @@
 import { useQuery } from 'convex/react';
+import type { FunctionReturnType } from 'convex/server';
 
 import { db } from '@db/core';
 import { toLiveQueryResult, useLiveMutation } from '@app/db/core/live';
@@ -7,7 +8,7 @@ import { CanonicalFactionStoredSchema, FactionInputSchema } from '@game/schema/f
 import type { FactionInput } from '@game/schema/faction';
 
 import { api } from '../../../convex/_generated/api';
-import type { Doc } from '../../../convex/_generated/dataModel';
+import type { Doc, Id } from '../../../convex/_generated/dataModel';
 import type { PublicAssetPublishingStatusProjection } from '../../../convex/assetPublishingStatus';
 import type {
   AssignedGroupSummary,
@@ -113,11 +114,9 @@ export type FactionDetailPageData = {
   rulesets: FactionRulesetSummary[];
 };
 
-type FactionDetailPageDataRaw = Omit<FactionDetailPageData, 'faction'> & {
-  faction: Omit<FactionRow, 'data'> & { data: unknown };
-};
-
-function toFactionDetailPageData(raw: FactionDetailPageDataRaw): FactionDetailPageData {
+function toFactionDetailPageData(
+  raw: FunctionReturnType<typeof api.factions.getBySlug>
+): FactionDetailPageData {
   return {
     faction: {
       ...raw.faction,
@@ -136,32 +135,25 @@ export async function loadFactionBySlug(slug: string): Promise<FactionDetailPage
 }
 
 export async function loadFactionsAll(): Promise<FactionEntry[]> {
-  const entries = await db.query<FactionRow[]>(api.factions.list, {});
+  const entries = await db.query(api.factions.list, {});
   return factionRowsToEntries(entries);
 }
 
 export async function loadFactionCataloguePage(): Promise<FactionCataloguePageData> {
-  const raw = await db.query<{
-    factions: FactionCatalogueRow[];
-    rulesets: FactionRulesetSummary[];
-    spotlights: {
-      newArrival: FactionCatalogueRow | null;
-      freshlyUpdated: FactionCatalogueRow | null;
-    };
-  }>(api.factions.cataloguePage, {});
+  const raw = await db.query(api.factions.cataloguePage, {});
   return toFactionCataloguePageData(raw);
 }
 
 export async function loadFactionsByOwner(ownerId: string): Promise<FactionEntry[]> {
-  const entries = await db.query<FactionRow[]>(api.factions.listByOwner, {
-    owner_id: ownerId,
+  const entries = await db.query(api.factions.listByOwner, {
+    owner_id: ownerId as Id<'users'>,
   });
   return factionRowsToEntries(entries);
 }
 
 export async function loadFactionsByGroup(groupId: string): Promise<FactionEntry[]> {
-  const entries = await db.query<FactionRow[]>(api.factions.listByGroup, {
-    group_id: groupId,
+  const entries = await db.query(api.factions.listByGroup, {
+    group_id: groupId as Id<'groups'>,
   });
   return factionRowsToEntries(entries);
 }
@@ -371,8 +363,6 @@ export function useSetFactionGroup() {
 }
 
 export async function loadFaction(slug: string): Promise<FactionDetailPageData> {
-  const raw = await db.query<FactionDetailPageDataRaw>(api.factions.getBySlug, {
-    slug,
-  });
+  const raw = await db.query(api.factions.getBySlug, { slug });
   return toFactionDetailPageData(raw);
 }

--- a/src/app/faq/db.ts
+++ b/src/app/faq/db.ts
@@ -1,4 +1,5 @@
 import { useQuery } from 'convex/react';
+import type { FunctionReturnType } from 'convex/server';
 
 import { db } from '@db/core';
 import { toLiveQueryResult, useLiveMutation } from '@app/db/core/live';
@@ -58,33 +59,7 @@ export type FaqProfileSummary = {
   avatarUrl: string | null;
 };
 
-export type FaqQuestionPage = {
-  ruleset: { id: string; slug: string; name: string };
-  question: {
-    id: string;
-    slug: string;
-    text: string;
-    tags: FaqTag[];
-    author: FaqProfileSummary | null;
-    createdAt: string;
-    updatedAt: string;
-    capabilities: { editQuestion: boolean; deleteQuestion: boolean };
-  };
-  viewer: { answerQuestion: boolean };
-  answers: Array<{
-    id: string;
-    text: string;
-    author: FaqProfileSummary | null;
-    createdAt: string;
-    accepted: boolean;
-    capabilities: {
-      editAnswer: boolean;
-      deleteAnswer: boolean;
-      acceptAnswer: boolean;
-      unacceptAnswer: boolean;
-    };
-  }>;
-};
+export type FaqQuestionPage = FunctionReturnType<typeof api.faq.questionPage>;
 
 type CommandState = {
   isPending: boolean;
@@ -137,7 +112,7 @@ function voidCommand<TVariables, TResult>(
 }
 
 export async function loadFaqQuestionPage(locator: FaqQuestionLocator): Promise<FaqQuestionPage> {
-  return await db.query<FaqQuestionPage>(api.faq.questionPage, locator);
+  return await db.query(api.faq.questionPage, locator);
 }
 
 export type UseFaqQuestionPageResult = ReturnType<typeof useFaqQuestionPage>;
@@ -146,7 +121,7 @@ export function useFaqQuestionPage(
   locator: FaqQuestionLocator,
   options?: { initialPage?: FaqQuestionPage }
 ) {
-  const livePage = useQuery(api.faq.questionPage, locator) as FaqQuestionPage | undefined;
+  const livePage = useQuery(api.faq.questionPage, locator);
   const query = toLiveQueryResult(livePage, true, () => options?.initialPage);
   const questionId = query.data?.question.id;
 

--- a/src/app/groups/db.ts
+++ b/src/app/groups/db.ts
@@ -1,10 +1,11 @@
 import { useQuery } from 'convex/react';
+import type { FunctionReturnType } from 'convex/server';
 
 import { db } from '@db/core';
 import { factionRowsToEntries } from '@db/factions';
 import type { FactionEntry } from '@db/factions';
 import { rulesetRowsToEntries } from '@db/rulesets';
-import type { RulesetEntry, RulesetRow } from '@db/rulesets';
+import type { RulesetEntry } from '@db/rulesets';
 import { toLiveQueryResult, useLiveMutation } from '@app/db/core/live';
 import { groupInputSchema } from '@app/groups/validation';
 
@@ -38,17 +39,10 @@ export type GroupDetailPageData = {
 
 export type GroupEditPageData = Pick<GroupDetailPageData, 'group' | 'viewerAccess'>;
 
-type GroupDetailPageRaw = {
-  group: GroupRow;
-  factions: Doc<'factions'>[];
-  rulesets: RulesetRow[];
-  owner: GroupOwnerSummary | null;
-  viewerAccess: GroupDetailPageData['viewerAccess'];
-  roster: GroupRosterEntry[];
-};
+type GroupDetailPageRaw = FunctionReturnType<typeof api.groups.detailBySlug>;
 
 export async function loadGroupDetailBySlug(slug: string): Promise<GroupDetailPageData> {
-  const result = await db.query<GroupDetailPageRaw>(api.groups.detailBySlug, { slug });
+  const result = await db.query(api.groups.detailBySlug, { slug });
   return normalizeGroupDetailFromConvex(result);
 }
 

--- a/src/app/homepage/db.ts
+++ b/src/app/homepage/db.ts
@@ -1,42 +1,15 @@
 import { useQuery } from 'convex/react';
+import type { FunctionReturnType } from 'convex/server';
 
 import { db } from '@db/core';
-import type { FactionCatalogueSpotlightData } from '@db/factions';
 import { toLiveQueryResult } from '@app/db/core/live';
 
 import { api } from '../../../convex/_generated/api';
-import type { Doc } from '../../../convex/_generated/dataModel';
 
-export type HomepageData = {
-  spotlights: {
-    newArrival: HomepageFactionSpotlight | null;
-    freshlyUpdated: HomepageFactionSpotlight | null;
-  };
-  community: {
-    counts: {
-      factions: number;
-      rulesets: number;
-      members: number;
-      questions: number;
-      answers: number;
-    };
-    newestMembers: Array<{
-      id: Doc<'profiles'>['_id'];
-      slug: string;
-      username: string;
-      avatarUrl: string;
-      createdAt: string;
-    }>;
-  };
-};
-
-type HomepageFactionSpotlight = FactionCatalogueSpotlightData & {
-  created_at: string;
-  updated_at: string;
-};
+export type HomepageData = FunctionReturnType<typeof api.homepage.get>;
 
 export async function loadHomepage(): Promise<HomepageData> {
-  return await db.query<HomepageData>(api.homepage.get, {});
+  return await db.query(api.homepage.get, {});
 }
 
 export function useHomepage(options?: { initialData?: HomepageData }) {

--- a/src/app/migrations/db.ts
+++ b/src/app/migrations/db.ts
@@ -1,43 +1,19 @@
 import { useQuery } from 'convex/react';
+import type { FunctionReturnType } from 'convex/server';
 
 import { db } from '@db/core';
 import { toLiveQueryResult, useLiveMutation } from '@app/db/core/live';
 
 import { api } from '../../../convex/_generated/api';
 
-export type MigrationStatusRow = {
-  name: string;
-  state: 'inProgress' | 'success' | 'failed' | 'canceled' | 'unknown';
-  isDone: boolean;
-  processed: number;
-  latestStart: number;
-  latestEnd?: number;
-  error?: string;
-};
-
-export type MigrationRunSnapshot = {
-  _id: string;
-  migration_id: string;
-  state: 'inProgress' | 'success' | 'failed' | 'canceled' | 'unknown';
-  is_done: boolean;
-  processed: number;
-  latest_start: number;
-  latest_end?: number;
-  error?: string;
-  updated_at: string;
-};
-
-export type AdminMigrationDashboardData = {
-  statuses: MigrationStatusRow[];
-  snapshots: MigrationRunSnapshot[];
-};
+export type AdminMigrationDashboardData = FunctionReturnType<typeof api.migrations.adminDashboard>;
+export type MigrationStatusRow = AdminMigrationDashboardData['statuses'][number];
+export type MigrationRunSnapshot = AdminMigrationDashboardData['snapshots'][number];
 
 export async function loadAdminMigrationDashboard(
   ids?: string[]
 ): Promise<AdminMigrationDashboardData> {
-  return await db.query<AdminMigrationDashboardData>(api.migrations.adminDashboard, {
-    ids,
-  });
+  return await db.query(api.migrations.adminDashboard, { ids });
 }
 
 export function useAdminMigrationDashboard(options?: {

--- a/src/app/profile/db.ts
+++ b/src/app/profile/db.ts
@@ -42,26 +42,26 @@ function normalizeProfilePage(result: ProfileDetailResult) {
 }
 
 export async function loadProfileBySlug(slug: string): Promise<ProfilePageData> {
-  const result = await db.query<ProfileDetailResult>(api.profiles.getBySlug, { slug });
+  const result = await db.query(api.profiles.getBySlug, { slug });
   return normalizeProfilePage(result);
 }
 
 export async function loadProfilesAll(): Promise<ProfileListEntry[]> {
-  const entries = await db.query<ProfileListEntry[]>(api.profiles.list, {});
+  const entries = await db.query(api.profiles.list, {});
   return entries;
 }
 
 export async function loadCurrentUserId(): Promise<string | null> {
-  return await db.query<string | null>(api.profiles.currentUserId, {});
+  return await db.query(api.profiles.currentUserId, {});
 }
 
 export async function loadCurrentProfile(): Promise<ProfileEntry | null> {
-  const currentRaw = await db.query<ProfileRow | null>(api.profiles.current, {});
+  const currentRaw = await db.query(api.profiles.current, {});
   const current = currentRaw ? currentRaw : null;
   if (current) {
     const needsBackfill = current.slug === 'user' || !current.username || !current.avatar_url;
     if (needsBackfill) {
-      const entry = await db.mutation<ProfileRow>(api.profiles.bootstrapCurrent, {});
+      const entry = await db.mutation(api.profiles.bootstrapCurrent, {});
       return entry;
     }
     return current;
@@ -72,7 +72,7 @@ export async function loadCurrentProfile(): Promise<ProfileEntry | null> {
     return null;
   }
 
-  const entry = await db.mutation<ProfileRow>(api.profiles.bootstrapCurrent, {});
+  const entry = await db.mutation(api.profiles.bootstrapCurrent, {});
   return entry;
 }
 

--- a/src/app/rulesets/db.ts
+++ b/src/app/rulesets/db.ts
@@ -1,4 +1,5 @@
 import { useQuery } from 'convex/react';
+import type { FunctionReturnType } from 'convex/server';
 
 import { db } from '@db/core';
 import type { FaqAnswerEntry, FaqItemWithDetails } from '@db/faq';
@@ -8,7 +9,7 @@ import { Background } from '@game/schema/faction';
 import type { FactionData } from '@game/schema/faction';
 
 import { api } from '../../../convex/_generated/api';
-import type { Doc } from '../../../convex/_generated/dataModel';
+import type { Doc, Id } from '../../../convex/_generated/dataModel';
 import type {
   AssignedGroupSummary,
   CollaborativeAccess,
@@ -62,15 +63,27 @@ export type RulesetDetailPageData = RulesetPageData & {
   faqItems: FaqItemWithDetails[];
 };
 
-function toRulesetPageData(raw: {
-  ruleset: RulesetRow;
-  factions: RulesetFactionSummaryRaw[];
-  viewerAccess: RulesetPageData['viewerAccess'];
-}): RulesetPageData {
+function toRulesetPageData(
+  raw: FunctionReturnType<typeof api.rulesets.getBySlug>
+): RulesetPageData {
   return {
     ruleset: toRulesetEntry(raw.ruleset),
     factions: raw.factions.map(normalizeRulesetFactionSummary),
     viewerAccess: raw.viewerAccess,
+  };
+}
+
+/** Canonical detail page model, shared by the route loader and the live subscription. */
+function normalizeRulesetDetailPage(
+  raw: NonNullable<FunctionReturnType<typeof api.rulesets.detailPageBySlug>>
+): RulesetDetailPageData {
+  return {
+    ruleset: toRulesetEntry(raw.ruleset),
+    factions: raw.factions.map(normalizeRulesetFactionSummary),
+    viewerAccess: raw.viewerAccess,
+    owner: raw.owner,
+    assignableGroups: raw.assignableGroups,
+    faqItems: mapFaqItemsFromConvex(raw.faqItems),
   };
 }
 
@@ -99,62 +112,41 @@ export function rulesetRowsToEntries(entries: RulesetRow[]): RulesetEntry[] {
 }
 
 export async function loadRulesetsAll(): Promise<RulesetEntry[]> {
-  const entries = await db.query<RulesetRow[]>(api.rulesets.list, {});
+  const entries = await db.query(api.rulesets.list, {});
   return rulesetRowsToEntries(entries);
 }
 
 export async function loadRuleset(id: string): Promise<RulesetEntry> {
-  const entry = await db.query<RulesetRow>(api.rulesets.get, { id });
+  const entry = await db.query(api.rulesets.get, { id: id as Id<'rulesets'> });
   return toRulesetEntry(entry);
 }
 
 export async function loadRulesetBySlug(slug: string): Promise<RulesetPageData> {
-  const result = await db.query<{
-    ruleset: RulesetRow;
-    factions: RulesetFactionSummaryRaw[];
-    viewerAccess: RulesetPageData['viewerAccess'];
-  }>(api.rulesets.getBySlug, { slug });
+  const result = await db.query(api.rulesets.getBySlug, { slug });
   return toRulesetPageData(result);
 }
 
 export async function loadRulesetDetailPage(slug: string): Promise<RulesetDetailPageData | null> {
-  const raw = await db.query<{
-    ruleset: RulesetRow;
-    factions: RulesetFactionSummaryRaw[];
-    viewerAccess: RulesetPageData['viewerAccess'];
-    owner: RulesetDetailPageData['owner'];
-    assignableGroups: AssignedGroupSummary[];
-    faqItems: FaqItemConvexRow[];
-  } | null>(api.rulesets.detailPageBySlug, { slug });
-  if (!raw) {
-    return null;
-  }
-  return {
-    ruleset: toRulesetEntry(raw.ruleset),
-    factions: raw.factions.map(normalizeRulesetFactionSummary),
-    viewerAccess: raw.viewerAccess,
-    owner: raw.owner,
-    assignableGroups: raw.assignableGroups,
-    faqItems: mapFaqItemsFromConvex(raw.faqItems),
-  };
+  const raw = await db.query(api.rulesets.detailPageBySlug, { slug });
+  return raw ? normalizeRulesetDetailPage(raw) : null;
 }
 
 export async function loadRulesetFactions(rulesetId: string): Promise<string[]> {
-  return await db.query<string[]>(api.rulesets.factionIds, { ruleset_id: rulesetId });
+  return await db.query(api.rulesets.factionIds, { ruleset_id: rulesetId as Id<'rulesets'> });
 }
 
 export async function loadRulesetFactionsWithDetails(
   rulesetId: string
 ): Promise<RulesetFactionSummary[]> {
-  const factions = await db.query<RulesetFactionSummaryRaw[]>(api.rulesets.factionDetails, {
-    ruleset_id: rulesetId,
+  const factions = await db.query(api.rulesets.factionDetails, {
+    ruleset_id: rulesetId as Id<'rulesets'>,
   });
   return factions.map(normalizeRulesetFactionSummary);
 }
 
 export async function loadRulesetsByFaction(factionId: string): Promise<RulesetEntry[]> {
-  const entries = await db.query<RulesetRow[]>(api.rulesets.listByFaction, {
-    faction_id: factionId,
+  const entries = await db.query(api.rulesets.listByFaction, {
+    faction_id: factionId as Id<'factions'>,
   });
   return entries.map(toRulesetEntry);
 }
@@ -207,14 +199,7 @@ export function useRulesetDetailPage(
       ? undefined
       : liveData === null
         ? null
-        : {
-            ruleset: toRulesetEntry(liveData.ruleset),
-            factions: liveData.factions.map(normalizeRulesetFactionSummary),
-            viewerAccess: liveData.viewerAccess,
-            owner: liveData.owner,
-            assignableGroups: liveData.assignableGroups,
-            faqItems: mapFaqItemsFromConvex(liveData.faqItems as FaqItemConvexRow[]),
-          };
+        : normalizeRulesetDetailPage(liveData);
   const result = toLiveQueryResult(normalized, true, () => options?.initialData);
   return {
     ...result,


### PR DESCRIPTION
Closes #234

**+76 / −180.** The `db.query`/`db.mutation` wrapper is parameterized (`FunctionArgs`/`FunctionReturnType` derive both sides from the function reference; the casts move inside the implementation), and all 22 hand-written transport generics are deleted — `grep 'db.query<'` over `src/app` returns nothing. One commit per domain, per the issue's migration plan.

Notable deletions:
- **rulesets** (the five-statement offender): both inline transport literals gone, and the loader/live duplication collapses into one shared `normalizeRulesetDetailPage`, which also removes the `as FaqItemConvexRow[]` cast.
- **faq**: the 27-line hand-written `FaqQuestionPage` and both unchecked casts are replaced by `FunctionReturnType<typeof api.faq.questionPage>`. The known `tags` optionality drift is fixed **by construction** — the derived type carries the server's optional `tags`, so the drift class is impossible rather than tested (per ADR-0001, no redundant assertion added).
- **groups / homepage / migrations**: `GroupDetailPageRaw`, the 27-line `HomepageData` restatement (and its cross-domain `FactionCatalogueSpotlightData` import), and the migrations dashboard shapes all derive now.
- **profile**: the last five generics drop; `ProfilePageData` was already fully derived in #232.

Route-param ids that were silently passed as `string` now carry explicit value-level `Id<...>` casts at the call site — the compiler surfaced every one of these latent arg-shape assertions, exactly as the issue predicted; the server-side validators continue to check them at runtime.

Acceptance criteria: no hand-written transport generic remains · `ProfilePageData` fully derived (done in #232) · `tags` drift fixed with a construction-level guarantee · `bun run test` (425), `typecheck`, `lint`, `format:check`, `publisher:release:verify` all pass. Wire shapes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)