### PR TITLE
Consolidate the FAQ question page into a typed read-model boundary

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -24,6 +24,7 @@ import type * as lib_factionCatalogue from "../lib/factionCatalogue.js";
 import type * as lib_factionData from "../lib/factionData.js";
 import type * as lib_factionInput from "../lib/factionInput.js";
 import type * as lib_faqProfileActivity from "../lib/faqProfileActivity.js";
+import type * as lib_faqQuestionPage from "../lib/faqQuestionPage.js";
 import type * as lib_faqRulesetList from "../lib/faqRulesetList.js";
 import type * as lib_faqTags from "../lib/faqTags.js";
 import type * as lib_ids from "../lib/ids.js";
@@ -71,6 +72,7 @@ declare const fullApi: ApiFromModules<{
   "lib/factionData": typeof lib_factionData;
   "lib/factionInput": typeof lib_factionInput;
   "lib/faqProfileActivity": typeof lib_faqProfileActivity;
+  "lib/faqQuestionPage": typeof lib_faqQuestionPage;
   "lib/faqRulesetList": typeof lib_faqRulesetList;
   "lib/faqTags": typeof lib_faqTags;
   "lib/ids": typeof lib_ids;

--- a/convex/faq.questionPage.test.ts
+++ b/convex/faq.questionPage.test.ts
@@ -1,0 +1,195 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import { convexTest } from 'convex-test';
+import { describe, expect, test } from 'vitest';
+
+import { api } from './_generated/api';
+import type { Id } from './_generated/dataModel';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+
+type SeedResult = {
+  askerId: Id<'users'>;
+  answererId: Id<'users'>;
+  thirdId: Id<'users'>;
+  answererProfileId: Id<'profiles'>;
+  acceptedAnswerId: Id<'faq_answers'>;
+  ghostAnswerId: Id<'faq_answers'>;
+  thirdAnswerId: Id<'faq_answers'>;
+};
+
+const at = (day: number) => `2026-07-${String(day).padStart(2, '0')}T00:00:00.000Z`;
+
+async function seedQuestionPage(t: ReturnType<typeof convexTest>): Promise<SeedResult> {
+  return await t.run(async (ctx) => {
+    const askerId = await ctx.db.insert('users', { name: 'Asker' });
+    const answererId = await ctx.db.insert('users', { name: 'Answerer' });
+    const thirdId = await ctx.db.insert('users', { name: 'Third' });
+    const ghostId = await ctx.db.insert('users', { name: 'Ghost' });
+
+    const profile = (userId: Id<'users'>, name: string) =>
+      ctx.db.insert('profiles', {
+        user_id: userId,
+        username: name,
+        avatar_url: null,
+        slug: name.toLowerCase(),
+        created_at: at(1),
+        updated_at: at(1),
+      });
+    await profile(askerId, 'Asker');
+    const answererProfileId = await profile(answererId, 'Answerer');
+    await profile(thirdId, 'Third');
+
+    const rulesetId = await ctx.db.insert('rulesets', {
+      name: 'Advanced',
+      slug: 'advanced',
+      created_at: at(1),
+      updated_at: at(1),
+      owner_id: askerId,
+      group_id: null,
+      is_deleted: false,
+      image_cover: null,
+    });
+
+    const questionId = await ctx.db.insert('faq_items', {
+      ruleset_id: rulesetId,
+      slug: '1',
+      question: 'How does the storm move?',
+      asked_by: askerId,
+      created_at: at(2),
+      updated_at: at(2),
+      accepted_answer_id: null,
+    });
+
+    const acceptedAnswerId = await ctx.db.insert('faq_answers', {
+      faq_item_id: questionId,
+      answer: 'One to six sectors.',
+      answered_by: answererId,
+      created_at: at(3),
+    });
+    const ghostAnswerId = await ctx.db.insert('faq_answers', {
+      faq_item_id: questionId,
+      answer: 'By storm deck.',
+      answered_by: ghostId,
+      created_at: at(4),
+    });
+    const thirdAnswerId = await ctx.db.insert('faq_answers', {
+      faq_item_id: questionId,
+      answer: 'Depends on the edition.',
+      answered_by: thirdId,
+      created_at: at(5),
+    });
+    await ctx.db.patch(questionId, { accepted_answer_id: acceptedAnswerId });
+
+    return {
+      askerId,
+      answererId,
+      thirdId,
+      answererProfileId,
+      acceptedAnswerId,
+      ghostAnswerId,
+      thirdAnswerId,
+    };
+  });
+}
+
+const locator = { rulesetSlug: 'advanced', questionSlug: '1' };
+
+describe('FAQ question page projection (api.faq.questionPage)', () => {
+  test('anonymous viewers get the page with no capabilities', async () => {
+    const t = convexTest(schema, modules);
+    await seedQuestionPage(t);
+
+    const page = await t.query(api.faq.questionPage, locator);
+
+    expect(page.viewer.answerQuestion).toBe(false);
+    expect(page.question.capabilities).toEqual({ editQuestion: false, deleteQuestion: false });
+    for (const answer of page.answers) {
+      expect(answer.capabilities).toEqual({
+        editAnswer: false,
+        deleteAnswer: false,
+        acceptAnswer: false,
+        unacceptAnswer: false,
+      });
+    }
+  });
+
+  test('the accepted answer sorts first regardless of age', async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedQuestionPage(t);
+
+    const page = await t.query(api.faq.questionPage, locator);
+
+    expect(page.answers[0]?.id).toBe(seed.acceptedAnswerId);
+    expect(page.answers[0]?.accepted).toBe(true);
+    expect(page.answers.slice(1).every((answer) => !answer.accepted)).toBe(true);
+  });
+
+  test('the question owner moderates: edit, delete, accept, unaccept', async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedQuestionPage(t);
+
+    const page = await t
+      .withIdentity({ subject: seed.askerId })
+      .query(api.faq.questionPage, locator);
+
+    expect(page.question.capabilities).toEqual({ editQuestion: true, deleteQuestion: true });
+    const accepted = page.answers.find((answer) => answer.id === seed.acceptedAnswerId);
+    expect(accepted?.capabilities).toMatchObject({
+      acceptAnswer: false,
+      unacceptAnswer: true,
+      deleteAnswer: true,
+      editAnswer: false,
+    });
+    const third = page.answers.find((answer) => answer.id === seed.thirdAnswerId);
+    expect(third?.capabilities).toMatchObject({ acceptAnswer: true, unacceptAnswer: false });
+    expect(page.viewer.answerQuestion).toBe(true);
+  });
+
+  test('an answer author owns only their answer and cannot answer twice', async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedQuestionPage(t);
+
+    const page = await t
+      .withIdentity({ subject: seed.answererId })
+      .query(api.faq.questionPage, locator);
+
+    const own = page.answers.find((answer) => answer.id === seed.acceptedAnswerId);
+    expect(own?.capabilities).toMatchObject({ editAnswer: true, deleteAnswer: true });
+    const others = page.answers.filter((answer) => answer.id !== seed.acceptedAnswerId);
+    expect(others.every((answer) => !answer.capabilities.editAnswer)).toBe(true);
+    expect(page.viewer.answerQuestion).toBe(false);
+  });
+
+  test('a missing author profile yields a null chip without corrupting the page', async () => {
+    const t = convexTest(schema, modules);
+    const seed = await seedQuestionPage(t);
+
+    const page = await t.query(api.faq.questionPage, locator);
+
+    const ghost = page.answers.find((answer) => answer.id === seed.ghostAnswerId);
+    expect(ghost?.author).toBeNull();
+    expect(page.answers).toHaveLength(3);
+    const accepted = page.answers.find((answer) => answer.id === seed.acceptedAnswerId);
+    expect(accepted?.author).toEqual({
+      id: seed.answererProfileId,
+      slug: 'answerer',
+      username: 'Answerer',
+      avatarUrl: null,
+    });
+  });
+
+  test('unknown locators throw', async () => {
+    const t = convexTest(schema, modules);
+    await seedQuestionPage(t);
+
+    await expect(
+      t.query(api.faq.questionPage, { rulesetSlug: 'advanced', questionSlug: '99' })
+    ).rejects.toThrow(/not found/);
+    await expect(
+      t.query(api.faq.questionPage, { rulesetSlug: 'missing', questionSlug: '1' })
+    ).rejects.toThrow(/not found/);
+  });
+});

