### PR TITLE
One publication work-budget contract, plus capture-route dignity

### DIFF
--- a/workers/publisher/browser.ts
+++ b/workers/publisher/browser.ts
@@ -18,7 +18,6 @@ import {
   assertReadyCaptureMarker,
   waitForCaptureMarkerSettled,
 } from './capture-lifecycle';
-import { captureDeadlineCookie, captureJobCookie } from './capture-route';
 import { inspectChromiumPdf } from './pdf-inspection';
 import { PUBLISHER_RENDERER_CONTRACT } from './renderer-contract';
 
@@ -120,7 +119,7 @@ export function publisherCaptureCookies(
 ): Parameters<BrowserContext['addCookies']>[0] {
   return [
     {
-      name: captureJobCookie,
+      name: CAPTURE_PROTOCOL.credentials.jobCookie,
       value: jobId,
       url: captureBaseUrl,
       httpOnly: true,
@@ -128,7 +127,7 @@ export function publisherCaptureCookies(
       sameSite: 'Strict',
     },
     {
-      name: captureDeadlineCookie,
+      name: CAPTURE_PROTOCOL.credentials.deadlineCookie,
       value: String(lifecycleDeadlineAt),
       url: captureBaseUrl,
       httpOnly: true,

--- a/workers/publisher/capture-route.test.ts
+++ b/workers/publisher/capture-route.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { captureJobHeader, handleCaptureRoute } from './capture-route';
+import { CAPTURE_PROTOCOL } from '../../src/shared/asset-publishing/capture-protocol';
+import { handleCaptureRoute } from './capture-route';
 import type { CaptureEnv } from './capture-route';
 
 const jobId = 'publication-job-000000000000001';
@@ -44,7 +45,7 @@ describe('dedicated exact-snapshot capture boundary', () => {
     const assetFetch = vi.fn(async (_request: Request) => new Response('<html>capture</html>'));
     const response = await handleCaptureRoute(
       new Request('https://publisher.example.com/__asset-publisher/capture', {
-        headers: { [captureJobHeader]: jobId },
+        headers: { [CAPTURE_PROTOCOL.credentials.jobHeader]: jobId },
       }),
       env(assetFetch)
     );
@@ -105,7 +106,7 @@ describe('dedicated exact-snapshot capture boundary', () => {
       const response = await handleCaptureRoute(
         new Request(`https://publisher.example.com${pathname}`, {
           headers: {
-            [captureJobHeader]: invalidToken,
+            [CAPTURE_PROTOCOL.credentials.jobHeader]: invalidToken,
             Cookie: `__Host-publication_job=${invalidToken}`,
           },
         }),
@@ -129,7 +130,7 @@ describe('dedicated exact-snapshot capture boundary', () => {
     vi.stubGlobal('fetch', upstream);
     const response = await handleCaptureRoute(
       new Request('https://publisher.example.com/__asset-publisher/snapshot', {
-        headers: { [captureJobHeader]: jobId },
+        headers: { [CAPTURE_PROTOCOL.credentials.jobHeader]: jobId },
       }),
       env()
     );
@@ -156,7 +157,7 @@ describe('dedicated exact-snapshot capture boundary', () => {
     vi.stubGlobal('fetch', upstream);
     const response = await handleCaptureRoute(
       new Request('https://publisher.example.com/__asset-publisher/snapshot', {
-        headers: { [captureJobHeader]: 'x'.repeat(257) },
+        headers: { [CAPTURE_PROTOCOL.credentials.jobHeader]: 'x'.repeat(257) },
       }),
       env()
     );

--- a/workers/publisher/capture-route.ts
+++ b/workers/publisher/capture-route.ts
@@ -3,6 +3,7 @@ import {
   serializePublisherLogEvent,
 } from '../../src/app/capture/publisher-diagnostics';
 import { CAPTURE_PROTOCOL } from '../../src/shared/asset-publishing/capture-protocol';
+import { absoluteHttpsUrl } from './config';
 import { readBoundedJson, runWithDeadline } from './http';
 
 const JOB_HEADER = CAPTURE_PROTOCOL.credentials.jobHeader;
@@ -21,14 +22,7 @@ function noStoreJson(value: unknown, status: number): Response {
 }
 
 function publicationJobId(request: Request): string | undefined {
-  const header = request.headers.get(JOB_HEADER) ?? undefined;
-  const cookie = request.headers
-    .get('Cookie')
-    ?.split(';')
-    .map((part) => part.trim())
-    .find((part) => part.startsWith(`${JOB_COOKIE}=`))
-    ?.slice(JOB_COOKIE.length + 1);
-  const value = header ?? cookie;
+  const value = request.headers.get(JOB_HEADER) ?? cookie(request, JOB_COOKIE);
   return typeof value === 'string' && value.length >= 1 && value.length <= 128 ? value : undefined;
 }
 
@@ -66,7 +60,7 @@ async function validatePublicationJob(
   }
   try {
     return await runWithDeadline(snapshotDeadline(request), async (signal) => {
-      const upstream = await fetch(env.CONVEX_RENDER_URL, {
+      const upstream = await fetch(absoluteHttpsUrl('CONVEX_RENDER_URL', env.CONVEX_RENDER_URL), {
         method: 'GET',
         headers: { Authorization: `Bearer ${jobId}` },
         signal,
@@ -157,7 +151,3 @@ export async function handleCaptureRoute(
   }
   return undefined;
 }
-
-export const captureJobHeader = JOB_HEADER;
-export const captureJobCookie = JOB_COOKIE;
-export const captureDeadlineCookie = DEADLINE_COOKIE;

--- a/workers/publisher/config.ts
+++ b/workers/publisher/config.ts
@@ -11,6 +11,8 @@ export type PublisherConfig = {
 };
 
 const COMPLETION_MARGIN_MS = 5000;
+/** Per-request clamp for executor round-trips; the single owner of the former hardcoded 15s. */
+export const EXECUTOR_REQUEST_MARGIN_MS = 15_000;
 export const MAX_ASSIGNED_ITEMS = PUBLICATION_MAX_PICKUP;
 
 function integer(name: string, value: string, minimum: number, maximum: number): number {
@@ -24,7 +26,7 @@ function integer(name: string, value: string, minimum: number, maximum: number):
   return parsed;
 }
 
-function absoluteHttpsUrl(name: string, value: string): string {
+export function absoluteHttpsUrl(name: string, value: string): string {
   const url = new URL(value);
   if (url.protocol !== 'https:' || url.username || url.password || url.hash) {
     throw new Error(`${name} must be an absolute HTTPS URL without credentials or fragment`);
@@ -71,5 +73,30 @@ export function parsePublisherConfig(env: Env): PublisherConfig {
     browserCaptureTimeoutMs,
     browserCleanupGraceMs,
     pdfMaxBytes: integer('PDF_MAX_BYTES', env.PDF_MAX_BYTES, 8_000_000, 8_000_000),
+  };
+}
+
+export type PublicationWorkBudget = {
+  workDeadlineAt: number;
+  completionDeadlineAt: number;
+  requestDeadline(): number;
+};
+
+/**
+ * The one timing contract for a publication work cycle: captures stop at the work deadline, the
+ * final report must land before the completion deadline, and each executor round-trip is clamped by
+ * the request margin. The validation in `parsePublisherConfig` guarantees these fit the executor's
+ * absolute lifecycle window.
+ */
+export function publicationWorkBudget(
+  config: Pick<PublisherConfig, 'workWindowMs' | 'browserCleanupGraceMs'>,
+  now: () => number
+): PublicationWorkBudget {
+  const workDeadlineAt = now() + config.workWindowMs;
+  const completionDeadlineAt = workDeadlineAt + config.browserCleanupGraceMs;
+  return {
+    workDeadlineAt,
+    completionDeadlineAt,
+    requestDeadline: () => Math.min(completionDeadlineAt, now() + EXECUTOR_REQUEST_MARGIN_MS),
   };
 }

--- a/workers/publisher/executor.ts
+++ b/workers/publisher/executor.ts
@@ -1,6 +1,7 @@
 import { createCacheToken } from '../../convex/lib/publicationHttp';
 import { TargetRenderError } from './browser';
 import type { CapturedPdf, PublisherBrowserSession } from './browser';
+import { publicationWorkBudget } from './config';
 import type { PublisherConfig } from './config';
 import type { AssignedPublicationJob, ConvexPublisherClient } from './convex';
 import { putPublishedAsset } from './r2';
@@ -30,10 +31,6 @@ export type ItemListExecution = {
   browserSessionId: string | null;
 };
 
-function requestDeadline(now: () => number, absoluteDeadlineAt: number): number {
-  return Math.min(absoluteDeadlineAt, now() + 15_000);
-}
-
 function assertCapturedSize(captured: CapturedPdf, maximum: number): void {
   if (captured.bytes.byteLength <= 0 || captured.bytes.byteLength > maximum) {
     throw new TargetRenderError(`Captured PDF must be between 1 and ${maximum} bytes`);
@@ -51,8 +48,7 @@ export async function executeItemList(
   }
   const now = dependencies.now ?? Date.now;
   const signCacheToken = dependencies.signCacheToken ?? createCacheToken;
-  const workDeadlineAt = now() + config.workWindowMs;
-  const completionDeadlineAt = workDeadlineAt + config.browserCleanupGraceMs;
+  const budget = publicationWorkBudget(config, now);
   const result: ItemListExecution = {
     assigned: items.length,
     rendered: 0,
@@ -73,13 +69,13 @@ export async function executeItemList(
     result.browserSessionId = browser.sessionId();
 
     for (const item of items) {
-      if (now() >= workDeadlineAt) {
+      if (now() >= budget.workDeadlineAt) {
         break;
       }
       try {
         const captured = await browser.capture(
           item.jobId,
-          Math.min(config.browserCaptureTimeoutMs, workDeadlineAt - now())
+          Math.min(config.browserCaptureTimeoutMs, budget.workDeadlineAt - now())
         );
         assertCapturedSize(captured, config.pdfMaxBytes);
         result.rendered += 1;
@@ -99,7 +95,7 @@ export async function executeItemList(
         const completion = await dependencies.client.complete(
           item.jobId,
           cacheToken,
-          requestDeadline(now, completionDeadlineAt)
+          budget.requestDeadline()
         );
         if (completion === 'completed') {
           result.completed += 1;
@@ -111,11 +107,7 @@ export async function executeItemList(
         if (!(error instanceof TargetRenderError)) {
           throw error;
         }
-        const failure = await dependencies.client.fail(
-          item.jobId,
-          error,
-          requestDeadline(now, completionDeadlineAt)
-        );
+        const failure = await dependencies.client.fail(item.jobId, error, budget.requestDeadline());
         if (failure === 'missing') {
           result.missing += 1;
         } else {

--- a/workers/publisher/index.ts
+++ b/workers/publisher/index.ts
@@ -1,7 +1,7 @@
 import { publisherFailureFields } from '../../src/app/capture/publisher-diagnostics';
 import { openPublisherBrowser } from './browser';
 import { handleCaptureRoute } from './capture-route';
-import { MAX_ASSIGNED_ITEMS, parsePublisherConfig } from './config';
+import { EXECUTOR_REQUEST_MARGIN_MS, MAX_ASSIGNED_ITEMS, parsePublisherConfig } from './config';
 import { ConvexPublisherClient } from './convex';
 import { handlePublicAssetRequest } from './delivery';
 import { executeItemList } from './executor';
@@ -98,7 +98,7 @@ export const publisherWorker = {
     try {
       const config = parsePublisherConfig(env);
       const publisher = client(env, config.convexExecutorBaseUrl);
-      const work = await publisher.takeWork(Date.now() + 15_000);
+      const work = await publisher.takeWork(Date.now() + EXECUTOR_REQUEST_MARGIN_MS);
       if (work.status === 'empty') {
         log({
           event: 'asset_publisher_cron',

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -3,8 +3,8 @@
 export const rendererManifest = {
   schemaVersion: 1,
   rendererIdentity:
-    'faction-sheet/sha256:6b9c7a66a42590a8862b722a8f5d2a120f7be99a4c72416e7f9f159abe815d44',
-  digest: '6b9c7a66a42590a8862b722a8f5d2a120f7be99a4c72416e7f9f159abe815d44',
+    'faction-sheet/sha256:a1d7a2a0e0075c316639ab647e2d82ccc047d11ba5e5fffc09acd086ee4fa57e',
+  digest: 'a1d7a2a0e0075c316639ab647e2d82ccc047d11ba5e5fffc09acd086ee4fa57e',
   contract: {
     viewport: {
       width: 2100,


### PR DESCRIPTION
Cluster-2 candidate 9 — the closing PR of the review.

- **`publicationWorkBudget`** (owned by `config.ts`, whose parse already validates that the pieces fit the executor lifecycle) yields the work deadline, completion deadline, and per-request clamp. The executor consumes the budget; the former hardcoded 15 seconds — previously written independently in `executor.ts` and `index.ts` — exists once as `EXECUTOR_REQUEST_MARGIN_MS`. The four-way timing convention is now one enforceable contract. (One review correction: the 5s completion margin and the 15s request clamp turned out to be genuinely different rules; both survive, each with one owner.)
- **Dignity fixes**: the capture route parses its job cookie through its own `cookie()` helper instead of an inlined duplicate; the snapshot fetch uses the normalized `CONVEX_RENDER_URL` its validator produces instead of re-trusting the raw env; and the cookie re-exports that existed to serve one test are gone — the browser driver and the test consume `CAPTURE_PROTOCOL` directly (finishing an ADR-0001 leftover from the capture-contract PR).
- **Renderer manifest regenerated — and this time we know exactly why**: the renderer identity hashes the *runtime-closure sources* (`browser.ts`, `capture-route.ts`, `index.ts`…) by design, since capture semantics carry rendering authority. The Chromium regression proves byte-identical output (2 pages, same size); no revision bump, no recapture.

Gates: publisher suite (158), both typechecks, lint, format, capture regression, `publisher:release:verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publication processing deadline handling for more reliable capture, completion, and failure requests.
  * Added safer URL resolution for upstream rendering requests.
  * Improved fallback handling when reading publication job credentials.
* **Refactor**
  * Centralized publication scheduling and request-margin configuration for more consistent processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->