### PR TITLE
Extract the FAQ editing session behind a tested seam

### DIFF
--- a/src/app/faq/faqEditingSession.test.ts
+++ b/src/app/faq/faqEditingSession.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { createFaqEditingSession } from './faqEditingSession';
+
+function harness(overrides?: {
+  editQuestion?: () => Promise<void>;
+  editAnswer?: () => Promise<void>;
+}) {
+  const editQuestion = vi.fn(overrides?.editQuestion ?? (async () => {}));
+  const editAnswer = vi.fn(overrides?.editAnswer ?? (async () => {}));
+  const session = createFaqEditingSession({
+    editQuestion,
+    editAnswer,
+    onState: () => {},
+  });
+  return { session, editQuestion, editAnswer };
+}
+
+describe('FAQ editing session', () => {
+  test('starting a question edit seeds the draft, falling back to the default tag', () => {
+    const { session } = harness();
+
+    session.startEditQuestion({ text: 'How does the storm move?', tags: [] });
+
+    expect(session.state).toMatchObject({
+      editingQuestion: true,
+      questionValue: 'How does the storm move?',
+      tagValues: ['other'],
+    });
+  });
+
+  test('an unchanged save closes the editor without calling the command', async () => {
+    const { session, editQuestion } = harness();
+    const item = { text: 'Question', tags: ['rules'] as never };
+    session.startEditQuestion(item);
+
+    await session.saveQuestion(item);
+
+    expect(editQuestion).not.toHaveBeenCalled();
+    expect(session.state.editingQuestion).toBe(false);
+  });
+
+  test('a changed save trims, submits, and closes', async () => {
+    const { session, editQuestion } = harness();
+    const item = { text: 'Question', tags: ['rules'] as never };
+    session.startEditQuestion(item);
+    session.setQuestionValue('  Sharper question  ');
+    session.toggleTag('errata' as never, true);
+
+    await session.saveQuestion(item);
+
+    expect(editQuestion).toHaveBeenCalledWith({
+      question: 'Sharper question',
+      tags: ['rules', 'errata'],
+    });
+    expect(session.state.editingQuestion).toBe(false);
+  });
+
+  test('a failed save keeps the editor open with the draft intact', async () => {
+    const { session } = harness({
+      editQuestion: async () => {
+        throw new Error('rejected');
+      },
+    });
+    const item = { text: 'Question', tags: ['rules'] as never };
+    session.startEditQuestion(item);
+    session.setQuestionValue('Changed');
+
+    await session.saveQuestion(item);
+
+    expect(session.state.editingQuestion).toBe(true);
+    expect(session.state.questionValue).toBe('Changed');
+  });
+
+  test('deselecting every tag blocks the save', async () => {
+    const { session, editQuestion } = harness();
+    const item = { text: 'Question', tags: ['rules'] as never };
+    session.startEditQuestion(item);
+    session.toggleTag('rules' as never, false);
+    session.setQuestionValue('Changed');
+
+    await session.saveQuestion(item);
+
+    expect(editQuestion).not.toHaveBeenCalled();
+    expect(session.state.editingQuestion).toBe(true);
+  });
+
+  test('answer edits mirror the rules: unchanged closes silently, changed submits trimmed', async () => {
+    const { session, editAnswer } = harness();
+    const answer = { id: 'a1', text: 'The storm moves.' };
+
+    session.startEditAnswer(answer);
+    await session.saveAnswer(answer);
+    expect(editAnswer).not.toHaveBeenCalled();
+    expect(session.state.editingAnswerId).toBeNull();
+
+    session.startEditAnswer(answer);
+    session.setAnswerValue('  It moves 1-6 sectors.  ');
+    await session.saveAnswer(answer);
+    expect(editAnswer).toHaveBeenCalledWith({ answerId: 'a1', answer: 'It moves 1-6 sectors.' });
+    expect(session.state.editingAnswerId).toBeNull();
+  });
+});

