### PR TITLE
Deliberate client boundary with a stale-version prompt

### DIFF
--- a/src/app/db/core/clientBoundary.ts
+++ b/src/app/db/core/clientBoundary.ts
@@ -1,0 +1,25 @@
+import type { z } from 'zod';
+
+/**
+ * Incoming data no longer matches this bundle's compiled expectations — the stale-tab signal.
+ * Rendered by the router's error component as a refresh prompt instead of a crash.
+ */
+export class StaleClientDataError extends Error {
+  constructor(context: string, options?: { cause?: unknown }) {
+    super(`${context} does not match this version of the app`, options);
+    this.name = 'StaleClientDataError';
+  }
+}
+
+/** Validate data entering the client runtime against this bundle's schema. */
+export function parseClientBoundary<Schema extends z.ZodType>(
+  schema: Schema,
+  value: unknown,
+  context: string
+): z.output<Schema> {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    throw new StaleClientDataError(context, { cause: result.error });
+  }
+  return result.data as z.output<Schema>;
+}

--- a/src/app/factions/db.ts
+++ b/src/app/factions/db.ts
@@ -2,8 +2,9 @@ import { useQuery } from 'convex/react';
 import type { FunctionReturnType } from 'convex/server';
 
 import { db } from '@db/core';
+import { parseClientBoundary } from '@app/db/core/clientBoundary';
 import { toLiveQueryResult, useLiveMutation } from '@app/db/core/live';
-import { CanonicalFactionStoredSchema, FactionInputSchema } from '@game/schema/faction';
+import { CanonicalFactionClientSchema, FactionInputSchema } from '@game/schema/faction';
 import type { FactionInput } from '@game/schema/faction';
 
 import { api } from '../../../convex/_generated/api';
