### PR TITLE
ci: add ci_ok fan-in check for branch protection

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -13,3 +13,15 @@ concurrency:
 jobs:
   verify:
     uses: ./.github/workflows/reusable-verify.yml
+
+  # Single required-status-check context for branch protection: the workflow
+  # file owns the definition of "green", so protection settings never chase
+  # job renames. if: always() + explicit result check because a skipped
+  # required check would otherwise count as passing.
+  ci_ok:
+    if: always()
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require full verify success
+        run: test "${{ needs.verify.result }}" = "success"


### PR DESCRIPTION
First step of [Enable branch protection and drop the on-main verify #289](https://github.com/ndelangen/dunezone/issues/289): a single `ci_ok` job that fails unless the whole verify workflow succeeded. Branch protection will require this one context (plus the drift `audit`) instead of pinning nine job names. `if: always()` with an explicit result test so a skipped verify can never satisfy the required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a consolidated continuous integration status check for pull requests.
  * The check passes only when all verification steps succeed, providing a consistent merge-readiness signal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->