### PR TITLE
Define one owned browser-capture lifecycle contract

### DIFF
--- a/src/app/capture/PublisherFactionSheetCapture.tsx
+++ b/src/app/capture/PublisherFactionSheetCapture.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { FactionSheetView } from '@app/components/factions/sheet/FactionSheetView';
 import type { FactionInput } from '@game/schema/faction';
 
+import { CAPTURE_PROTOCOL } from '../../shared/asset-publishing/capture-protocol';
 import { publisherCaptureSnapshotSchema } from '../../shared/asset-publishing/publisher-snapshot';
 import { publisherErrorMessage, redactPublisherResource } from './publisher-diagnostics';
 import { assertRequiredPublisherFonts } from './publisher-fonts';
@@ -162,7 +163,7 @@ export function PublisherFactionSheetCapture() {
     );
     void (async () => {
       try {
-        const response = await fetch('/__asset-publisher/snapshot', {
+        const response = await fetch(CAPTURE_PROTOCOL.paths.snapshot, {
           cache: 'no-store',
           credentials: 'same-origin',
           signal: controller.signal,
@@ -231,9 +232,11 @@ export function PublisherFactionSheetCapture() {
   return (
     <>
       <output
-        id="capture-status"
-        data-capture-state={state}
-        data-payload-hash={payloadHash}
+        id={CAPTURE_PROTOCOL.marker.id}
+        {...{
+          [CAPTURE_PROTOCOL.marker.stateAttribute]: state,
+          [CAPTURE_PROTOCOL.marker.payloadHashAttribute]: payloadHash,
+        }}
         aria-live="polite"
         hidden
       >

--- a/src/app/components/factions/editor/FactionSheetPagePreview.tsx
+++ b/src/app/components/factions/editor/FactionSheetPagePreview.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 
 import type { Faction } from '@db/factions';
 
+import { CAPTURE_PROTOCOL } from '../../../../shared/asset-publishing/capture-protocol';
 import { FactionSheetView } from '../sheet/FactionSheetView';
 import styles from './FactionSheetPagePreview.module.css';
 
@@ -36,7 +37,9 @@ function alignIframePage(iframe: HTMLIFrameElement | null, pageNumber: 1 | 2) {
   if (!document) {
     return;
   }
-  const target = document.querySelector<HTMLElement>(`[data-faction-sheet-page="${pageNumber}"]`);
+  const target = document.querySelector<HTMLElement>(
+    `[${CAPTURE_PROTOCOL.pageMarker.attribute}="${pageNumber}"]`
+  );
   if (!target) {
     return;
   }

--- a/src/game/assets/faction/sheet/Sheet.tsx
+++ b/src/game/assets/faction/sheet/Sheet.tsx
@@ -1,5 +1,6 @@
 import type { z } from 'zod';
 
+import { CAPTURE_PROTOCOL } from '../../../../shared/asset-publishing/capture-protocol';
 import { MarkdownContent } from '../../../components/block/MarkdownContent';
 import type { FactionRender } from '../../../schema/faction';
 import { isLight } from '../../utils/contrast';
@@ -39,7 +40,7 @@ export const FactionSheet = (props: SheetProps) => {
 
 export function FactionSheetPage1(props: SheetProps) {
   return (
-    <div className={styles.page} data-faction-sheet-page="1">
+    <div className={styles.page} {...{ [CAPTURE_PROTOCOL.pageMarker.attribute]: '1' }}>
       <div className={`${styles.page_title} ${styles.title}`}>{props.name}</div>
       <div className={styles.logo}>
         <Token logo={props.logo} background={props.background} />
@@ -103,7 +104,7 @@ export function FactionSheetPage2(props: SheetProps) {
       {props.rules.advantages.filter((r) => !!r.karama).length > 0 ||
       props.troops.length > 0 ||
       props.leaders.length > 0 ? (
-        <div className={styles.page} data-faction-sheet-page="2">
+        <div className={styles.page} {...{ [CAPTURE_PROTOCOL.pageMarker.attribute]: '2' }}>
           <div className={`${styles.page_subtitle} ${styles.subtitle}`}>Karama effects</div>
           <div className={styles.details}>
             <div className={styles.karama}>

--- a/src/shared/asset-publishing/capture-protocol.ts
+++ b/src/shared/asset-publishing/capture-protocol.ts
@@ -1,0 +1,49 @@
+/**
+ * The one owner of the browser-capture handshake vocabulary (#201). The capture route, the browser
+ * driver, the React capture document, and the Chromium regression all consume these values by
+ * import; none may hard-code a path, cookie name, marker selector, attribute, or state string
+ * locally. Changing any value here is a cross-runtime protocol change: keep it backward-compatible
+ * during rollout or deploy all consumers atomically.
+ */
+export const CAPTURE_PROTOCOL = {
+  version: 1,
+  paths: {
+    /** Authenticated Worker route serving the capture document. */
+    document: '/__asset-publisher/capture',
+    /** Authenticated Worker route serving the validated snapshot envelope. */
+    snapshot: '/__asset-publisher/snapshot',
+    /** Renderer-owned isolated bundle document (also served gated by the route). */
+    bundleDocument: '/publisher-capture.html',
+    /** Prefix for the bundle's hashed assets. */
+    bundleAssetPrefix: '/publisher-capture/',
+  },
+  credentials: {
+    jobHeader: 'X-Publication-Job',
+    jobCookie: '__Host-publication_job',
+    deadlineCookie: '__Host-asset_render_deadline',
+  },
+  marker: {
+    id: 'capture-status',
+    selector: '#capture-status',
+    stateAttribute: 'data-capture-state',
+    payloadHashAttribute: 'data-payload-hash',
+  },
+  states: {
+    loading: 'loading',
+    ready: 'ready',
+    failed: 'error',
+  },
+  pageMarker: {
+    attribute: 'data-faction-sheet-page',
+    selector: '[data-faction-sheet-page]',
+  },
+} as const;
+
+export type CaptureMarkerState =
+  (typeof CAPTURE_PROTOCOL.states)[keyof typeof CAPTURE_PROTOCOL.states];
+
+const PAYLOAD_HASH_PATTERN = /^[0-9a-f]{64}$/;
+
+export function isCapturePayloadHash(value: string | null): value is string {
+  return value !== null && PAYLOAD_HASH_PATTERN.test(value);
+}

--- a/workers/publisher/browser.ts
+++ b/workers/publisher/browser.ts
@@ -12,6 +12,12 @@ import {
   redactPublisherResource,
   sanitizePublisherDiagnostic,
 } from '../../src/app/capture/publisher-diagnostics';
+import { CAPTURE_PROTOCOL } from '../../src/shared/asset-publishing/capture-protocol';
+import {
+  assertCapturePhysicalBounds,
+  assertReadyCaptureMarker,
+  waitForCaptureMarkerSettled,
+} from './capture-lifecycle';
 import { captureDeadlineCookie, captureJobCookie } from './capture-route';
 import { inspectChromiumPdf } from './pdf-inspection';
 import { PUBLISHER_RENDERER_CONTRACT } from './renderer-contract';
@@ -145,44 +151,6 @@ export async function inspectPublisherPdf(bytes: Uint8Array) {
   }
 }
 
-async function assertPageBounds(page: Page, deadline: number): Promise<void> {
-  await page.emulateMedia({ media: 'print' });
-  const margins = await page.evaluate(() => {
-    const browserGlobal = globalThis as typeof globalThis & {
-      document: { body: unknown };
-      getComputedStyle(element: unknown): {
-        marginTop: string;
-        marginRight: string;
-        marginBottom: string;
-        marginLeft: string;
-      };
-    };
-    const style = browserGlobal.getComputedStyle(browserGlobal.document.body);
-    return [style.marginTop, style.marginRight, style.marginBottom, style.marginLeft];
-  });
-  if (margins.some((margin) => margin !== '0px')) {
-    throw new Error(`Capture document body margins are not zero: ${margins.join(' ')}`);
-  }
-  const width = (PDF_CONTRACT.pageWidthMm * 96) / 25.4;
-  const height = (PDF_CONTRACT.pageHeightMm * 96) / 25.4;
-  const pages = page.locator('[data-faction-sheet-page]');
-  if ((await pages.count()) !== PDF_CONTRACT.pageCount) {
-    throw new Error(`Capture route did not render exactly ${PDF_CONTRACT.pageCount} pages`);
-  }
-  for (let index = 0; index < PDF_CONTRACT.pageCount; index += 1) {
-    const bounds = await pages.nth(index).boundingBox({ timeout: remaining(deadline) });
-    if (
-      !bounds ||
-      Math.abs(bounds.x) > 0.5 ||
-      Math.abs(bounds.y - index * height) > 0.5 ||
-      Math.abs(bounds.width - width) > 0.5 ||
-      Math.abs(bounds.height - height) > 0.5
-    ) {
-      throw new Error(`Capture page ${index + 1} has invalid physical bounds`);
-    }
-  }
-}
-
 export class PublisherBrowserSession {
   constructor(
     private readonly browser: Browser,
@@ -210,41 +178,17 @@ export class PublisherBrowserSession {
       const page = await context.newPage();
       const diagnostics = registerCaptureDiagnostics(page);
       phase = 'load';
-      const response = await page.goto(`${this.captureBaseUrl}/__asset-publisher/capture`, {
+      const response = await page.goto(`${this.captureBaseUrl}${CAPTURE_PROTOCOL.paths.document}`, {
         waitUntil: 'domcontentloaded',
         timeout: remaining(deadline),
       });
       if (!response?.ok()) {
         throw new Error(`Capture navigation returned HTTP ${response?.status()}`);
       }
-      const marker = page.locator('#capture-status');
-      await marker.waitFor({ state: 'attached', timeout: remaining(deadline) });
-      await page.waitForFunction(
-        () => {
-          const browserGlobal = globalThis as typeof globalThis & {
-            document: {
-              querySelector(selector: string): { getAttribute(name: string): string | null } | null;
-            };
-          };
-          return (
-            browserGlobal.document
-              .querySelector('#capture-status')
-              ?.getAttribute('data-capture-state') !== 'loading'
-          );
-        },
-        undefined,
-        { timeout: remaining(deadline) }
-      );
-      const state = await marker.getAttribute('data-capture-state');
-      if (state !== 'ready') {
-        throw new Error(`Capture route reported ${state}: ${await marker.textContent()}`);
-      }
-      const payloadHash = await marker.getAttribute('data-payload-hash');
-      if (!payloadHash || !/^[0-9a-f]{64}$/.test(payloadHash)) {
-        throw new Error('Capture route did not expose the exact payload hash');
-      }
+      const markerResult = await waitForCaptureMarkerSettled(page, () => remaining(deadline));
+      const payloadHash = assertReadyCaptureMarker(markerResult);
       phase = 'validate';
-      await assertPageBounds(page, deadline);
+      await assertCapturePhysicalBounds(page, () => remaining(deadline));
       assertCaptureDiagnostics(diagnostics);
       phase = 'pdf';
       const bytes = await page.pdf({

--- a/workers/publisher/capture-contract-regression.ts
+++ b/workers/publisher/capture-contract-regression.ts
@@ -4,6 +4,8 @@ import { chromium } from 'playwright';
 import type { Browser, Page } from 'playwright';
 
 import { assetPublishingFaction } from '../../src/game/fixtures/assetPublishingFaction';
+import { CAPTURE_PROTOCOL } from '../../src/shared/asset-publishing/capture-protocol';
+import { assertCapturePhysicalBounds, waitForCaptureMarkerSettled } from './capture-lifecycle';
 import { inspectChromiumPdf } from './pdf-inspection';
 import { PUBLISHER_RENDERER_CONTRACT } from './renderer-contract';
 
@@ -31,10 +33,13 @@ const server = Bun.serve({
   port: 0,
   async fetch(request) {
     const pathname = decodeURIComponent(new URL(request.url).pathname);
-    if (pathname === '/__asset-publisher/snapshot') {
+    if (pathname === CAPTURE_PROTOCOL.paths.snapshot) {
       return Response.json(snapshot, { headers: { 'Cache-Control': 'no-store' } });
     }
-    const relative = pathname === '/' ? 'publisher-capture.html' : pathname.replace(/^\/+/, '');
+    const relative =
+      pathname === '/'
+        ? CAPTURE_PROTOCOL.paths.bundleDocument.slice(1)
+        : pathname.replace(/^\/+/, '');
     if (relative.split('/').includes('..')) {
       return new Response('Not found', { status: 404 });
     }
@@ -51,26 +56,12 @@ function newPublisherPage(browser: Browser): Promise<Page> {
   });
 }
 
-async function waitForCaptureResult(page: Page): Promise<{
-  detail: string;
-  payloadHash: string | null;
-  state: string | null;
-}> {
-  const marker = page.locator('#capture-status');
-  await marker.waitFor({ state: 'attached' });
-  await page.waitForFunction(
-    () =>
-      document.querySelector('#capture-status')?.getAttribute('data-capture-state') !== 'loading'
-  );
-  return {
-    detail: (await marker.textContent()) ?? '',
-    payloadHash: await marker.getAttribute('data-payload-hash'),
-    state: await marker.getAttribute('data-capture-state'),
-  };
+function waitForCaptureResult(page: Page) {
+  return waitForCaptureMarkerSettled(page);
 }
 
 async function openCapture(page: Page) {
-  await page.goto(`http://127.0.0.1:${server.port}/publisher-capture.html`, {
+  await page.goto(`http://127.0.0.1:${server.port}${CAPTURE_PROTOCOL.paths.bundleDocument}`, {
     waitUntil: 'domcontentloaded',
   });
   return await waitForCaptureResult(page);
@@ -109,28 +100,7 @@ async function checkCorruptExternalUse(browser: Browser): Promise<void> {
 }
 
 async function assertPageBounds(page: Page): Promise<void> {
-  await page.emulateMedia({ media: 'print' });
-  const bodyMargin = await page.evaluate(() => getComputedStyle(document.body).margin);
-  invariant(bodyMargin === '0px', `Publisher body margin was ${bodyMargin}`);
-
-  const expectedWidthPx = (PUBLISHER_RENDERER_CONTRACT.pdf.pageWidthMm * 96) / 25.4;
-  const expectedHeightPx = (PUBLISHER_RENDERER_CONTRACT.pdf.pageHeightMm * 96) / 25.4;
-  const pages = page.locator('[data-faction-sheet-page]');
-  invariant(
-    (await pages.count()) === PUBLISHER_RENDERER_CONTRACT.pdf.pageCount,
-    `Production-shaped capture did not render exactly ${PUBLISHER_RENDERER_CONTRACT.pdf.pageCount} pages`
-  );
-  for (let index = 0; index < PUBLISHER_RENDERER_CONTRACT.pdf.pageCount; index += 1) {
-    const bounds = await pages.nth(index).boundingBox();
-    invariant(bounds, `Production-shaped capture page ${index + 1} had no bounds`);
-    invariant(
-      Math.abs(bounds.x) <= 0.5 &&
-        Math.abs(bounds.y - index * expectedHeightPx) <= 0.5 &&
-        Math.abs(bounds.width - expectedWidthPx) <= 0.5 &&
-        Math.abs(bounds.height - expectedHeightPx) <= 0.5,
-      `Production-shaped capture page ${index + 1} bounds were ${JSON.stringify(bounds)}`
-    );
-  }
+  await assertCapturePhysicalBounds(page);
   invariant(
     (await page.locator('[aria-label="Troop Token"]').count()) > 0,
     'Production-shaped capture must render omitted troop modifiers as bounded TroopToken components'

--- a/workers/publisher/capture-lifecycle.ts
+++ b/workers/publisher/capture-lifecycle.ts
@@ -1,0 +1,130 @@
+import {
+  CAPTURE_PROTOCOL,
+  isCapturePayloadHash,
+} from '../../src/shared/asset-publishing/capture-protocol';
+import { PUBLISHER_RENDERER_CONTRACT } from './renderer-contract';
+
+const { pdf: PDF_CONTRACT } = PUBLISHER_RENDERER_CONTRACT;
+
+/**
+ * Structural page surface shared by @cloudflare/playwright (production driver) and playwright
+ * (Chromium regression), so both runtimes execute the same lifecycle implementation instead of
+ * reimplementing marker waits and physical-bounds checks.
+ */
+type CaptureLocator = {
+  waitFor(options?: { state?: 'attached'; timeout?: number }): Promise<unknown>;
+  getAttribute(name: string, options?: { timeout?: number }): Promise<string | null>;
+  textContent(options?: { timeout?: number }): Promise<string | null>;
+  count(): Promise<number>;
+  nth(index: number): CaptureLocator;
+  boundingBox(options?: {
+    timeout?: number;
+  }): Promise<{ x: number; y: number; width: number; height: number } | null>;
+};
+
+export type CapturePage = {
+  locator(selector: string): CaptureLocator;
+  waitForFunction<Arg>(
+    fn: (arg: Arg) => unknown,
+    arg: Arg,
+    options?: { timeout?: number }
+  ): Promise<unknown>;
+  evaluate<Result>(fn: () => Result): Promise<Result>;
+  emulateMedia(options: { media: 'print' }): Promise<unknown>;
+};
+
+export type CaptureMarkerResult = {
+  state: string | null;
+  payloadHash: string | null;
+  detail: string;
+};
+
+/** Waits until the capture document leaves `loading`, then reads the marker verbatim. */
+export async function waitForCaptureMarkerSettled(
+  page: CapturePage,
+  timeoutFor: () => number | undefined = () => undefined
+): Promise<CaptureMarkerResult> {
+  const marker = page.locator(CAPTURE_PROTOCOL.marker.selector);
+  await marker.waitFor({ state: 'attached', timeout: timeoutFor() });
+  await page.waitForFunction(
+    (probe) => {
+      const browserGlobal = globalThis as typeof globalThis & {
+        document: {
+          querySelector(selector: string): { getAttribute(name: string): string | null } | null;
+        };
+      };
+      return (
+        browserGlobal.document.querySelector(probe.selector)?.getAttribute(probe.attribute) !==
+        probe.loading
+      );
+    },
+    {
+      selector: CAPTURE_PROTOCOL.marker.selector,
+      attribute: CAPTURE_PROTOCOL.marker.stateAttribute,
+      loading: CAPTURE_PROTOCOL.states.loading,
+    },
+    { timeout: timeoutFor() }
+  );
+  return {
+    state: await marker.getAttribute(CAPTURE_PROTOCOL.marker.stateAttribute),
+    payloadHash: await marker.getAttribute(CAPTURE_PROTOCOL.marker.payloadHashAttribute),
+    detail: (await marker.textContent()) ?? '',
+  };
+}
+
+/** Grants rendering authority: only a ready marker with an exact payload hash may be captured. */
+export function assertReadyCaptureMarker(result: CaptureMarkerResult): string {
+  if (result.state !== CAPTURE_PROTOCOL.states.ready) {
+    throw new Error(`Capture route reported ${result.state}: ${result.detail}`);
+  }
+  if (!isCapturePayloadHash(result.payloadHash)) {
+    throw new Error('Capture route did not expose the exact payload hash');
+  }
+  return result.payloadHash;
+}
+
+/**
+ * The physical page contract: zero body margins and every sheet page exactly at its print position
+ * and size. Shared verbatim by the production driver and the Chromium regression so the two cannot
+ * drift apart.
+ */
+export async function assertCapturePhysicalBounds(
+  page: CapturePage,
+  timeoutFor: () => number | undefined = () => undefined
+): Promise<void> {
+  await page.emulateMedia({ media: 'print' });
+  const margins = await page.evaluate(() => {
+    const browserGlobal = globalThis as typeof globalThis & {
+      document: { body: unknown };
+      getComputedStyle(element: unknown): {
+        marginTop: string;
+        marginRight: string;
+        marginBottom: string;
+        marginLeft: string;
+      };
+    };
+    const style = browserGlobal.getComputedStyle(browserGlobal.document.body);
+    return [style.marginTop, style.marginRight, style.marginBottom, style.marginLeft];
+  });
+  if (margins.some((margin) => margin !== '0px')) {
+    throw new Error(`Capture document body margins are not zero: ${margins.join(' ')}`);
+  }
+  const width = (PDF_CONTRACT.pageWidthMm * 96) / 25.4;
+  const height = (PDF_CONTRACT.pageHeightMm * 96) / 25.4;
+  const pages = page.locator(CAPTURE_PROTOCOL.pageMarker.selector);
+  if ((await pages.count()) !== PDF_CONTRACT.pageCount) {
+    throw new Error(`Capture route did not render exactly ${PDF_CONTRACT.pageCount} pages`);
+  }
+  for (let index = 0; index < PDF_CONTRACT.pageCount; index += 1) {
+    const bounds = await pages.nth(index).boundingBox({ timeout: timeoutFor() });
+    if (
+      !bounds ||
+      Math.abs(bounds.x) > 0.5 ||
+      Math.abs(bounds.y - index * height) > 0.5 ||
+      Math.abs(bounds.width - width) > 0.5 ||
+      Math.abs(bounds.height - height) > 0.5
+    ) {
+      throw new Error(`Capture page ${index + 1} has invalid physical bounds`);
+    }
+  }
+}

--- a/workers/publisher/capture-route.ts
+++ b/workers/publisher/capture-route.ts
@@ -2,11 +2,12 @@ import {
   publisherErrorMessage,
   serializePublisherLogEvent,
 } from '../../src/app/capture/publisher-diagnostics';
+import { CAPTURE_PROTOCOL } from '../../src/shared/asset-publishing/capture-protocol';
 import { readBoundedJson, runWithDeadline } from './http';
 
-const JOB_HEADER = 'X-Publication-Job';
-const JOB_COOKIE = '__Host-publication_job';
-const DEADLINE_COOKIE = '__Host-asset_render_deadline';
+const JOB_HEADER = CAPTURE_PROTOCOL.credentials.jobHeader;
+const JOB_COOKIE = CAPTURE_PROTOCOL.credentials.jobCookie;
+const DEADLINE_COOKIE = CAPTURE_PROTOCOL.credentials.deadlineCookie;
 const MAX_SNAPSHOT_BYTES = 1_000_000;
 const SNAPSHOT_DEADLINE_MS = 30_000;
 
@@ -94,7 +95,7 @@ async function captureDocument(request: Request, env: CaptureEnv): Promise<Respo
   if (request.method !== 'GET' || (await validatePublicationJob(request, env)).status !== 'valid') {
     return noStoreJson({ error: 'Not found' }, 404);
   }
-  const assetUrl = new URL('/publisher-capture.html', request.url);
+  const assetUrl = new URL(CAPTURE_PROTOCOL.paths.bundleDocument, request.url);
   const asset = await env.ASSETS.fetch(new Request(assetUrl, request));
   const headers = new Headers(asset.headers);
   headers.set('Cache-Control', 'no-store');
@@ -142,13 +143,16 @@ export async function handleCaptureRoute(
   env: CaptureEnv
 ): Promise<Response | undefined> {
   const pathname = new URL(request.url).pathname;
-  if (pathname === '/__asset-publisher/capture') {
+  if (pathname === CAPTURE_PROTOCOL.paths.document) {
     return await captureDocument(request, env);
   }
-  if (pathname === '/__asset-publisher/snapshot') {
+  if (pathname === CAPTURE_PROTOCOL.paths.snapshot) {
     return await exactSnapshot(request, env);
   }
-  if (pathname === '/publisher-capture.html' || pathname.startsWith('/publisher-capture/')) {
+  if (
+    pathname === CAPTURE_PROTOCOL.paths.bundleDocument ||
+    pathname.startsWith(CAPTURE_PROTOCOL.paths.bundleAssetPrefix)
+  ) {
     return await gatedCaptureAsset(request, env);
   }
   return undefined;

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -3,8 +3,8 @@
 export const rendererManifest = {
   schemaVersion: 1,
   rendererIdentity:
-    'faction-sheet/sha256:5132c7f42432d0766effc6b4d42a47c8916d979286efb57b832b400a0a14f9de',
-  digest: '5132c7f42432d0766effc6b4d42a47c8916d979286efb57b832b400a0a14f9de',
+    'faction-sheet/sha256:9ec45c14e5e682be90c470afc2404cb7ec323e9ad00aee27e7e63ccbb42ad87f',
+  digest: '9ec45c14e5e682be90c470afc2404cb7ec323e9ad00aee27e7e63ccbb42ad87f',
   contract: {
     viewport: {
       width: 2100,


### PR DESCRIPTION
Closes #201 — the last open issue from the architecture cluster.

**One protocol owner.** `src/shared/asset-publishing/capture-protocol.ts` (versioned, with the cross-runtime rollout rule documented on the module) owns every piece of the handshake the four runtimes previously shared by convention: route paths — including the snapshot path the React document was hard-coding — cookie and header names, the marker's id/selector/attributes, the loading/ready/failed state strings, the sheet page markers, and the payload-hash shape.

**One lifecycle implementation.** `workers/publisher/capture-lifecycle.ts` owns the behavior the browser driver and the Chromium regression each reimplemented: the marker settle-wait (previously duplicated `waitForFunction` bodies), the ready+payload-hash rendering-authority check, and the physical-bounds contract (the regression's copy had drifted to a weaker single-margin check; both now run the production four-margin implementation). It is typed structurally over a minimal page surface, so `@cloudflare/playwright` (production) and `playwright` (regression) execute **the same code** — the "cannot silently drift apart" criterion holds by construction, not discipline.

**Six consumers migrated** (the issue's four, plus the two page-marker emitters found during migration: `Sheet.tsx` and the editor's page preview). The regression keeps its product-specific assertions (troop tokens, starting spice) — renderer content, not lifecycle. All security semantics untouched: the credential matrix tests in `capture-route.test.ts` pass unchanged, snapshot validation still happens against the canonical schema before rendering authority, and the browser session close paths are untouched.

**Renderer manifest**: regenerated (2-line identity change) because the capture bundle's bytes changed with the protocol imports. The Chromium regression proves the rendered output is identical — 2 pages, exact print geometry — so **no Renderer revision bump** and no recapture storm; per the deployment contract, equal revisions are a no-op.

Gates: `publisher:test` (363), `publisher:typecheck`, repo `typecheck`/`lint`/`format:check`/`test`, **`publisher:capture-contract-regression` passed** (the executable contract: real Chromium against the real built bundle), `publisher:release:verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PDF and faction sheet capture reliability by coordinating page readiness and capture completion more consistently.
  - Added validation for payload integrity, page counts, print settings, margins, and physical page dimensions.
  - Improved handling of capture routes, document loading, and page identification to reduce inconsistent or incomplete exports.

- **Refactor**
  - Standardized capture behavior across the application and publishing workflows for more predictable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->