### PR TITLE
Deepen faction authoring into a tested session boundary

### DIFF
--- a/src/app/components/factions/editor/factionAuthoringContract.test.ts
+++ b/src/app/components/factions/editor/factionAuthoringContract.test.ts
@@ -50,32 +50,6 @@ describe('faction authoring contract', () => {
     ).toBe(true);
   });
 
-  it('preserves loaded extras byte-for-byte even if submitted form values are changed', () => {
-    const baseline = {
-      ...structuredClone(defaultFaction),
-      extras: [
-        {
-          name: 'Existing TTS content',
-          description: 'Not owned by the editor',
-          items: [{ url: 'https://example.com/item.png', description: 'Existing item' }],
-        },
-      ],
-    };
-    const values = {
-      ...structuredClone(baseline),
-      name: 'Edited faction',
-      extras: [{ name: 'Changed', items: [] }],
-    };
-    const baselineExtrasBytes = JSON.stringify(baseline.extras);
-
-    const submitted = preserveFactionExtras(values, baseline);
-
-    expect(submitted.name).toBe('Edited faction');
-    expect(submitted.extras).toEqual(baseline.extras);
-    expect(submitted.extras).not.toBe(baseline.extras);
-    expect(JSON.stringify(submitted.extras)).toBe(baselineExtrasBytes);
-  });
-
   it('round-trips optional and uncommon schema data without dropping it', () => {
     const baseline = structuredClone(defaultFaction);
     baseline.planet = [

--- a/src/app/components/factions/editor/factionAuthoringSession.test.ts
+++ b/src/app/components/factions/editor/factionAuthoringSession.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import type { Faction, FactionEntry } from '@db/factions';
+
+import { assetPublishingFaction } from '../../../../game/fixtures/assetPublishingFaction';
+import { createFactionAuthoringSession } from './factionAuthoringSession';
+
+function makeHarness(overrides?: { save?: (draft: unknown) => Promise<FactionEntry> }) {
+  const formResets: Array<{ values: Faction; options?: { keepDefaultValues?: boolean } }> = [];
+  const form = {
+    reset: (values: Faction, options?: { keepDefaultValues?: boolean }) => {
+      formResets.push({ values, options });
+    },
+    markLoadedDraftDirty: vi.fn(),
+  };
+  const persistenceReset = vi.fn();
+  const savedEntries: FactionEntry[] = [];
+  const errorsLog: string[][] = [];
+
+  const baseline = structuredClone(assetPublishingFaction);
+  const save =
+    overrides?.save ??
+    (async (draft: unknown) => ({ data: draft, slug: 'saved' }) as unknown as FactionEntry);
+
+  const session = createFactionAuthoringSession({
+    initialData: baseline,
+    form,
+    persistence: { save: save as never, reset: persistenceReset },
+    onSaved: (entry) => savedEntries.push(entry),
+    onErrors: (errors) => errorsLog.push(errors),
+  });
+
+  return { session, formResets, form, persistenceReset, savedEntries, errorsLog, baseline };
+}
+
+describe('faction authoring session', () => {
+  test('a valid save replaces the baseline with the canonical result', async () => {
+    const { session, formResets, savedEntries, errorsLog } = makeHarness();
+    const draft = { ...structuredClone(assetPublishingFaction), name: 'Edited' };
+
+    await session.persistDraft(draft);
+
+    expect(errorsLog.at(-1)).toEqual([]);
+    expect(savedEntries).toHaveLength(1);
+    expect(formResets.at(-1)?.values.name).toBe('Edited');
+    expect(session.savedBaseline.name).toBe('Edited');
+  });
+
+  test('an invalid draft blocks persistence and exposes validation errors', async () => {
+    const saveSpy = vi.fn();
+    const { session, savedEntries, errorsLog } = makeHarness({ save: saveSpy as never });
+
+    await session.persistDraft({ ...structuredClone(assetPublishingFaction), name: 42 as never });
+
+    expect(saveSpy).not.toHaveBeenCalled();
+    expect(savedEntries).toHaveLength(0);
+    expect(errorsLog.at(-1)?.[0]).toMatch(/name/);
+  });
+
+  test('a failed save preserves the draft baseline and exposes a stable error', async () => {
+    const { session, errorsLog, baseline } = makeHarness({
+      save: async () => {
+        throw new Error('Convex is unreachable');
+      },
+    });
+
+    await session.persistDraft({ ...structuredClone(assetPublishingFaction), name: 'Edited' });
+
+    expect(errorsLog.at(-1)).toEqual(['Convex is unreachable']);
+    expect(session.savedBaseline.name).toBe(baseline.name);
+  });
+
+  test('loading a draft stays local: marks dirty, resets errors, never saves', () => {
+    const { session, form, formResets, persistenceReset, savedEntries } = makeHarness();
+    const loaded = { ...structuredClone(assetPublishingFaction), name: 'Loaded B' };
+
+    session.loadDraft(loaded);
+
+    expect(formResets.at(-1)).toMatchObject({
+      values: { name: 'Loaded B' },
+      options: { keepDefaultValues: true },
+    });
+    expect(form.markLoadedDraftDirty).toHaveBeenCalledOnce();
+    expect(persistenceReset).toHaveBeenCalledOnce();
+    expect(savedEntries).toHaveLength(0);
+    expect(session.savedBaseline.name).not.toBe('Loaded B');
+  });
+
+  test('reset returns to the last saved baseline, including after a save', async () => {
+    const { session, formResets } = makeHarness();
+    await session.persistDraft({ ...structuredClone(assetPublishingFaction), name: 'Saved once' });
+    session.loadDraft({ ...structuredClone(assetPublishingFaction), name: 'Loaded B' });
+
+    session.reset();
+
+    expect(formResets.at(-1)?.values.name).toBe('Saved once');
+  });
+
+  test('a save after loading a draft preserves stored extras from the loaded source', async () => {
+    const { session, savedEntries } = makeHarness();
+    const extras = [{ name: 'Tokens', items: [] }];
+    const withExtras = { ...structuredClone(assetPublishingFaction), extras };
+    session.loadDraft(withExtras);
+
+    await session.persistDraft({ ...structuredClone(assetPublishingFaction), name: 'Edited' });
+
+    expect(savedEntries).toHaveLength(1);
+    const savedData = savedEntries[0]?.data as { extras?: unknown } | undefined;
+    expect(savedData?.extras).toEqual(extras);
+  });
+
+  test('switching source replaces both baselines without saving the previous draft', () => {
+    const { session, formResets, persistenceReset, savedEntries } = makeHarness();
+    const next = { ...structuredClone(assetPublishingFaction), name: 'Other faction' };
+
+    session.switchSource(next);
+
+    expect(formResets.at(-1)?.values.name).toBe('Other faction');
+    expect(session.savedBaseline.name).toBe('Other faction');
+    expect(persistenceReset).toHaveBeenCalledOnce();
+    expect(savedEntries).toHaveLength(0);
+  });
+});

--- a/src/app/components/factions/editor/factionAuthoringSession.ts
+++ b/src/app/components/factions/editor/factionAuthoringSession.ts
@@ -1,0 +1,108 @@
+import type { Faction, FactionEntry } from '@db/factions';
+import { FactionInputSchema } from '@game/schema/faction';
+
+import { preserveFactionExtras } from './factionAuthoringContract';
+
+/** The two form operations the session needs; the React form adapter satisfies this. */
+export type FactionFormPort = {
+  reset: (values: Faction, options?: { keepDefaultValues?: boolean }) => void;
+  markLoadedDraftDirty: () => void;
+};
+
+export type FactionSessionPersistencePort = {
+  save: (draft: Faction) => Promise<FactionEntry>;
+  reset: () => void;
+};
+
+function formatZodIssues(error: {
+  issues: readonly { path: PropertyKey[]; message: string }[];
+}): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.map((segment) => String(segment)).join('.') || '(root)';
+      return `${path}: ${issue.message}`;
+    })
+    .join('\n');
+}
+
+/**
+ * Faction authoring session: a framework-free machine owning the baselines (saved canonical vs.
+ * loaded draft source), extras preservation, canonical validation, save lifecycle, and source
+ * switching. React hosts only the rendering-bound form; the session drives it through
+ * `FactionFormPort`. Testable in plain vitest with fake ports (ADR-0002).
+ */
+export function createFactionAuthoringSession({
+  initialData,
+  form,
+  persistence,
+  onSaved,
+  onErrors,
+}: {
+  initialData: Faction;
+  form: FactionFormPort;
+  persistence: FactionSessionPersistencePort;
+  onSaved: (entry: FactionEntry) => void;
+  onErrors: (errors: string[]) => void;
+}) {
+  let savedBaseline = structuredClone(initialData);
+  let draftSource = savedBaseline;
+
+  return {
+    /** The values `reset` returns to; replaced by the canonical result of each successful save. */
+    get savedBaseline(): Faction {
+      return savedBaseline;
+    },
+
+    async persistDraft(value: Faction): Promise<void> {
+      const parsed = FactionInputSchema.safeParse(preserveFactionExtras(value, draftSource));
+      if (!parsed.success) {
+        onErrors([formatZodIssues(parsed.error)]);
+        return;
+      }
+
+      onErrors([]);
+      let entry: FactionEntry;
+      try {
+        entry = await persistence.save(parsed.data);
+      } catch (error) {
+        onErrors([error instanceof Error ? error.message : 'The faction could not be saved.']);
+        return;
+      }
+
+      const canonical = structuredClone(entry.data);
+      savedBaseline = canonical;
+      draftSource = canonical;
+      form.reset(canonical);
+      onSaved(entry);
+    },
+
+    loadDraft(draft: Faction): void {
+      const next = structuredClone(draft);
+      draftSource = next;
+      form.reset(next, { keepDefaultValues: true });
+      form.markLoadedDraftDirty();
+      persistence.reset();
+      onErrors([]);
+    },
+
+    reset(): void {
+      const baseline = structuredClone(savedBaseline);
+      draftSource = baseline;
+      form.reset(baseline);
+      persistence.reset();
+      onErrors([]);
+    },
+
+    /** Intentional change to another faction source; never silently saves the previous draft. */
+    switchSource(nextInitialData: Faction): void {
+      const next = structuredClone(nextInitialData);
+      savedBaseline = next;
+      draftSource = next;
+      form.reset(next);
+      persistence.reset();
+      onErrors([]);
+    },
+  };
+}
+
+export type FactionAuthoringSession = ReturnType<typeof createFactionAuthoringSession>;

