### PR TITLE
Deepen the Faction catalogue into one read-model entry point

### DIFF
--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -17,11 +17,7 @@ import {
   factionWithRulesetsValidator,
   rulesetSummaryValidator,
 } from './lib/collaborativeAccessValidators';
-import {
-  enrichFactionsWithRulesets,
-  listActiveRulesetSummaries,
-  selectFactionCatalogueSpotlights,
-} from './lib/factionCatalogue';
+import { loadFactionCatalogue, selectFactionCatalogueSpotlights } from './lib/factionCatalogue';
 import { parseFactionInput } from './lib/factionInput';
 import { requireAuthUserId } from './lib/policy';
 import { enqueueFactionSheetPublication } from './lib/publication';
@@ -128,12 +124,7 @@ export const cataloguePage = query({
     }),
   }),
   handler: async (ctx) => {
-    const rows = await ctx.db
-      .query('factions')
-      .withIndex('by_deleted', (q) => q.eq('is_deleted', false))
-      .take(500);
-    const rulesets = await listActiveRulesetSummaries(ctx);
-    const factions = await enrichFactionsWithRulesets(ctx, rows, rulesets);
+    const { factions, rulesets } = await loadFactionCatalogue(ctx);
 
     return {
       factions,

--- a/convex/lib/collaborativeAccess.ts
+++ b/convex/lib/collaborativeAccess.ts
@@ -486,8 +486,8 @@ export async function loadAssetAccessBundle(
   }
 
   const groupById = new Map<Id<'groups'>, Doc<'groups'>>();
-  for (const groupId of groupIds) {
-    const group = await ctx.db.get('groups', groupId);
+  const groups = await Promise.all([...groupIds].map((groupId) => ctx.db.get('groups', groupId)));
+  for (const group of groups) {
     if (group) {
       groupById.set(group._id, group);
     }
@@ -536,15 +536,20 @@ export async function loadGroupAccessBundle(ctx: QueryCtx, group: Doc<'groups'>)
   for (const membership of members) {
     userIds.add(membership.user_id);
   }
-  for (const userId of userIds) {
-    const profile = await ctx.db
-      .query('profiles')
-      .withIndex('by_user_id', (q) => q.eq('user_id', userId))
-      .unique();
-    if (!profile) {
-      throw new Error(`Invariant: every user must have a profile (missing for ${userId})`);
-    }
-    profileByUserId.set(userId, profile);
+  const profiles = await Promise.all(
+    [...userIds].map(async (userId) => {
+      const profile = await ctx.db
+        .query('profiles')
+        .withIndex('by_user_id', (q) => q.eq('user_id', userId))
+        .unique();
+      if (!profile) {
+        throw new Error(`Invariant: every user must have a profile (missing for ${userId})`);
+      }
+      return profile;
+    })
+  );
+  for (const profile of profiles) {
+    profileByUserId.set(profile.user_id, profile);
   }
 
   const actorIsActive =

--- a/convex/lib/factionCatalogue.ts
+++ b/convex/lib/factionCatalogue.ts
@@ -14,7 +14,12 @@ export type CatalogueFaction = Omit<Doc<'factions'>, 'data'> & {
   rulesets: FactionRulesetSummary[];
 };
 
-export async function listActiveRulesetSummaries(ctx: QueryCtx): Promise<FactionRulesetSummary[]> {
+const FACTION_LIMIT = 500;
+/* Bounded whole-index scan of ruleset_factions for the catalogue path; one read replaces one
+ * indexed read per faction. The bound mirrors the pre-existing per-faction take(500) caps. */
+const FACTION_LINK_SCAN_LIMIT = 5000;
+
+async function listActiveRulesetSummaries(ctx: QueryCtx): Promise<FactionRulesetSummary[]> {
   const rows = await ctx.db
     .query('rulesets')
     .withIndex('by_deleted_name', (q) => q.eq('is_deleted', false))
@@ -23,41 +28,73 @@ export async function listActiveRulesetSummaries(ctx: QueryCtx): Promise<Faction
   return rows.map((row) => ({ id: row._id, slug: row.slug, name: row.name }));
 }
 
-export async function enrichFactionsWithRulesets(
+/**
+ * Faction catalogue read model: one call owns row selection, ruleset enrichment (active rulesets
+ * only, name-then-id order), and canonical faction parsing. The catalogue path batches the link
+ * table in one bounded scan; the owner path uses per-faction indexed reads, which win for the
+ * handful of factions one owner has.
+ */
+export async function loadFactionCatalogue(
   ctx: QueryCtx,
-  rows: Doc<'factions'>[],
-  activeRulesets: FactionRulesetSummary[]
-): Promise<CatalogueFaction[]> {
-  const activeRulesetById = new Map(activeRulesets.map((ruleset) => [ruleset.id, ruleset]));
+  options: { ownerId?: Id<'users'> } = {}
+): Promise<{ factions: CatalogueFaction[]; rulesets: FactionRulesetSummary[] }> {
+  const { ownerId } = options;
+  const rows = ownerId
+    ? await ctx.db
+        .query('factions')
+        .withIndex('by_owner_deleted', (q) => q.eq('owner_id', ownerId).eq('is_deleted', false))
+        .take(FACTION_LIMIT)
+    : await ctx.db
+        .query('factions')
+        .withIndex('by_deleted', (q) => q.eq('is_deleted', false))
+        .take(FACTION_LIMIT);
+  const rulesets = await listActiveRulesetSummaries(ctx);
+  const linksByFaction = ownerId
+    ? await factionLinksByIndexedReads(ctx, rows)
+    : await factionLinksByScan(ctx);
+  const activeRulesetById = new Map(rulesets.map((ruleset) => [ruleset.id, ruleset]));
 
-  return await Promise.all(
+  const factions = rows.map((row) => ({
+    ...row,
+    data: CanonicalFactionStoredSchema.parse(row.data),
+    rulesets: (linksByFaction.get(row._id) ?? [])
+      .map((rulesetId) => activeRulesetById.get(rulesetId))
+      .filter((ruleset): ruleset is FactionRulesetSummary => ruleset != null)
+      .sort(compareRulesets),
+  }));
+
+  return { factions, rulesets };
+}
+
+async function factionLinksByIndexedReads(ctx: QueryCtx, rows: Doc<'factions'>[]) {
+  const linksByFaction = new Map<Id<'factions'>, Id<'rulesets'>[]>();
+  await Promise.all(
     rows.map(async (row) => {
       const links = await ctx.db
         .query('ruleset_factions')
         .withIndex('by_faction', (q) => q.eq('faction_id', row._id))
         .take(500);
-      const rulesets = links
-        .map((link) => activeRulesetById.get(link.ruleset_id))
-        .filter((ruleset): ruleset is FactionRulesetSummary => ruleset != null)
-        .sort(compareRulesets);
-
-      return {
-        ...row,
-        data: CanonicalFactionStoredSchema.parse(row.data),
-        rulesets,
-      };
+      linksByFaction.set(
+        row._id,
+        links.map((link) => link.ruleset_id)
+      );
     })
   );
+  return linksByFaction;
 }
 
-export async function loadFactionCatalogueSpotlights(ctx: QueryCtx) {
-  const rows = await ctx.db
-    .query('factions')
-    .withIndex('by_deleted', (q) => q.eq('is_deleted', false))
-    .take(500);
-  const rulesets = await listActiveRulesetSummaries(ctx);
-  const factions = await enrichFactionsWithRulesets(ctx, rows, rulesets);
-  return selectFactionCatalogueSpotlights(factions);
+async function factionLinksByScan(ctx: QueryCtx) {
+  const links = await ctx.db.query('ruleset_factions').take(FACTION_LINK_SCAN_LIMIT);
+  const linksByFaction = new Map<Id<'factions'>, Id<'rulesets'>[]>();
+  for (const link of links) {
+    const existing = linksByFaction.get(link.faction_id);
+    if (existing) {
+      existing.push(link.ruleset_id);
+    } else {
+      linksByFaction.set(link.faction_id, [link.ruleset_id]);
+    }
+  }
+  return linksByFaction;
 }
 
 /** Homepage spotlights omit ruleset enrichment because they only render faction identity. */
@@ -65,7 +102,7 @@ export async function loadFactionCatalogueSpotlightPreviews(ctx: QueryCtx) {
   const rows = await ctx.db
     .query('factions')
     .withIndex('by_deleted', (q) => q.eq('is_deleted', false))
-    .take(500);
+    .take(FACTION_LIMIT);
   const selected = selectFactionCatalogueSpotlights(rows);
   const preview = (row: Doc<'factions'> | null) => {
     if (!row) {

--- a/convex/lib/profileDetail.ts
+++ b/convex/lib/profileDetail.ts
@@ -1,5 +1,5 @@
 import type { QueryCtx } from '../types';
-import { enrichFactionsWithRulesets, listActiveRulesetSummaries } from './factionCatalogue';
+import { loadFactionCatalogue } from './factionCatalogue';
 import { loadFaqAnswersGivenBy, loadFaqQuestionsAskedBy } from './faqProfileActivity';
 
 const PROFILE_DETAIL_LIMIT = 500;
@@ -43,12 +43,7 @@ export async function loadProfileDetailBySlug(ctx: QueryCtx, slug: string) {
     loadFaqAnswersGivenBy(ctx, profile.user_id),
   ]);
 
-  const factionRows = await ctx.db
-    .query('factions')
-    .withIndex('by_owner_deleted', (q) => q.eq('owner_id', profile.user_id).eq('is_deleted', false))
-    .take(PROFILE_DETAIL_LIMIT);
-  const activeRulesets = await listActiveRulesetSummaries(ctx);
-  const factions = await enrichFactionsWithRulesets(ctx, factionRows, activeRulesets);
+  const { factions } = await loadFactionCatalogue(ctx, { ownerId: profile.user_id });
 
   return {
     profile,


### PR DESCRIPTION
Closes #237 — the last issue from the 2026-08-06 verification/review cluster.

- **One deep entry point**: `loadFactionCatalogue(ctx, { ownerId? })` returns `{ factions, rulesets }`; the two-call protocol (`listActiveRulesetSummaries` then `enrichFactionsWithRulesets` in the right order) is now implementation, not interface. Both callers — the public Faction catalogue and the profile detail read model — migrate to the single call.
- **Batched enrichment**: the catalogue path reads `ruleset_factions` in **one bounded scan** grouped by faction id, replacing up to 500 per-faction indexed reads. Per the issue's own risk note, the owner path (profile detail) keeps parallel indexed point reads — for one owner's handful of factions the index wins over a whole-table scan. The scan bound (5000 links) is documented in-code and mirrors the per-faction caps it replaces.
- **Dead code deleted**: `loadFactionCatalogueSpotlights` (no callers, and the expensive variant).
- **Sequential loops parallelized**: the two `await`-in-`for` per-entity loads in the collaborative-access bundles (group lookups in `loadAssetAccessBundle`, profile lookups in `loadGroupAccessBundle`) now `Promise.all` — up to ~500 serialized round-trips per Group page become one parallel batch.

Per ADR-0002, no new tests: the existing boundary suites already pin both callers' output including enrichment content and ordering (`factions.catalogue.test.ts`, `profiles.detail.test.ts`), and all 428 pass unchanged against the batched implementation — that *is* the characterization evidence. The constant-read property is guaranteed by construction (one scan), which beats asserting it.

Out of scope, as the issue states: the `profiles.list` count fan-out (a denormalized-counter/aggregate decision).

Gates: `bun run test` (428), `typecheck`, `lint`, `format:check`, `publisher:release:verify`; bindings regenerated. Wire shapes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)