--- a/convex/faq.ts
+++ b/convex/faq.ts
@@ -1,4 +1,3 @@
-import { getAuthUserId } from '@convex-dev/auth/server';
 import { v } from 'convex/values';
 
 import type { FAQ_TAG_VALUES } from '../src/app/faq/tags';
@@ -7,9 +6,9 @@ import { internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 import { internalMutation, mutation } from './functions';
+import { faqQuestionPageValidator, loadFaqQuestionPage } from './lib/faqQuestionPage';
 import { faqTagValidator } from './lib/faqTags';
 import { requireAuthUserId } from './lib/policy';
-import { profileSummary } from './lib/profileSummary';
 import { nowIso } from './lib/utils';
 import type { MutationCtx, QueryCtx } from './types';
 
@@ -19,13 +18,6 @@ const FAQ_ITEM_DELETE_TRANSACTION_RESERVE_OPERATIONS = 16;
 
 async function getRuleset(ctx: QueryCtx | MutationCtx, id: Id<'rulesets'>) {
   return await ctx.db.get(id);
-}
-
-async function getRulesetBySlug(ctx: QueryCtx | MutationCtx, slug: string) {
-  return await ctx.db
-    .query('rulesets')
-    .withIndex('by_slug', (q) => q.eq('slug', slug))
-    .unique();
 }
 
 async function getFaqItem(ctx: QueryCtx | MutationCtx, id: Id<'faq_items'>) {
@@ -107,109 +99,10 @@ async function allocateNextFaqItemSlug(
   }
 }
 
-async function loadFaqItemByLocator(
-  ctx: QueryCtx | MutationCtx,
-  rulesetSlug: string,
-  questionSlug: string
-) {
-  const ruleset = await getRulesetBySlug(ctx, rulesetSlug);
-  if (!ruleset || ruleset.is_deleted) {
-    throw new Error(`Ruleset with slug ${rulesetSlug} not found`);
-  }
-  const item = await ctx.db
-    .query('faq_items')
-    .withIndex('by_ruleset_slug', (q) => q.eq('ruleset_id', ruleset._id).eq('slug', questionSlug))
-    .unique();
-  if (!item) {
-    throw new Error(`FAQ item with slug ${questionSlug} not found in ruleset ${rulesetSlug}`);
-  }
-  const answers = await ctx.db
-    .query('faq_answers')
-    .withIndex('by_faq_item_created', (q) => q.eq('faq_item_id', item._id))
-    .take(200);
-  return { ruleset, item, answers };
-}
-
-async function questionPageHandler(
-  ctx: QueryCtx,
-  args: { rulesetSlug: string; questionSlug: string }
-) {
-  const { ruleset, item, answers } = await loadFaqItemByLocator(
-    ctx,
-    args.rulesetSlug,
-    args.questionSlug
-  );
-  const viewerId = await getAuthUserId(ctx);
-  const questionOwner = viewerId === item.asked_by;
-  const viewerAnswered = viewerId
-    ? (await ctx.db
-        .query('faq_answers')
-        .withIndex('by_faq_item_answered_by', (q) =>
-          q.eq('faq_item_id', item._id).eq('answered_by', viewerId)
-        )
-        .unique()) !== null
-    : false;
-  const asker = await profileSummary(ctx, item.asked_by);
-  const answerers = await Promise.all(
-    answers.map((answer) => profileSummary(ctx, answer.answered_by))
-  );
-  const projectedAnswers = answers.map((answer, index) => {
-    const answerOwner = viewerId === answer.answered_by;
-    const accepted = item.accepted_answer_id === answer._id;
-    const author = answerers[index];
-    return {
-      id: answer._id,
-      text: answer.answer,
-      author: author
-        ? {
-            id: author.id,
-            slug: author.slug,
-            username: author.username,
-            avatarUrl: author.avatar_url,
-          }
-        : null,
-      createdAt: answer.created_at,
-      accepted,
-      capabilities: {
-        editAnswer: answerOwner,
-        deleteAnswer: answerOwner || questionOwner,
-        acceptAnswer: questionOwner && !accepted,
-        unacceptAnswer: questionOwner && accepted,
-      },
-    };
-  });
-  projectedAnswers.sort((left, right) => Number(right.accepted) - Number(left.accepted));
-
-  return {
-    ruleset: { id: ruleset._id, slug: ruleset.slug, name: ruleset.name },
-    question: {
-      id: item._id,
-      slug: item.slug,
-      text: item.question,
-      tags: item.tags,
-      author: asker
-        ? {
-            id: asker.id,
-            slug: asker.slug,
-            username: asker.username,
-            avatarUrl: asker.avatar_url,
-          }
-        : null,
-      createdAt: item.created_at,
-      updatedAt: item.updated_at,
-      capabilities: {
-        editQuestion: questionOwner,
-        deleteQuestion: questionOwner,
-      },
-    },
-    viewer: { answerQuestion: viewerId !== null && !viewerAnswered },
-    answers: projectedAnswers,
-  };
-}
-
 export const questionPage = query({
   args: { rulesetSlug: v.string(), questionSlug: v.string() },
-  handler: questionPageHandler,
+  returns: faqQuestionPageValidator,
+  handler: async (ctx, args) => await loadFaqQuestionPage(ctx, args),
 });
 
 async function createQuestionHandler(

--- a/convex/lib/faqQuestionPage.ts
+++ b/convex/lib/faqQuestionPage.ts
@@ -1,0 +1,142 @@
+import { getAuthUserId } from '@convex-dev/auth/server';
+import { v } from 'convex/values';
+
+import type { QueryCtx } from '../types';
+import { faqTagValidator } from './faqTags';
+import { profileSummary } from './profileSummary';
+
+const QUESTION_PAGE_ANSWER_LIMIT = 200;
+
+const authorChipValidator = v.object({
+  id: v.id('profiles'),
+  slug: v.string(),
+  username: v.union(v.string(), v.null()),
+  avatarUrl: v.union(v.string(), v.null()),
+});
+
+export const faqQuestionPageValidator = v.object({
+  ruleset: v.object({ id: v.id('rulesets'), slug: v.string(), name: v.string() }),
+  question: v.object({
+    id: v.id('faq_items'),
+    slug: v.string(),
+    text: v.string(),
+    tags: v.optional(v.array(faqTagValidator)),
+    author: v.union(authorChipValidator, v.null()),
+    createdAt: v.string(),
+    updatedAt: v.string(),
+    capabilities: v.object({ editQuestion: v.boolean(), deleteQuestion: v.boolean() }),
+  }),
+  viewer: v.object({ answerQuestion: v.boolean() }),
+  answers: v.array(
+    v.object({
+      id: v.id('faq_answers'),
+      text: v.string(),
+      author: v.union(authorChipValidator, v.null()),
+      createdAt: v.string(),
+      accepted: v.boolean(),
+      capabilities: v.object({
+        editAnswer: v.boolean(),
+        deleteAnswer: v.boolean(),
+        acceptAnswer: v.boolean(),
+        unacceptAnswer: v.boolean(),
+      }),
+    })
+  ),
+});
+
+function authorChip(summary: Awaited<ReturnType<typeof profileSummary>>) {
+  return summary
+    ? {
+        id: summary.id,
+        slug: summary.slug,
+        username: summary.username,
+        avatarUrl: summary.avatar_url,
+      }
+    : null;
+}
+
+/**
+ * FAQ question-page read model. Owns the locator resolution, the per-role capability rules (the FAQ
+ * question owner accepts/unaccepts/removes answers; an answer author alone edits their answer; each
+ * viewer may answer once), and the accepted-first ordering behind `api.faq.questionPage` (see
+ * CONTEXT.md: FAQ question, FAQ answer). The wire contract is `faqQuestionPageValidator`.
+ */
+export async function loadFaqQuestionPage(
+  ctx: QueryCtx,
+  args: { rulesetSlug: string; questionSlug: string }
+) {
+  const ruleset = await ctx.db
+    .query('rulesets')
+    .withIndex('by_slug', (q) => q.eq('slug', args.rulesetSlug))
+    .unique();
+  if (!ruleset || ruleset.is_deleted) {
+    throw new Error(`Ruleset with slug ${args.rulesetSlug} not found`);
+  }
+  const item = await ctx.db
+    .query('faq_items')
+    .withIndex('by_ruleset_slug', (q) =>
+      q.eq('ruleset_id', ruleset._id).eq('slug', args.questionSlug)
+    )
+    .unique();
+  if (!item) {
+    throw new Error(
+      `FAQ item with slug ${args.questionSlug} not found in ruleset ${args.rulesetSlug}`
+    );
+  }
+  const answers = await ctx.db
+    .query('faq_answers')
+    .withIndex('by_faq_item_created', (q) => q.eq('faq_item_id', item._id))
+    .take(QUESTION_PAGE_ANSWER_LIMIT);
+
+  const viewerId = await getAuthUserId(ctx);
+  const questionOwner = viewerId === item.asked_by;
+  const viewerAnswered = viewerId
+    ? (await ctx.db
+        .query('faq_answers')
+        .withIndex('by_faq_item_answered_by', (q) =>
+          q.eq('faq_item_id', item._id).eq('answered_by', viewerId)
+        )
+        .unique()) !== null
+    : false;
+  const asker = await profileSummary(ctx, item.asked_by);
+  const answerers = await Promise.all(
+    answers.map((answer) => profileSummary(ctx, answer.answered_by))
+  );
+  const projectedAnswers = answers.map((answer, index) => {
+    const answerOwner = viewerId === answer.answered_by;
+    const accepted = item.accepted_answer_id === answer._id;
+    return {
+      id: answer._id,
+      text: answer.answer,
+      author: authorChip(answerers[index] ?? null),
+      createdAt: answer.created_at,
+      accepted,
+      capabilities: {
+        editAnswer: answerOwner,
+        deleteAnswer: answerOwner || questionOwner,
+        acceptAnswer: questionOwner && !accepted,
+        unacceptAnswer: questionOwner && accepted,
+      },
+    };
+  });
+  projectedAnswers.sort((left, right) => Number(right.accepted) - Number(left.accepted));
+
+  return {
+    ruleset: { id: ruleset._id, slug: ruleset.slug, name: ruleset.name },
+    question: {
+      id: item._id,
+      slug: item.slug,
+      text: item.question,
+      tags: item.tags,
+      author: authorChip(asker),
+      createdAt: item.created_at,
+      updatedAt: item.updated_at,
+      capabilities: {
+        editQuestion: questionOwner,
+        deleteQuestion: questionOwner,
+      },
+    },
+    viewer: { answerQuestion: viewerId !== null && !viewerAnswered },
+    answers: projectedAnswers,
+  };
+}

--- a/src/app/components/profile/ProfileFaqActivity.tsx
+++ b/src/app/components/profile/ProfileFaqActivity.tsx
@@ -1,7 +1,10 @@
 import { Link } from '@tanstack/react-router';
 import clsx from 'clsx';
 
-import type { FaqAnswerWithParent, FaqItemAskedByWithRuleset } from '@db/faq';
+import type { ProfilePageData } from '@db/profiles';
+
+type FaqQuestionAsked = ProfilePageData['faqAsked'][number];
+type FaqAnswerGiven = ProfilePageData['faqAnswers'][number];
 import { FaqItemList, FaqItemListRow } from '@app/components/faq/FaqItemList';
 import { ProfileLink } from '@app/components/profile/ProfileLink';
 import { formatRelativeDate } from '@app/utils/formatRelativeDate';
@@ -20,7 +23,7 @@ function AskerChip({
   profile,
   viewedProfileId,
 }: {
-  profile: NonNullable<FaqAnswerWithParent['asker_profile']>;
+  profile: NonNullable<FaqAnswerGiven['asker_profile']>;
   viewedProfileId: string;
 }) {
   if (profile.id === viewedProfileId) {
@@ -39,7 +42,7 @@ function AskerChip({
   );
 }
 
-export function ProfileFaqQuestionsAsked({ items }: { items: FaqItemAskedByWithRuleset[] }) {
+export function ProfileFaqQuestionsAsked({ items }: { items: FaqQuestionAsked[] }) {
   if (items.length === 0) {
     return <p className={styles.noResults}>No questions asked yet.</p>;
   }
@@ -78,7 +81,7 @@ export function ProfileFaqAnswersGiven({
   items,
   viewedProfileId,
 }: {
-  items: FaqAnswerWithParent[];
+  items: FaqAnswerGiven[];
   viewedProfileId: string;
 }) {
   if (items.length === 0) {

--- a/src/app/faq/db.ts
+++ b/src/app/faq/db.ts
@@ -21,23 +21,6 @@ export type FaqItemWithDetails = FaqItemEntry & {
   asker_profile: ProfileSummary | null;
 };
 
-export type FaqItemAskedByWithRuleset = FaqItemEntry & {
-  ruleset: { id: string; name: string; slug: string };
-};
-
-export type FaqAnswerWithParent = FaqAnswerEntry & {
-  faq_item: {
-    id: FaqItemRow['_id'];
-    slug: string;
-    question: string;
-    ruleset_id: string;
-    asked_by: string;
-    accepted_answer_id: string | null;
-  };
-  asker_profile: ProfileSummary | null;
-  ruleset: { id: string; name: string; slug: string };
-};
-
 export type FaqQuestionLocator = {
   rulesetSlug: string;
   questionSlug: string;


### PR DESCRIPTION
Closes #235 — the direct sibling of #199, net-positive by design (the missing owned test boundary was most of the point).

- **`convex/lib/faqQuestionPage.ts`** owns the locator resolution, the per-role capability rules (FAQ question owner accepts/unaccepts/removes answers; an answer author alone edits their own; each viewer answers once — CONTEXT.md's FAQ question/answer contracts), and the accepted-first ordering. `api.faq.questionPage` is a thin wrapper.
- **The missing `returns` validator exists now** (`faqQuestionPageValidator`) — this was the only page query without one; convex-test enforces it through the whole suite. The client side needed *zero* changes: `FaqQuestionPage` already derives via `FunctionReturnType` since #240, so the validator slotted under it.
- **`faq.ts` is a pure command module** — no query projection logic remains; its 7-mutation surface is unchanged (pinned by `faq.test.ts`).
- **Boundary suite** (`convex/faq.questionPage.test.ts`, 6 tests, written against the pre-extraction implementation and kept green through it): anonymous no-capabilities, accepted-first ordering regardless of age, owner moderation incl. accept/unaccept asymmetry, answer-author ownership + answer-once, null author-chip tolerance, not-found locators. Sized to the capability rules per the ADR-0002 footnote — the ask→answer→accept flow itself is covered by the #244 e2e spec, not duplicated here.
- **The last FAQ→profile type coupling is gone**: `ProfileFaqActivity` types its props from `ProfilePageData` (the contract it actually renders), and the orphaned `FaqItemAskedByWithRuleset`/`FaqAnswerWithParent` hand types are deleted.

Gates: `bun run test` (428: 422 + 6 new), `typecheck`, `lint`, `format:check`, `publisher:release:verify`; Convex bindings regenerated. Wire shape unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)