### PR TITLE
Stop re-validating stored ruleset names on the read path

### DIFF
--- a/src/app/rulesets/db.ts
+++ b/src/app/rulesets/db.ts
@@ -104,7 +104,7 @@ function toRulesetEntry(entry: RulesetRow): RulesetEntry {
   return {
     ...entry,
     id: entry._id,
-    name: rulesetInputSchema.parse({ name: entry.name }).name,
+    name: entry.name,
   };
 }
 
@@ -170,7 +170,7 @@ export function useRuleset(id: string) {
       ? {
           ...result.data,
           id: result.data._id,
-          name: rulesetInputSchema.parse({ name: result.data.name }).name,
+          name: result.data.name,
         }
       : undefined,
   };


### PR DESCRIPTION
Found by the cluster-2 architecture review: `toRulesetEntry` (and the same inline parse in `useRuleset`) ran `rulesetInputSchema` — a user-input constraint — against every stored ruleset name on read. One legacy-named row would throw and crash its page render. The wire already validates the shape via `rulesetValidator`; input validation remains on the four write-path sites, untouched. Groups reads the identical shape with no re-parse, which is now consistent.

Two-line fix. Gates: full test suite, typecheck, lint, format, `publisher:release:verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ruleset names are now preserved directly from database entries, preventing valid names from being altered or rejected during loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->