### PR TITLE
Finish the authority sweep: viewer access, discovery, and the executor wire

### DIFF
--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -14,10 +14,12 @@ import {
 } from './lib/collaborativeAccess';
 import {
   factionDetailPageValidator,
+  factionValidator,
   factionWithRulesetsValidator,
   rulesetSummaryValidator,
 } from './lib/collaborativeAccessValidators';
 import { loadFactionCatalogue, selectFactionCatalogueSpotlights } from './lib/factionCatalogue';
+import { factionDataValidator } from './lib/factionData';
 import { parseFactionInput } from './lib/factionInput';
 import { requireAuthUserId } from './lib/policy';
 import { enqueueFactionSheetPublication } from './lib/publication';
@@ -103,6 +105,7 @@ export const getBySlug = query({
 
 export const list = query({
   args: {},
+  returns: v.array(factionValidator),
   handler: async (ctx) => {
     const rows = await ctx.db
       .query('factions')
@@ -135,8 +138,22 @@ export const cataloguePage = query({
 });
 
 /** Factions + resolved group/owner labels and the caller's group memberships for the load picker. */
+const loadPickerRowValidator = v.object({
+  id: v.id('factions'),
+  slug: v.string(),
+  data: factionDataValidator,
+  groupId: v.union(v.id('groups'), v.null()),
+  groupLabel: v.string(),
+  ownerId: v.id('users'),
+  ownerUsername: v.union(v.string(), v.null()),
+});
+
 export const listForLoadPicker = query({
   args: {},
+  returns: v.object({
+    rows: v.array(loadPickerRowValidator),
+    memberGroupIds: v.array(v.id('groups')),
+  }),
   handler: async (ctx) => {
     const userId = await requireAuthUserId(ctx);
 

--- a/convex/homepage.ts
+++ b/convex/homepage.ts
@@ -3,7 +3,10 @@ import { v } from 'convex/values';
 import { query } from './_generated/server';
 import { loadFactionCatalogueSpotlightPreviews } from './lib/factionCatalogue';
 import { factionDataValidator } from './lib/factionData';
-import { loadNewestDiscoverableProfiles } from './lib/profileDiscovery';
+import {
+  discoverableProfileValidator,
+  loadNewestDiscoverableProfiles,
+} from './lib/profileDiscovery';
 import { loadGlobalStatisticsTotals } from './lib/statistics';
 
 const spotlightValidator = v.object({
@@ -26,15 +29,7 @@ const spotlightsValidator = v.object({
   freshlyUpdated: v.union(spotlightValidator, v.null()),
 });
 
-const newestMembersValidator = v.array(
-  v.object({
-    id: v.id('profiles'),
-    slug: v.string(),
-    username: v.string(),
-    avatarUrl: v.string(),
-    createdAt: v.string(),
-  })
-);
+const newestMembersValidator = v.array(discoverableProfileValidator);
 
 /** Permanent homepage read composed from reusable domain boundaries. */
 export const get = query({

--- a/convex/lib/collaborativeAccess.ts
+++ b/convex/lib/collaborativeAccess.ts
@@ -1,55 +1,26 @@
 import { getAuthUserId } from '@convex-dev/auth/server';
+import type { Infer } from 'convex/values';
 
 import type { Doc, Id } from '../_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '../_generated/server';
+import type {
+  assignedGroupSummaryValidator,
+  factionViewerAccessValidator,
+  groupViewerAccessValidator,
+  publicViewerValidator,
+  rulesetViewerAccessValidator,
+} from './collaborativeAccessValidators';
 
 export type MembershipState = 'none' | 'pending' | 'active';
 
-export type PublicViewer =
-  | { kind: 'anonymous' }
-  | { kind: 'authenticated'; membership: MembershipState };
+export type PublicViewer = Infer<typeof publicViewerValidator>;
 
-export type AssignedGroupSummary = {
-  id: Id<'groups'>;
-  name: string;
-  slug: string;
-};
+export type AssignedGroupSummary = Infer<typeof assignedGroupSummaryValidator>;
 
 export type CollaborativeAccess =
-  | {
-      kind: 'group';
-      viewer: PublicViewer;
-      capabilities: {
-        requestMembership: boolean;
-        rename: boolean;
-        delete: boolean;
-        addMember: boolean;
-      };
-    }
-  | {
-      kind: 'faction';
-      assignedGroup: AssignedGroupSummary | null;
-      viewer: PublicViewer;
-      capabilities: {
-        requestMembership: boolean;
-        edit: boolean;
-        rename: boolean;
-        changeGroup: boolean;
-        delete: boolean;
-      };
-    }
-  | {
-      kind: 'ruleset';
-      assignedGroup: AssignedGroupSummary | null;
-      viewer: PublicViewer;
-      capabilities: {
-        requestMembership: boolean;
-        edit: boolean;
-        rename: boolean;
-        changeGroup: boolean;
-        delete: boolean;
-      };
-    };
+  | Infer<typeof groupViewerAccessValidator>
+  | Infer<typeof factionViewerAccessValidator>
+  | Infer<typeof rulesetViewerAccessValidator>;
 
 export type StoredMembershipState = MembershipState | 'removed';
 

--- a/convex/lib/collaborativeAccessValidators.ts
+++ b/convex/lib/collaborativeAccessValidators.ts
@@ -71,14 +71,12 @@ const groupViewerAccessValidator = v.object({
   }),
 });
 
+const factionViewerAccessValidator = assetViewerAccessValidator('faction');
+const rulesetViewerAccessValidator = assetViewerAccessValidator('ruleset');
+
 const rosterEntryValidator = v.object({
   membershipId: v.id('group_members'),
-  user: v.object({
-    id: v.id('profiles'),
-    slug: v.string(),
-    username: v.union(v.string(), v.null()),
-    avatar_url: v.union(v.string(), v.null()),
-  }),
+  user: profileSummaryValidator,
   status: v.union(v.literal('pending'), v.literal('active')),
   requestedAt: v.string(),
   capabilities: v.object({
@@ -88,7 +86,7 @@ const rosterEntryValidator = v.object({
   }),
 });
 
-function assetViewerAccessValidator(kind: 'faction' | 'ruleset') {
+function assetViewerAccessValidator<Kind extends 'faction' | 'ruleset'>(kind: Kind) {
   return v.object({
     kind: v.literal(kind),
     assignedGroup: v.union(assignedGroupSummaryValidator, v.null()),
@@ -114,7 +112,7 @@ export const factionDetailPageValidator = v.object({
   faction: factionValidator,
   owner: profileValidator,
   assetPublishing: assetPublishingValidator,
-  viewerAccess: assetViewerAccessValidator('faction'),
+  viewerAccess: factionViewerAccessValidator,
   assignableGroups: v.array(assignedGroupSummaryValidator),
   rulesets: v.array(rulesetSummaryValidator),
 });
@@ -132,7 +130,7 @@ const rulesetFactionSummaryValidator = v.object({
 export const rulesetPublicBundleValidator = v.object({
   ruleset: rulesetValidator,
   factions: v.array(rulesetFactionSummaryValidator),
-  viewerAccess: assetViewerAccessValidator('ruleset'),
+  viewerAccess: rulesetViewerAccessValidator,
 });
 
 const faqAnswerValidator = docValidator('faq_answers');
@@ -193,6 +191,8 @@ export const groupDetailPageValidator = v.object({
 
 export {
   factionValidator,
+  factionViewerAccessValidator,
+  rulesetViewerAccessValidator,
   rulesetSummaryValidator,
   assignedGroupSummaryValidator,
   assetViewerAccessValidator,

--- a/convex/lib/profileDiscovery.ts
+++ b/convex/lib/profileDiscovery.ts
@@ -1,6 +1,7 @@
 import { DirectAggregate } from '@convex-dev/aggregate';
 import type { Triggers } from 'convex-helpers/server/triggers';
 import { v } from 'convex/values';
+import type { Infer } from 'convex/values';
 
 import { components } from '../_generated/api';
 import type { DataModel, Doc, Id } from '../_generated/dataModel';
@@ -16,13 +17,7 @@ export const discoverableProfileValidator = v.object({
   createdAt: v.string(),
 });
 
-export type DiscoverableProfile = {
-  id: Id<'profiles'>;
-  slug: string;
-  username: string;
-  avatarUrl: string;
-  createdAt: string;
-};
+export type DiscoverableProfile = Infer<typeof discoverableProfileValidator>;
 
 type ProfileDiscoveryItem = {
   key: string;

--- a/convex/publicationJobs.test.ts
+++ b/convex/publicationJobs.test.ts
@@ -6,6 +6,7 @@ import { convexTest } from 'convex-test';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { assetPublishingFaction } from '../src/game/fixtures/assetPublishingFaction';
+import { takeWorkResultSchema } from '../src/shared/asset-publishing/publication';
 import { api, internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import schema from './schema';
@@ -50,6 +51,12 @@ afterEach(() => {
 });
 
 describe('Publication save coalescing', () => {
+  test('takeWork output parses against the shared executor wire schema', async () => {
+    const t = convexTest(schema, modules);
+    const empty = await t.mutation(internal.publicationJobs.takeWork, {});
+    expect(() => takeWorkResultSchema.parse(empty)).not.toThrow();
+  });
+
   test('updates one pending job payload and resets its attempts', async () => {
     const { t, asUser } = await authenticatedTest();
     const faction = await createFaction(asUser);

--- a/src/shared/asset-publishing/publication.ts
+++ b/src/shared/asset-publishing/publication.ts
@@ -53,3 +53,40 @@ export const publicationRevisionRequestSchema = z.discriminatedUnion('operation'
 ]);
 
 export type FactionSheetAssetData = z.infer<typeof factionSheetAssetDataSchema>;
+
+/**
+ * Wire contract for the executor take-work exchange. The worker parses every response through these
+ * schemas; the Convex mutation's id-branded validator stays the server-side authority, linked by a
+ * drift test in convex/publicationJobs.test.ts.
+ */
+export const assignedPublicationJobSchema = z.object({
+  jobId: z.string(),
+  assetType: z.literal('faction_sheet'),
+  assetId: z.string(),
+  expiresAt: z.number().finite(),
+});
+
+export type AssignedPublicationJob = z.infer<typeof assignedPublicationJobSchema>;
+
+export const takeWorkResultSchema = z.discriminatedUnion('status', [
+  z.object({
+    status: z.literal('empty'),
+    reason: z.enum(['disabled', 'no_pending_work']),
+    recovered: z.number().finite(),
+    items: z.array(assignedPublicationJobSchema).max(0),
+  }),
+  z.object({
+    status: z.literal('assigned'),
+    recovered: z.number().finite(),
+    items: z.array(assignedPublicationJobSchema).min(1).max(PUBLICATION_MAX_PICKUP),
+  }),
+]);
+
+export type TakeWorkResult = z.infer<typeof takeWorkResultSchema>;
+
+const executorEnvelopeSchema = z.looseObject({ ok: z.literal(true), schemaVersion: z.literal(1) });
+
+export function parseTakeWorkResponse(value: unknown): TakeWorkResult {
+  executorEnvelopeSchema.parse(value);
+  return takeWorkResultSchema.parse(value);
+}

--- a/workers/publisher/convex.test.ts
+++ b/workers/publisher/convex.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 
-import { ConvexPublisherClient, parseTakeWork } from './convex';
+import { parseTakeWorkResponse as parseTakeWork } from '../../src/shared/asset-publishing/publication';
+import { ConvexPublisherClient } from './convex';
 
 function assignedJob(index = 1) {
   return {

--- a/workers/publisher/convex.ts
+++ b/workers/publisher/convex.ts
@@ -1,94 +1,26 @@
 import { publisherErrorMessage } from '../../src/app/capture/publisher-diagnostics';
-import { PUBLICATION_MAX_PICKUP } from '../../src/shared/asset-publishing/publication';
-import { postJson } from './http';
+import { parseTakeWorkResponse } from '../../src/shared/asset-publishing/publication';
+import type { TakeWorkResult } from '../../src/shared/asset-publishing/publication';
 
-export type AssignedPublicationJob = {
-  jobId: string;
-  assetType: 'faction_sheet';
-  assetId: string;
-  expiresAt: number;
-};
-
-export type TakeWorkResult =
-  | {
-      status: 'empty';
-      reason: 'disabled' | 'no_pending_work';
-      recovered: number;
-      items: [];
-    }
-  | {
-      status: 'assigned';
-      recovered: number;
-      items: AssignedPublicationJob[];
-    };
+export type {
+  AssignedPublicationJob,
+  TakeWorkResult,
+} from '../../src/shared/asset-publishing/publication';
 
 type RecordValue = Record<string, unknown>;
 
-function record(value: unknown): value is RecordValue {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function finite(value: unknown): value is number {
-  return typeof value === 'number' && Number.isFinite(value);
-}
-
 function okRecord(value: unknown): RecordValue {
-  if (!record(value) || value.ok !== true) {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    Array.isArray(value) ||
+    (value as RecordValue).ok !== true
+  ) {
     throw new Error('Convex Publication response is invalid');
   }
-  return value;
+  return value as RecordValue;
 }
-
-function parseAssignedJob(value: unknown): AssignedPublicationJob {
-  if (
-    !record(value) ||
-    typeof value.jobId !== 'string' ||
-    value.assetType !== 'faction_sheet' ||
-    typeof value.assetId !== 'string' ||
-    !finite(value.expiresAt)
-  ) {
-    throw new Error('Convex assigned Publication job is invalid');
-  }
-  return {
-    jobId: value.jobId,
-    assetType: 'faction_sheet',
-    assetId: value.assetId,
-    expiresAt: value.expiresAt,
-  };
-}
-
-export function parseTakeWork(value: unknown): TakeWorkResult {
-  const body = okRecord(value);
-  if (body.schemaVersion !== 1 || !finite(body.recovered) || !Array.isArray(body.items)) {
-    throw new Error('Convex take-work response is invalid');
-  }
-  if (body.status === 'empty') {
-    if (
-      (body.reason !== 'disabled' && body.reason !== 'no_pending_work') ||
-      body.items.length !== 0
-    ) {
-      throw new Error('Convex empty take-work response is invalid');
-    }
-    return {
-      status: 'empty',
-      reason: body.reason,
-      recovered: body.recovered,
-      items: [],
-    };
-  }
-  if (
-    body.status !== 'assigned' ||
-    body.items.length < 1 ||
-    body.items.length > PUBLICATION_MAX_PICKUP
-  ) {
-    throw new Error('Convex assigned take-work response is invalid');
-  }
-  return {
-    status: 'assigned',
-    recovered: body.recovered,
-    items: body.items.map(parseAssignedJob),
-  };
-}
+import { postJson } from './http';
 
 function truncatedError(error: unknown): string {
   return publisherErrorMessage(error).slice(0, 2000);
@@ -105,7 +37,9 @@ export class ConvexPublisherClient {
   ) {}
 
   async takeWork(deadlineAt?: number): Promise<TakeWorkResult> {
-    return parseTakeWork(await this.postExecutor('take-work', { schemaVersion: 1 }, deadlineAt));
+    return parseTakeWorkResponse(
+      await this.postExecutor('take-work', { schemaVersion: 1 }, deadlineAt)
+    );
   }
 
   async complete(


### PR DESCRIPTION
Cluster-2 candidate 3. **+108 / −151.** The shapes #236 didn't reach, each reduced to one authority:

- **`CollaborativeAccess`, `PublicViewer`, `AssignedGroupSummary`** now derive from their validators via `Infer` — the ~45-line hand-written union is gone. The asset-access validator helper became generic so the `kind` discriminant survives derivation (`Extract<CollaborativeAccess, {kind: 'ruleset'}>` consumers unchanged).
- **`rosterEntryValidator.user`** reuses `profileSummaryValidator` instead of restating it 18 lines below its own "derive from this, never restate" comment.
- **`DiscoverableProfile`** derives from its validator; `homepage.ts` imports the validator instead of keeping a third copy.
- **The executor take-work wire contract** lives once, as shared Zod schemas in `src/shared/asset-publishing/publication.ts`. The worker's 60-line hand-rolled parser and hand types are deleted; it now `parse`s through the schema (keeping every strictness the parser had: envelope, `faction_sheet` narrowing, item-count bounds). The Convex mutation keeps its id-branded validator as the server authority, with a **drift test** running real `takeWork` output through the shared schema.
- **`returns` validators added** to `factions.list/listByOwner/listByGroup` and `listForLoadPicker` — the last unvalidated faction queries; unlocks the client re-parse deletions (next candidate).

**Deliberately deferred:** unifying the chip's camelCase/snake_case split — that is a *wire-shape* change needing a compatibility window, unlike everything here, which leaves every payload byte-identical.

Gates: repo suite (2065), publisher suite (870), both typechecks, lint, format, bindings, `publisher:release:verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of faction, profile, group, owner, and access information returned throughout the app.
  * Added stronger validation for publication work responses, helping prevent malformed or incomplete publishing data from being processed.

* **Reliability**
  * Standardized shared data contracts across discovery, collaborative access, faction loading, and publication workflows.
  * Improved handling of cases where no publication work is available.

* **Tests**
  * Added coverage confirming publication responses remain valid when no work is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->