--- a/src/app/components/factions/editor/useFactionAuthoring.ts
+++ b/src/app/components/factions/editor/useFactionAuthoring.ts
@@ -3,9 +3,9 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { Faction, FactionEntry } from '@db/factions';
 import type { FactionSaveState } from '@app/factions/authoringState';
-import { FactionInputSchema } from '@game/schema/faction';
 
-import { factionAuthoringWarnings, preserveFactionExtras } from './factionAuthoringContract';
+import { factionAuthoringWarnings } from './factionAuthoringContract';
+import { createFactionAuthoringSession } from './factionAuthoringSession';
 
 export type FactionAuthoringPersistence = {
   save: (draft: Faction) => Promise<FactionEntry>;
@@ -14,17 +14,6 @@ export type FactionAuthoringPersistence = {
   hasSaved: boolean;
   reset: () => void;
 };
-
-function formatZodIssues(error: {
-  issues: readonly { path: PropertyKey[]; message: string }[];
-}): string {
-  return error.issues
-    .map((issue) => {
-      const path = issue.path.map((segment) => String(segment)).join('.') || '(root)';
-      return `${path}: ${issue.message}`;
-    })
-    .join('\n');
-}
 
 export function useFactionAuthoring({
   sessionKey,
@@ -40,9 +29,11 @@ export function useFactionAuthoring({
   const sessionKeyRef = useRef(sessionKey);
   const initialBaselineRef = useRef<Faction>(undefined);
   initialBaselineRef.current ??= structuredClone(initialData);
-  const savedBaselineRef = useRef(initialBaselineRef.current);
-  const draftSourceRef = useRef(initialBaselineRef.current);
   const [errors, setErrors] = useState<string[]>([]);
+
+  const sessionRef = useRef<ReturnType<typeof createFactionAuthoringSession>>(undefined);
+  const latestRef = useRef({ persistence, onSaved });
+  latestRef.current = { persistence, onSaved };
 
   const form = useForm<
     Faction,
@@ -58,48 +49,33 @@ export function useFactionAuthoring({
     undefined,
     undefined
   >({
-    defaultValues: savedBaselineRef.current,
-    onSubmit: async ({ value }) => await persistDraft(value),
+    defaultValues: initialBaselineRef.current,
+    onSubmit: async ({ value }) => await sessionRef.current?.persistDraft(value),
   });
 
-  async function persistDraft(value: Faction) {
-    const parsed = FactionInputSchema.safeParse(
-      preserveFactionExtras(value, draftSourceRef.current)
-    );
-    if (!parsed.success) {
-      setErrors([formatZodIssues(parsed.error)]);
-      return;
-    }
-
-    setErrors([]);
-    let entry: FactionEntry;
-    try {
-      entry = await persistence.save(parsed.data);
-    } catch (error) {
-      setErrors([error instanceof Error ? error.message : 'The faction could not be saved.']);
-      return;
-    }
-
-    const canonical = structuredClone(entry.data);
-    savedBaselineRef.current = canonical;
-    draftSourceRef.current = canonical;
-    form.reset(canonical);
-    onSaved(entry);
-  }
+  sessionRef.current ??= createFactionAuthoringSession({
+    initialData,
+    form: {
+      reset: (values, options) => form.reset(values, options),
+      markLoadedDraftDirty: () =>
+        form.setFieldMeta('name', (meta) => ({ ...meta, isDirty: true, isTouched: true })),
+    },
+    persistence: {
+      save: (draft) => latestRef.current.persistence.save(draft),
+      reset: () => latestRef.current.persistence.reset(),
+    },
+    onSaved: (entry) => latestRef.current.onSaved(entry),
+    onErrors: setErrors,
+  });
+  const session = sessionRef.current;
 
   useEffect(() => {
     if (sessionKeyRef.current === sessionKey) {
       return;
     }
-
     sessionKeyRef.current = sessionKey;
-    const next = structuredClone(initialData);
-    savedBaselineRef.current = next;
-    draftSourceRef.current = next;
-    form.reset(next);
-    persistence.reset();
-    setErrors([]);
-  }, [form, initialData, persistence, sessionKey]);
+    session.switchSource(initialData);
+  }, [initialData, session, sessionKey]);
 
   const editing = useStore(form.store, (state) => ({
     isDirty: state.isDirty,
@@ -107,26 +83,8 @@ export function useFactionAuthoring({
     warnings: factionAuthoringWarnings(state.values),
   }));
 
-  const loadDraft = useCallback(
-    (draft: Faction) => {
-      const next = structuredClone(draft);
-      draftSourceRef.current = next;
-      form.reset(next, { keepDefaultValues: true });
-      form.setFieldMeta('name', (meta) => ({ ...meta, isDirty: true, isTouched: true }));
-      persistence.reset();
-      setErrors([]);
-    },
-    [form, persistence]
-  );
-
-  const reset = useCallback(() => {
-    const baseline = structuredClone(savedBaselineRef.current);
-    draftSourceRef.current = baseline;
-    form.reset(baseline);
-    persistence.reset();
-    setErrors([]);
-  }, [form, persistence]);
-
+  const loadDraft = useCallback((draft: Faction) => session.loadDraft(draft), [session]);
+  const reset = useCallback(() => session.reset(), [session]);
   const submit = useCallback(async () => await form.handleSubmit(), [form]);
 
   const saveState: FactionSaveState = persistence.isPending


### PR DESCRIPTION
Closes #203

## The two shapes, compared (as the issue mandates)

**Shape A — framework-free session owning a headless `FormApi`** (`@tanstack/form-core`): probed first, rejected on evidence. The editor tree consumes `form.Field`/`form.Subscribe` React components throughout the section files — those exist only on the React-extended API that `useForm` creates, so a headless `FormApi` cannot serve the rendering layer without rewrapping the whole editor.

**Shape B — chosen: framework-free session machine + form port.** Everything the issue lists as session-owned — baseline/source tracking, extras preservation, canonical validation, remote save errors, canonical reset after persistence, session switching — lives in `createFactionAuthoringSession`, a plain closure with no React imports. It touches the form through a two-method port (`reset`, `markLoadedDraftDirty`); the spike showed those are the *only* form operations any transition performs. React keeps hosting exactly what is genuinely render-bound.

## What changed

- **`factionAuthoringSession.ts`** — the session machine; smallest useful caller surface (`persistDraft`, `loadDraft`, `reset`, `switchSource`, `savedBaseline`).
- **`useFactionAuthoring.ts`** — now a thin adapter: creates the form, builds the port, delegates every transition. **Public surface unchanged** — both routes, both stories, and `FactionEditor` are untouched.
- **`factionAuthoringSession.test.ts`** — 7 transition tests in plain vitest (fake ports, no jsdom, no renderHook): valid save replaces the baseline with the canonical result; invalid draft blocks persistence with validation errors; failed save preserves the draft baseline with a stable error; loading a draft stays local (marks dirty, never saves); reset returns to the last *saved* baseline; save-after-load preserves stored extras through the real transition; source switching replaces both baselines without saving the previous draft. This is the "no test exercises the real session" gap closed at the level the issue asked for.
- **One superseded helper test deleted** (direct `preserveFactionExtras` call — now covered through the transition). The rest stay deliberately: the round-trip suites pin `FactionInputSchema` semantics, the warnings tests pin warning content, and the coverage-contract test is schema governance — none are session behavior.

## Verification

`bun run test` (434), `typecheck`, `lint`, `format:check`, `publisher:release:verify` — and the full local e2e suite **5/5**, where the faction-lifecycle spec drives the rewired hook through create, load-draft, reset, warning focus, name blocking, and save in a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved faction authoring with reliable draft loading, resetting, source switching, and save workflows.
  * Preserves additional faction data while applying form edits.
  * Provides clearer validation and persistence error handling.
  * Updates saved state immediately after successful saves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->