--- a/src/app/faq/faqEditingSession.ts
+++ b/src/app/faq/faqEditingSession.ts
@@ -1,0 +1,123 @@
+import { DEFAULT_FAQ_TAG } from '@app/faq/tags';
+import type { FaqTag } from '@app/faq/tags';
+
+export type FaqEditingState = {
+  editingQuestion: boolean;
+  questionValue: string;
+  tagValues: FaqTag[];
+  editingAnswerId: string | null;
+  answerValue: string;
+};
+
+export type FaqEditingPorts = {
+  editQuestion(input: { question: string; tags: FaqTag[] }): Promise<void>;
+  editAnswer(input: { answerId: string; answer: string }): Promise<void>;
+  onState(state: FaqEditingState): void;
+};
+
+type QuestionSource = { text: string; tags?: readonly FaqTag[] };
+
+function tagsOf(item: QuestionSource): FaqTag[] {
+  return Array.isArray(item.tags) && item.tags.length > 0 ? [...item.tags] : [DEFAULT_FAQ_TAG];
+}
+
+const INITIAL: FaqEditingState = {
+  editingQuestion: false,
+  questionValue: '',
+  tagValues: [],
+  editingAnswerId: null,
+  answerValue: '',
+};
+
+/**
+ * FAQ editing session: the draft-vs-current rules for editing a question and its answers (seed from
+ * current with the default-tag fallback, trim, treat unchanged saves as a plain close, stay open on
+ * failure so the command error shows). Framework-free, mirroring the faction authoring session; the
+ * route hosts it through a state sink.
+ */
+export function createFaqEditingSession(ports: FaqEditingPorts) {
+  let state = INITIAL;
+  const set = (patch: Partial<FaqEditingState>) => {
+    state = { ...state, ...patch };
+    ports.onState(state);
+  };
+
+  return {
+    get state(): FaqEditingState {
+      return state;
+    },
+
+    startEditQuestion(item: QuestionSource): void {
+      set({ editingQuestion: true, questionValue: item.text, tagValues: tagsOf(item) });
+    },
+
+    setQuestionValue(value: string): void {
+      set({ questionValue: value });
+    },
+
+    toggleTag(tag: FaqTag, checked: boolean): void {
+      set({
+        tagValues: checked
+          ? state.tagValues.includes(tag)
+            ? state.tagValues
+            : [...state.tagValues, tag]
+          : state.tagValues.filter((value) => value !== tag),
+      });
+    },
+
+    cancelQuestion(): void {
+      set({ editingQuestion: false });
+    },
+
+    async saveQuestion(item: QuestionSource): Promise<void> {
+      const question = state.questionValue.trim();
+      if (!question || state.tagValues.length === 0) {
+        return;
+      }
+      const currentTags = tagsOf(item);
+      const unchanged =
+        question === item.text &&
+        [...state.tagValues].sort().join('|') === [...currentTags].sort().join('|');
+      if (unchanged) {
+        set({ editingQuestion: false });
+        return;
+      }
+      try {
+        await ports.editQuestion({ question, tags: state.tagValues });
+        set({ editingQuestion: false });
+      } catch {
+        // Stay open; the command's own error state carries the message.
+      }
+    },
+
+    startEditAnswer(answer: { id: string; text: string }): void {
+      set({ editingAnswerId: answer.id, answerValue: answer.text });
+    },
+
+    setAnswerValue(value: string): void {
+      set({ answerValue: value });
+    },
+
+    cancelAnswer(): void {
+      set({ editingAnswerId: null });
+    },
+
+    async saveAnswer(current: { id: string; text: string } | undefined): Promise<void> {
+      const answer = state.answerValue.trim();
+      if (!current || !answer || answer === current.text) {
+        set({ editingAnswerId: null });
+        return;
+      }
+      try {
+        await ports.editAnswer({ answerId: current.id, answer });
+        set({ editingAnswerId: null });
+      } catch {
+        // Stay open; the command's own error state carries the message.
+      }
+    },
+  };
+}
+
+export type FaqEditingSession = ReturnType<typeof createFaqEditingSession>;
+
+export const INITIAL_FAQ_EDITING_STATE = INITIAL;

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
@@ -1,9 +1,8 @@
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { Check, MessageSquarePlus, Pencil, Trash2, X } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { loadFaqQuestionPage, useFaqQuestionPage } from '@db/faq';
-import { loadRulesetBySlug } from '@db/rulesets';
 import { Answer } from '@app/components/faq/Answer';
 import { FormField } from '@app/components/form/FormField';
 import { FormTooltip } from '@app/components/form/FormTooltip';
@@ -13,15 +12,15 @@ import { Card } from '@app/components/generic/surfaces/Card';
 import { UIButton } from '@app/components/generic/ui/UIButton';
 import { ProfileLink } from '@app/components/profile/ProfileLink';
 import { PageLayout } from '@app/components/shell';
