### PR TITLE
Extract the ruleset public-page read model

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -36,6 +36,7 @@ import type * as lib_profileDiscovery from "../lib/profileDiscovery.js";
 import type * as lib_profileSummary from "../lib/profileSummary.js";
 import type * as lib_publication from "../lib/publication.js";
 import type * as lib_publicationHttp from "../lib/publicationHttp.js";
+import type * as lib_rulesetDetailPage from "../lib/rulesetDetailPage.js";
 import type * as lib_statistics from "../lib/statistics.js";
 import type * as lib_utils from "../lib/utils.js";
 import type * as localDevelopment from "../localDevelopment.js";
@@ -85,6 +86,7 @@ declare const fullApi: ApiFromModules<{
   "lib/profileSummary": typeof lib_profileSummary;
   "lib/publication": typeof lib_publication;
   "lib/publicationHttp": typeof lib_publicationHttp;
+  "lib/rulesetDetailPage": typeof lib_rulesetDetailPage;
   "lib/statistics": typeof lib_statistics;
   "lib/utils": typeof lib_utils;
   localDevelopment: typeof localDevelopment;

--- a/convex/lib/rulesetDetailPage.ts
+++ b/convex/lib/rulesetDetailPage.ts
@@ -1,0 +1,105 @@
+import { CanonicalFactionStoredSchema } from '../../src/game/schema/faction';
+import type { Doc, Id } from '../_generated/dataModel';
+import type { QueryCtx } from '../types';
+import { loadAssetAccessBundle, loadRulesetAccessForLoadedSubject } from './collaborativeAccess';
+import { loadFaqItemsForRuleset } from './faqRulesetList';
+import { profileSummary } from './profileSummary';
+
+const RULESET_FACTION_LIMIT = 500;
+
+/** A non-deleted ruleset resolved by its public slug, or null. The one soft-delete gate. */
+export async function loadPublicRulesetBySlug(
+  ctx: QueryCtx,
+  slug: string
+): Promise<Doc<'rulesets'> | null> {
+  const row = await ctx.db
+    .query('rulesets')
+    .withIndex('by_slug', (q) => q.eq('slug', slug))
+    .unique();
+  if (!row || row.is_deleted) {
+    return null;
+  }
+  return row;
+}
+
+/**
+ * Degradation rule: a linked faction whose stored data fails the canonical schema is still listed
+ * (identity chips are optional), rendered with a null identity rather than hiding the link or
+ * failing the page.
+ */
+function factionIdentityForClient(data: unknown) {
+  const parsedFaction = CanonicalFactionStoredSchema.safeParse(data);
+  if (!parsedFaction.success) {
+    return null;
+  }
+  return {
+    logo: parsedFaction.data.logo,
+    background: parsedFaction.data.background,
+  };
+}
+
+/**
+ * Name rule: a faction row whose data carries no readable name falls back to its durable id so the
+ * link stays navigable; soft-deleted and dangling links are dropped.
+ */
+async function listPublicRulesetFactions(ctx: QueryCtx, rulesetId: Id<'rulesets'>) {
+  const links = await ctx.db
+    .query('ruleset_factions')
+    .withIndex('by_ruleset', (q) => q.eq('ruleset_id', rulesetId))
+    .take(RULESET_FACTION_LIMIT);
+  const factions = await Promise.all(links.map((link) => ctx.db.get('factions', link.faction_id)));
+
+  return factions.flatMap((faction) => {
+    if (!faction || faction.is_deleted) {
+      return [];
+    }
+    const dataObj =
+      faction.data != null && typeof faction.data === 'object' && !Array.isArray(faction.data)
+        ? (faction.data as Record<string, unknown>)
+        : null;
+    const name = typeof dataObj?.name === 'string' ? dataObj.name : String(faction._id);
+    return [
+      {
+        factionId: faction._id,
+        name,
+        urlSlug: faction.slug,
+        identity: factionIdentityForClient(faction.data),
+      },
+    ];
+  });
+}
+
+/**
+ * Ruleset public-page read model behind `api.rulesets.getBySlug` and
+ * `api.rulesets.detailPageBySlug`. Owns slug resolution, the soft-delete gate, the faction listing
+ * with its degradation rules, and viewer access; the wire contracts are
+ * `rulesetPublicBundleValidator` / `rulesetDetailPageValidator`.
+ */
+export async function loadRulesetPublicBundleBySlug(ctx: QueryCtx, slug: string) {
+  const row = await loadPublicRulesetBySlug(ctx, slug);
+  if (!row) {
+    throw new Error(`Ruleset with slug ${slug} not found`);
+  }
+  const access = await loadRulesetAccessForLoadedSubject(ctx, row);
+  return {
+    ruleset: row,
+    factions: await listPublicRulesetFactions(ctx, row._id),
+    viewerAccess: access.viewerAccess,
+  };
+}
+
+export async function loadRulesetDetailPageBySlug(ctx: QueryCtx, slug: string) {
+  const row = await loadPublicRulesetBySlug(ctx, slug);
+  if (!row) {
+    return null;
+  }
+  const access = await loadAssetAccessBundle(ctx, { kind: 'ruleset', row });
+  return {
+    ruleset: row,
+    factions: await listPublicRulesetFactions(ctx, row._id),
+    viewerAccess: access.viewerAccess,
+    faqItems: await loadFaqItemsForRuleset(ctx, row._id),
+    owner: await profileSummary(ctx, row.owner_id),
+    assignableGroups: access.assignableGroups,
+  };
+}

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -1,13 +1,10 @@
 import { v } from 'convex/values';
 
 import { rulesetInputSchema } from '../src/app/rulesets/validation';
-import { CanonicalFactionStoredSchema } from '../src/game/schema/faction';
-import type { Doc, Id } from './_generated/dataModel';
+import type { Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 import { mutation } from './functions';
 import {
-  loadAssetAccessBundle,
-  loadRulesetAccessForLoadedSubject,
   requireAssignableGroup,
   requireRulesetMaintenance,
   requireRulesetSoftDelete,
@@ -17,57 +14,16 @@ import {
   rulesetDetailPageValidator,
   rulesetPublicBundleValidator,
 } from './lib/collaborativeAccessValidators';
-import { loadFaqItemsForRuleset } from './lib/faqRulesetList';
 import { requireAuthUserId } from './lib/policy';
-import { profileSummary } from './lib/profileSummary';
+import {
+  loadRulesetDetailPageBySlug,
+  loadRulesetPublicBundleBySlug,
+} from './lib/rulesetDetailPage';
 import { nowIso, slugify } from './lib/utils';
 import type { MutationCtx, QueryCtx } from './types';
 
 async function getRulesetById(ctx: QueryCtx | MutationCtx, id: Id<'rulesets'>) {
   return await ctx.db.get(id);
-}
-
-async function getFactionById(ctx: QueryCtx | MutationCtx, id: Id<'factions'>) {
-  return await ctx.db.get(id);
-}
-
-function factionIdentityForClient(data: unknown) {
-  const parsedFaction = CanonicalFactionStoredSchema.safeParse(data);
-  if (!parsedFaction.success) {
-    return null;
-  }
-  const faction = parsedFaction.data;
-  return {
-    logo: faction.logo,
-    background: faction.background,
-  };
-}
-
-async function listPublicRulesetFactions(ctx: QueryCtx, rulesetId: Id<'rulesets'>) {
-  const links = await ctx.db
-    .query('ruleset_factions')
-    .withIndex('by_ruleset', (q) => q.eq('ruleset_id', rulesetId))
-    .take(500);
-  const factions = await Promise.all(links.map((link) => getFactionById(ctx, link.faction_id)));
-
-  return factions.flatMap((faction) => {
-    if (!faction || faction.is_deleted) {
-      return [];
-    }
-    const dataObj =
-      faction.data != null && typeof faction.data === 'object' && !Array.isArray(faction.data)
-        ? (faction.data as Record<string, unknown>)
-        : null;
-    const name = typeof dataObj?.name === 'string' ? dataObj.name : String(faction._id);
-    return [
-      {
-        factionId: faction._id,
-        name,
-        urlSlug: faction.slug,
-        identity: factionIdentityForClient(faction.data),
-      },
-    ];
-  });
 }
 
 async function resolveUniqueRulesetSlug(
@@ -112,66 +68,16 @@ export const get = query({
   },
 });
 
-async function rulesetBySlugMaybe(ctx: QueryCtx, slug: string) {
-  const locatedRow = await ctx.db
-    .query('rulesets')
-    .withIndex('by_slug', (q) => q.eq('slug', slug))
-    .unique();
-  if (!locatedRow || locatedRow.is_deleted) {
-    return null;
-  }
-  return locatedRow;
-}
-
-async function rulesetPublicPage(
-  ctx: QueryCtx,
-  row: Doc<'rulesets'>,
-  viewerAccess: Awaited<ReturnType<typeof loadRulesetAccessForLoadedSubject>>['viewerAccess']
-) {
-  const factions = await listPublicRulesetFactions(ctx, row._id);
-  return {
-    ruleset: row,
-    factions,
-    viewerAccess,
-  };
-}
-
-async function rulesetPublicBundleBySlug(ctx: QueryCtx, slug: string) {
-  const row = await rulesetBySlugMaybe(ctx, slug);
-  if (!row) {
-    throw new Error(`Ruleset with slug ${slug} not found`);
-  }
-  const access = await loadRulesetAccessForLoadedSubject(ctx, row);
-  return await rulesetPublicPage(ctx, row, access.viewerAccess);
-}
-
 export const getBySlug = query({
   args: { slug: v.string() },
   returns: rulesetPublicBundleValidator,
-  handler: async (ctx, args) => rulesetPublicBundleBySlug(ctx, args.slug),
+  handler: async (ctx, args) => await loadRulesetPublicBundleBySlug(ctx, args.slug),
 });
 
 export const detailPageBySlug = query({
   args: { slug: v.string() },
   returns: rulesetDetailPageValidator,
-  handler: async (ctx, args) => {
-    const row = await rulesetBySlugMaybe(ctx, args.slug);
-    if (!row) {
-      return null;
-    }
-    const access = await loadAssetAccessBundle(ctx, { kind: 'ruleset', row });
-    const page = await rulesetPublicPage(ctx, row, access.viewerAccess);
-    const faqItems = await loadFaqItemsForRuleset(ctx, row._id);
-
-    const owner = await profileSummary(ctx, row.owner_id);
-
-    return {
-      ...page,
-      faqItems,
-      owner,
-      assignableGroups: access.assignableGroups,
-    };
-  },
+  handler: async (ctx, args) => await loadRulesetDetailPageBySlug(ctx, args.slug),
 });
 
 export const listByFaction = query({
@@ -308,7 +214,7 @@ export const addFaction = mutation({
   handler: async (ctx, args) => {
     await requireRulesetMaintenance(ctx, args.ruleset_id);
 
-    const faction = await getFactionById(ctx, args.faction_id);
+    const faction = await ctx.db.get('factions', args.faction_id);
     if (!faction || faction.is_deleted) {
       throw new Error('Faction not found');
     }


### PR DESCRIPTION
Cluster-2 candidate 5 — the last page projection that deserved the profileDetail treatment (the same review honestly cleared groups and factions detail as fine).

- **`convex/lib/rulesetDetailPage.ts`** owns slug resolution, the soft-delete gate (previously written three independent times), the faction listing, and viewer access; `getBySlug` and `detailPageBySlug` are now thin validator'd wrappers. The endpoint file drops ~110 lines of scattered projection.
- **The two quiet rules are now documented owned behavior** instead of implementation trivia: a linked faction with unparseable data is *still listed* with a null identity (chips are optional; the link survives), and a faction whose data lacks a readable name falls back to its durable id so navigation never breaks.
- Wire shapes byte-identical, pinned by the existing `rulesetPublicBundleValidator`/`rulesetDetailPageValidator` and the suites that exercise both queries (collaborative-access matrix, authoring round-trip, FAQ list seam). Per ADR-0002, no new tests — the existing coverage is the characterization.

Gates: 388 tests, typecheck, lint, format, bindings, `publisher:release:verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)