@@ -52,14 +53,14 @@ export type FactionCataloguePageData = {
 function toFactionEntry(entry: FactionRow): FactionEntry {
   return {
     ...entry,
-    data: CanonicalFactionStoredSchema.parse(entry.data),
+    data: parseClientBoundary(CanonicalFactionClientSchema, entry.data, 'Faction data'),
   };
 }
 
 function toFactionCatalogueEntry(entry: FactionCatalogueRow): FactionCatalogueEntry {
   return {
     ...entry,
-    data: CanonicalFactionStoredSchema.parse(entry.data),
+    data: parseClientBoundary(CanonicalFactionClientSchema, entry.data, 'Faction data'),
   };
 }
 
@@ -112,7 +113,7 @@ function toFactionDetailPageData(
   return {
     faction: {
       ...raw.faction,
-      data: CanonicalFactionStoredSchema.parse(raw.faction.data),
+      data: parseClientBoundary(CanonicalFactionClientSchema, raw.faction.data, 'Faction data'),
     },
     owner: raw.owner,
     assetPublishing: raw.assetPublishing,
@@ -140,20 +141,7 @@ export function useFaction(
   const liveData = useQuery(api.factions.getBySlug, { slug });
   const normalized = liveData ? toFactionDetailPageData(liveData) : undefined;
   const result = toLiveQueryResult(normalized, true, () => options?.initialData ?? undefined);
-  return {
-    ...result,
-    faction: result.data?.faction,
-    owner: result.data?.owner,
-    viewerAccess: result.data?.viewerAccess,
-    assignableGroups: result.data?.assignableGroups ?? [],
-    rulesets: result.data?.rulesets ?? [],
-    assetPublishing: result.data?.assetPublishing ?? {
-      status: null,
-      captureStatus: null,
-      publicationHref: null,
-      lastPublishedAt: null,
-    },
-  };
+  return result;
 }
 
 export function useFactionCataloguePage(options?: { initialData?: FactionCataloguePageData }) {
@@ -187,7 +175,7 @@ export function useFactionLoadPicker(options?: { initialData?: FactionLoadPicker
     ? {
         rows: liveData.rows.map((row) => ({
           ...row,
-          data: CanonicalFactionStoredSchema.parse(row.data),
+          data: parseClientBoundary(CanonicalFactionClientSchema, row.data, 'Faction data'),
         })),
         memberGroupIds: liveData.memberGroupIds,
       }

--- a/src/app/groups/db.ts
+++ b/src/app/groups/db.ts
@@ -64,15 +64,7 @@ export function useGroupDetailBySlug(
     true,
     () => options?.initialData
   );
-  return {
-    ...result,
-    group: result.data?.group,
-    factions: result.data?.factions,
-    rulesets: result.data?.rulesets,
-    owner: result.data?.owner ?? null,
-    viewerAccess: result.data?.viewerAccess,
-    roster: result.data?.roster,
-  };
+  return result;
 }
 
 export function useGroupEditBySlug(slug: string, options?: { initialData?: GroupEditPageData }) {
@@ -86,11 +78,7 @@ export function useGroupEditBySlug(slug: string, options?: { initialData?: Group
     true,
     () => options?.initialData
   );
-  return {
-    ...result,
-    group: result.data?.group,
-    viewerAccess: result.data?.viewerAccess,
-  };
+  return result;
 }
 
 /** Call only when `createdBy` is a real user id (e.g. mount a child after profile is known). */

--- a/src/app/migrations/db.ts
+++ b/src/app/migrations/db.ts
@@ -22,11 +22,7 @@ export function useAdminMigrationDashboard(options?: {
     | AdminMigrationDashboardData
     | undefined;
   const result = toLiveQueryResult(liveData, true, () => options?.initialData);
-  return {
-    ...result,
-    statuses: result.data?.statuses ?? [],
-    snapshots: result.data?.snapshots ?? [],
-  };
+  return result;
 }
 
 export function useSyncMigrationRuns() {

--- a/src/app/profile/db.ts
+++ b/src/app/profile/db.ts
@@ -60,15 +60,7 @@ export function useProfileBySlug(
   const liveData = useQuery(api.profiles.getBySlug, { slug });
   const normalized = liveData ? normalizeProfilePage(liveData) : undefined;
   const result = toLiveQueryResult(normalized, true, () => options?.initialData);
-  return {
-    ...result,
-    profile: result.data ? result.data.profile : undefined,
-    groupSummaries: result.data?.groupSummaries,
-    faqAsked: result.data?.faqAsked,
-    faqAnswers: result.data?.faqAnswers,
-    factions: result.data?.factions,
-    acceptedAnswerCount: result.data?.acceptedAnswerCount,
-  };
+  return result;
 }
 
 export function useProfilesAll(options?: { initialData?: ProfileListEntry[] }) {

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,6 +1,23 @@
-import { createRouter as createTanStackRouter } from '@tanstack/react-router';
+import { ErrorComponent, createRouter as createTanStackRouter } from '@tanstack/react-router';
+
+import { StaleClientDataError } from '@app/db/core/clientBoundary';
 
 import { routeTree } from './routeTree.gen';
+
+function AppErrorComponent({ error }: { error: Error }) {
+  if (error instanceof StaleClientDataError) {
+    return (
+      <div role="alert" style={{ maxWidth: '28rem', margin: '4rem auto', textAlign: 'center' }}>
+        <h1>This page changed</h1>
+        <p>The data no longer matches this version of the app.</p>
+        <button type="button" onClick={() => window.location.reload()}>
+          Refresh
+        </button>
+      </div>
+    );
+  }
+  return <ErrorComponent error={error} />;
+}
 
 export function getRouter() {
   const router = createTanStackRouter({
@@ -8,6 +25,7 @@ export function getRouter() {
     scrollRestoration: true,
     defaultPreload: 'intent',
     defaultPreloadStaleTime: 0,
+    defaultErrorComponent: AppErrorComponent,
   });
 
   return router;

--- a/src/app/routes/_app/admin/migrations.tsx
+++ b/src/app/routes/_app/admin/migrations.tsx
@@ -28,7 +28,8 @@ function formatDate(timestamp?: number) {
 function AdminMigrationsPage() {
   const loaderData = Route.useLoaderData();
   const profile = useCurrentProfile();
-  const dashboard = useAdminMigrationDashboard({ initialData: loaderData.dashboard });
+  const dashboardQuery = useAdminMigrationDashboard({ initialData: loaderData.dashboard });
+  const dashboard = dashboardQuery.data;
   const syncRuns = useSyncMigrationRuns();
 
   if (!profile.data?._id) {
@@ -46,7 +47,7 @@ function AdminMigrationsPage() {
   return (
     <PageLayout header={<h1>Migration activity</h1>}>
       <Stack gap={3}>
-        {dashboard.isPending && <p>Loading migration dashboard…</p>}
+        {dashboardQuery.isPending && <p>Loading migration dashboard…</p>}
         <Card>
           <Stack gap={2}>
             <h2>Live migration status</h2>
@@ -76,7 +77,7 @@ function AdminMigrationsPage() {
                 </tr>
               </thead>
               <tbody>
-                {dashboard.statuses.map((row) => (
+                {(dashboard?.statuses ?? []).map((row) => (
                   <tr key={row.name}>
                     <td>{row.name}</td>
                     <td>{row.state}</td>
@@ -107,7 +108,7 @@ function AdminMigrationsPage() {
                 </tr>
               </thead>
               <tbody>
-                {dashboard.snapshots.map((row) => (
+                {(dashboard?.snapshots ?? []).map((row) => (
                   <tr key={row._id}>
                     <td>{row.migration_id}</td>
                     <td>{row.state}</td>

--- a/src/app/routes/_app/factions/$factionId/edit.tsx
+++ b/src/app/routes/_app/factions/$factionId/edit.tsx
@@ -38,9 +38,11 @@ function FactionEditPage() {
   const setFactionGroup = useSetFactionGroup();
   const [confirmDelete, setConfirmDelete] = useState(false);
 
-  const { faction, viewerAccess, assignableGroups, assetPublishing } = useFaction(factionId, {
+  const factionQuery = useFaction(factionId, {
     initialData: loaderData,
   });
+  const { faction, viewerAccess, assignableGroups, assetPublishing } =
+    factionQuery.data ?? loaderData;
   const authoringFaction = faction ?? loaderData.faction;
   const authoring = useFactionAuthoring({
     sessionKey: authoringFaction._id,

--- a/src/app/routes/_app/factions/$factionId/index.tsx
+++ b/src/app/routes/_app/factions/$factionId/index.tsx
@@ -99,12 +99,13 @@ function FactionDetailPage() {
   const loaderData = Route.useLoaderData();
   const factionSeed = loaderData;
 
-  const { faction, viewerAccess, owner, assetPublishing, rulesets } = useFaction(factionId, {
+  const factionQuery = useFaction(factionId, {
     initialData: factionSeed,
   });
   const membershipWorkflow = useGroupMembershipWorkflow();
+  const page = factionQuery.data;
 
-  if (!faction) {
+  if (!page) {
     return (
       <PageLayout
         header={
@@ -125,6 +126,8 @@ function FactionDetailPage() {
       </PageLayout>
     );
   }
+
+  const { faction, viewerAccess, owner, assetPublishing, rulesets } = page;
 
   const canEdit = viewerAccess?.capabilities.edit ?? false;
   const assignedGroup = viewerAccess?.assignedGroup ?? null;

--- a/src/app/routes/_app/groups/$groupSlug/edit.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/edit.tsx
@@ -22,7 +22,8 @@ function GroupEditPage() {
   const loaderData = Route.useLoaderData();
   const groupData = useGroupEditBySlug(groupSlug, { initialData: loaderData.groupEdit });
 
-  if (groupData.isError || !groupData.group || !groupData.viewerAccess) {
+  const editPage = groupData.data;
+  if (groupData.isError || !editPage) {
     return (
       <PageLayout header={<h1>Edit group</h1>}>
         <Card>
@@ -35,8 +36,8 @@ function GroupEditPage() {
     );
   }
 
-  const group = groupData.group;
-  const viewerAccess = groupData.viewerAccess;
+  const group = editPage.group;
+  const viewerAccess = editPage.viewerAccess;
   const header = <h1>{`Edit ${group.name}`}</h1>;
   const toolbar = (
     <Toolbar>

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -37,19 +37,20 @@ function GroupDetailPage() {
     );
   }
 
-  if (!groupData.group || !groupData.viewerAccess) {
+  const page = groupData.data;
+  if (!page) {
     return <PageLayout header={<h1>Group</h1>}>Loading group…</PageLayout>;
   }
 
-  const group = groupData.group;
+  const group = page.group;
   const groupId = group._id;
-  const viewerAccess = groupData.viewerAccess;
-  const ownerProfile = groupData.owner;
+  const viewerAccess = page.viewerAccess;
+  const ownerProfile = page.owner;
   const membershipStatus =
     viewerAccess.viewer.kind === 'authenticated' ? viewerAccess.viewer.membership : 'none';
-  const factions = groupData.factions ?? [];
-  const rulesets = groupData.rulesets ?? [];
-  const roster = groupData.roster ?? [];
+  const factions = page.factions;
+  const rulesets = page.rulesets;
+  const roster = page.roster;
 
   const membersModerationBusy =
     membershipWorkflow.approve.isPending ||

--- a/src/app/routes/_app/profiles/$profileSlug/index.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/index.tsx
@@ -40,12 +40,13 @@ export const Route = createFileRoute('/_app/profiles/$profileSlug/')({
 function ProfileDetailPage() {
   const { profileSlug } = Route.useParams();
   const loaderData = Route.useLoaderData();
-  const profileData = useProfileBySlug(profileSlug, { initialData: loaderData.profilePage });
+  const profileQuery = useProfileBySlug(profileSlug, { initialData: loaderData.profilePage });
+  const page = profileQuery.data;
   const currentProfile = useCurrentProfile();
   const { signOut } = useAuthActions();
   const navigate = useNavigate();
 
-  if (!profileData.profile) {
+  if (!page) {
     return (
       <PageLayout header={<h1>Profile</h1>}>
         <Card>
@@ -58,9 +59,9 @@ function ProfileDetailPage() {
     );
   }
 
-  const isSelf = currentProfile.data?._id === profileData.profile._id;
+  const isSelf = currentProfile.data?._id === page.profile._id;
   const initials =
-    profileData.profile.username
+    page.profile.username
       ?.slice(0, 2)
       .toUpperCase()
       .replace(/[^A-Z]/g, '') || '?';
@@ -70,7 +71,7 @@ function ProfileDetailPage() {
     await navigate({ to: '/auth/login' });
   };
 
-  const acceptedAnswerCount = profileData.acceptedAnswerCount ?? 0;
+  const acceptedAnswerCount = page.acceptedAnswerCount;
 
   const toolbar = (
     <Toolbar>
@@ -124,17 +125,17 @@ function ProfileDetailPage() {
     <PageLayout
       header={
         <div className={styles.identityRow}>
-          {profileData.profile.avatar_url ? (
+          {page.profile.avatar_url ? (
             <img
-              src={profileData.profile.avatar_url}
-              alt={profileData.profile.username ?? 'Avatar'}
+              src={page.profile.avatar_url}
+              alt={page.profile.username ?? 'Avatar'}
               className={styles.avatar}
             />
           ) : (
             <span className={styles.avatarPlaceholder}>{initials}</span>
           )}
           <Stack gap={1}>
-            <h1 className={styles.displayName}>{profileData.profile.username ?? 'Unknown'}</h1>
+            <h1 className={styles.displayName}>{page.profile.username ?? 'Unknown'}</h1>
             {isSelf && <p className={styles.selfHint}>This is you!</p>}
             <p className={styles.profileSummary}>
               <strong>Proposed bio:</strong> A short introduction describing this contributor's
@@ -152,8 +153,8 @@ function ProfileDetailPage() {
             <h2 className={styles.iconHeading}>
               <Shield size={20} aria-hidden /> Factions created
             </h2>
-            {profileData.factions && profileData.factions.length > 0 ? (
-              <FactionList factions={profileData.factions} />
+            {page.factions.length > 0 ? (
+              <FactionList factions={page.factions} />
             ) : (
               <Card>
                 <p className={styles.empty}>No factions created yet.</p>
@@ -180,10 +181,10 @@ function ProfileDetailPage() {
               <MessageCircleReply size={20} aria-hidden /> Answers contributed
             </h2>
             <Card>
-              {profileData.faqAnswers && profileData.faqAnswers.length > 0 ? (
+              {page.faqAnswers.length > 0 ? (
                 <ProfileFaqAnswersGiven
-                  items={profileData.faqAnswers}
-                  viewedProfileId={profileData.profile._id}
+                  items={page.faqAnswers}
+                  viewedProfileId={page.profile._id}
                 />
               ) : (
                 <p className={styles.empty}>No FAQ answers yet.</p>
@@ -196,8 +197,8 @@ function ProfileDetailPage() {
               <CircleHelp size={20} aria-hidden /> Questions asked
             </h2>
             <Card>
-              {profileData.faqAsked && profileData.faqAsked.length > 0 ? (
-                <ProfileFaqQuestionsAsked items={profileData.faqAsked} />
+              {page.faqAsked.length > 0 ? (
+                <ProfileFaqQuestionsAsked items={page.faqAsked} />
               ) : (
                 <p className={styles.empty}>No questions asked yet.</p>
               )}
@@ -217,17 +218,17 @@ function ProfileDetailPage() {
               <div className={styles.factList}>
                 <p>
                   <Shield size={18} aria-hidden />
-                  <strong>{profileData.factions?.length ?? 0}</strong>
+                  <strong>{page.factions.length}</strong>
                   <span>Factions</span>
                 </p>
                 <p>
                   <UsersRound size={18} aria-hidden />
-                  <strong>{profileData.groupSummaries?.length ?? 0}</strong>
+                  <strong>{page.groupSummaries.length}</strong>
                   <span>Groups</span>
                 </p>
                 <p>
                   <MessageCircleReply size={18} aria-hidden />
-                  <strong>{profileData.faqAnswers?.length ?? 0}</strong>
+                  <strong>{page.faqAnswers.length}</strong>
                   <span>Answers</span>
                 </p>
                 <p>
@@ -237,7 +238,7 @@ function ProfileDetailPage() {
                 </p>
                 <p>
                   <CircleHelp size={18} aria-hidden />
-                  <strong>{profileData.faqAsked?.length ?? 0}</strong>
+                  <strong>{page.faqAsked.length}</strong>
                   <span>Questions</span>
                 </p>
               </div>
@@ -257,11 +258,11 @@ function ProfileDetailPage() {
                 </p>
                 <p className={styles.memberSince}>
                   Member since{' '}
-                  <time dateTime={profileData.profile.created_at}>
+                  <time dateTime={page.profile.created_at}>
                     {new Intl.DateTimeFormat('en', {
                       month: 'short',
                       year: 'numeric',
-                    }).format(new Date(profileData.profile.created_at))}
+                    }).format(new Date(page.profile.created_at))}
                   </time>
                 </p>
               </Stack>
@@ -274,7 +275,7 @@ function ProfileDetailPage() {
                 </h2>
               }
             >
-              <ProfileGroupMemberships groups={profileData.groupSummaries ?? []} />
+              <ProfileGroupMemberships groups={page.groupSummaries} />
             </Card>
           </Stack>
         </aside>

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
@@ -35,16 +35,17 @@ function RulesetEditPage() {
   const loaderData = Route.useLoaderData();
   const detailSeed =
     !loaderData.notFound && loaderData.detailPage ? loaderData.detailPage : undefined;
-  const page = useRulesetDetailPage(rulesetSlug, { initialData: detailSeed });
+  const pageQuery = useRulesetDetailPage(rulesetSlug, { initialData: detailSeed });
+  const page = pageQuery.data;
 
-  const header = page.ruleset ? (
+  const header = page?.ruleset ? (
     <Group wrap="nowrap" align="center" gap="lg" className={styles.pageHead}>
       <Paper className={styles.rulesetHeadCover} radius="md" withBorder>
-        {page.ruleset.image_cover ? (
+        {page?.ruleset.image_cover ? (
           <Image
-            src={page.ruleset.image_cover}
+            src={page?.ruleset.image_cover}
             fallbackSrc="/image/background/card.jpg"
-            alt={`Cover for ${page.ruleset.name}`}
+            alt={`Cover for ${page?.ruleset.name}`}
             className={styles.coverImage}
           />
         ) : (
@@ -57,7 +58,7 @@ function RulesetEditPage() {
       </Paper>
       <Stack gap={6} className={styles.pageHeadText}>
         <Title order={1} className={styles.rulesetTitle}>
-          Edit {page.ruleset.name}
+          Edit {page?.ruleset.name}
         </Title>
       </Stack>
     </Group>
@@ -78,7 +79,7 @@ function RulesetEditPage() {
             <ArrowLeft size={17} aria-hidden />
           </ActionIcon>
         </Tooltip>
-        {page.ruleset ? (
+        {page?.ruleset ? (
           <Tooltip label="View ruleset">
             <ActionIcon
               variant="light"
@@ -89,7 +90,7 @@ function RulesetEditPage() {
                 <Link
                   {...rootProps}
                   to="/rulesets/$rulesetSlug"
-                  params={{ rulesetSlug: page.ruleset?.slug ?? rulesetSlug }}
+                  params={{ rulesetSlug: page?.ruleset?.slug ?? rulesetSlug }}
                 />
               )}
             >
@@ -111,7 +112,7 @@ function RulesetEditPage() {
     );
   }
 
-  if (!page.ruleset) {
+  if (!page?.ruleset) {
     return (
       <PageLayout header={header} toolbar={toolbar}>
         <Paper withBorder p="xl" radius="md">

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -129,14 +129,15 @@ function RulesetDetailPage() {
   const loaderData = Route.useLoaderData();
   const navigate = useNavigate();
   const detailSeed = loaderData.notFound ? undefined : loaderData.detailPage;
-  const page = useRulesetDetailPage(rulesetSlug, { initialData: detailSeed });
+  const pageQuery = useRulesetDetailPage(rulesetSlug, { initialData: detailSeed });
+  const page = pageQuery.data;
   const profile = useCurrentProfile();
   const deleteRuleset = useDeleteRuleset();
   const updateRuleset = useUpdateRuleset();
   const assignRulesetGroup = useUpdateRuleset();
   const membershipWorkflow = useGroupMembershipWorkflow();
 
-  if (loaderData.notFound || !page.ruleset) {
+  if (loaderData.notFound || !page) {
     return (
       <PageLayout
         header={
@@ -454,7 +455,7 @@ function RulesetDetailPage() {
             <SectionHeading id="factions-heading" icon={<Layers3 size={20} aria-hidden />}>
               Included factions
             </SectionHeading>
-            {page.factions && page.factions.length > 0 ? (
+            {page.factions.length > 0 ? (
               <SimpleGrid cols={{ base: 1, lg: 2 }} spacing="md">
                 {page.factions.map((f) => (
                   <Card key={f.factionId} withBorder padding="md" radius="md">
@@ -571,8 +572,8 @@ function RulesetDetailPage() {
               <Group gap="lg" wrap="wrap">
                 <IconStat
                   icon={<Layers3 size={17} aria-hidden />}
-                  value={page.factions?.length ?? 0}
-                  label={`${page.factions?.length ?? 0} ${(page.factions?.length ?? 0) === 1 ? 'faction' : 'factions'}`}
+                  value={page.factions.length}
+                  label={`${page.factions.length} ${page.factions.length === 1 ? 'faction' : 'factions'}`}
                 />
                 <IconStat
                   icon={<CircleHelp size={17} aria-hidden />}

--- a/src/app/routes/preview/sheet/$factionSlug.tsx
+++ b/src/app/routes/preview/sheet/$factionSlug.tsx
@@ -24,7 +24,8 @@ export const Route = createFileRoute('/preview/sheet/$factionSlug')({
 function FactionSheetDbMode() {
   const { factionSlug } = Route.useParams();
   const loaderData = Route.useLoaderData();
-  const { faction } = useFaction(factionSlug, { initialData: loaderData });
+  const factionQuery = useFaction(factionSlug, { initialData: loaderData });
+  const faction = factionQuery.data?.faction ?? loaderData?.faction;
 
   useEffect(() => {
     document.documentElement.dataset.factionSheet = '';

--- a/src/app/rulesets/db.ts
+++ b/src/app/rulesets/db.ts
@@ -3,9 +3,10 @@ import type { FunctionReturnType } from 'convex/server';
 
 import { db } from '@db/core';
 import type { FaqAnswerEntry, FaqItemWithDetails } from '@db/faq';
+import { parseClientBoundary } from '@app/db/core/clientBoundary';
 import { toLiveQueryResult, useLiveMutation } from '@app/db/core/live';
 import { rulesetInputSchema } from '@app/rulesets/validation';
-import { Background } from '@game/schema/faction';
+import { BackgroundClientSchema } from '@game/schema/faction';
 import type { FactionData } from '@game/schema/faction';
 
 import { api } from '../../../convex/_generated/api';
@@ -39,7 +40,11 @@ function normalizeRulesetFactionSummary(faction: RulesetFactionSummaryRaw): Rule
     identity: faction.identity
       ? {
           logo: faction.identity.logo,
-          background: Background.parse(faction.identity.background),
+          background: parseClientBoundary(
+            BackgroundClientSchema,
+            faction.identity.background,
+            'Faction identity'
+          ),
         }
       : null,
   };
@@ -133,12 +138,7 @@ export function useRulesetBySlug(slug: string, options?: { initialData?: Ruleset
   const liveData = useQuery(api.rulesets.getBySlug, { slug });
   const normalized = liveData ? toRulesetPageData(liveData) : undefined;
   const result = toLiveQueryResult(normalized, true, () => options?.initialData);
-  return {
-    ...result,
-    ruleset: result.data ? toRulesetEntry(result.data.ruleset) : undefined,
-    factions: result.data?.factions.map(normalizeRulesetFactionSummary),
-    viewerAccess: result.data?.viewerAccess,
-  };
+  return result;
 }
 
 export function useRulesetDetailPage(
@@ -155,15 +155,7 @@ export function useRulesetDetailPage(
         ? null
         : normalizeRulesetDetailPage(liveData);
   const result = toLiveQueryResult(normalized, true, () => options?.initialData);
-  return {
-    ...result,
-    ruleset: result.data?.ruleset,
-    factions: result.data?.factions,
-    viewerAccess: result.data?.viewerAccess,
-    owner: result.data?.owner ?? null,
-    assignableGroups: result.data?.assignableGroups ?? [],
-    faqItems: result.data?.faqItems ?? [],
-  };
+  return result;
 }
 
 export function useCreateRuleset() {

--- a/src/game/schema/faction.ts
+++ b/src/game/schema/faction.ts
@@ -156,6 +156,14 @@ export const CanonicalFactionStoredSchema = z.strictObject({
   name: z.string(),
 });
 
+/**
+ * Client read-path variants: tolerate unknown top-level fields so additive server changes never
+ * break stale tabs; genuine breaks (missing or mistyped fields) still fail the client boundary (see
+ * db/core/clientBoundary).
+ */
+export const CanonicalFactionClientSchema = z.looseObject({ ...factionShape, name: z.string() });
+export const BackgroundClientSchema = z.looseObject(Background.shape);
+
 /** URL slug on the `factions` row — not a field on `FactionInput` / `factions.data`. */
 export const FactionRowSlugSchema = z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
 

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -3,8 +3,8 @@
 export const rendererManifest = {
   schemaVersion: 1,
   rendererIdentity:
-    'faction-sheet/sha256:9ec45c14e5e682be90c470afc2404cb7ec323e9ad00aee27e7e63ccbb42ad87f',
-  digest: '9ec45c14e5e682be90c470afc2404cb7ec323e9ad00aee27e7e63ccbb42ad87f',
+    'faction-sheet/sha256:6b9c7a66a42590a8862b722a8f5d2a120f7be99a4c72416e7f9f159abe815d44',
+  digest: '6b9c7a66a42590a8862b722a8f5d2a120f7be99a4c72416e7f9f159abe815d44',
   contract: {
     viewport: {
       width: 2100,


### PR DESCRIPTION
Cluster-2 candidate 2, reshaped by discussion: **client-boundary validation stays** — the browser keeps checking incoming data against its own compiled expectations (the stale-tab alarm) — and its three accidental defects are fixed:

1. **Additive tolerance**: the boundary parses through *loose* variants of the same canonical Zod schemas (`CanonicalFactionClientSchema`, `BackgroundClientSchema`). Missing or mistyped fields — a genuine model break — still trip it; an added field (our "safe" deploy class, thirteen of them yesterday) no longer crashes old tabs.
2. **A prompt instead of a crash**: boundary failures throw `StaleClientDataError`, and the router's new `defaultErrorComponent` renders *"This page changed — the data no longer matches this version of the app"* with a Refresh button. Semantically triggered — fires only when the model actually stopped matching, never merely because a deploy happened.
3. **The unrelated field-copying band is deleted**: seven hooks returned `{...result, field: result.data?.field, ...}` with inconsistent `??` defaults that routes re-applied anyway. Hooks now return the query result; nine routes narrow `.data` once and read the real page object — the pattern the three cleanest pages already used.

Renderer manifest regenerated (schema exports reach the capture bundle); the Chromium regression proves byte-identical output.

Verified: 2065 unit tests, **all 5 e2e flows** (the real check for nine route rewrites), both typechecks, lint, format, capture regression, `publisher:release:verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for data received by the application, helping detect outdated or invalid information safely.
  * Added a refresh prompt when stale data prevents a page from loading correctly.
* **Bug Fixes**
  * Improved handling of live data across faction, group, profile, ruleset, and migration pages.
  * Preserved loader data when live results are temporarily unavailable.
  * Improved loading and not-found states across detail and edit pages.
  * Prevented missing dashboard, faction, and related data from causing rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->