### PR TITLE
ci: drop the on-main re-verify; branch protection is the gate now

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -12,14 +12,13 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+# No verify job here: branch protection on main (required ci_ok + audit
+# checks, strict up-to-date, PRs only, admins enforced) guarantees every
+# push is a merge whose content PR CI already verified via the merge
+# preview ref. Decision: https://github.com/ndelangen/dunezone/issues/286
 jobs:
-  verify:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    uses: ./.github/workflows/reusable-verify.yml
-
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: verify
     environment: production
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Final step of [Enable branch protection and drop the on-main verify #289](https://github.com/ndelangen/dunezone/issues/289), per the decision on [the merge-queue grilling #286](https://github.com/ndelangen/dunezone/issues/286).

Branch protection is already live on main (required `ci_ok` + `audit`, strict up-to-date, PRs only, enforced for admins — [#290](https://github.com/ndelangen/dunezone/pull/290) merged through it). With that gate, every push to main is a merge whose content PR CI verified on the merge preview ref, so the on-main re-verify is redundant serial work. Deploy now starts immediately on push.

**The merge of this PR is the measurement**: click-to-live expected ~1.3 min, from ~4.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the production deployment workflow by removing a redundant verification step.
  * Added documentation clarifying that pull request checks verify protected main-branch merges before deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->