### PR TITLE
ci: build the Worker release concurrently with verify in deploy-main

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -17,9 +17,70 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: ./.github/workflows/reusable-verify.yml
 
+  # Builds the Worker release concurrently with verify; deploy consumes the
+  # artifact instead of rebuilding. Carries environment: production only to
+  # read the env-scoped VITE_CONVEX_URL — the environment has no human gates.
+  build:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    environment: production
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2.2.0
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check generated Worker types
+        run: bun run publisher:types:check
+
+      - name: Typecheck Worker release
+        run: bun run publisher:typecheck
+
+      - name: Restore generated images
+        id: image_cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            public/image
+            public/web
+            src/game/data/assetMap.generated.ts
+          key: generated-images-${{ hashFiles('media/**', 'src/shared/assetRules.ts', 'scripts/generate-images.ts', 'bun.lock') }}
+      - name: Generate image variants
+        if: steps.image_cache.outputs.cache-hit != 'true'
+        run: bun run generate:images
+      - name: Verify generated images structurally
+        run: bun run verify:images
+      - name: Log generated output digest (informational, not part of identity)
+        run: find public/image public/web -type f | sort | xargs shasum -a 256 | shasum -a 256
+      - name: Build unified Worker release
+        run: bun run publisher:assets
+        env:
+          VITE_CONVEX_URL: ${{ secrets.VITE_CONVEX_URL }}
+
+      - name: Verify assembled Worker assets
+        run: bun run publisher:assets:check
+
+      - name: Verify release build kept merged source exact
+        run: >-
+          git diff --exit-code &&
+          git diff --cached --exit-code &&
+          test -z "$(git ls-files --others --exclude-standard)"
+
+      - name: Upload Worker release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: publisher-dist-${{ github.sha }}
+          path: workers/publisher/dist
+          if-no-files-found: error
+          retention-days: 7
+
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: verify
+    needs: [verify, build]
     environment: production
     runs-on: ubuntu-latest
     permissions:
@@ -66,41 +127,14 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           VITE_CONVEX_URL: ${{ secrets.VITE_CONVEX_URL }}
 
-      - name: Check generated Worker types
-        run: bun run publisher:types:check
-
-      - name: Typecheck Worker release
-        run: bun run publisher:typecheck
-
-      - name: Restore generated images
-        id: image_cache
-        uses: actions/cache@v4
+      - name: Download built Worker release
+        uses: actions/download-artifact@v4
         with:
-          path: |
-            public/image
-            public/web
-            src/game/data/assetMap.generated.ts
-          key: generated-images-${{ hashFiles('media/**', 'src/shared/assetRules.ts', 'scripts/generate-images.ts', 'bun.lock') }}
-      - name: Generate image variants
-        if: steps.image_cache.outputs.cache-hit != 'true'
-        run: bun run generate:images
-      - name: Verify generated images structurally
-        run: bun run verify:images
-      - name: Log generated output digest (informational, not part of identity)
-        run: find public/image public/web -type f | sort | xargs shasum -a 256 | shasum -a 256
-      - name: Build unified Worker release
-        run: bun run publisher:assets
-        env:
-          VITE_CONVEX_URL: ${{ secrets.VITE_CONVEX_URL }}
+          name: publisher-dist-${{ github.sha }}
+          path: workers/publisher/dist
 
       - name: Verify assembled Worker assets
         run: bun run publisher:assets:check
-
-      - name: Verify release build kept merged source exact
-        run: >-
-          git diff --exit-code &&
-          git diff --cached --exit-code &&
-          test -z "$(git ls-files --others --exclude-standard)"
 
       - name: Dry-run exact Worker release
         run: bun run publisher:release:dry-run


### PR DESCRIPTION
Executes [Hoist publisher:assets build to run concurrently with verify in deploy-main #285](https://github.com/ndelangen/dunezone/issues/285) from wayfinder map #284.

The deploy job previously waited ~3 min for all nine verify jobs, then spent ~2.5 min on steps that depend only on the checkout: Worker typechecks, image generation, `publisher:assets`, and the assembled-assets check. Those now run in a `build` job concurrent with verify; deploy downloads the built `workers/publisher/dist` artifact instead of rebuilding.

Constraints from the ticket, preserved:
- **Source-exactness** (`git diff --exit-code` after build) runs in the build job, against the tree that actually built the artifact.
- **Same artifact deployed as verified**: `publisher:assets:check` is `inspectPublisherAssets(workers/publisher/dist)` only — no dependency on intermediate build outputs — so the deploy job re-runs it against the *downloaded* artifact before the dry-run and deploy.
- The build job carries `environment: production` solely to read the env-scoped `VITE_CONVEX_URL`; the environment has no reviewers or wait timers (verified via API — only a branch policy), so this adds no gate. Cloudflare/Convex secrets stay exclusive to the deploy job.

Expected: merge-to-production latency drops by roughly the build time (~1.5–2.5 min), since deploy now starts at max(verify, build) with the artifact ready.

**Verification is post-merge by design** (PR CI does not exercise `deploy-main.yml`): watch the first main deploy land green and confirm the deployed Worker serves. That observation resolves #285 per the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved release validation to ensure Worker builds are generated, assembled, and verified before deployment.
  * Deployments now use the exact validated release artifact, reducing the risk of inconsistencies between verification and production.
* **Chores**
  * Streamlined the deployment workflow by separating build validation from deployment execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->