### PR TITLE
Purge the dead client and server surface

### DIFF
--- a/convex/factions.authoringRoundTrip.test.ts
+++ b/convex/factions.authoringRoundTrip.test.ts
@@ -213,7 +213,7 @@ describe('faction authoring full-field round trip', () => {
       throw new Error('Missing faction sheet job after create');
     }
 
-    const rulesetId = await t.run(async (ctx) => {
+    await t.run(async (ctx) => {
       const id = await ctx.db.insert('rulesets', {
         name: 'Canonical transition proof',
         slug: 'canonical-transition-proof',
@@ -260,18 +260,18 @@ describe('faction authoring full-field round trip', () => {
       ],
     });
     await expect(
-      t.query(api.rulesets.factionDetails, {
-        ruleset_id: rulesetId,
-      })
-    ).resolves.toMatchObject([
-      {
-        identity: {
-          background: {
-            invert: false,
+      t.query(api.rulesets.getBySlug, { slug: 'canonical-transition-proof' })
+    ).resolves.toMatchObject({
+      factions: [
+        {
+          identity: {
+            background: {
+              invert: false,
+            },
           },
         },
-      },
-    ]);
+      ],
+    });
 
     const editedInput: FactionInput = {
       ...structuredClone(createdInput),

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -318,31 +318,3 @@ export const softDelete = mutation({
     });
   },
 });
-
-export const getFullBySlug = query({
-  args: { slug: v.string() },
-  handler: async (ctx, args) => {
-    const row = await ctx.db
-      .query('factions')
-      .withIndex('by_slug', (q) => q.eq('slug', args.slug))
-      .unique();
-    if (!row || row.is_deleted) {
-      throw new Error(`Faction with slug ${args.slug} not found`);
-    }
-    const profile = await ctx.db
-      .query('profiles')
-      .withIndex('by_user_id', (q) => q.eq('user_id', row.owner_id))
-      .unique();
-    if (!profile) {
-      throw new Error(`Profile with user id ${row.owner_id} not found`);
-    }
-    const group = row.group_id ? await ctx.db.get('groups', row.group_id) : null;
-
-    return {
-      ...row,
-      data: factionDataForClient(row.data),
-      owner: profile,
-      group,
-    };
-  },
-});

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -101,20 +101,6 @@ export const getBySlug = query({
   handler: async (ctx, args) => await loadProfileDetailBySlug(ctx, args.slug),
 });
 
-export const getByUserId = query({
-  args: { user_id: v.id('users') },
-  handler: async (ctx, args) => {
-    const profile = await ctx.db
-      .query('profiles')
-      .withIndex('by_user_id', (q) => q.eq('user_id', args.user_id))
-      .unique();
-    if (!profile) {
-      throw new Error(`Profile with user id ${args.user_id} not found`);
-    }
-    return profile;
-  },
-});
-
 export const list = query({
   args: {},
   handler: async (ctx) => {

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -174,19 +174,6 @@ export const detailPageBySlug = query({
   },
 });
 
-export const factionIds = query({
-  args: { ruleset_id: v.id('rulesets') },
-  handler: async (ctx, args) => {
-    const factions = await listPublicRulesetFactions(ctx, args.ruleset_id);
-    return factions.map((faction) => faction.factionId);
-  },
-});
-
-export const factionDetails = query({
-  args: { ruleset_id: v.id('rulesets') },
-  handler: async (ctx, args) => listPublicRulesetFactions(ctx, args.ruleset_id),
-});
-
 export const listByFaction = query({
   args: { faction_id: v.id('factions') },
   handler: async (ctx, args) => {

--- a/src/app/factions/db.ts
+++ b/src/app/factions/db.ts
@@ -3,12 +3,11 @@ import type { FunctionReturnType } from 'convex/server';
 
 import { db } from '@db/core';
 import { toLiveQueryResult, useLiveMutation } from '@app/db/core/live';
-import type { LiveQueryResult } from '@app/db/core/live';
 import { CanonicalFactionStoredSchema, FactionInputSchema } from '@game/schema/faction';
 import type { FactionInput } from '@game/schema/faction';
 
 import { api } from '../../../convex/_generated/api';
-import type { Doc, Id } from '../../../convex/_generated/dataModel';
+import type { Doc } from '../../../convex/_generated/dataModel';
 import type { PublicAssetPublishingStatusProjection } from '../../../convex/assetPublishingStatus';
 import type {
   AssignedGroupSummary,
@@ -48,13 +47,6 @@ export type FactionCataloguePageData = {
     newArrival: FactionCatalogueEntry | null;
     freshlyUpdated: FactionCatalogueEntry | null;
   };
-};
-
-export type FactionInsert = Omit<FactionEntry, 'data'> & {
-  data: FactionData;
-};
-export type FactionUpdate = Omit<Partial<FactionEntry>, 'data'> & {
-  data?: FactionData;
 };
 
 function toFactionEntry(entry: FactionRow): FactionEntry {
@@ -134,28 +126,9 @@ export async function loadFactionBySlug(slug: string): Promise<FactionDetailPage
   return await loadFaction(slug);
 }
 
-export async function loadFactionsAll(): Promise<FactionEntry[]> {
-  const entries = await db.query(api.factions.list, {});
-  return factionRowsToEntries(entries);
-}
-
 export async function loadFactionCataloguePage(): Promise<FactionCataloguePageData> {
   const raw = await db.query(api.factions.cataloguePage, {});
   return toFactionCataloguePageData(raw);
-}
-
-export async function loadFactionsByOwner(ownerId: string): Promise<FactionEntry[]> {
-  const entries = await db.query(api.factions.listByOwner, {
-    owner_id: ownerId as Id<'users'>,
-  });
-  return factionRowsToEntries(entries);
-}
-
-export async function loadFactionsByGroup(groupId: string): Promise<FactionEntry[]> {
-  const entries = await db.query(api.factions.listByGroup, {
-    group_id: groupId as Id<'groups'>,
-  });
-  return factionRowsToEntries(entries);
 }
 
 export function useFaction(
@@ -183,12 +156,6 @@ export function useFaction(
   };
 }
 
-export function useFactionsAll(options?: { initialData?: FactionEntry[] }) {
-  const liveData = useQuery(api.factions.list, {});
-  const normalized = liveData ? factionRowsToEntries(liveData) : undefined;
-  return toLiveQueryResult(normalized, true, () => options?.initialData ?? undefined);
-}
-
 export function useFactionCataloguePage(options?: { initialData?: FactionCataloguePageData }) {
   const liveData = useQuery(api.factions.cataloguePage, {});
   const normalized = liveData ? toFactionCataloguePageData(liveData) : undefined;
@@ -214,8 +181,6 @@ export type FactionLoadPickerPayload = {
   memberGroupIds: Doc<'groups'>['_id'][];
 };
 
-export type FactionLoadPickerQuery = LiveQueryResult<FactionLoadPickerPayload>;
-
 export function useFactionLoadPicker(options?: { initialData?: FactionLoadPickerPayload }) {
   const liveData = useQuery(api.factions.listForLoadPicker, {});
   const normalized = liveData
@@ -227,22 +192,6 @@ export function useFactionLoadPicker(options?: { initialData?: FactionLoadPicker
         memberGroupIds: liveData.memberGroupIds,
       }
     : undefined;
-  return toLiveQueryResult(normalized, true, () => options?.initialData ?? undefined);
-}
-
-export function useFactionsByOwner(ownerId: string, options?: { initialData?: FactionEntry[] }) {
-  const liveData = useQuery(api.factions.listByOwner, {
-    owner_id: ownerId,
-  } as never);
-  const normalized = liveData ? factionRowsToEntries(liveData) : undefined;
-  return toLiveQueryResult(normalized, true, () => options?.initialData ?? undefined);
-}
-
-export function useFactionsByGroup(groupId: string, options?: { initialData?: FactionEntry[] }) {
-  const liveData = useQuery(api.factions.listByGroup, {
-    group_id: groupId,
-  } as never);
-  const normalized = liveData ? factionRowsToEntries(liveData) : undefined;
   return toLiveQueryResult(normalized, true, () => options?.initialData ?? undefined);
 }
 

--- a/src/app/faq/db.ts
+++ b/src/app/faq/db.ts
@@ -26,13 +26,6 @@ export type FaqQuestionLocator = {
   questionSlug: string;
 };
 
-export type FaqProfileSummary = {
-  id: string;
-  slug: string;
-  username: string | null;
-  avatarUrl: string | null;
-};
-
 export type FaqQuestionPage = FunctionReturnType<typeof api.faq.questionPage>;
 
 type CommandState = {
@@ -88,8 +81,6 @@ function voidCommand<TVariables, TResult>(
 export async function loadFaqQuestionPage(locator: FaqQuestionLocator): Promise<FaqQuestionPage> {
   return await db.query(api.faq.questionPage, locator);
 }
-
-export type UseFaqQuestionPageResult = ReturnType<typeof useFaqQuestionPage>;
 
 export function useFaqQuestionPage(
   locator: FaqQuestionLocator,
@@ -163,8 +154,6 @@ export type AskFaqQuestionInput = {
   initialAnswer?: string;
   tags: FaqTag[];
 };
-
-export type UseAskFaqQuestionResult = ReturnType<typeof useAskFaqQuestion>;
 
 export function useAskFaqQuestion() {
   const mutation = useLiveMutation<

--- a/src/app/groups/db.ts
+++ b/src/app/groups/db.ts
@@ -19,16 +19,11 @@ import type { ProfileSummary } from '../../../convex/lib/collaborativeAccessVali
 
 export type GroupRow = Doc<'groups'>;
 export type GroupEntry = GroupRow & { id: GroupRow['_id'] };
-export type GroupInsert = GroupEntry;
-export type GroupUpdate = Partial<GroupEntry>;
-
-export type GroupOwnerSummary = ProfileSummary;
-
 export type GroupDetailPageData = {
   group: GroupEntry;
   factions: FactionEntry[];
   rulesets: RulesetEntry[];
-  owner: GroupOwnerSummary | null;
+  owner: ProfileSummary | null;
   viewerAccess: Extract<CollaborativeAccess, { kind: 'group' }>;
   roster: GroupRosterEntry[];
 };
@@ -45,16 +40,6 @@ export async function loadGroupDetailBySlug(slug: string): Promise<GroupDetailPa
 export async function loadGroupEditBySlug(slug: string): Promise<GroupEditPageData> {
   const result = await loadGroupDetailBySlug(slug);
   return { group: result.group, viewerAccess: result.viewerAccess };
-}
-
-/** Call only when `id` is a real group id (mount a child component if the id is optional). */
-export function useGroup(id: string) {
-  const liveData = useQuery(api.groups.getById, { id } as never) as GroupRow | undefined;
-  const result = toLiveQueryResult(liveData, true);
-  return {
-    ...result,
-    data: result.data ? { ...result.data, id: result.data._id } : undefined,
-  };
 }
 
 function normalizeGroupDetailFromConvex(raw: GroupDetailPageRaw): GroupDetailPageData {
@@ -105,15 +90,6 @@ export function useGroupEditBySlug(slug: string, options?: { initialData?: Group
     ...result,
     group: result.data?.group,
     viewerAccess: result.data?.viewerAccess,
-  };
-}
-
-export function useGroupsAll(options?: { initialData?: GroupEntry[] }) {
-  const liveData = useQuery(api.groups.list, {});
-  const result = toLiveQueryResult(liveData, true, () => options?.initialData ?? undefined);
-  return {
-    ...result,
-    data: result.data?.map((entry) => ({ ...entry, id: entry._id })),
   };
 }
 

--- a/src/app/members/db.ts
+++ b/src/app/members/db.ts
@@ -5,11 +5,9 @@ import { api } from '../../../convex/_generated/api';
 import type { Doc } from '../../../convex/_generated/dataModel';
 
 export type GroupMemberRow = Doc<'group_members'>;
-export type GroupMemberStatus = GroupMemberRow['status'];
-
 type MembershipCommandAcknowledgement = {
   membershipId: string;
-  status: GroupMemberStatus;
+  status: 'pending' | 'active' | 'removed';
 };
 
 type GroupMembershipCommand<TInput> = {

--- a/src/app/migrations/db.ts
+++ b/src/app/migrations/db.ts
@@ -7,9 +7,6 @@ import { toLiveQueryResult, useLiveMutation } from '@app/db/core/live';
 import { api } from '../../../convex/_generated/api';
 
 export type AdminMigrationDashboardData = FunctionReturnType<typeof api.migrations.adminDashboard>;
-export type MigrationStatusRow = AdminMigrationDashboardData['statuses'][number];
-export type MigrationRunSnapshot = AdminMigrationDashboardData['snapshots'][number];
-
 export async function loadAdminMigrationDashboard(
   ids?: string[]
 ): Promise<AdminMigrationDashboardData> {

--- a/src/app/profile/db.ts
+++ b/src/app/profile/db.ts
@@ -51,40 +51,6 @@ export async function loadProfilesAll(): Promise<ProfileListEntry[]> {
   return entries;
 }
 
-export async function loadCurrentUserId(): Promise<string | null> {
-  return await db.query(api.profiles.currentUserId, {});
-}
-
-export async function loadCurrentProfile(): Promise<ProfileEntry | null> {
-  const currentRaw = await db.query(api.profiles.current, {});
-  const current = currentRaw ? currentRaw : null;
-  if (current) {
-    const needsBackfill = current.slug === 'user' || !current.username || !current.avatar_url;
-    if (needsBackfill) {
-      const entry = await db.mutation(api.profiles.bootstrapCurrent, {});
-      return entry;
-    }
-    return current;
-  }
-
-  const userId = await loadCurrentUserId();
-  if (!userId) {
-    return null;
-  }
-
-  const entry = await db.mutation(api.profiles.bootstrapCurrent, {});
-  return entry;
-}
-
-export function useProfile(id: string) {
-  const liveData = useQuery(api.profiles.getById, { id } as never) as ProfileRow | null | undefined;
-  const result = toLiveQueryResult(liveData, true);
-  return {
-    ...result,
-    data: result.data ?? undefined,
-  };
-}
-
 export function useProfileBySlug(
   slug: string,
   options?: {

--- a/src/app/rulesets/db.ts
+++ b/src/app/rulesets/db.ts
@@ -9,7 +9,7 @@ import { Background } from '@game/schema/faction';
 import type { FactionData } from '@game/schema/faction';
 
 import { api } from '../../../convex/_generated/api';
-import type { Doc, Id } from '../../../convex/_generated/dataModel';
+import type { Doc } from '../../../convex/_generated/dataModel';
 import type {
   AssignedGroupSummary,
   CollaborativeAccess,
@@ -22,13 +22,6 @@ export type RulesetEntry = Omit<RulesetRow, 'name'> & {
   name: Ruleset['name'];
   id: RulesetRow['_id'];
 };
-export type RulesetInsert = Omit<RulesetEntry, 'name'> & {
-  name: Ruleset['name'];
-};
-export type RulesetUpdate = Omit<Partial<RulesetEntry>, 'name'> & {
-  name?: Ruleset['name'];
-};
-
 export type RulesetFactionSummary = {
   factionId: string;
   name: string;
@@ -117,11 +110,6 @@ export async function loadRulesetsAll(): Promise<RulesetEntry[]> {
   return rulesetRowsToEntries(entries);
 }
 
-export async function loadRuleset(id: string): Promise<RulesetEntry> {
-  const entry = await db.query(api.rulesets.get, { id: id as Id<'rulesets'> });
-  return toRulesetEntry(entry);
-}
-
 export async function loadRulesetBySlug(slug: string): Promise<RulesetPageData> {
   const result = await db.query(api.rulesets.getBySlug, { slug });
   return toRulesetPageData(result);
@@ -132,47 +120,12 @@ export async function loadRulesetDetailPage(slug: string): Promise<RulesetDetail
   return raw ? normalizeRulesetDetailPage(raw) : null;
 }
 
-export async function loadRulesetFactions(rulesetId: string): Promise<string[]> {
-  return await db.query(api.rulesets.factionIds, { ruleset_id: rulesetId as Id<'rulesets'> });
-}
-
-export async function loadRulesetFactionsWithDetails(
-  rulesetId: string
-): Promise<RulesetFactionSummary[]> {
-  const factions = await db.query(api.rulesets.factionDetails, {
-    ruleset_id: rulesetId as Id<'rulesets'>,
-  });
-  return factions.map(normalizeRulesetFactionSummary);
-}
-
-export async function loadRulesetsByFaction(factionId: string): Promise<RulesetEntry[]> {
-  const entries = await db.query(api.rulesets.listByFaction, {
-    faction_id: factionId as Id<'factions'>,
-  });
-  return entries.map(toRulesetEntry);
-}
-
 export function useRulesetsAll(options?: { initialData?: RulesetEntry[] }) {
   const liveData = useQuery(api.rulesets.list, {});
   const result = toLiveQueryResult(liveData, true, () => options?.initialData ?? undefined);
   return {
     ...result,
     data: result.data?.map(toRulesetEntry),
-  };
-}
-
-export function useRuleset(id: string) {
-  const liveData = useQuery(api.rulesets.get, { id } as never) as RulesetRow | undefined;
-  const result = toLiveQueryResult(liveData, true);
-  return {
-    ...result,
-    data: result.data
-      ? {
-          ...result.data,
-          id: result.data._id,
-          name: result.data.name,
-        }
-      : undefined,
   };
 }
 
@@ -210,41 +163,6 @@ export function useRulesetDetailPage(
     owner: result.data?.owner ?? null,
     assignableGroups: result.data?.assignableGroups ?? [],
     faqItems: result.data?.faqItems ?? [],
-  };
-}
-
-export function useRulesetFactions(rulesetId: string) {
-  const liveData = useQuery(api.rulesets.factionIds, { ruleset_id: rulesetId } as never) as
-    | string[]
-    | undefined;
-  return toLiveQueryResult(liveData, true);
-}
-
-export function useRulesetFactionsWithDetails(
-  rulesetId: string,
-  options?: { initialData?: RulesetFactionSummary[] }
-) {
-  const liveData = useQuery(api.rulesets.factionDetails, {
-    ruleset_id: rulesetId,
-  } as never) as RulesetFactionSummaryRaw[] | undefined;
-  const result = toLiveQueryResult(liveData, true, () => options?.initialData ?? undefined);
-  return {
-    ...result,
-    data: result.data?.map(normalizeRulesetFactionSummary),
-  };
-}
-
-export function useRulesetsByFaction(
-  factionRowId: string,
-  options?: { initialData?: RulesetEntry[] }
-) {
-  const liveData = useQuery(api.rulesets.listByFaction, {
-    faction_id: factionRowId,
-  } as never) as RulesetRow[] | undefined;
-  const result = toLiveQueryResult(liveData, true, () => options?.initialData ?? undefined);
-  return {
-    ...result,
-    data: result.data?.map(toRulesetEntry),
   };
 }
 


### PR DESCRIPTION
Cluster-2 candidate 1. **+15 / −277, pure removal** — every deleted symbol was verified to have zero references outside its defining file before deletion, and the compiler confirmed the three internal exceptions (inlined or repointed).

- 10 hooks + 8 loaders with no callers — which carried **all 8 remaining production `as never` casts**, the only places the derived-type chain was manually severed. They leave with their hosts; no production `as never` remains outside one live hook (tracked for the next pass).
- Dead server queries: `factions.getFullBySlug`, `profiles.getByUserId`, `rulesets.factionIds`/`factionDetails`. One test probed `factionDetails` as a convenience; it now probes the public `rulesets.getBySlug` page query instead — a strictly more production-shaped assertion.
- Orphaned exported types: the pre-page-query CRUD `*Insert`/`*Update` vocabulary, the never-referenced camelCase `FaqProfileSummary`, `GroupOwnerSummary` (inlined to `ProfileSummary`), and friends.

Each `db.ts` module's published surface is now exactly the load/use pair its routes import.

Gates: full suite (2064), typecheck, lint, format, bindings regenerated, `publisher:release:verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)