### PR TITLE
docs: archive image-optimization research and spike findings into main

### DIFF
--- a/docs/research/chromium-pdf-image-embedding.md
+++ b/docs/research/chromium-pdf-image-embedding.md
@@ -1,0 +1,202 @@
+# How Chromium print-to-PDF embeds and rasterizes images
+
+Date: 2026-08-06
+
+Research for [#251](https://github.com/ndelangen/dunezone/issues/251), feeding the PDF size
+spike ([#256](https://github.com/ndelangen/dunezone/issues/256)). The pipeline under study is
+Playwright `page.pdf()` in [`workers/publisher/browser.ts`](../../workers/publisher/browser.ts)
+on Cloudflare Browser Rendering's managed Chromium, rendering the faction sheet whose
+[`Background.tsx`](../../src/game/assets/utils/Background.tsx) draws one texture JPEG through
+~7 SVG `<pattern>`/`<mask>` instances with a
+`grayscale() invert() contrast() blur()` filter on the pattern `<image>`.
+
+Sources are Chromium and Skia `main` as fetched on 2026-08-06 (line numbers cited against
+that snapshot), the Chrome DevTools Protocol docs, Playwright docs, and Cloudflare's Browser
+Rendering docs. The behavior of Cloudflare's pinned Chromium build may differ from `main`;
+everything marked "verify in spike" below is on #256's list.
+
+## The pipeline in one paragraph
+
+Playwright `page.pdf()` issues CDP `Page.printToPDF`
+([Playwright `page.pdf`](https://playwright.dev/docs/api/class-page#page-pdf), which also
+switches rendering to `print` CSS media by default). Chromium's headless print path builds
+`printing::PrintSettings` with `set_dpi(printing::kPointsPerInch)` — 72 DPI layout units
+([`components/printing/browser/print_to_pdf/pdf_print_utils.cc:106`](https://github.com/chromium/chromium/blob/main/components/printing/browser/print_to_pdf/pdf_print_utils.cc)).
+The renderer records the page as Skia paint records; the print compositor service replays them
+into Skia's PDF backend, created by `printing::MakePdfDocument` with a hardcoded
+`metadata.fRasterDPI = 300.0f`
+([`printing/common/metafile_utils.cc:415-442`](https://github.com/chromium/chromium/blob/main/printing/common/metafile_utils.cc)).
+Skia's PDF document then decides, per drawn image, whether to pass encoded bytes through,
+re-encode, or rasterize.
+
+## 1. JPEG passthrough vs re-encode; PNG and AVIF
+
+The decision lives in `serialize_image`
+([`src/pdf/SkPDFBitmap.cpp:371-399`](https://github.com/google/skia/blob/main/src/pdf/SkPDFBitmap.cpp)):
+
+1. **JPEG passthrough.** If the `SkImage` still carries its original encoded bytes
+   (`img->refEncodedData()`), `do_jpeg` embeds those bytes *byte-for-byte* as a `DCTDecode`
+   XObject — no recompression, no quality knob involved. Passthrough requires **all** of
+   (`SkPDFBitmap.cpp:287-344`):
+   - the document has a JPEG decoder callback (Chromium gets Skia's default:
+     `SkPDF::MakeDocument` fills `jpegDecoder`/`jpegEncoder` with `SkPDF::JPEG::Decode/Encode`
+     when unset,
+     [`src/pdf/SkPDFDocument.cpp:720-724`](https://github.com/google/skia/blob/main/src/pdf/SkPDFDocument.cpp));
+   - the data actually decodes as JPEG with matching dimensions;
+   - color type is **YCbCr or grayscale** — CMYK JPEGs fail the `goodColorType` check;
+   - EXIF orientation is top-left (any EXIF rotation kills passthrough).
+
+   ICC profiles from the codec (or the image's color space) are embedded alongside as an
+   `ICCBased` color space. The encoded bytes survive Chromium's cross-process print
+   serialization: `GetImageData` skips re-encoding when `refEncodedData()` is present, and
+   only PNG-encodes images that have no encoded origin
+   ([`printing/common/metafile_utils.cc:390-403`](https://github.com/chromium/chromium/blob/main/printing/common/metafile_utils.cc)).
+
+2. **JPEG re-encode** happens only when passthrough failed **and**
+   `fEncodingQuality <= 100` **and** the image is opaque (`SkPDFBitmap.cpp:390-397`).
+   Chromium never sets `fEncodingQuality`, so it stays at the default **101 = lossless**
+   ([`include/docs/SkPDFDocument.h:159`](https://github.com/google/skia/blob/main/include/docs/SkPDFDocument.h)).
+   **In Chromium this branch is dead code**: there is no launch flag, CDP parameter, or
+   Playwright option that reaches it.
+
+3. **Everything else is deflated raw pixels.** PNG, AVIF, WebP, GIF, canvas/rasterized
+   content, and any JPEG that failed passthrough are decoded to 8-bit BGRA and written as
+   zlib-compressed (`FlateDecode`) raw RGB, with a separate deflated 8-bit alpha `SMask`
+   when not opaque (`do_deflated_image`, `SkPDFBitmap.cpp:203-285`). PNG is **not** embedded
+   as PNG — PDF has no PNG filter — and Skia's flate stream uses no PNG-style predictors, so
+   the embedded bytes are routinely several times larger than the source PNG/AVIF file.
+
+Duplicate draws of the *same* `SkImage` are embedded once: the document caches XObjects per
+image key in `fPDFBitmapMap`
+([`src/pdf/SkPDFDevice.cpp:1852-1860`](https://github.com/google/skia/blob/main/src/pdf/SkPDFDevice.cpp)).
+Seven unfiltered `<img>`/`<image>` references to one texture would share one embedded JPEG.
+Seven *separately rasterized filter results* are seven distinct images — no dedup.
+
+**Version caveat (verify in spike):** the `jpegDecoder`-callback design landed in Skia in
+2023; before that, passthrough was gated on `fEncodingQuality > 100` and a stricter header
+scan. Current `main` attempts passthrough regardless of quality and does not reject
+progressive JPEGs explicitly (only color type + orientation). Whether Cloudflare's pinned
+build passes progressive JPEGs through should be confirmed empirically.
+
+## 2. When SVG `<pattern>` / filtered content rasterizes, and at what DPI
+
+PDF has no filter or compositing model rich enough for CSS/SVG filters, so Skia's PDF device
+rasterizes them:
+
+- **Any saveLayer with an image filter or color filter becomes a raster layer.**
+  `SkPDFDevice::createDevice` returns a plain `SkBitmapDevice` whenever the layer paint has
+  an `ImageFilter` **or** `ColorFilter`
+  ([`src/pdf/SkPDFDevice.cpp:302-316`](https://github.com/google/skia/blob/main/src/pdf/SkPDFDevice.cpp)).
+  Blink lowers `filter: grayscale(...) ... blur(...)` on the pattern `<image>` to exactly
+  such layers, and SVG `<mask>` also goes through a luminance color-filtered layer — so in
+  our `Background.tsx` both the filtered texture *and* the mask application are raster
+  layers, not vector content.
+
+- **Raster resolution is `fRasterDPI`, and Chromium hardcodes 300.** The PDF page canvas is
+  pre-scaled by `fRasterDPI / 72`, so bitmap layer devices are allocated at that scale — the
+  in-source comment says explicitly that layers are created "at the rasterized scale, not
+  the 72dpi scale"
+  ([`src/pdf/SkPDFDocument.cpp:271-305`](https://github.com/google/skia/blob/main/src/pdf/SkPDFDocument.cpp),
+  `fRasterScale` at 241-242). With Chromium's `fRasterDPI = 300`
+  ([`metafile_utils.cc:422`](https://github.com/chromium/chromium/blob/main/printing/common/metafile_utils.cc)),
+  filtered content rasterizes at **300 px per inch of final page** ≈ 3.125 raster px per CSS
+  px (96 CSS px/in). A stale comment in `createDevice` mentions "100dpi"; the page-scaling
+  code is what actually executes.
+
+- **Unsupported shaders rasterize with a ~1-megapixel clamp.** Image shaders with
+  repeat/mirror tiling can become native PDF tiling patterns
+  (`SkPDFShader.cpp:82-268`), but any shader the backend can't express (picture-record
+  shaders, which is how SVG `<pattern>` content is often carried) falls back to
+  `make_fallback_shader`: shade the covered device-space area into a bitmap, **clamped to
+  `kMaxBitmapArea = 1024*1024` pixels** by uniform downscale
+  ([`src/pdf/SkPDFShader.cpp:270-330`](https://github.com/google/skia/blob/main/src/pdf/SkPDFShader.cpp)).
+  A full A4 area at 300 DPI wants ~8.7 Mpx, so a fallback-shader path would be downscaled
+  ~3× — visibly soft — while the saveLayer path keeps full 300 DPI. Which path our
+  pattern+mask combination actually takes is a spike question.
+
+**What does and does not influence the raster DPI:**
+
+| Knob | Effect |
+| --- | --- |
+| `fRasterDPI` | The lever — but hardcoded 300, no flag/CDP/Playwright exposure |
+| Paper size / `preferCSSPageSize` / CSS `@page` | Sets page area in points → total raster pixels (area × 300 DPI), not density |
+| `scale` (CDP/Playwright) | Scales layout within the fixed page; changes how much content area gets rasterized, not the DPI |
+| Viewport size | Print layout uses paper size, not viewport; affects only JS/viewport-unit-driven layout before capture |
+| `deviceScaleFactor` | Should not affect print raster density (print uses its own 72-unit space, `pdf_print_utils.cc:106`); it does affect `srcset`/`image-set` selection and canvas backing stores. Verify in spike |
+| Print emulation (`emulateMedia`) | Chooses print CSS; no DPI effect |
+| Launch flags | `--rasterize-pdf-dpi` exists but applies to printing *existing PDFs* via the PDF viewer, not to `printToPDF` output. No flag reaches `fRasterDPI` |
+
+`Page.printToPDF` exposes layout-only parameters (paper, margins, scale, ranges, header /
+footer, `preferCSSPageSize`, `generateTaggedPDF`, `generateDocumentOutline`, `transferMode`)
+— **no image quality, compression, or DPI parameter of any kind**
+([CDP Page.printToPDF](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF)).
+
+### Consequence for the faction sheet
+
+The texture JPEG's passthrough eligibility is irrelevant today: the filter + mask force each
+pattern instance through raster layers, producing large `FlateDecode` RGB images (plus alpha
+SMasks) — with no dedup across the ~7 instances because each raster is a distinct image.
+That, not the source JPEG's size, is the dominant size mechanism to confirm in the spike.
+
+## 3. Levers to shrink embedded image bytes
+
+Available everywhere (including Cloudflare):
+
+1. **Pre-bake the filter treatment into the asset.** Apply
+   grayscale/invert/contrast/blur offline (build-time per `definition`/`invert` bucket, or
+   once at runtime via canvas → JPEG blob) and drop the SVG filter/mask at print time. Then
+   the texture is a plain opaque JPEG draw: byte-for-byte passthrough + a single shared
+   XObject across all instances. This is the only lever that changes the mechanism rather
+   than the constants.
+2. **Optimize the source JPEG itself** (dimensions, quality, baseline, no EXIF rotation,
+   YCbCr not CMYK). Only pays off once passthrough applies; while filters force
+   rasterization, embedded size depends on rasterized page area, not source bytes.
+3. **Shrink the rasterized area**: fewer/smaller filtered regions, or one full-page
+   background layer instead of ~7 overlapping instances.
+4. **Post-process the PDF** after capture: downsample/JPEG-recompress Flate image XObjects
+   (Ghostscript/mupdf-class tooling). Inside a Worker this means WASM builds and real CPU/
+   memory cost against Browser Rendering + Worker limits; more realistic as a separate
+   processing step than in the publisher hot path.
+
+Unavailable in Cloudflare's managed Chromium (`@cloudflare/playwright`):
+
+- **Any Chromium launch flag.** `launch(binding)` takes the binding, not `args`; Cloudflare
+  runs a managed, pinned Chromium (only Chrome is supported, "different versions of Chrome"
+  explicitly unsupported;
+  [Cloudflare Playwright docs](https://developers.cloudflare.com/browser-rendering/platform/playwright/),
+  [limits](https://developers.cloudflare.com/browser-rendering/platform/limits/)). Not that
+  flags would help: no flag reaches `fRasterDPI` or `fEncodingQuality` anyway.
+- **Skia metadata knobs** (`fRasterDPI`, `fEncodingQuality`, `fCompressionLevel`) — not
+  exposed by any Chromium build, headless or otherwise.
+- **CDP escape hatches** — `Page.printToPDF` simply has no image parameters, so raw CDP
+  access buys nothing here.
+
+## What the spike (#256) should verify empirically
+
+1. **Chromium/Skia version in Cloudflare Browser Rendering** (`browser.version()`), since all
+   line citations are against `main`.
+2. **Anatomy of the current faction-sheet PDF**: per-XObject filter type
+   (`DCTDecode` vs `FlateDecode`), pixel dimensions, byte sizes, and count — does the
+   texture appear ~7× as rasterized layers? Are layers at 300 DPI (full-page ≈ 2480×3508)
+   or 1 Mpx-clamped fallback-shader tiles (≈ 3× downscaled)? Extend
+   [`workers/publisher/pdf-inspection.ts`](../../workers/publisher/pdf-inspection.ts) or use
+   a local script.
+3. **JPEG passthrough proof**: render the texture unfiltered and confirm the embedded
+   `DCTDecode` stream byte-matches the source file, and that N references share one XObject.
+4. **Progressive JPEG** passthrough in the deployed build (version-dependent, see §1).
+5. **`deviceScaleFactor` invariance**: same page at dsf 1 vs 2 → identical PDF image
+   dimensions expected.
+6. **Pre-baked treatment quality**: does an offline grayscale/invert/contrast/blur bake
+   visually match the live SVG filter chain at print size, and what is the resulting PDF
+   size?
+
+## Conclusion
+
+Chromium's print-to-PDF embeds original JPEG bytes untouched whenever the image reaches Skia
+unfiltered, undecoded, un-rotated, and non-CMYK; everything else — including every PNG/AVIF
+and every pixel touched by a CSS/SVG filter or mask — becomes zlib-compressed raw RGB. Filtered
+content rasterizes at a hardcoded 300 DPI of page area (with a ~1 Mpx clamp on fallback
+shader tiles), and neither Playwright, CDP, nor Cloudflare's managed Chromium exposes any
+knob over raster DPI or image encoding. The practical lever for the faction sheet is to move
+the texture treatment out of print-time filters so the pipeline's passthrough + dedup path
+can do its job.

--- a/docs/research/image-formats-and-sharp-determinism.md
+++ b/docs/research/image-formats-and-sharp-determinism.md
@@ -1,0 +1,168 @@
+# Image formats and sharp encoder byte-determinism
+
+Date: 2026-08-06
+
+Research for #252 (part of #250): whether the image pipeline can ship AVIF without a JPEG
+fallback, and whether sharp-generated variants are byte-stable enough to commit to the repo
+under a SHA-256 renderer identity.
+
+## Recommendation
+
+1. **Serve AVIF first, keep one fallback.** Every evergreen browser and iOS Safari 16+ decodes
+   AVIF, but roughly 6–7% of global traffic (dominated by older iOS/macOS Safari) still does
+   not. AVIF-only is not yet safe in 2026; AVIF + JPEG via `<picture>` covers effectively
+   everything, while AVIF + WebP still strands the pre-Safari-14 tail. JPEG is the fallback
+   worth keeping.
+2. **Commit the generated variants; do not generate them in CI.** sharp/libvips makes no
+   byte-stability promise, demonstrably changes output bytes across versions (including a
+   breaking AVIF retune in sharp v0.35.0), and has produced different bytes on macOS vs Linux
+   at the same version. Generate variants once on a dev machine with a pinned sharp version,
+   commit them, and treat regeneration as an explicit, reviewed event. This is the only
+   arrangement under which the publisher's SHA-256 renderer identity stays quiet.
+
+## Format support matrix
+
+### AVIF
+
+Per [caniuse AVIF](https://caniuse.com/avif) and
+[MDN's image type guide](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Image_types):
+
+| Browser | Supported since |
+| --- | --- |
+| Chrome | 85 (2020) |
+| Firefox | 93 (2021); animated AVIF from 113 |
+| Edge | 121 (January 2024) |
+| Safari (macOS) | 16.4 full (partial 16.1–16.3); requires macOS Ventura+ for full support |
+| iOS Safari | 16.x |
+| Samsung Internet | 14 |
+
+Global support is about **93.4%** as of mid-2026 ([caniuse AVIF](https://caniuse.com/avif)).
+The unsupported tail is concentrated in devices frozen on old Safari: iOS 15 and earlier, and
+Safari on macOS Monterey and earlier. Evergreen desktop browsers are all covered (Edge was the
+last holdout, closing the gap in 121). MDN also notes AVIF has **no progressive rendering** —
+the file must fully download before anything paints — which is an argument for keeping hero
+images modest in size, not against the format.
+
+### WebP
+
+Per [caniuse WebP](https://caniuse.com/webp) and MDN: supported by all current browsers;
+global support is about **96.1%**. The caveat is again Safari: WebP arrived in Safari 14, and
+on macOS it additionally requires Big Sur or later
+([MDN](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/Image_types)).
+
+### What this means for fallback choice
+
+The ~3-point gap between WebP (96.1%) and AVIF (93.4%) is mostly Safari 14–16.0-era devices.
+Adding WebP as the fallback rescues those, but still abandons the pre-Safari-14 / iOS-13 tail
+plus various embedded viewers, link-preview scrapers, and mail clients that only understand
+JPEG. Since the pipeline needs to encode a fallback either way, JPEG buys universal coverage
+for the same mechanism:
+
+```html
+<picture>
+  <source srcset="image.avif" type="image/avif" />
+  <img src="image.jpg" alt="…" />
+</picture>
+```
+
+A three-way AVIF/WebP/JPEG stack is defensible but buys little over AVIF/JPEG: any browser
+new enough for WebP-but-not-AVIF is a shrinking sliver, and each extra format multiplies the
+committed-variant count. **Uncertainty note:** exact percentages are caniuse global-usage
+figures as of August 2026 and will drift upward; the qualitative picture (AVIF-only unsafe,
+AVIF+JPEG complete) is stable.
+
+### Cloudflare Browser Rendering
+
+Both Cloudflare-supported drivers pin Chromium versions far past the AVIF/WebP thresholds:
+
+- [@cloudflare/puppeteer v1.1.0](https://developers.cloudflare.com/browser-rendering/platform/puppeteer/)
+  is based on Puppeteer v22.13.1, which bundles Chrome for Testing **126**
+  ([Puppeteer supported browsers](https://pptr.dev/supported-browsers)).
+- [@cloudflare/playwright v1.3.0](https://developers.cloudflare.com/browser-rendering/platform/playwright/)
+  is based on Playwright v1.58.2, which bundles Chromium **145.0.7632.6**
+  ([Playwright release notes](https://playwright.dev/docs/release-notes)).
+
+AVIF needs Chromium 85; WebP predates that. The PDF renderer can therefore consume AVIF or
+WebP directly — no separate raster set is needed for print. (Cloudflare's docs do not publish
+an independent "our Chromium is version X" statement; the version is implied by the pinned
+driver, so re-check on driver upgrades.)
+
+## Is sharp output byte-deterministic?
+
+Short answer: **deterministic enough within one pinned version on one platform; not stable
+across versions; not guaranteed across platforms.** Neither sharp nor libvips documents any
+byte-stability contract.
+
+### Across versions: definitively unstable
+
+- Each sharp release pins a specific libvips build with pinned codec versions — currently
+  libvips 8.18.5 with aom 3.14.1, libheif 1.23.1, libwebp 1.6.0, mozjpeg at a pinned commit
+  ([sharp-libvips `versions.properties`](https://github.com/lovell/sharp-libvips/blob/main/versions.properties)).
+  Encoder version bumps routinely change the emitted bitstream even at identical settings.
+- sharp itself changes encoder behavior between releases. The
+  [v0.35.0 changelog](https://sharp.pixelplumbing.com/changelog/v0.35.0/) is explicit:
+  "Breaking: Lossy AVIF output is now tuned using SSIMULACRA2-based `iq` quality metrics" —
+  every AVIF byte changed at that boundary — alongside a libvips 8.18.3 upgrade.
+  [v0.34.0](https://sharp.pixelplumbing.com/changelog/v0.34.0/) similarly changed GIF and HEIF
+  output defaults.
+
+Any CI pipeline that regenerates variants with a floating (or even routinely-updated) sharp
+version will churn every asset hash on upgrade.
+
+### Across platforms: no guarantee, one documented counterexample
+
+sharp ships per-platform prebuilt binaries compiled from the same pinned sources. In
+[sharp #2707](https://github.com/lovell/sharp/issues/2707), the same sharp version produced
+different palette-PNG bytes on macOS vs Linux; the maintainer confirmed the quantizer's
+"dithering relies on pseudo-random numbers, which may produce different results on different
+systems/compilers e.g. clang vs gcc." That case is PNG-specific (libimagequant), but it
+establishes the general point: cross-platform byte identity is an accident of implementation,
+not a contract.
+
+For the codecs in scope here, the practical picture (uncertainty flagged):
+
+- **JPEG (mozjpeg)**: integer DCT, single-threaded, no timestamps or randomness — in practice
+  byte-stable per version across platforms. High confidence, but undocumented.
+- **WebP (libwebp)**: integer codec, deterministic per version in practice; no published
+  cross-architecture guarantee.
+- **AVIF (libheif + aom)**: aom's own test suite asserts identical MD5s across thread counts
+  with row multithreading, i.e. thread-count determinism is a tested property
+  ([aom commit adding matching-MD5 multithread tests](https://aomedia.googlesource.com/aom/+/0ec03a4c128a53cc1275c376503fea1fe7723f82%5E!/)),
+  but nothing warrants x86-vs-ARM or clang-vs-gcc byte identity, and aom versions change
+  output freely.
+
+**Conclusion for the repo decision:** committed variants are the only option that makes the
+SHA-256 renderer identity meaningful. The commit freezes the exact bytes; sharp version drift
+becomes a visible diff instead of silent identity churn. CI can still *verify* (decode and
+compare pixels, or check that committed files exist for every source image) without ever
+*re-encoding*.
+
+## Prior art: committing variants vs build-time generation
+
+- **eleventy-img** caches processed images to disk, skips files that are unchanged and already
+  present, and for remote sources explicitly suggests checking processed output into git to
+  avoid refetching ([Eleventy Image docs](https://www.11ty.dev/docs/plugins/image/)). The
+  ecosystem norm for static-site image pipelines is "generate at build, cache aggressively" —
+  which works because those sites do not hash their outputs into an identity.
+- The general argument **against** committing generated files — bloat, merge conflicts, drift
+  from source ([Kent C. Dodds](https://kentcdodds.com/blog/why-i-dont-commit-generated-files-to-master)) —
+  applies weakly to binary image variants: they never merge-conflict meaningfully (regenerate
+  instead), and "drift from source" is precisely what a reviewed regeneration commit makes
+  visible.
+- The argument **for** committing build outputs — deployment reliability and independence from
+  the generating toolchain ([Max F., "It's OK to put compiled front-end assets in git"](https://medium.com/@maxf/its-ok-to-put-compiled-front-end-assets-in-git-9b41abdb803a);
+  [Sean C. Davis on images in git](https://www.seancdavis.com/posts/should-i-add-images-to-my-git-repository/)) —
+  applies strongly here, with the hash-identity requirement adding a reason those authors did
+  not have.
+- Repo-size hygiene: binary variants are immutable once committed, so history growth is
+  bounded by regeneration frequency. If the variant set grows large, Git LFS is the standard
+  escape hatch; not needed at current scale.
+
+## Conclusion
+
+Ship AVIF with a JPEG fallback through `<picture>`; both Cloudflare Browser Rendering drivers
+run Chromium ≥126, so the PDF path consumes the same AVIF assets. Generate variants once with
+a pinned sharp version, commit the bytes, and let CI verify rather than re-encode: sharp's
+cross-version encoder changes are documented and breaking, its cross-platform byte identity is
+unguaranteed, and the publisher's SHA-256 renderer identity only stays stable if the bytes
+live in the repo.

--- a/docs/research/pdf-post-compression-cloudflare.md
+++ b/docs/research/pdf-post-compression-cloudflare.md
@@ -1,0 +1,225 @@
+# Post-capture PDF compression in Cloudflare infrastructure
+
+Date: 2026-08-06
+
+Research for [#259](https://github.com/ndelangen/dunezone/issues/259), feeding the
+published-PDF-policy decision ([#257](https://github.com/ndelangen/dunezone/issues/257)) and
+the PDF size spike ([#256](https://github.com/ndelangen/dunezone/issues/256)). Companion to
+[chromium-pdf-image-embedding.md](./chromium-pdf-image-embedding.md), which established *what*
+the publisher's Chromium emits; this document evaluates the options for producing a compressed
+clone of that output inside Cloudflare's infrastructure, after capture, before or alongside the
+R2 write in [`workers/publisher`](../../workers/publisher/).
+
+Sources are Cloudflare's Workers and Containers docs, the npm registry, the mupdf and jSquash
+projects, and pdf-lib, all fetched 2026-08-06. Cost and CPU figures marked *estimate* have no
+primary-source measurement behind them and are on #256's verification list.
+
+## The input, precisely
+
+Per the companion research, Chromium's print path produces exactly two kinds of image XObject:
+
+1. **`DCTDecode` passthrough JPEGs** — original bytes, already compressed. Leave untouched.
+2. **`FlateDecode` raw rasters** — 8-bit RGB rows, no predictors, one per rasterized
+   filter/mask layer at 300 DPI of page area, plus a separate deflated 8-bit grayscale `SMask`
+   XObject when the layer is not opaque. These dominate the faction-sheet PDF's size and are
+   the compression target: inflate, optionally downsample, re-encode as JPEG, swap the filter
+   to `DCTDecode`.
+
+How safe is the "8-bit RGB Flate" assumption?
+
+- **SMasks: expect them.** Filter/mask layers carry alpha, so the base image will usually have
+  an `SMask` entry. That is not an obstacle: `SMask` is a *separate* grayscale image XObject
+  referenced from the base image's dictionary (PDF 32000-1:2008 §11.6.5.2, Table 89), fully
+  independent of the base image's filter — a `DCTDecode` base with a `FlateDecode` SMask is
+  valid. Near-binary masks compress superbly under flate already; the safe default is to leave
+  SMasks alone (optionally re-encode large smooth ones as grayscale JPEG later).
+- **Indexed color: not emitted.** Skia's `do_deflated_image` writes raw RGB/gray only — no
+  `Indexed` palettes ([`SkPDFBitmap.cpp`](https://github.com/google/skia/blob/main/src/pdf/SkPDFBitmap.cpp)).
+- **ICC: uncertain for the deflate path.** The companion doc confirmed `ICCBased` embedding for
+  JPEG passthrough; whether Chromium's deflated rasters get `DeviceRGB` or an `ICCBased` sRGB
+  stream needs a look at a real capture (**verify in spike**). Either way an ICC color space
+  survives a filter swap — it lives in `/ColorSpace`, not in the stream.
+
+So the recompressor should **gate defensively rather than assume**: touch only XObjects with
+`Subtype /Image`, `BitsPerComponent 8`, `ColorSpace` `DeviceRGB` or 3-component `ICCBased`,
+`Filter` exactly `FlateDecode` (single filter, no `DecodeParms` predictors), no `Decode` array,
+not an `ImageMask`. Everything else passes through unmodified. Against Chromium's actual output
+this gate matches every big raster; against a hand-crafted PDF it degrades to a no-op.
+
+## Platform constraints recap
+
+| Constraint | Value | Source |
+| --- | --- | --- |
+| Worker memory | 128 MB per isolate, **including WASM allocations**, not raisable | [Workers limits](https://developers.cloudflare.com/workers/platform/limits/) |
+| Worker CPU (HTTP) | 30 s default, `cpu_ms` configurable to 300 000 ms | same |
+| Worker CPU (**cron**, interval < 1 h) | **30 s, `cpu_ms` does not raise it** | same |
+| Worker bundle | 10 MB compressed (paid) | same |
+| Publisher config | `cpu_ms: 30000`, `PDF_MAX_BYTES: 8000000`, cron `*/5`, ≤ ~20 captures per run | [`wrangler.jsonc`](../../workers/publisher/wrangler.jsonc) |
+
+The cron CPU cap is the sleeper constraint: the publisher's capture loop runs from the `*/5`
+cron, where CPU is hard-capped at 30 s regardless of `cpu_ms`. Any in-Worker compression that
+risks multi-second CPU per PDF should run in an **HTTP-invoked step** (self-`fetch` or a queue
+consumer), where `cpu_ms` up to 300 000 applies — an invocation-shape change, not new infra.
+
+## Route 1 — Targeted Worker-side recompression (pdf-lib + native inflate + jSquash)
+
+**Stack.** All license-clean, all small:
+
+- [`pdf-lib` 1.17.1](https://github.com/Hopding/pdf-lib) (MIT, already a publisher dependency)
+  exposes the needed low-level surface: `doc.context.enumerateIndirectObjects()`,
+  `PDFRawStream` (dict + raw bytes), and `context.assign(ref, newStream)` to swap an object.
+  The dict edit is: replace stream bytes with JPEG output, set `Filter /DCTDecode`, drop
+  `DecodeParms`, fix `Length` (handled by `PDFRawStream.of`). pdf-lib also exports
+  `decodePDFRawStream`, though for Chromium's plain single-flate streams the runtime can do it.
+- **Inflate**: the publisher already has `nodejs_compat`, so `node:zlib` is available, and the
+  Workers runtime natively supports `DecompressionStream('deflate')`
+  ([Workers Web standards](https://developers.cloudflare.com/workers/runtime-apis/web-standards/)).
+  No pako needed.
+- **JPEG encode**: [`@jsquash/jpeg` 1.6.0](https://github.com/jamsinclair/jSquash)
+  (Apache-2.0, MozJPEG compiled to WASM, ~0.5 MB unpacked) ships **explicit Cloudflare Workers
+  examples** and deliberately avoids runtime features Workers block. `@jsquash/resize`
+  (Apache-2.0, ~0.25 MB) covers optional 300→150 DPI downsampling. Bundle impact is negligible
+  against the 10 MB limit.
+
+**Memory arithmetic** (the binding constraint). Worst plausible single raster is a full A4 page
+layer at 300 DPI ≈ 2480×3506 ≈ 8.7 Mpx: 26 MB as RGB, 35 MB as the RGBA `ImageData` mozjpeg
+wants. Processing strictly one image at a time, freeing each buffer as soon as the next stage
+consumes it: ~8 MB input PDF + pdf-lib's parsed objects (~2× the file, *estimate*) + 26 MB
+inflated + 35 MB RGBA ≈ **85–95 MB peak** — inside 128 MB, but with little headroom, and WASM
+heaps count against the same 128 MB. This works only because `PDF_MAX_BYTES` caps input at
+8 MB; it does not generalize to arbitrary PDFs. **Verify peak RSS in the spike** with a real
+capture under `wrangler dev` and in production observability.
+
+**CPU** (*estimate*). Inflate is cheap; mozjpeg-WASM encode is roughly 0.2–0.5 s per Mpx, so
+~2–4 s per full-page raster and possibly ~15–25 s for a 7-layer faction sheet at 300 DPI —
+uncomfortably close to 30 s if run inside the cron handler (hence the HTTP-invoked step above).
+Downsampling to 150 DPI first quarters the encode input. **Spike: measure ms/Mpx in workerd.**
+
+**Expected compression** (*estimate*). Deflated raw RGB → JPEG q75–85 typically shrinks those
+streams 5–15×; with 150 DPI downsampling 20–40×. On a PDF dominated by such rasters, whole-file
+reduction of roughly **4–10×** is realistic. Quality at q80/150 DPI vs the current output is a
+spike question, not a research one.
+
+**Risks.** pdf-lib is unmaintained (last release 2021) — acceptable here because only the
+stable low-level object model is used, not its high-level features; round-trip integrity of a
+re-saved Chromium PDF (opens in Acrobat/Preview/Chrome, prints correctly) must be spot-checked
+in the spike.
+
+## Route 2 — MuPDF-WASM or Ghostscript-WASM in a Worker
+
+**MuPDF.** The official [`mupdf` npm package](https://mupdf.readthedocs.io/) (Artifex, 1.28.0)
+is a real, maintained WASM binding: 14.3 MB unpacked (WASM ~10 MB, plausibly ~3–4 MB gzipped —
+*estimate*, but likely inside the 10 MB compressed bundle limit). Its `PDFObject` API
+(`readStream`/`writeStream`, which auto-manage `Length`/`Filter`/`DecodeParms`) would make the
+Route 1 rewrite more robust than pdf-lib. **But it does not remove the hard part**: MuPDF's
+[PDF write options](https://mupdf.readthedocs.io/en/latest/reference/common/pdf-write-options.html)
+offer `garbage`, `compress`, `compress-images` (flate/CCITT of existing data) — **no image
+downsampling and no JPEG re-encoding on save**. You would still bring `@jsquash/jpeg` for the
+DCT step. So MuPDF buys a sturdier parser, nothing more.
+
+**The price is AGPL.** `mupdf` is `AGPL-3.0-or-later` (dual-licensed commercially by Artifex).
+Linking it into the publisher Worker makes the Worker a combined work; AGPL §13 then requires
+offering the complete corresponding source of that combined work under AGPL to everyone who
+interacts with it over the network. The repo is public but currently has **no license file**,
+so this would force an explicit AGPL grant for the publisher (or a paid Artifex license). That
+is a real project-licensing decision, not a technicality — and it is not worth it for a parser
+upgrade. Verdict: **fallback only**, if the spike shows pdf-lib mangling Chromium's output.
+
+**Ghostscript-WASM: not credible.** There is no official build. Community npm builds are stale
+or alpha (`@jspawn/ghostscript-wasm` 0.0.2, 2022, AGPL, 16.3 MB unpacked;
+`@privyid/ghostscript` 0.1.0-alpha, 2024, AGPL, 19.5 MB). A full `-dPDFSETTINGS` pipeline
+under Emscripten needs an emulated filesystem and working memory that has to fit — with the
+input and output PDFs — inside the same 128 MB isolate; the bundle alone flirts with the 10 MB
+compressed limit. AGPL applies identically. Dismissed.
+
+## Route 3 — Cloudflare Containers running real Ghostscript
+
+**Status: GA.** Containers left beta on 2026-04-13
+([changelog](https://developers.cloudflare.com/changelog/post/2026-04-13-containers-sandbox-ga/)),
+on the Workers Paid plan. A container class is bound to the Worker; the publisher would
+`getContainer(env.COMPRESSOR, id).fetch(pdfBytes)` and write the response to R2. Instance
+types range from `lite` (1/16 vCPU, 256 MiB) to `standard-4`
+([limits](https://developers.cloudflare.com/containers/platform-details/limits/)); `basic`
+(1/4 vCPU, 1 GiB) is comfortable for 8 MB PDFs. Instances scale to zero and bill per 10 ms of
+active runtime ([pricing](https://developers.cloudflare.com/containers/pricing/)).
+
+**Capability: the strongest of all routes.** Native Ghostscript
+(`gs -sDEVICE=pdfwrite -dPDFSETTINGS=/ebook`, i.e. 150 DPI downsample + DCT re-encode) is the
+canonical tool for exactly this job. It handles SMasks, ICC, indexed color, and every edge case
+itself — no Chromium-shape assumptions needed — and routinely shrinks lossless-raster-heavy
+PDFs **5–15×** (*estimate*, consistent with Route 1's arithmetic since it performs the same
+transform plus stream-level cleanup).
+
+**Cost: pennies.** Even at the theoretical ceiling — 20 captures per 5-min cron around the
+clock (5 760/day) at ~5 s each on `basic` — usage is ~240 GiB-hours/month of memory and
+~60 vCPU-hours/month, landing at roughly **$6/month** after the included allotment (25
+GiB-hours, 375 vCPU-minutes); realistic capture volume is a small fraction of that. Cold
+starts are seconds — irrelevant for a cron-driven batch.
+
+**Licensing: manageable, with a flag.** Unlike Route 2, Ghostscript here runs as an
+**unmodified standalone binary in a separate process**; the publisher talks to it over
+exec/HTTP, which the FSF treats as mere aggregation, not a combined work
+([GPL FAQ, "MereAggregation"](https://www.gnu.org/licenses/gpl-faq.html#MereAggregation)).
+Ghostscript's *output* PDFs are not covered by its license. Compliance then means being able to
+provide the unmodified Ghostscript source (trivial — it is public). Caveat worth naming:
+Artifex historically interprets its licenses aggressively and monetizes via commercial
+licensing; the separate-process argument is standard and strong, but this is the one route
+where a lawyer-grade check would be prudent if the project ever commercializes.
+
+**Complexity: the real cost.** A new deployable: Dockerfile (alpine + ghostscript ≈ 60 MB,
+well under limits), image build/push in CI, container class + binding in `wrangler.jsonc`, a
+tiny HTTP shim inside the container, and observability for a second runtime. None of it is
+hard; all of it is surface area the project does not currently have.
+
+## Route 4 — Managed / third-party APIs (briefly)
+
+[Adobe PDF Services' Compress PDF](https://developer.adobe.com/document-services/docs/overview/limits)
+has a free tier of 500 document transactions/month — an order of magnitude under the
+publisher's theoretical ceiling (5 760 captures/day), with pay-as-you-go around $0.05 per
+transaction beyond it. CloudConvert, iLovePDF and similar are priced per operation in the same
+ballpark. All of them ship the PDF out of Cloudflare to a third party, add per-document cost
+that dwarfs Route 3, and add an external dependency to the capture path. Not competitive here;
+only sensible for a team unwilling to run any processing of its own.
+
+## Recommended ranking
+
+1. **Route 1 — targeted pdf-lib + jSquash recompression in the Worker.** Cheapest, zero new
+   infrastructure, MIT/Apache only, and viable precisely because the companion research proved
+   the input is Chromium's narrow, predictable shape and `PDF_MAX_BYTES` bounds it at 8 MB.
+   Run it as an HTTP-invoked step (not inside the cron handler) to escape the 30 s cron CPU
+   cap. This is what the spike (#256) should build.
+2. **Route 3 — Containers + Ghostscript.** The upgrade path if the spike shows Route 1
+   breaching memory/CPU or mangling output — and the automatic answer the day the PDFs stop
+   being predictable (bigger pages, arbitrary content, >8 MB inputs). More robust compression
+   than Route 1, ~$0–6/month, but a second deployable and a licensing posture to document.
+3. **Route 2 — MuPDF-WASM.** Only as a parser fallback inside Route 1's design, and only if
+   pdf-lib proves unreliable; it still needs jSquash for the actual DCT step and drags AGPL
+   into the Worker bundle. Ghostscript-WASM: rejected outright.
+4. **Route 4 — managed APIs.** Rejected: cost, data egress, external dependency.
+
+## What the spike (#256) should verify empirically
+
+1. **XObject anatomy of a real capture** (already on #256's list): confirms Route 1's
+   defensive gate matches every large raster — filter, color space (`DeviceRGB` vs
+   `ICCBased`), `BitsPerComponent`, SMask presence.
+2. **Peak memory** of parse→inflate→RGBA→encode on the largest real raster inside workerd,
+   one image at a time, against the 128 MB isolate limit.
+3. **mozjpeg-WASM throughput** (ms/Mpx) in Workers, and total CPU for a full faction sheet at
+   300 DPI vs 150-DPI-downsampled — does it need the HTTP-invoked escape hatch, and does even
+   that fit comfortably in `cpu_ms`?
+4. **Visual quality** at q75–q85 and 150 vs 300 DPI on the faction sheet's filtered texture.
+5. **Round-trip integrity** of the pdf-lib re-save: renders in Chrome/Preview/Acrobat, prints,
+   and file size actually drops by the predicted factor.
+6. If Route 1 fails any of the above: a `basic`-instance Containers prototype with
+   `gs -dPDFSETTINGS=/ebook`, measuring wall time and monthly cost at realistic volume.
+
+## Conclusion
+
+Inside Cloudflare there are two serious options, and they are complementary rather than
+competing: a small, license-clean, in-Worker recompressor that exploits how narrow Chromium's
+output is (pdf-lib walk → native inflate → mozjpeg-WASM → `DCTDecode` swap), and a
+Containers-hosted Ghostscript for the day the inputs outgrow that narrowness. The WASM PDF
+engines occupy an awkward middle — MuPDF adds AGPL without adding the missing JPEG step, and
+Ghostscript-WASM does not realistically fit a Worker at all — and managed APIs solve a problem
+this project does not have. Start with Route 1 in the spike; keep Route 3 as the documented
+fallback.

--- a/docs/research/spike-pdf-size/recompress-harness.ts
+++ b/docs/research/spike-pdf-size/recompress-harness.ts
@@ -1,0 +1,93 @@
+// Clean PDF recompression harness — the validated reference for the Train 2
+// implementation (wayfinder #271), final policy per #257. Run with bun from the
+// repo root (pdf-lib from repo deps; sharp from a local install — adjust path).
+//
+//   INPUT=<pdf> GRAY=skip RGB=lossless:0.35 OUT=out.pdf bun run recompress-harness.ts
+//
+// Policy grammar: skip | jpeg:<q>[:<a>:<b> chroma] | lossless:<scale>
+// Final decided policy (#257): GRAY=skip RGB=lossless:0.35 — JPEG is banned
+// (streaks this art style's grain at any quality; see report.md).
+// Only images >=300px in BOTH dims and without /SMask entries are ever touched.
+import { deflateSync, inflateSync } from 'node:zlib';
+import path from 'node:path';
+
+import { PDFDocument, PDFName, PDFRawStream } from 'pdf-lib';
+
+const SHARP_DIR = process.env.SHARP_DIR ?? '';
+const sharp = (await import(path.join(SHARP_DIR, 'node_modules/sharp/dist/index.cjs'))).default;
+
+const GRAY = process.env.GRAY ?? 'skip';
+const RGB = process.env.RGB ?? 'lossless:0.35';
+const OUT = process.env.OUT ?? 'rewritten.pdf';
+const INPUT = process.env.INPUT!;
+
+type Policy =
+  | { kind: 'skip' }
+  | { kind: 'jpeg'; q: number; chroma: string }
+  | { kind: 'lossless'; scale: number };
+
+function parsePolicy(spec: string): Policy {
+  if (spec === 'skip') return { kind: 'skip' };
+  const [kind, a, b, c] = spec.split(':');
+  if (kind === 'jpeg') return { kind: 'jpeg', q: Number(a), chroma: b && c ? `${b}:${c}` : '4:2:0' };
+  if (kind === 'lossless') return { kind: 'lossless', scale: Number(a) };
+  throw new Error(`bad policy ${spec}`);
+}
+const grayPolicy = parsePolicy(GRAY);
+const rgbPolicy = parsePolicy(RGB);
+
+const bytes = new Uint8Array(await Bun.file(INPUT).arrayBuffer());
+const doc = await PDFDocument.load(bytes);
+
+let swapped = 0;
+for (const [ref, obj] of doc.context.enumerateIndirectObjects()) {
+  if (!(obj instanceof PDFRawStream)) continue;
+  const dict = obj.dict;
+  if (dict.get(PDFName.of('Subtype')) !== PDFName.of('Image')) continue;
+  if (dict.get(PDFName.of('Filter'))?.toString() !== '/FlateDecode') continue;
+  if (dict.has(PDFName.of('SMask'))) continue;
+  const w = Number(dict.get(PDFName.of('Width'))?.toString());
+  const h = Number(dict.get(PDFName.of('Height'))?.toString());
+  if (w < 300 || h < 300) continue;
+
+  const raw = inflateSync(Buffer.from(obj.contents));
+  const channels = raw.length === w * h * 3 ? 3 : raw.length === w * h ? 1 : 0;
+  if (!channels) continue;
+  const policy = channels === 3 ? rgbPolicy : grayPolicy;
+  if (policy.kind === 'skip') continue;
+
+  let outW = w;
+  let outH = h;
+  let encoded: Buffer;
+  if (policy.kind === 'lossless') {
+    outW = Math.round(w * policy.scale);
+    outH = Math.round(h * policy.scale);
+    const resized = await sharp(raw, { raw: { width: w, height: h, channels } })
+      .resize(outW, outH)
+      .raw()
+      .toBuffer();
+    encoded = deflateSync(resized, { level: 9 });
+  } else {
+    encoded = await sharp(raw, { raw: { width: w, height: h, channels } })
+      .jpeg({ quality: policy.q, mozjpeg: true, chromaSubsampling: policy.chroma })
+      .toBuffer();
+  }
+  if (encoded.length >= obj.contents.length) continue;
+  console.log(
+    `swap ${w}x${h} ch=${channels} ${policy.kind} ${Math.round(obj.contents.length / 1024)}KB -> ${Math.round(encoded.length / 1024)}KB (out ${outW}x${outH})`
+  );
+  dict.set(
+    PDFName.of('Filter'),
+    PDFName.of(policy.kind === 'lossless' ? 'FlateDecode' : 'DCTDecode')
+  );
+  dict.set(PDFName.of('Width'), doc.context.obj(outW));
+  dict.set(PDFName.of('Height'), doc.context.obj(outH));
+  dict.delete(PDFName.of('DecodeParms'));
+  dict.delete(PDFName.of('Length'));
+  doc.context.assign(ref, PDFRawStream.of(dict, new Uint8Array(encoded)));
+  swapped += 1;
+}
+
+const saved = await doc.save({ useObjectStreams: false });
+await Bun.write(OUT, saved);
+console.log(JSON.stringify({ out: OUT, swapped, kb: Math.round(saved.length / 1024) }));

--- a/docs/research/spike-pdf-size/report.md
+++ b/docs/research/spike-pdf-size/report.md
@@ -1,0 +1,84 @@
+# Spike: what actually drives faction-sheet PDF size (wayfinder #256)
+
+Local Playwright capture of the reference fixture (`assetPublishingFaction`, 5 leaders + 1 troop)
+through the exact publisher contract (viewport 2100×2970, dsf 1, `preferCSSPageSize`,
+`printBackground`), followed by pdf-lib anatomy of every image XObject. Harness:
+`spike-pdf-run.ts` (matrix), `spike-pdf-recompress.ts` (passthrough probe + estimates),
+`spike-pdf-rewrite.ts` (real recompressed PDFs — the #259 approach executed locally).
+
+## Findings
+
+1. **Source resolution is irrelevant to PDF size.** Full-res (3648²) vs 1280 vs 640 texture:
+   byte-identical PDFs (±2 KB). `deviceScaleFactor` 1 vs 2: identical. Confirms #251's
+   fixed-DPI rasterization.
+2. **Pre-baking the filter is dead.** Serving pre-filtered textures + stripping the SVG filter
+   attribute produced zero DCTDecode streams — SVG `<pattern>` + mask structure rasterizes
+   regardless of filters. (Baked cells were *larger*: inverted grayscale Flates worse.)
+   DCT passthrough itself is real — a bare `<img>` JPEG probe embeds byte-for-byte — but the
+   sheet's rendering structure never qualifies, and render-structure changes are off-limits.
+3. **Effects are not the lever either.** Inventory: 16 filter instances, 19 masked elements,
+   0 box-shadows. Stripping every filter+shadow removed only 18 of 61 images (~117 KB).
+   The masks (unstrippable — they're structural) keep everything rasterized.
+4. **Anatomy of the 1757 KB baseline:** 61 image XObjects, all lossless FlateDecode,
+   1656 KB total (94%). Five leader portraits (367×369 RGB/ICC): ~900 KB. Five to seven
+   grayscale texture tiles (~429×426): ~530 KB. ~45 small mask-pair fragments (names,
+   plates, logos): ~200 KB. Non-image overhead (fonts, content streams): ~101 KB.
+5. **Post-capture recompression is the lever, with a safety rule.** Rewriting Flate → JPEG
+   in place works, but two classes must never be touched: images with an `/SMask` entry and
+   anything under 300 px in either dimension (re-encoding the wide-short name-shape masks
+   erases the engraved leader names; discovered empirically at q85/q90). The safe target set
+   is exactly the big square-ish art rasters: portraits + tiles.
+
+## Results (targeted-safe policy, real rewritten PDFs)
+
+| Variant | KB | Verdict at screen scale + 200% zoom |
+|---|---|---|
+| baseline (lossless) | 1757 | reference |
+| **q90 uniform, full-res** | **554** | **indistinguishable — no seams, names intact** |
+| mixed q85 portraits / q70 tiles | 485 | pattern-tile seam visible on some tokens |
+| q70 uniform, full-res | 455 | same seam, slightly washed tiles |
+| q80/q75 half-res | 383/373 | rejected — moiré striping on tiles and portraits |
+
+Downsampling and q<~85 tiles both break the seamless pattern tiling. The floor with the safe
+policy is ~450 KB; going below ~350 KB requires touching mask pairs (breaks text) or changing
+how the sheet renders (ruled out). The 200 KB aspiration is **not reachable safely**; 550 KB
+(a 3.2× shrink, and far below the multi-MB dealbreaker) is, with pixel-fidelity intact.
+Sizes scale with leader count; this fixture is typical.
+
+## Verdict (Norbert, HITL)
+
+Grain fidelity on the texture tiles is non-negotiable — the pattern is faction identity.
+JPEG at q90 *and* q95 both leave visible directional streaks in the tile grain at zoom
+(the troop token, whose tile fell under the 300 px threshold and stayed lossless, was the
+tell). **Accepted candidate: `tiles-lossless-portraits-q90.pdf` — texture tiles byte-identical
+to baseline, only the five RGB portraits re-encoded at q90: 1757 → 978 KB (1.8×).**
+
+Final safe recompression rule for the production tool (#259 design):
+re-encode **only RGB images ≥300 px in both dimensions without an /SMask entry**
+(in practice: leader portraits). Grayscale images (texture tiles, masks), mask pairs,
+and anything small stay lossless. JPEG-on-noise is the boundary this spike mapped:
+photographic content compresses invisibly at q90; isotropic grain does not, at any q tried.
+
+## Final policy (#257, decided on production data)
+
+The fixture-era verdict was superseded after testing on a real production PDF
+(faction-test.pdf, 3824 KB — bigger portraits than the fixture, incl. a 1024² at 1.4 MB):
+**JPEG is banned from the pipeline entirely.** Even q90 4:4:4 on the portraits streaked the
+paper-grain in their backgrounds — the same failure as the tiles, because this art style is
+grain everywhere. The safe verb is **lossless downsampling**: resize + re-deflate, still
+FlateDecode. Decided policy: RGB rasters (≥300px both dims, no /SMask) → lossless 0.35×;
+grayscale tiles and all fragments byte-untouched. Production result: 3824 → 1250 KB (3.05×),
+accepted eyes-on at 300 DPI zoom. ilovepdf's 687 KB reference rejected (portraits crushed to
+~0.2× with visible posterization; fragments JPEG'd). See `recompress-harness.ts` for the
+validated reference implementation; Train 2 implementation ticket: #271.
+
+## Feed-forward to #257 (published PDF policy)
+
+- One recompressed variant (portraits-q90, tiles lossless, ~1 MB for a 5-leader faction)
+  is pixel-faithful on pattern grain and visually print-grade — the two-variant question
+  may still collapse into one, at ~1 MB rather than the original 200 KB aspiration.
+- The #259 Worker recompression design is validated end-to-end on real bytes, including the
+  targeted-safe selection rule it must implement (≥300 px both dimensions, no `/SMask` entry,
+  skip when JPEG ≥ Flate). Masks stay Flate; ICC colorspaces carry over untouched.
+- Chromium XObject shapes matched #259's assumptions: 8-bit, unpredicted Flate, DeviceRGB/
+  DeviceGray/ICCBased; zero skips after handling ICCBased as 3-channel.

--- a/docs/research/spike-pdf-size/spike-pdf-recompress.ts
+++ b/docs/research/spike-pdf-size/spike-pdf-recompress.ts
@@ -1,0 +1,103 @@
+// Spike part 2: (a) probe whether this Chromium emits DCT passthrough at all;
+// (b) estimate post-capture recompression by inflating baseline.pdf's Flate
+// image XObjects and re-encoding RGB ones as JPEG (the #259 approach, locally).
+import { inflateSync } from 'node:zlib';
+import path from 'node:path';
+
+import { PDFDocument, PDFName, PDFRawStream } from 'pdf-lib';
+import { chromium } from 'playwright';
+
+const spikeDir =
+  '/private/tmp/claude-501/-Users-me-Projects-Dune-dunezone--claude-worktrees-image-optimization-web-pdf-298fff/3b954549-5ba3-4782-b17f-7f59ef03554c/scratchpad/spike';
+const repoRoot = import.meta.dirname;
+
+// --- (a) passthrough probe: bare <img> JPEG on an A4 page, no SVG anywhere ---
+const jpeg = await Bun.file(path.join(repoRoot, 'public/image/texture/021.jpg')).arrayBuffer();
+const probeHtml = `<!doctype html><html><head><style>
+  @page { size: 210mm 297mm; margin: 0; }
+  body { margin: 0; }
+  img { width: 100mm; height: 100mm; }
+</style></head><body><img src="data:image/jpeg;base64,${Buffer.from(jpeg).toString('base64')}"></body></html>`;
+
+const browser = await chromium.launch();
+const page = await browser.newPage({ viewport: { width: 2100, height: 2970 } });
+await page.setContent(probeHtml, { waitUntil: 'load' });
+await page.emulateMedia({ media: 'print' });
+const probeBytes = await page.pdf({
+  margin: { top: 0, right: 0, bottom: 0, left: 0 },
+  preferCSSPageSize: true,
+  printBackground: true,
+});
+await browser.close();
+
+const probeDoc = await PDFDocument.load(new Uint8Array(probeBytes));
+const probeFilters: string[] = [];
+for (const [, obj] of probeDoc.context.enumerateIndirectObjects()) {
+  if (obj instanceof PDFRawStream && obj.dict.get(PDFName.of('Subtype')) === PDFName.of('Image')) {
+    probeFilters.push(
+      `${obj.dict.get(PDFName.of('Width'))}x${obj.dict.get(PDFName.of('Height'))} ${obj.dict.get(PDFName.of('Filter'))} ${Math.round(obj.contents.length / 1024)}KB`
+    );
+  }
+}
+console.log('PROBE bare <img> jpeg:', JSON.stringify({ pdfKb: Math.round(probeBytes.length / 1024), images: probeFilters }));
+
+// --- (b) recompression estimate on baseline.pdf ---
+const sharp = (await import(path.join(spikeDir, 'node_modules/sharp/dist/index.cjs'))).default;
+const bytes = new Uint8Array(await Bun.file(path.join(spikeDir, 'out/baseline.pdf')).arrayBuffer());
+const doc = await PDFDocument.load(bytes);
+
+const QUALITY = Number(process.env.Q ?? 80);
+let before = 0;
+let after = 0;
+let rgbCount = 0;
+let grayCount = 0;
+let skipped: string[] = [];
+for (const [, obj] of doc.context.enumerateIndirectObjects()) {
+  if (!(obj instanceof PDFRawStream)) continue;
+  const dict = obj.dict;
+  if (dict.get(PDFName.of('Subtype')) !== PDFName.of('Image')) continue;
+  const filter = dict.get(PDFName.of('Filter'))?.toString();
+  const w = Number(dict.get(PDFName.of('Width'))?.toString());
+  const h = Number(dict.get(PDFName.of('Height'))?.toString());
+  const cs = dict.get(PDFName.of('ColorSpace'))?.toString();
+  const bpc = Number(dict.get(PDFName.of('BitsPerComponent'))?.toString());
+  const decodeParms = dict.get(PDFName.of('DecodeParms'))?.toString() ?? 'none';
+  before += obj.contents.length;
+  if (filter !== '/FlateDecode' || bpc !== 8) {
+    skipped.push(`${w}x${h} ${filter} bpc=${bpc}`);
+    after += obj.contents.length;
+    continue;
+  }
+  const raw = inflateSync(Buffer.from(obj.contents));
+  const channels = raw.length === w * h * 3 ? 3 : raw.length === w * h ? 1 : 0;
+  if (!channels) {
+    skipped.push(`${w}x${h} cs=${cs} parms=${decodeParms} raw=${raw.length}`);
+    after += obj.contents.length;
+    continue;
+  }
+  const SCALE = Number(process.env.SCALE ?? 1);
+  let pipeline = sharp(raw, { raw: { width: w, height: h, channels } });
+  if (SCALE < 1 && Math.max(w, h) > 250) {
+    pipeline = pipeline.resize(Math.round(w * SCALE), Math.round(h * SCALE));
+  }
+  const encoded = await pipeline
+    .jpeg({ quality: QUALITY, progressive: false, mozjpeg: true })
+    .toBuffer();
+  after += Math.min(encoded.length, obj.contents.length);
+  if (channels === 3) rgbCount += 1;
+  else grayCount += 1;
+}
+
+const pdfOverheadKb = Math.round((bytes.length - before) / 1024);
+console.log(
+  'RECOMPRESS estimate:',
+  JSON.stringify({
+    imagesBeforeKb: Math.round(before / 1024),
+    imagesAfterKb: Math.round(after / 1024),
+    projectedPdfKb: Math.round((bytes.length - before + after) / 1024),
+    pdfOverheadKb,
+    rgbCount,
+    grayCount,
+    skipped,
+  })
+);

--- a/docs/research/spike-pdf-size/spike-pdf-rewrite.ts
+++ b/docs/research/spike-pdf-size/spike-pdf-rewrite.ts
@@ -1,0 +1,74 @@
+// Spike part 3: actually rewrite baseline.pdf — swap Flate image XObjects for
+// JPEG (DCTDecode) streams in place, exactly what the #259 Worker step would do.
+// Produces real PDFs for visual judgment.
+import { inflateSync } from 'node:zlib';
+import path from 'node:path';
+
+import { PDFDocument, PDFName, PDFRawStream } from 'pdf-lib';
+
+const spikeDir =
+  '/private/tmp/claude-501/-Users-me-Projects-Dune-dunezone--claude-worktrees-image-optimization-web-pdf-298fff/3b954549-5ba3-4782-b17f-7f59ef03554c/scratchpad/spike';
+const sharp = (await import(path.join(spikeDir, 'node_modules/sharp/dist/index.cjs'))).default;
+
+const QUALITY = Number(process.env.Q ?? 75);
+const SCALE = Number(process.env.SCALE ?? 1);
+const OUT = process.env.OUT ?? 'rewritten.pdf';
+
+const bytes = new Uint8Array(await Bun.file(path.join(spikeDir, 'out/baseline.pdf')).arrayBuffer());
+const doc = await PDFDocument.load(bytes);
+
+// Safe policy: never touch mask pairs — collect every ref used as an /SMask.
+const smaskRefs = new Set<string>();
+for (const [, obj] of doc.context.enumerateIndirectObjects()) {
+  if (obj instanceof PDFRawStream && obj.dict.get(PDFName.of('Subtype')) === PDFName.of('Image')) {
+    const sm = obj.dict.get(PDFName.of('SMask'));
+    if (sm) smaskRefs.add(sm.toString());
+  }
+}
+
+let swapped = 0;
+for (const [ref, obj] of doc.context.enumerateIndirectObjects()) {
+  if (!(obj instanceof PDFRawStream)) continue;
+  const dict = obj.dict;
+  if (dict.get(PDFName.of('Subtype')) !== PDFName.of('Image')) continue;
+  if (dict.get(PDFName.of('Filter'))?.toString() !== '/FlateDecode') continue;
+  if (dict.has(PDFName.of('SMask'))) continue;
+  const width = Number(dict.get(PDFName.of('Width'))?.toString());
+  const height = Number(dict.get(PDFName.of('Height'))?.toString());
+  // Only square-ish art rasters (portraits, texture tiles). Text/name masks are
+  // wide-and-short; anything under 300px in either dimension stays lossless.
+  if (width < 300 || height < 300) continue;
+  const w = Number(dict.get(PDFName.of('Width'))?.toString());
+  const h = Number(dict.get(PDFName.of('Height'))?.toString());
+  const raw = inflateSync(Buffer.from(obj.contents));
+  const channels = raw.length === w * h * 3 ? 3 : raw.length === w * h ? 1 : 0;
+  if (!channels) continue;
+
+  let outW = w;
+  let outH = h;
+  let pipeline = sharp(raw, { raw: { width: w, height: h, channels } });
+  if (SCALE < 1 && Math.max(w, h) > 250) {
+    outW = Math.round(w * SCALE);
+    outH = Math.round(h * SCALE);
+    pipeline = pipeline.resize(outW, outH);
+  }
+  const q = channels === 3 ? Number(process.env.Q_RGB ?? QUALITY) : QUALITY;
+  const encoded = await pipeline
+    .jpeg({ quality: q, progressive: false, mozjpeg: true })
+    .toBuffer();
+  if (encoded.length >= obj.contents.length) continue;
+  if (process.env.DEBUG) console.log(`swap ${w}x${h} ch=${channels} smaskRef=${dict.has(PDFName.of('SMask'))} isMask=${dict.has(PDFName.of('Matte')) || ''} ${Math.round(obj.contents.length/1024)}KB -> ${Math.round(encoded.length/1024)}KB`);
+
+  dict.set(PDFName.of('Filter'), PDFName.of('DCTDecode'));
+  dict.set(PDFName.of('Width'), doc.context.obj(outW));
+  dict.set(PDFName.of('Height'), doc.context.obj(outH));
+  dict.delete(PDFName.of('DecodeParms'));
+  dict.delete(PDFName.of('Length'));
+  const rewritten = PDFRawStream.of(dict, new Uint8Array(encoded));
+  doc.context.assign(ref, rewritten);
+  swapped += 1;
+}
+
+const saved = await doc.save({ useObjectStreams: false });
+await Bun.write(path.join(spikeDir, 'out', OUT), saved);
+console.log(JSON.stringify({ out: OUT, swapped, kb: Math.round(saved.length / 1024) }));

--- a/docs/research/spike-pdf-size/spike-pdf-run.ts
+++ b/docs/research/spike-pdf-size/spike-pdf-run.ts
@@ -1,0 +1,214 @@
+// PDF-size spike runner (wayfinder #256). Untracked scratch harness — mirrors
+// workers/publisher/capture-contract-regression.ts server + browser.ts capture options.
+import path from 'node:path';
+
+import { PDFDocument, PDFName, PDFRawStream } from 'pdf-lib';
+import { chromium } from 'playwright';
+import type { Browser, Page } from 'playwright';
+
+import { assetPublishingFaction } from './src/game/fixtures/assetPublishingFaction';
+import { PUBLISHER_RENDERER_CONTRACT } from './workers/publisher/renderer-contract';
+
+const repoRoot = import.meta.dirname;
+const publisherDist = path.join(repoRoot, 'workers/publisher/dist');
+const publicDir = path.join(repoRoot, 'public');
+const spikeDir =
+  '/private/tmp/claude-501/-Users-me-Projects-Dune-dunezone--claude-worktrees-image-optimization-web-pdf-298fff/3b954549-5ba3-4782-b17f-7f59ef03554c/scratchpad/spike';
+const variantsDir = path.join(spikeDir, 'variants');
+const outDir = path.join(spikeDir, 'out');
+
+const payload = {
+  factionId: 'k17spikeFaction',
+  slug: 'spike-faction',
+  faction: assetPublishingFaction,
+};
+const payloadHash = new Bun.CryptoHasher('sha256').update(JSON.stringify(payload)).digest('hex');
+const snapshot = { ok: true, payload, payloadHash };
+
+type Cell = {
+  name: string;
+  overrides?: Record<string, string>;
+  stripPatternFilter?: boolean;
+  injectCss?: string;
+  deviceScaleFactor?: number;
+  screenshotPages?: boolean;
+};
+
+const TEX = '/image/texture/021.jpg';
+const NO_FX_CSS = `
+  * { filter: none !important; box-shadow: none !important; text-shadow: none !important; }
+`;
+
+const CELLS: Cell[] = [
+  { name: 'baseline', screenshotPages: true },
+  { name: 'tex-w1280', overrides: { [TEX]: `${variantsDir}/021-w1280.jpg` } },
+  { name: 'tex-w640', overrides: { [TEX]: `${variantsDir}/021-w640.jpg` } },
+  {
+    name: 'baked-full',
+    overrides: { [TEX]: `${variantsDir}/021-baked-full.jpg` },
+    stripPatternFilter: true,
+  },
+  {
+    name: 'baked-w1280',
+    overrides: { [TEX]: `${variantsDir}/021-baked-w1280.jpg` },
+    stripPatternFilter: true,
+    screenshotPages: true,
+  },
+  {
+    name: 'baked-w640',
+    overrides: { [TEX]: `${variantsDir}/021-baked-w640.jpg` },
+    stripPatternFilter: true,
+  },
+  {
+    name: 'no-fx-baked-w1280',
+    overrides: { [TEX]: `${variantsDir}/021-baked-w1280.jpg` },
+    stripPatternFilter: true,
+    injectCss: NO_FX_CSS,
+  },
+  { name: 'baseline-dsf2', deviceScaleFactor: 2 },
+];
+
+let activeOverrides: Record<string, string> = {};
+
+const server = Bun.serve({
+  port: 0,
+  async fetch(request) {
+    const pathname = decodeURIComponent(new URL(request.url).pathname);
+    if (pathname === '/__asset-publisher/snapshot') {
+      return Response.json(snapshot, { headers: { 'Cache-Control': 'no-store' } });
+    }
+    const override = activeOverrides[pathname];
+    if (override) {
+      return new Response(Bun.file(override), { headers: { 'Cache-Control': 'no-store' } });
+    }
+    const relative = pathname === '/' ? 'publisher-capture.html' : pathname.replace(/^\/+/, '');
+    if (relative.split('/').includes('..')) return new Response('Not found', { status: 404 });
+    const fromDist = Bun.file(path.join(publisherDist, relative));
+    if (await fromDist.exists()) {
+      return new Response(fromDist, { headers: { 'Cache-Control': 'no-store' } });
+    }
+    const fromPublic = Bun.file(path.join(publicDir, relative));
+    if (await fromPublic.exists()) {
+      return new Response(fromPublic, { headers: { 'Cache-Control': 'no-store' } });
+    }
+    return new Response('Not found', { status: 404 });
+  },
+});
+
+async function waitReady(page: Page) {
+  const marker = page.locator('#capture-status');
+  await marker.waitFor({ state: 'attached' });
+  await page.waitForFunction(
+    () =>
+      document.querySelector('#capture-status')?.getAttribute('data-capture-state') !== 'loading',
+    undefined,
+    { timeout: 60_000 }
+  );
+  const state = await marker.getAttribute('data-capture-state');
+  if (state !== 'ready') {
+    throw new Error(`capture state ${state}: ${await marker.textContent()}`);
+  }
+}
+
+type ImageX = { w: number; h: number; filter: string; kb: number; smask: boolean };
+
+async function inspect(bytes: Uint8Array) {
+  const doc = await PDFDocument.load(bytes);
+  const images: ImageX[] = [];
+  let flateNonImageKb = 0;
+  for (const [, obj] of doc.context.enumerateIndirectObjects()) {
+    if (!(obj instanceof PDFRawStream)) continue;
+    const dict = obj.dict;
+    const subtype = dict.get(PDFName.of('Subtype'));
+    if (subtype === PDFName.of('Image')) {
+      images.push({
+        w: Number(dict.get(PDFName.of('Width'))?.toString() ?? 0),
+        h: Number(dict.get(PDFName.of('Height'))?.toString() ?? 0),
+        filter: dict.get(PDFName.of('Filter'))?.toString() ?? 'none',
+        kb: Math.round(obj.contents.length / 1024),
+        smask: dict.has(PDFName.of('SMask')),
+      });
+    } else {
+      flateNonImageKb += obj.contents.length / 1024;
+    }
+  }
+  images.sort((a, b) => b.kb - a.kb);
+  return { images, flateNonImageKb: Math.round(flateNonImageKb) };
+}
+
+async function runCell(browser: Browser, cell: Cell) {
+  activeOverrides = cell.overrides ?? {};
+  const page = await browser.newPage({
+    viewport: PUBLISHER_RENDERER_CONTRACT.viewport,
+    deviceScaleFactor: cell.deviceScaleFactor ?? PUBLISHER_RENDERER_CONTRACT.deviceScaleFactor,
+    locale: 'en-US',
+    timezoneId: 'UTC',
+  });
+  await page.goto(`http://127.0.0.1:${server.port}/publisher-capture.html`, {
+    waitUntil: 'domcontentloaded',
+  });
+  await waitReady(page);
+
+  const inventory = await page.evaluate(() => {
+    const withAttr = document.querySelectorAll('[filter]').length;
+    let computedFilter = 0;
+    let boxShadow = 0;
+    let masked = 0;
+    for (const el of Array.from(document.querySelectorAll('*'))) {
+      const cs = getComputedStyle(el as Element);
+      if (cs.filter && cs.filter !== 'none') computedFilter += 1;
+      if (cs.boxShadow && cs.boxShadow !== 'none') boxShadow += 1;
+      if ((cs.mask && cs.mask !== 'none') || (el as Element).getAttribute('mask')) masked += 1;
+    }
+    return {
+      filterAttrs: withAttr,
+      computedFilter,
+      boxShadow,
+      masked,
+      patterns: document.querySelectorAll('pattern').length,
+      patternImages: document.querySelectorAll('pattern image').length,
+    };
+  });
+
+  if (cell.stripPatternFilter) {
+    await page.evaluate(() => {
+      document.querySelectorAll('pattern image[filter]').forEach((el) => {
+        el.removeAttribute('filter');
+      });
+    });
+  }
+  if (cell.injectCss) await page.addStyleTag({ content: cell.injectCss });
+
+  if (cell.screenshotPages) {
+    const pages = page.locator('[data-faction-sheet-page]');
+    const count = await pages.count();
+    for (let i = 0; i < count; i += 1) {
+      await pages
+        .nth(i)
+        .screenshot({ path: path.join(outDir, `${cell.name}-page${i + 1}.png`) });
+    }
+  }
+
+  await page.emulateMedia({ media: 'print' });
+  const bytes = await page.pdf({
+    displayHeaderFooter: false,
+    margin: { top: 0, right: 0, bottom: 0, left: 0 },
+    preferCSSPageSize: true,
+    printBackground: true,
+  });
+  await Bun.write(path.join(outDir, `${cell.name}.pdf`), bytes);
+  const anatomy = await inspect(new Uint8Array(bytes));
+  await page.close();
+  return { cell: cell.name, totalKb: Math.round(bytes.length / 1024), inventory, ...anatomy };
+}
+
+const browser = await chromium.launch();
+const results = [];
+for (const cell of CELLS) {
+  const result = await runCell(browser, cell);
+  console.log(JSON.stringify(result));
+  results.push(result);
+}
+await browser.close();
+server.stop();
+await Bun.write(path.join(outDir, 'results.json'), JSON.stringify(results, null, 2));


### PR DESCRIPTION
Findings from the wayfinder map #250 research/spike branches, preserved
in-repo before deleting the throwaway branches. Binary artifacts (PDFs,
comparison PNGs) stay in the ticket history on GitHub.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added research on browser image handling, image formats, encoder consistency, and PDF compression options.
  * Documented PDF-size experiments, findings, production recommendations, and safety considerations.

* **Tools**
  * Added experimental utilities to inspect, measure, recompress, and compare PDF image streams.
  * Added configurable capture and analysis workflows for evaluating image and PDF size optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->