### PR TITLE
Add group and FAQ happy-path e2e specs, retire superseded seam tests

### DIFF
--- a/e2e/faq-happy-path.spec.ts
+++ b/e2e/faq-happy-path.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@playwright/test';
+
+test.use({ storageState: '.playwright/user-a-faq.json' });
+
+test('FAQ happy path: ask, answer, accept, profile activity', async ({ page, browser }) => {
+  test.setTimeout(90_000);
+
+  const suffix = Date.now();
+  const questionText = `What is the E2E spice cycle ${suffix}?`;
+  const answerText = `The E2E spice must flow ${suffix}.`;
+
+  await test.step('asker posts a question on the baseline ruleset', async () => {
+    await page.goto('/rulesets/e2ebaselineruleset/faq/create');
+    await page.getByPlaceholder('Your question...').fill(questionText);
+    await page.getByRole('button', { name: 'Ask' }).click();
+    await expect(page).toHaveURL(/\/rulesets\/e2ebaselineruleset\/faq\/\d+$/);
+    await expect(page.getByText(questionText)).toBeVisible();
+  });
+  const questionUrl = page.url();
+
+  const userBContext = await browser.newContext({ storageState: '.playwright/user-b-faq.json' });
+  const userBPage = await userBContext.newPage();
+
+  await test.step('another member answers', async () => {
+    await userBPage.goto(questionUrl);
+    await userBPage.getByPlaceholder('Your answer...').fill(answerText);
+    await userBPage.getByRole('button', { name: 'Add answer' }).click();
+    await expect(userBPage.getByText(answerText)).toBeVisible();
+  });
+
+  await test.step('asker accepts the answer through the live subscription', async () => {
+    await expect(page.getByText(answerText)).toBeVisible();
+    await page.getByRole('button', { name: 'Mark as accepted answer' }).click();
+    await expect(page.getByText('Accepted answer')).toBeVisible();
+  });
+
+  await test.step('the answer and its acceptance appear on the answerer profile', async () => {
+    const userASlug = (process.env.PLAYWRIGHT_USER_A_EMAIL ?? 'e2e-user-a@example.com').split(
+      '@'
+    )[0]!;
+    const hrefs = await page
+      .locator('main a[href^="/profiles/"]')
+      .evaluateAll((els) => els.map((el) => el.getAttribute('href') ?? ''));
+    const answererHref = hrefs.find((href) => href && !href.endsWith(`/${userASlug}`));
+    expect(answererHref).toBeTruthy();
+    await page.goto(answererHref!);
+    await expect(page.getByText(questionText)).toBeVisible();
+    const pickedFact = page.locator('p', { hasText: 'Picked answers' });
+    await expect(pickedFact.locator('strong')).toHaveText('1');
+  });
+
+  await userBContext.close();
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -87,9 +87,33 @@ export default async function globalSetup(config: FullConfig) {
   });
 
   await loginWithLocalAuth(baseUrl, {
+    email: userAEmail,
+    password: userPassword,
+    storageStatePath: '.playwright/user-a-faq.json',
+  });
+
+  await loginWithLocalAuth(baseUrl, {
+    email: userAEmail,
+    password: userPassword,
+    storageStatePath: '.playwright/user-a-group.json',
+  });
+
+  await loginWithLocalAuth(baseUrl, {
     email: userBEmail,
     password: userPassword,
     storageStatePath: '.playwright/user-b.json',
+  });
+
+  await loginWithLocalAuth(baseUrl, {
+    email: userBEmail,
+    password: userPassword,
+    storageStatePath: '.playwright/user-b-faq.json',
+  });
+
+  await loginWithLocalAuth(baseUrl, {
+    email: userBEmail,
+    password: userPassword,
+    storageStatePath: '.playwright/user-b-group.json',
   });
 
   execSync(`npx convex run e2e:seedBaseline '${JSON.stringify({ ownerEmail: userAEmail })}'`, {

--- a/e2e/group-membership-lifecycle.spec.ts
+++ b/e2e/group-membership-lifecycle.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test';
+
+test.use({ storageState: '.playwright/user-a-group.json' });
+
+test('membership lifecycle: request, approve, moderate, remove', async ({ page, browser }) => {
+  test.setTimeout(90_000);
+
+  const suffix = Date.now();
+  const groupName = `E2EMembership${suffix}`;
+
+  await test.step('owner creates the Group', async () => {
+    await page.goto('/groups/create');
+    await page.getByRole('textbox', { name: 'Group name' }).fill(groupName);
+    await page.getByRole('button', { name: 'Save group' }).click();
+    await expect(page).toHaveURL(/\/profiles\//);
+    await page.goto(`/groups/${groupName.toLowerCase()}`);
+    await expect(page.getByRole('heading', { name: groupName })).toBeVisible();
+  });
+  const groupUrl = page.url();
+
+  const userBContext = await browser.newContext({ storageState: '.playwright/user-b-group.json' });
+  const userBPage = await userBContext.newPage();
+
+  await test.step('visitor requests membership', async () => {
+    await userBPage.goto(groupUrl);
+    await expect(userBPage.getByText('Not a member')).toBeVisible();
+    await userBPage.getByRole('button', { name: 'Request membership' }).click();
+    await expect(userBPage.getByText('Pending approval')).toBeVisible();
+  });
+
+  await test.step('owner approves from the roster', async () => {
+    await page.goto(groupUrl);
+    await expect(page.getByText('(pending)')).toBeVisible();
+    await page.getByRole('button', { name: 'Approve membership' }).click();
+    await expect(page.getByText('(pending)')).not.toBeVisible();
+  });
+
+  await test.step('member sees active status through the live subscription', async () => {
+    await expect(userBPage.getByText('Active member')).toBeVisible();
+    await expect(userBPage.getByRole('button', { name: 'Request membership' })).not.toBeVisible();
+  });
+
+  await test.step('owner removes the member', async () => {
+    page.on('dialog', (dialog) => void dialog.accept());
+    await page.getByRole('button', { name: 'Remove member' }).click();
+    await expect(page.getByRole('button', { name: 'Remove member' })).not.toBeVisible();
+  });
+
+  await test.step('removed member loses membership and may request again', async () => {
+    await expect(userBPage.getByText('Not a member')).toBeVisible();
+    await expect(userBPage.getByRole('button', { name: 'Request membership' })).toBeVisible();
+  });
+
+  await userBContext.close();
+});

--- a/src/app/faq/db.test.tsx
+++ b/src/app/faq/db.test.tsx
@@ -25,7 +25,7 @@ vi.mock('convex/react', () => ({
   useMutation: mocks.useMutation,
 }));
 
-import { loadFaqQuestionPage, useAskFaqQuestion, useFaqQuestionPage } from './db';
+import { useAskFaqQuestion, useFaqQuestionPage } from './db';
 
 const serverPage = {
   ruleset: { id: 'ruleset-1', slug: 'test-ruleset', name: 'TestRuleset' },
@@ -99,41 +99,6 @@ beforeEach(() => {
 });
 
 describe('FAQ question page interface', () => {
-  test('uses the same canonical page for loader handoff and live data', async () => {
-    mocks.dbQuery.mockResolvedValue(serverPage);
-    const loaded = await loadFaqQuestionPage({
-      rulesetSlug: 'test-ruleset',
-      questionSlug: '1',
-    });
-
-    expect(loaded).toEqual(serverPage);
-    expect(mocks.dbQuery).toHaveBeenCalledWith(api.faq.questionPage, {
-      rulesetSlug: 'test-ruleset',
-      questionSlug: '1',
-    });
-
-    mocks.useQuery.mockReturnValue(undefined);
-    const loaderHandoff = renderHook(() =>
-      useFaqQuestionPage(
-        { rulesetSlug: 'test-ruleset', questionSlug: '1' },
-        { initialPage: loaded }
-      )
-    );
-    expect(loaderHandoff.result.current.page).toEqual(serverPage);
-    loaderHandoff.unmount();
-
-    mocks.useQuery.mockReturnValue(serverPage);
-    const live = renderHook(() =>
-      useFaqQuestionPage({ rulesetSlug: 'test-ruleset', questionSlug: '1' })
-    );
-    expect(live.result.current.page).toEqual(serverPage);
-    expect(mocks.useQuery).toHaveBeenLastCalledWith(api.faq.questionPage, {
-      rulesetSlug: 'test-ruleset',
-      questionSlug: '1',
-    });
-    live.unmount();
-  });
-
   test('binds domain commands to the loaded question and canonical operations', async () => {
     mocks.useQuery.mockReturnValue(serverPage);
     const hook = renderHook(() =>

--- a/src/app/groups/db.test.tsx
+++ b/src/app/groups/db.test.tsx
@@ -3,8 +3,6 @@
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-import { api } from '../../../convex/_generated/api';
-
 const mocks = vi.hoisted(() => ({
   dbQuery: vi.fn(),
   useQuery: vi.fn(),
@@ -16,12 +14,7 @@ vi.mock('convex/react', () => ({
   useMutation: vi.fn(),
 }));
 
-import {
-  loadGroupDetailBySlug,
-  loadGroupEditBySlug,
-  useGroupDetailBySlug,
-  useGroupEditBySlug,
-} from './db';
+import { loadGroupEditBySlug, useGroupEditBySlug } from './db';
 
 const group = {
   _id: 'group-1',
@@ -74,36 +67,6 @@ beforeEach(() => {
 });
 
 describe('Group page interface', () => {
-  test('normalizes the canonical detail projection without exposing legacy authorization rows', async () => {
-    mocks.dbQuery.mockResolvedValue(serverPage);
-
-    const loaded = await loadGroupDetailBySlug('dune-designers');
-
-    expect(loaded.group.id).toBe('group-1');
-    expect(loaded.viewerAccess).toEqual(viewerAccess);
-    expect(loaded.roster).toEqual(roster);
-    expect(loaded).not.toHaveProperty('members');
-    expect(loaded).not.toHaveProperty('profiles');
-    expect(mocks.dbQuery).toHaveBeenCalledWith(api.groups.detailBySlug, {
-      slug: 'dune-designers',
-    });
-
-    mocks.useQuery.mockReturnValue(undefined);
-    const loaderHandoff = renderHook(() =>
-      useGroupDetailBySlug('dune-designers', { initialData: loaded })
-    );
-    expect(loaderHandoff.result.current.data).toEqual(loaded);
-    loaderHandoff.unmount();
-
-    mocks.useQuery.mockReturnValue(serverPage);
-    const live = renderHook(() => useGroupDetailBySlug('dune-designers'));
-    expect(live.result.current.data).toEqual(loaded);
-    expect(mocks.useQuery).toHaveBeenLastCalledWith(api.groups.detailBySlug, {
-      slug: 'dune-designers',
-    });
-    live.unmount();
-  });
-
   test('gives Group edit only its Group and owner capability projection', async () => {
     mocks.dbQuery.mockResolvedValue(serverPage);
 

--- a/src/app/profile/db.test.tsx
+++ b/src/app/profile/db.test.tsx
@@ -1,9 +1,6 @@
 // @vitest-environment jsdom
 
-import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-import { api } from '../../../convex/_generated/api';
 
 const mocks = vi.hoisted(() => ({
   dbQuery: vi.fn(),
@@ -16,7 +13,7 @@ vi.mock('convex/react', () => ({
   useMutation: vi.fn(),
 }));
 
-import { loadProfileBySlug, useProfileBySlug } from './db';
+import { loadProfileBySlug } from './db';
 
 const profile = {
   _id: 'profile-1',
@@ -47,27 +44,6 @@ beforeEach(() => {
 });
 
 describe('profile page interface', () => {
-  test('loader and live paths produce one canonical page with ordered Group summaries', async () => {
-    mocks.dbQuery.mockResolvedValue(serverPage);
-
-    const loaded = await loadProfileBySlug('chani');
-
-    expect(loaded.groupSummaries).toEqual(groupSummaries);
-    expect(loaded).not.toHaveProperty('memberships');
-    expect(loaded).not.toHaveProperty('groups');
-    expect(mocks.dbQuery).toHaveBeenCalledWith(api.profiles.getBySlug, { slug: 'chani' });
-
-    mocks.useQuery.mockReturnValue(undefined);
-    const loaderHandoff = renderHook(() => useProfileBySlug('chani', { initialData: loaded }));
-    expect(loaderHandoff.result.current.data).toEqual(loaded);
-    loaderHandoff.unmount();
-
-    mocks.useQuery.mockReturnValue(serverPage);
-    const live = renderHook(() => useProfileBySlug('chani'));
-    expect(live.result.current.data).toEqual(loaded);
-    live.unmount();
-  });
-
   test('counts only answers whose parent question accepted them', async () => {
     const acceptedAnswer = {
       _id: 'answer-1',


### PR DESCRIPTION
Closes #241

The one net-positive PR in the series, by design: the confidence anchor gets reinforced before the middle band shrinks (ADR-0002's sequencing rule).

## New specs (verified locally: full suite 5/5 in ~1m)

- **`e2e/group-membership-lifecycle.spec.ts`** — owner creates a Group; a second user requests membership; the owner approves via the roster capability buttons; the member sees active status arrive over the live subscription; the owner removes them; the removed member can request again. This restores the roster-moderation flow coverage that #238 declared as its accepted gap — now covered by a real browser driving the real stack instead of source-text greps.
- **`e2e/faq-happy-path.spec.ts`** — ask on the baseline ruleset; a second user answers; the asker sees the answer arrive live and accepts it; the answerer's profile shows the activity and a picked-answers count of 1 (exercising the derived `acceptedAnswerCount` end to end).

Both specs follow the repo's dedicated-session convention (`user-a-group.json` etc. in global-setup) — shared storage states go stale when an earlier spec's token refresh rotates the refresh token, which is why `user-a-ruleset.json` already existed.

## Retired seam tests — inventory

| Test | What carries its confidence now |
|---|---|
| profile `loader and live paths produce one canonical page…` | Ordering: server boundary suite (`profiles.detail.test.ts`). Transport absence: `returns` validator + fully derived types (#234). Loader/live flow: the FAQ spec's profile step + every page's real paths |
| groups `normalizes the canonical detail projection…` | Shape pass-through: validator + derived types. Live updates: exercised for real by the group spec. `id` aliasing: used by every e2e group interaction |
| faq `uses the same canonical page for loader handoff and live data` | Pure pass-through of a now-derived shape; the FAQ spec drives the page live |

**Kept (7):** `acceptedAnswerCount` derivation, group-edit key-set narrowness, and all command-semantics/error-isolation tests in `members`/`faq` — behavior neither types nor a happy path cover.

## Incidental finding

The FAQ ask form's `FormField` label is not programmatically associated with its input (accessible name falls back to the placeholder) — flagged as a separate task rather than fixed here.

Gates: `bun run test` (422), `typecheck`, `lint`, `format:check`, `publisher:release:verify`; local e2e suite 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for FAQ workflows, including question creation, answers, live updates, acceptance, and profile activity.
  * Added end-to-end coverage for group membership requests, approvals, removals, and rejoining.
  * Updated authenticated test scenarios to support FAQ and group workflows.
  * Removed outdated detail-page loading and live-data consistency tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->