-import { DEFAULT_FAQ_TAG, FAQ_TAG_LABELS, FAQ_TAG_VALUES } from '@app/faq/tags';
-import type { FaqTag } from '@app/faq/tags';
+import { INITIAL_FAQ_EDITING_STATE, createFaqEditingSession } from '@app/faq/faqEditingSession';
+import type { FaqEditingSession } from '@app/faq/faqEditingSession';
+import { FAQ_TAG_LABELS, FAQ_TAG_VALUES } from '@app/faq/tags';
 
 import styles from './$questionSlug.module.css';
 
 export const Route = createFileRoute('/_app/rulesets/$rulesetSlug/faq/$questionSlug')({
   loader: async ({ params }) => {
     try {
-      await loadRulesetBySlug(params.rulesetSlug);
       const page = await loadFaqQuestionPage({
         rulesetSlug: params.rulesetSlug,
         questionSlug: params.questionSlug,
@@ -45,11 +44,16 @@ function FaqDetailPage() {
     }
   );
 
-  const [editingQuestion, setEditingQuestion] = useState(false);
-  const [editingAnswerId, setEditingAnswerId] = useState<string | null>(null);
-  const [editQuestionValue, setEditQuestionValue] = useState('');
-  const [editTagValues, setEditTagValues] = useState<FaqTag[]>([]);
-  const [editAnswerValue, setEditAnswerValue] = useState('');
+  const [editing, setEditing] = useState(INITIAL_FAQ_EDITING_STATE);
+  const editingSessionRef = useRef<FaqEditingSession>(undefined);
+  const commandsRef = useRef({ faq });
+  commandsRef.current = { faq };
+  editingSessionRef.current ??= createFaqEditingSession({
+    editQuestion: (input) => commandsRef.current.faq.editQuestion.run(input),
+    editAnswer: (input) => commandsRef.current.faq.editAnswer.run(input),
+    onState: setEditing,
+  });
+  const editingSession = editingSessionRef.current;
 
   const page = faq.page;
   const item = page?.question;
@@ -124,59 +128,11 @@ function FaqDetailPage() {
       .catch(() => undefined);
   };
 
-  const startEditQuestion = () => {
-    setEditQuestionValue(item.text);
-    setEditTagValues(
-      Array.isArray(item.tags) && item.tags.length > 0 ? (item.tags as FaqTag[]) : [DEFAULT_FAQ_TAG]
-    );
-    setEditingQuestion(true);
-  };
-
-  const toggleEditTag = (tag: FaqTag, checked: boolean) => {
-    setEditTagValues((prev) => {
-      if (checked) {
-        return prev.includes(tag) ? prev : [...prev, tag];
-      }
-      return prev.filter((value) => value !== tag);
-    });
-  };
-
-  const saveQuestion = () => {
-    const trimmed = editQuestionValue.trim();
-    if (!trimmed || editTagValues.length === 0) {
-      return;
-    }
-    const currentTags =
-      Array.isArray(item.tags) && item.tags.length > 0 ? item.tags : [DEFAULT_FAQ_TAG];
-    const questionChanged = trimmed !== item.text;
-    const tagsChanged = [...editTagValues].sort().join('|') !== [...currentTags].sort().join('|');
-    if (!questionChanged && !tagsChanged) {
-      setEditingQuestion(false);
-      return;
-    }
-    void faq.editQuestion
-      .run({ question: trimmed, tags: editTagValues })
-      .then(() => setEditingQuestion(false))
-      .catch(() => undefined);
-  };
-
-  const startEditAnswer = (a: (typeof answers)[0]) => {
-    setEditAnswerValue(a.text);
-    setEditingAnswerId(a.id);
-  };
-
-  const saveAnswer = (answerId: string) => {
-    const trimmed = editAnswerValue.trim();
-    const a = answers.find((x) => x.id === answerId);
-    if (!a || !trimmed || trimmed === a.text) {
-      setEditingAnswerId(null);
-      return;
-    }
-    void faq.editAnswer
-      .run({ answerId, answer: trimmed })
-      .then(() => setEditingAnswerId(null))
-      .catch(() => undefined);
-  };
+  const startEditQuestion = () => editingSession.startEditQuestion(item);
+  const saveQuestion = () => void editingSession.saveQuestion(item);
+  const startEditAnswer = (a: (typeof answers)[0]) => editingSession.startEditAnswer(a);
+  const saveAnswer = (answerId: string) =>
+    void editingSession.saveAnswer(answers.find((x) => x.id === answerId));
 
   const handleDeleteAnswer = (answerId: string) => {
     if (!window.confirm('Delete this answer?')) {
@@ -190,12 +146,12 @@ function FaqDetailPage() {
       <Card>
         <Stack gap={4}>
           <Stack gap={3}>
-            {editingQuestion ? (
+            {editing.editingQuestion ? (
               <Stack gap={3}>
                 <FormField label="Edit question">
                   <MultilineTextField
-                    value={editQuestionValue}
-                    onChange={(e) => setEditQuestionValue(e.target.value)}
+                    value={editing.questionValue}
+                    onChange={(e) => editingSession.setQuestionValue(e.target.value)}
                     rows={2}
                   />
                 </FormField>
@@ -206,8 +162,8 @@ function FaqDetailPage() {
                       <label key={tag} className={styles.tagOption}>
                         <input
                           type="checkbox"
-                          checked={editTagValues.includes(tag)}
-                          onChange={(e) => toggleEditTag(tag, e.target.checked)}
+                          checked={editing.tagValues.includes(tag)}
+                          onChange={(e) => editingSession.toggleTag(tag, e.target.checked)}
                         />
                         <span>{FAQ_TAG_LABELS[tag]}</span>
                       </label>
@@ -232,7 +188,7 @@ function FaqDetailPage() {
                       type="button"
                       iconOnly
                       aria-label="Cancel editing question"
-                      onClick={() => setEditingQuestion(false)}
+                      onClick={() => editingSession.cancelQuestion()}
                     >
                       <X size={16} aria-hidden />
                     </UIButton>
@@ -345,7 +301,7 @@ function FaqDetailPage() {
           {answers.length > 0 ? (
             <Answer.List className={styles.answerList}>
               {answers.map((a) => {
-                const isEditing = editingAnswerId === a.id;
+                const isEditing = editing.editingAnswerId === a.id;
                 const isUserAnswer = a.capabilities.editAnswer;
                 const isAccepted = a.accepted;
                 return (
@@ -359,8 +315,8 @@ function FaqDetailPage() {
                       <Stack gap={3}>
                         <FormField label="Edit your answer">
                           <MultilineTextField
-                            value={editAnswerValue}
-                            onChange={(e) => setEditAnswerValue(e.target.value)}
+                            value={editing.answerValue}
+                            onChange={(e) => editingSession.setAnswerValue(e.target.value)}
                             rows={3}
                           />
                         </FormField>
@@ -382,7 +338,7 @@ function FaqDetailPage() {
                               type="button"
                               iconOnly
                               aria-label="Cancel editing answer"
-                              onClick={() => setEditingAnswerId(null)}
+                              onClick={() => editingSession.cancelAnswer()}
                             >
                               <X size={16} aria-hidden />
                             </UIButton>


### PR DESCRIPTION
Cluster-2 candidate 8 — the faction-authoring pattern applied to its sibling.

- **`src/app/faq/faqEditingSession.ts`**: framework-free session owning the draft-vs-current rules that lived inline in the route — seed from current with the default-tag fallback, trim on save, treat unchanged saves as a plain close, block empty questions and empty tag sets, and **stay open on failure** so the command's error state carries the message (a rule the inline code enforced only implicitly through promise-chain shape).
- **Six plain-vitest transition tests** — no jsdom, fake command ports — including the failure-keeps-draft case.
- The route drops to presentation + dispatch (five `useState`s and ~55 lines of transition logic replaced by a session host), and its loader **deletes the discarded `loadRulesetBySlug` call** — a full page normalization paid per load purely as an existence check the question query already provides.

Verified: 396 unit tests, **all 5 e2e flows** (the FAQ spec drives this exact route: ask → answer → accept), typecheck, lint, format, `publisher:release:verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized FAQ editing behavior for question and answer drafts.
  * Supports editing tags, trimming values, validation, saving, and cancelling changes.
  * Preserves edits when a save fails and closes unchanged edits automatically.

* **Bug Fixes**
  * Prevents saving FAQs with empty tags.
  * Applies default tags when none are available.

* **Tests**
  * Added coverage for FAQ editing, validation, saving, cancellation, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->