### PR TITLE
Bump faction-sheet renderer revision: recapture with Train 1 assets

### DIFF
--- a/src/shared/asset-publishing/renderer-revisions.ts
+++ b/src/shared/asset-publishing/renderer-revisions.ts
@@ -5,5 +5,5 @@ import { FACTION_SHEET_ASSET_TYPE } from './publication';
  * Renderer implementation.
  */
 export const CHECKED_IN_RENDERER_REVISIONS = {
-  [FACTION_SHEET_ASSET_TYPE]: 5,
+  [FACTION_SHEET_ASSET_TYPE]: 6,
 } as const;


### PR DESCRIPTION
One-line bump per the recapture mechanism (see workers/publisher/README.md): Train 1's asset pipeline landed in #276 but activation compares CHECKED_IN_RENDERER_REVISIONS, which was not incremented — the deploy logged `changedAssetTypes: []` and no recapture was enqueued. This enqueues the full wave. Wayfinder [#275](https://github.com/ndelangen/dunezone/issues/275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the faction sheet renderer revision to ensure assets are processed using the latest rendering version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->