### PR TITLE
Profile activity counts move to the aggregate component

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -29,6 +29,7 @@ import type * as lib_faqRulesetList from "../lib/faqRulesetList.js";
 import type * as lib_faqTags from "../lib/faqTags.js";
 import type * as lib_ids from "../lib/ids.js";
 import type * as lib_policy from "../lib/policy.js";
+import type * as lib_profileActivity from "../lib/profileActivity.js";
 import type * as lib_profileBootstrap from "../lib/profileBootstrap.js";
 import type * as lib_profileDetail from "../lib/profileDetail.js";
 import type * as lib_profileDiscovery from "../lib/profileDiscovery.js";
@@ -77,6 +78,7 @@ declare const fullApi: ApiFromModules<{
   "lib/faqTags": typeof lib_faqTags;
   "lib/ids": typeof lib_ids;
   "lib/policy": typeof lib_policy;
+  "lib/profileActivity": typeof lib_profileActivity;
   "lib/profileBootstrap": typeof lib_profileBootstrap;
   "lib/profileDetail": typeof lib_profileDetail;
   "lib/profileDiscovery": typeof lib_profileDiscovery;
@@ -128,4 +130,5 @@ export declare const components: {
   migrations: import("@convex-dev/migrations/_generated/component.js").ComponentApi<"migrations">;
   statistics: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"statistics">;
   profileDiscovery: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"profileDiscovery">;
+  profileActivity: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"profileActivity">;
 };

--- a/convex/collaborationPermissions.test.ts
+++ b/convex/collaborationPermissions.test.ts
@@ -13,6 +13,7 @@ const modules = import.meta.glob('./**/*.ts');
 async function collaborationFixture() {
   const t = convexTest(schema, modules);
   aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileActivity');
   aggregateTest.register(t, 'profileDiscovery');
   const ids = await t.run(async (ctx) => {
     const ownerId = await ctx.db.insert('users', { name: 'Group asset owner' });

--- a/convex/collaborativeAccess.test.ts
+++ b/convex/collaborativeAccess.test.ts
@@ -15,6 +15,7 @@ const now = '2026-08-05T00:00:00.000Z';
 async function groupAccessFixture() {
   const t = convexTest(schema, modules);
   aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileActivity');
   aggregateTest.register(t, 'profileDiscovery');
   const ids = await t.run(async (ctx) => {
     const ownerId = await ctx.db.insert('users', { name: 'Group owner' });

--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -6,5 +6,6 @@ const app = defineApp();
 app.use(migrations);
 app.use(aggregate, { name: 'statistics' });
 app.use(aggregate, { name: 'profileDiscovery' });
+app.use(aggregate, { name: 'profileActivity' });
 
 export default app;

--- a/convex/factions.authoringRoundTrip.test.ts
+++ b/convex/factions.authoringRoundTrip.test.ts
@@ -169,6 +169,7 @@ describe('faction authoring full-field round trip', () => {
   test('creates, schedules, reloads, edits, and shares every admitted field without loss', async () => {
     const t = convexTest(schema, modules);
     aggregateTest.register(t, 'statistics');
+    aggregateTest.register(t, 'profileActivity');
     aggregateTest.register(t, 'profileDiscovery');
     const userId = await t.run(
       async (ctx) => await ctx.db.insert('users', { name: 'Faction authoring proof user' })

--- a/convex/factions.slugReservations.test.ts
+++ b/convex/factions.slugReservations.test.ts
@@ -15,6 +15,7 @@ const modules = import.meta.glob('./**/*.ts');
 async function authenticatedTest() {
   const t = convexTest(schema, modules);
   aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileActivity');
   aggregateTest.register(t, 'profileDiscovery');
   const userId = await t.run(
     async (ctx) => await ctx.db.insert('users', { name: 'Faction slug reservation test user' })
@@ -68,6 +69,7 @@ describe('faction slug reservations', () => {
   test('the repair keeps the active public slug and archives the deleted duplicate', async () => {
     const t = convexTest(schema, modules);
     aggregateTest.register(t, 'statistics');
+    aggregateTest.register(t, 'profileActivity');
     aggregateTest.register(t, 'profileDiscovery');
     migrationsTest.register(t);
     const { activeId, deletedId } = await t.run(async (ctx) => {

--- a/convex/faq.test.ts
+++ b/convex/faq.test.ts
@@ -22,6 +22,7 @@ function faqTest(
     ? convexTest({ schema, modules, transactionLimits })
     : convexTest(schema, modules);
   aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileActivity');
   aggregateTest.register(t, 'profileDiscovery');
   return t;
 }

--- a/convex/homepage.test.ts
+++ b/convex/homepage.test.ts
@@ -18,6 +18,7 @@ describe('homepage page data', () => {
   test('serves exact Statistics totals without migration readiness', async () => {
     const t = convexTest(schema, modules);
     aggregateTest.register(t, 'statistics');
+    aggregateTest.register(t, 'profileActivity');
     aggregateTest.register(t, 'profileDiscovery');
     const userId = await t.run((ctx) => ctx.db.insert('users', { name: 'Homepage maker' }));
     await t.run((rawCtx) =>
@@ -86,6 +87,7 @@ describe('homepage page data', () => {
   test('reuses discoverable profiles in the homepage with exact eligibility and ordering', async () => {
     const t = convexTest(schema, modules);
     aggregateTest.register(t, 'statistics');
+    aggregateTest.register(t, 'profileActivity');
     aggregateTest.register(t, 'profileDiscovery');
     migrationsTest.register(t);
     await t.run(async (ctx) => {

--- a/convex/lib/applicationTriggers.ts
+++ b/convex/lib/applicationTriggers.ts
@@ -2,10 +2,12 @@ import { Triggers } from 'convex-helpers/server/triggers';
 
 import type { DataModel } from '../_generated/dataModel';
 import type { MutationCtx } from '../_generated/server';
+import { registerProfileActivityTriggers } from './profileActivity';
 import { registerProfileDiscoveryTriggers } from './profileDiscovery';
 import { registerStatisticsTriggers } from './statistics';
 
 export const applicationTriggers = new Triggers<DataModel, MutationCtx>();
 
 registerStatisticsTriggers(applicationTriggers);
+registerProfileActivityTriggers(applicationTriggers);
 registerProfileDiscoveryTriggers(applicationTriggers);

--- a/convex/lib/profileActivity.ts
+++ b/convex/lib/profileActivity.ts
@@ -1,0 +1,168 @@
+import { DirectAggregate } from '@convex-dev/aggregate';
+import type { Triggers } from 'convex-helpers/server/triggers';
+
+import { components } from '../_generated/api';
+import type { DataModel, Doc, Id } from '../_generated/dataModel';
+import type { MutationCtx, QueryCtx } from '../_generated/server';
+
+export const PROFILE_ACTIVITY_METRICS = ['groups', 'factions', 'questions', 'answers'] as const;
+
+export type ProfileActivityMetric = (typeof PROFILE_ACTIVITY_METRICS)[number];
+
+type ActivityItem = {
+  namespace: ProfileActivityMetric;
+  key: [string];
+  id: string;
+};
+
+const profileActivity = new DirectAggregate<{
+  Namespace: ProfileActivityMetric;
+  Key: [string];
+  Id: string;
+}>(components.profileActivity);
+
+function membershipItem(membership: Doc<'group_members'>): ActivityItem | null {
+  return membership.status === 'active'
+    ? { namespace: 'groups', key: [membership.user_id], id: membership._id }
+    : null;
+}
+
+function factionItem(faction: Doc<'factions'>): ActivityItem | null {
+  return faction.is_deleted
+    ? null
+    : { namespace: 'factions', key: [faction.owner_id], id: faction._id };
+}
+
+function questionItem(question: Doc<'faq_items'>): ActivityItem {
+  return { namespace: 'questions', key: [question.asked_by], id: question._id };
+}
+
+function answerItem(answer: Doc<'faq_answers'>): ActivityItem {
+  return { namespace: 'answers', key: [answer.answered_by], id: answer._id };
+}
+
+function sameItem(left: ActivityItem | null, right: ActivityItem | null): boolean {
+  return (
+    left?.namespace === right?.namespace && left?.key[0] === right?.key[0] && left?.id === right?.id
+  );
+}
+
+async function applyTransition(
+  ctx: MutationCtx,
+  oldItem: ActivityItem | null,
+  newItem: ActivityItem | null
+) {
+  if (sameItem(oldItem, newItem)) {
+    if (newItem) {
+      await profileActivity.insertIfDoesNotExist(ctx, newItem);
+    }
+    return;
+  }
+  if (oldItem && newItem) {
+    await profileActivity.replaceOrInsert(ctx, oldItem, newItem);
+    return;
+  }
+  if (oldItem) {
+    await profileActivity.deleteIfExists(ctx, oldItem);
+    return;
+  }
+  if (newItem) {
+    await profileActivity.insertIfDoesNotExist(ctx, newItem);
+  }
+}
+
+export function registerProfileActivityTriggers(triggers: Triggers<DataModel, MutationCtx>) {
+  triggers.register('group_members', async (ctx, change) => {
+    await applyTransition(
+      ctx,
+      change.oldDoc ? membershipItem(change.oldDoc) : null,
+      change.newDoc ? membershipItem(change.newDoc) : null
+    );
+  });
+
+  triggers.register('factions', async (ctx, change) => {
+    await applyTransition(
+      ctx,
+      change.oldDoc ? factionItem(change.oldDoc) : null,
+      change.newDoc ? factionItem(change.newDoc) : null
+    );
+  });
+
+  triggers.register('faq_items', async (ctx, change) => {
+    await applyTransition(
+      ctx,
+      change.oldDoc ? questionItem(change.oldDoc) : null,
+      change.newDoc ? questionItem(change.newDoc) : null
+    );
+  });
+
+  triggers.register('faq_answers', async (ctx, change) => {
+    await applyTransition(
+      ctx,
+      change.oldDoc ? answerItem(change.oldDoc) : null,
+      change.newDoc ? answerItem(change.newDoc) : null
+    );
+  });
+}
+
+export type ProfileActivityCounts = {
+  groupCount: number;
+  factionCount: number;
+  questionCount: number;
+  answerCount: number;
+};
+
+/** Per-user activity counts in one batched aggregate read. */
+export async function loadProfileActivityCounts(
+  ctx: QueryCtx,
+  userIds: Id<'users'>[]
+): Promise<ProfileActivityCounts[]> {
+  const counts = await profileActivity.countBatch(
+    ctx,
+    userIds.flatMap((userId) =>
+      PROFILE_ACTIVITY_METRICS.map((namespace) => ({
+        namespace,
+        bounds: { prefix: [userId] as [string] },
+      }))
+    )
+  );
+  return userIds.map((_, index) => ({
+    groupCount: counts[index * 4] ?? 0,
+    factionCount: counts[index * 4 + 1] ?? 0,
+    questionCount: counts[index * 4 + 2] ?? 0,
+    answerCount: counts[index * 4 + 3] ?? 0,
+  }));
+}
+
+export async function clearProfileActivity(ctx: MutationCtx) {
+  await profileActivity.clearAll(ctx);
+}
+
+export async function reconcileMembershipActivity(
+  ctx: MutationCtx,
+  membership: Doc<'group_members'>
+) {
+  const item = { namespace: 'groups' as const, key: [membership.user_id] as [string] };
+  if (membership.status === 'active') {
+    await profileActivity.insertIfDoesNotExist(ctx, { ...item, id: membership._id });
+  } else {
+    await profileActivity.deleteIfExists(ctx, { ...item, id: membership._id });
+  }
+}
+
+export async function reconcileFactionActivity(ctx: MutationCtx, faction: Doc<'factions'>) {
+  const item = { namespace: 'factions' as const, key: [faction.owner_id] as [string] };
+  if (faction.is_deleted) {
+    await profileActivity.deleteIfExists(ctx, { ...item, id: faction._id });
+  } else {
+    await profileActivity.insertIfDoesNotExist(ctx, { ...item, id: faction._id });
+  }
+}
+
+export async function reconcileQuestionActivity(ctx: MutationCtx, question: Doc<'faq_items'>) {
+  await profileActivity.insertIfDoesNotExist(ctx, questionItem(question));
+}
+
+export async function reconcileAnswerActivity(ctx: MutationCtx, answer: Doc<'faq_answers'>) {
+  await profileActivity.insertIfDoesNotExist(ctx, answerItem(answer));
+}

--- a/convex/localDevelopment.test.ts
+++ b/convex/localDevelopment.test.ts
@@ -21,6 +21,7 @@ describe('local faction development import', () => {
   test('maps imported factions and groups onto the two local auth users', async () => {
     const t = convexTest(schema, modules);
     aggregateTest.register(t, 'statistics');
+    aggregateTest.register(t, 'profileActivity');
     aggregateTest.register(t, 'profileDiscovery');
     const [ownerId, collaboratorId] = await t.run(async (ctx) => {
       const owner = await ctx.db.insert('users', { email: 'user-a@example.com' });
@@ -104,6 +105,7 @@ describe('local faction development import', () => {
     vi.stubEnv('IS_TEST', 'false');
     const t = convexTest(schema, modules);
     aggregateTest.register(t, 'statistics');
+    aggregateTest.register(t, 'profileActivity');
     aggregateTest.register(t, 'profileDiscovery');
 
     await expect(

--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -105,6 +105,26 @@
       "id": "profile_discovery_ready",
       "phase": "narrow",
       "requires": ["profile_discovery_profiles_v1"]
+    },
+    {
+      "id": "profile_activity_memberships_v1",
+      "phase": "widen",
+      "requires": []
+    },
+    {
+      "id": "profile_activity_factions_v1",
+      "phase": "widen",
+      "requires": []
+    },
+    {
+      "id": "profile_activity_questions_v1",
+      "phase": "widen",
+      "requires": []
+    },
+    {
+      "id": "profile_activity_answers_v1",
+      "phase": "widen",
+      "requires": []
     }
   ]
 }

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -7,6 +7,12 @@ import { components, internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 import { internalMutation, mutation } from './functions';
+import {
+  reconcileAnswerActivity,
+  reconcileFactionActivity,
+  reconcileMembershipActivity,
+  reconcileQuestionActivity,
+} from './lib/profileActivity';
 import { ensureProfileForUser, profileSourcesFromUserDoc } from './lib/profileBootstrap';
 import { reconcileProfileDiscovery } from './lib/profileDiscovery';
 import {
@@ -37,6 +43,10 @@ const MIGRATION_IDS: Record<string, MigrationRef> = {
   statistics_questions_v1: internal.migrations.statistics_questions_v1,
   statistics_answers_v1: internal.migrations.statistics_answers_v1,
   profile_discovery_profiles_v1: internal.migrations.profile_discovery_profiles_v1,
+  profile_activity_memberships_v1: internal.migrations.profile_activity_memberships_v1,
+  profile_activity_factions_v1: internal.migrations.profile_activity_factions_v1,
+  profile_activity_questions_v1: internal.migrations.profile_activity_questions_v1,
+  profile_activity_answers_v1: internal.migrations.profile_activity_answers_v1,
 };
 
 type MigrationId = keyof typeof MIGRATION_IDS;
@@ -325,6 +335,42 @@ export const statistics_answers_v1 = migrations.define({
   batchSize: 50,
   migrateOne: async (ctx, row) => {
     await reconcileAnswerStatistics(ctx, row);
+  },
+});
+
+/** Populates per-user activity counts from active memberships; live writes maintain them. */
+export const profile_activity_memberships_v1 = migrations.define({
+  table: 'group_members',
+  batchSize: 50,
+  migrateOne: async (ctx, row) => {
+    await reconcileMembershipActivity(ctx, row);
+  },
+});
+
+/** Populates per-user activity counts from non-deleted factions. */
+export const profile_activity_factions_v1 = migrations.define({
+  table: 'factions',
+  batchSize: 50,
+  migrateOne: async (ctx, row) => {
+    await reconcileFactionActivity(ctx, row);
+  },
+});
+
+/** Populates per-user activity counts from questions asked. */
+export const profile_activity_questions_v1 = migrations.define({
+  table: 'faq_items',
+  batchSize: 50,
+  migrateOne: async (ctx, row) => {
+    await reconcileQuestionActivity(ctx, row);
+  },
+});
+
+/** Populates per-user activity counts from answers given. */
+export const profile_activity_answers_v1 = migrations.define({
+  table: 'faq_answers',
+  batchSize: 50,
+  migrateOne: async (ctx, row) => {
+    await reconcileAnswerActivity(ctx, row);
   },
 });
 

--- a/convex/profiles.test.ts
+++ b/convex/profiles.test.ts
@@ -1,16 +1,22 @@
 /// <reference types="vite/client" />
 
+import aggregateTest from '@convex-dev/aggregate/test';
 import { convexTest } from 'convex-test';
 import { expect, test } from 'vitest';
 
 import { api } from './_generated/api';
+import { applicationTriggers } from './lib/applicationTriggers';
 import schema from './schema';
 
 const modules = import.meta.glob('./**/*.ts');
 
 test('profile list includes activity counts', async () => {
   const t = convexTest(schema, modules);
-  const ids = await t.run(async (ctx) => {
+  aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileDiscovery');
+  aggregateTest.register(t, 'profileActivity');
+  const ids = await t.run(async (rawCtx) => {
+    const ctx = applicationTriggers.wrapDB(rawCtx);
     const userId = await ctx.db.insert('users', {});
     const profileId = await ctx.db.insert('profiles', {
       user_id: userId,

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -6,8 +6,9 @@ import type { Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 import type { MutationCtx } from './_generated/server';
 import { mutation } from './functions';
-import { profileDetailPageValidator } from './lib/collaborativeAccessValidators';
+import { profileDetailPageValidator, profileValidator } from './lib/collaborativeAccessValidators';
 import { requireAuthUserId } from './lib/policy';
+import { loadProfileActivityCounts } from './lib/profileActivity';
 import { ensureProfileForUser } from './lib/profileBootstrap';
 import { loadProfileDetailBySlug } from './lib/profileDetail';
 import {
@@ -101,47 +102,33 @@ export const getBySlug = query({
   handler: async (ctx, args) => await loadProfileDetailBySlug(ctx, args.slug),
 });
 
+const profileListEntryValidator = profileValidator.extend({
+  activity: v.object({
+    groupCount: v.number(),
+    factionCount: v.number(),
+    questionCount: v.number(),
+    answerCount: v.number(),
+  }),
+});
+
 export const list = query({
   args: {},
+  returns: v.array(profileListEntryValidator),
   handler: async (ctx) => {
     const profiles = await ctx.db.query('profiles').take(500);
-
-    return await Promise.all(
-      profiles.map(async (profile) => {
-        const [memberships, factions, questions, answers] = await Promise.all([
-          ctx.db
-            .query('group_members')
-            .withIndex('by_user_status', (q) =>
-              q.eq('user_id', profile.user_id).eq('status', 'active')
-            )
-            .take(500),
-          ctx.db
-            .query('factions')
-            .withIndex('by_owner_deleted', (q) =>
-              q.eq('owner_id', profile.user_id).eq('is_deleted', false)
-            )
-            .take(500),
-          ctx.db
-            .query('faq_items')
-            .withIndex('by_asked_by_created', (q) => q.eq('asked_by', profile.user_id))
-            .take(500),
-          ctx.db
-            .query('faq_answers')
-            .withIndex('by_answered_by_created', (q) => q.eq('answered_by', profile.user_id))
-            .take(500),
-        ]);
-
-        return {
-          ...profile,
-          activity: {
-            groupCount: memberships.length,
-            factionCount: factions.length,
-            questionCount: questions.length,
-            answerCount: answers.length,
-          },
-        };
-      })
+    const activity = await loadProfileActivityCounts(
+      ctx,
+      profiles.map((profile) => profile.user_id)
     );
+    return profiles.map((profile, index) => ({
+      ...profile,
+      activity: activity[index] ?? {
+        groupCount: 0,
+        factionCount: 0,
+        questionCount: 0,
+        answerCount: 0,
+      },
+    }));
   },
 });
 

--- a/convex/publicationJobs.test.ts
+++ b/convex/publicationJobs.test.ts
@@ -17,6 +17,7 @@ const CACHE_TOKEN = `v1.${'a'.repeat(22)}.${'b'.repeat(43)}`;
 async function authenticatedTest(options: { admin?: boolean } = {}) {
   const t = convexTest(schema, modules);
   aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileActivity');
   aggregateTest.register(t, 'profileDiscovery');
   const userId = await t.run(
     async (ctx) =>

--- a/convex/statistics.test.ts
+++ b/convex/statistics.test.ts
@@ -15,6 +15,7 @@ const modules = import.meta.glob('./**/*.ts');
 test('maintains global and per-ruleset totals through wrapped writes', async () => {
   const t = convexTest(schema, modules);
   aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileActivity');
   aggregateTest.register(t, 'profileDiscovery');
 
   const ids = await t.run(async (rawCtx) => {
@@ -139,6 +140,7 @@ test('maintains global and per-ruleset totals through wrapped writes', async () 
 test('backfills Statistics resumably and rebuilds after later writes bypass triggers', async () => {
   const t = convexTest(schema, modules);
   aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileActivity');
   aggregateTest.register(t, 'profileDiscovery');
   migrationsTest.register(t);
 

--- a/src/app/profile/db.ts
+++ b/src/app/profile/db.ts
@@ -13,14 +13,7 @@ import type { Doc } from '../../../convex/_generated/dataModel';
 
 export type ProfileRow = Doc<'profiles'>;
 export type ProfileEntry = ProfileRow;
-export type ProfileListEntry = ProfileRow & {
-  activity: {
-    groupCount: number;
-    factionCount: number;
-    questionCount: number;
-    answerCount: number;
-  };
-};
+export type ProfileListEntry = FunctionReturnType<typeof api.profiles.list>[number];
 
 /** Server-owned profile detail contract; the read model lives in `convex/lib/profileDetail.ts`. */
 export type ProfileDetailResult = FunctionReturnType<typeof api.profiles.getBySlug>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import { configDefaults, defineConfig } from 'vitest/config';
 
 const config = defineConfig({
   test: {
-    exclude: [...configDefaults.exclude, 'e2e/**'],
+    exclude: [...configDefaults.exclude, 'e2e/**', '.claude/**'],
   },
   build: {
     assetsDir: 'public', // will make your static assets appear under /public/


### PR DESCRIPTION
Cluster-2 candidate 6, following the `statistics` template exactly.

- **The fan-out is gone**: `profiles.list` recomputed 4 index scans × 500 profiles (up to 2,000 reads and half a million rows) on every mutation to five tables — to render four tooltip numbers. It now does one bounded profile read plus **one batched aggregate count** (`countBatch`, 4 entries per profile in a single call).
- **A third `DirectAggregate` instance** (`profileActivity`), namespaced per metric and keyed `[userId]`, maintained by triggers registered beside the existing statistics/discovery ones — same transition semantics (active-only memberships, soft-delete aware factions).
- **Backfill**: four widen migrations through the reconcile helpers, entered in `migration-guards.json`, run automatically by the deploy pipeline (and by `dev-strict` locally / in the e2e container).
- **One authority for the shape**: the query gains a `returns` validator (`profileValidator.extend({ activity })`) and the client `ProfileListEntry` now derives from it — the hand-written copy is gone.
- The counts test seeds through the trigger-wrapped DB (the homepage-test pattern) so it exercises the real maintenance path; all convex suites register the new component.
- Housekeeping: `.claude/**` (background-agent worktrees) excluded from the vitest glob — a spawned worktree was being double-counted by the root suite.

Gates: repo suite (388 across 63 files, post-debt-PR baseline), publisher suite, both typechecks, lint, format, bindings, `publisher:release:verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)