### PR TITLE
feat: e2e coverage on PRs (Chromium V8 → monocart → Codecov)

### DIFF
--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -373,6 +373,15 @@ jobs:
         env:
           E2E_ENV_FILE: ${{ runner.temp }}/.env.e2e.local
           PLAYWRIGHT_HEADLESS: "true"
+          E2E_COVERAGE: "1"
+      - name: Upload e2e coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/e2e/lcov.info
+          flags: e2e
+          disable_search: true
+          fail_ci_if_error: false
       - name: Upload E2E artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/bun.lock
+++ b/bun.lock
@@ -61,6 +61,7 @@
         "convex-test": "^0.0.55",
         "jsdom": "^30.0.1",
         "knip": "^6.32.0",
+        "monocart-coverage-reports": "^2.12.12",
         "oxfmt": "0.62.0",
         "oxlint": "1.77.0",
         "playwright": "^1.62.1",
@@ -845,6 +846,10 @@
 
     "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
 
+    "acorn-loose": ["acorn-loose@8.5.2", "", { "dependencies": { "acorn": "^8.15.0" } }, "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A=="],
+
+    "acorn-walk": ["acorn-walk@8.3.5", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw=="],
+
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
@@ -893,7 +898,11 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
+
+    "console-grid": ["console-grid@2.2.4", "", {}, "sha512-OLjCRTiHhOpTRo9lQp/2FgJDyq5uQHwkEmVJulEnQ6JVf27oKKzXHZnNOv/e72V4++UdMZCrDWtvXW5sx4lyQg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -949,6 +958,8 @@
 
     "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
+    "eight-colors": ["eight-colors@1.3.3", "", {}, "sha512-4B54S2Qi4pJjeHmCbDIsveQZWQ/TSSQng4ixYJ9/SYHHpeS5nYK0pzcHvWzWUfRsvJQjwoIENhAwqg59thQceg=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.400", "", {}, "sha512-96EWDNjM59SYflgeV5Ylsf4EMiq1a25YjCnJH7cxn/AF2H3pILRweaUnoLax0yKHWdpOzY6JKEu45e8irqZIHA=="],
 
     "empathic": ["empathic@2.0.1", "", {}, "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q=="],
@@ -982,6 +993,8 @@
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fetchdts": ["fetchdts@0.1.7", "", {}, "sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA=="],
+
+    "foreground-child": ["foreground-child@4.0.3", "", { "dependencies": { "signal-exit": "^4.0.1" } }, "sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw=="],
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
@@ -1119,6 +1132,8 @@
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
+    "lz-utils": ["lz-utils@2.1.1", "", {}, "sha512-d3Thjos0PSJQAoyMj6vipSSrtrRHS7DImqUNR8x9NW3+zQIftPIbMJAWhi5nPdg5Q9zHz6lxtN8kp/VdMlhi/Q=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.5.4", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "source-map-js": "^1.2.1" } }, "sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w=="],
@@ -1140,6 +1155,10 @@
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "monocart-coverage-reports": ["monocart-coverage-reports@2.12.12", "", { "dependencies": { "acorn": "^8.16.0", "acorn-loose": "^8.5.2", "acorn-walk": "^8.3.5", "commander": "^14.0.3", "console-grid": "^2.2.4", "eight-colors": "^1.3.3", "foreground-child": "^4.0.3", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "lz-utils": "^2.1.1", "monocart-locator": "^1.0.3" }, "bin": { "mcr": "lib/cli.js" } }, "sha512-d9FdUr2dn58Crweon0IE0zVi8r/i4vLvfvb2G7eL5vL5LfrxCB2X6F6qzuiwV6RioA4zbAI//7CYi6LjCvN3zA=="],
+
+    "monocart-locator": ["monocart-locator@1.0.3", "", {}, "sha512-pe29W2XAoA1WQmZZqxXoP7s06ZEXUhcb81086v68cqjk1HnVL7Q/iU/WJnnetxjPcLqwb4qG8vaSGUOMQU602g=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -1292,6 +1311,8 @@
     "shell-quote": ["shell-quote@1.10.0", "", {}, "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "smol-toml": ["smol-toml@1.7.1", "", {}, "sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ=="],
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,8 @@
 
 codecov:
   notify:
-    # unit + publisher today; bump as e2e and storybook flags land.
-    after_n_builds: 2
+    # unit + publisher + e2e today; bump when the storybook flag lands.
+    after_n_builds: 3
 
 coverage:
   status:
@@ -23,7 +23,9 @@ flags:
     carryforward: true
   publisher:
     carryforward: true
+  e2e:
+    carryforward: true
 
 comment:
-  after_n_builds: 2
+  after_n_builds: 3
   layout: "diff, flags, files"

--- a/e2e/coverage.ts
+++ b/e2e/coverage.ts
@@ -1,0 +1,47 @@
+// Chromium V8 coverage for the e2e suite, opt-in via E2E_COVERAGE=1.
+// Design: docs/research/combined-coverage-codecov.md §4; recipe validated on
+// branch prototype/combined-coverage. Each test collects V8 entries and feeds
+// them to monocart-coverage-reports, which persists raw data to the shared
+// outputDir cache across Playwright workers; global-teardown.ts generates the
+// final lcov report.
+import { test as base, expect } from '@playwright/test';
+import MCR from 'monocart-coverage-reports';
+import type { CoverageReportOptions } from 'monocart-coverage-reports';
+
+export const coverageEnabled = process.env.E2E_COVERAGE === '1';
+
+export const mcrOptions: CoverageReportOptions = {
+  name: 'e2e coverage',
+  outputDir: 'coverage/e2e',
+  reports: [['lcovonly'], ['console-summary']],
+  // Only modules served from the app's /src tree; dev-server dep bundles and
+  // vite client internals are not ours to count.
+  entryFilter: (entry) => entry.url.includes('/src/'),
+  // Vite dev inline sourcemaps carry bare filenames ("AppShell.tsx");
+  // info.distFile holds the served path, which IS the repo path for
+  // transform-in-place dev modules. Remap first, then filter.
+  sourcePath: (filePath, info) => {
+    const served = (info as { distFile?: string } | undefined)?.distFile ?? filePath;
+    const i = served.indexOf('src/');
+    return i >= 0 ? served.slice(i) : served;
+  },
+  sourceFilter: (sourcePath) => sourcePath.startsWith('src/'),
+};
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    // The animation project asserts per-frame samples and runs isolated;
+    // V8 precise coverage adds in-page overhead it cannot afford.
+    const collect = coverageEnabled && test.info().project.name !== 'animation';
+    if (collect) {
+      await page.coverage.startJSCoverage({ resetOnNavigation: false });
+    }
+    await use(page);
+    if (collect) {
+      const entries = await page.coverage.stopJSCoverage();
+      await MCR(mcrOptions).add(entries);
+    }
+  },
+});
+
+export { expect };

--- a/e2e/coverage.ts
+++ b/e2e/coverage.ts
@@ -11,6 +11,11 @@ import type { CoverageReportOptions } from 'monocart-coverage-reports';
 
 export const coverageEnabled = process.env.E2E_COVERAGE === '1';
 
+// V8 collection costs the long specs real headroom in CI: faction-lifecycle
+// ran 78s of its 90s budget on a green coverage run and over it on a slower
+// runner. Coverage runs get 1.5x.
+export const longSpecTimeoutMs = coverageEnabled ? 135_000 : 90_000;
+
 export const mcrOptions: CoverageReportOptions = {
   name: 'e2e coverage',
   outputDir: 'coverage/e2e',

--- a/e2e/coverage.ts
+++ b/e2e/coverage.ts
@@ -49,11 +49,14 @@ export async function newCoveredPage(
   return {
     page,
     close: async () => {
-      if (collect) {
-        const entries = await page.coverage.stopJSCoverage();
-        await MCR(mcrOptions).add(entries);
+      try {
+        if (collect) {
+          const entries = await page.coverage.stopJSCoverage();
+          await MCR(mcrOptions).add(entries);
+        }
+      } finally {
+        await context.close();
       }
-      await context.close();
     },
   };
 }

--- a/e2e/coverage.ts
+++ b/e2e/coverage.ts
@@ -5,6 +5,7 @@
 // outputDir cache across Playwright workers; global-teardown.ts generates the
 // final lcov report.
 import { test as base, expect } from '@playwright/test';
+import type { Browser, BrowserContextOptions, Page } from '@playwright/test';
 import MCR from 'monocart-coverage-reports';
 import type { CoverageReportOptions } from 'monocart-coverage-reports';
 
@@ -28,11 +29,40 @@ export const mcrOptions: CoverageReportOptions = {
   sourceFilter: (sourcePath) => sourcePath.startsWith('src/'),
 };
 
+const shouldCollect = () => coverageEnabled && test.info().project.name !== 'animation';
+
+/**
+ * Coverage-aware replacement for `browser.newContext()` + `context.newPage()`. The returned `close`
+ * collects the page's V8 coverage (when enabled) before closing the context — after close the CDP
+ * session is gone and coverage is unrecoverable, so always close through it.
+ */
+export async function newCoveredPage(
+  browser: Browser,
+  options: BrowserContextOptions
+): Promise<{ page: Page; close: () => Promise<void> }> {
+  const context = await browser.newContext(options);
+  const page = await context.newPage();
+  const collect = shouldCollect();
+  if (collect) {
+    await page.coverage.startJSCoverage({ resetOnNavigation: false });
+  }
+  return {
+    page,
+    close: async () => {
+      if (collect) {
+        const entries = await page.coverage.stopJSCoverage();
+        await MCR(mcrOptions).add(entries);
+      }
+      await context.close();
+    },
+  };
+}
+
 export const test = base.extend({
   page: async ({ page }, use) => {
     // The animation project asserts per-frame samples and runs isolated;
     // V8 precise coverage adds in-page overhead it cannot afford.
-    const collect = coverageEnabled && test.info().project.name !== 'animation';
+    const collect = shouldCollect();
     if (collect) {
       await page.coverage.startJSCoverage({ resetOnNavigation: false });
     }

--- a/e2e/faction-lifecycle.spec.ts
+++ b/e2e/faction-lifecycle.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 
-import { expect, test } from './coverage';
+import { expect, longSpecTimeoutMs, test } from './coverage';
 
 async function createFaction(page: Page, name: string, factionLeaderName: string) {
   await page.goto('/factions/create');
@@ -22,7 +22,7 @@ async function loadFactionDraft(page: Page, factionName: string) {
 }
 
 test('owner can author a faction through its complete lifecycle', async ({ page }) => {
-  test.setTimeout(90_000);
+  test.setTimeout(longSpecTimeoutMs);
   await page.setViewportSize({ width: 1200, height: 900 });
 
   const suffix = Date.now();

--- a/e2e/faction-lifecycle.spec.ts
+++ b/e2e/faction-lifecycle.spec.ts
@@ -1,5 +1,6 @@
-import { expect, test } from '@playwright/test';
 import type { Page } from '@playwright/test';
+
+import { expect, test } from './coverage';
 
 async function createFaction(page: Page, name: string, factionLeaderName: string) {
   await page.goto('/factions/create');

--- a/e2e/faq-happy-path.spec.ts
+++ b/e2e/faq-happy-path.spec.ts
@@ -1,9 +1,9 @@
-import { expect, newCoveredPage, test } from './coverage';
+import { expect, longSpecTimeoutMs, newCoveredPage, test } from './coverage';
 
 test.use({ storageState: '.playwright/user-a-faq.json' });
 
 test('FAQ happy path: ask, answer, accept, profile activity', async ({ page, browser }) => {
-  test.setTimeout(90_000);
+  test.setTimeout(longSpecTimeoutMs);
 
   const suffix = Date.now();
   const questionText = `What is the E2E spice cycle ${suffix}?`;

--- a/e2e/faq-happy-path.spec.ts
+++ b/e2e/faq-happy-path.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage';
 
 test.use({ storageState: '.playwright/user-a-faq.json' });
 

--- a/e2e/faq-happy-path.spec.ts
+++ b/e2e/faq-happy-path.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from './coverage';
+import { expect, newCoveredPage, test } from './coverage';
 
 test.use({ storageState: '.playwright/user-a-faq.json' });
 
@@ -18,8 +18,8 @@ test('FAQ happy path: ask, answer, accept, profile activity', async ({ page, bro
   });
   const questionUrl = page.url();
 
-  const userBContext = await browser.newContext({ storageState: '.playwright/user-b-faq.json' });
-  const userBPage = await userBContext.newPage();
+  const userB = await newCoveredPage(browser, { storageState: '.playwright/user-b-faq.json' });
+  const userBPage = userB.page;
 
   await test.step('another member answers', async () => {
     await userBPage.goto(questionUrl);
@@ -49,5 +49,5 @@ test('FAQ happy path: ask, answer, accept, profile activity', async ({ page, bro
     await expect(pickedFact.locator('strong')).toHaveText('1');
   });
 
-  await userBContext.close();
+  await userB.close();
 });

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,0 +1,12 @@
+// Generates the e2e lcov report from the raw coverage cache the workers
+// wrote via e2e/coverage.ts. No-op unless E2E_COVERAGE=1.
+import MCR from 'monocart-coverage-reports';
+
+import { coverageEnabled, mcrOptions } from './coverage';
+
+export default async function globalTeardown(): Promise<void> {
+  if (!coverageEnabled) {
+    return;
+  }
+  await MCR(mcrOptions).generate();
+}

--- a/e2e/group-membership-lifecycle.spec.ts
+++ b/e2e/group-membership-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from './coverage';
+import { expect, newCoveredPage, test } from './coverage';
 
 test.use({ storageState: '.playwright/user-a-group.json' });
 
@@ -18,8 +18,8 @@ test('membership lifecycle: request, approve, moderate, remove', async ({ page, 
   });
   const groupUrl = page.url();
 
-  const userBContext = await browser.newContext({ storageState: '.playwright/user-b-group.json' });
-  const userBPage = await userBContext.newPage();
+  const userB = await newCoveredPage(browser, { storageState: '.playwright/user-b-group.json' });
+  const userBPage = userB.page;
 
   await test.step('visitor requests membership', async () => {
     await userBPage.goto(groupUrl);
@@ -51,5 +51,5 @@ test('membership lifecycle: request, approve, moderate, remove', async ({ page, 
     await expect(userBPage.getByRole('button', { name: 'Request membership' })).toBeVisible();
   });
 
-  await userBContext.close();
+  await userB.close();
 });

--- a/e2e/group-membership-lifecycle.spec.ts
+++ b/e2e/group-membership-lifecycle.spec.ts
@@ -1,9 +1,9 @@
-import { expect, newCoveredPage, test } from './coverage';
+import { expect, longSpecTimeoutMs, newCoveredPage, test } from './coverage';
 
 test.use({ storageState: '.playwright/user-a-group.json' });
 
 test('membership lifecycle: request, approve, moderate, remove', async ({ page, browser }) => {
-  test.setTimeout(90_000);
+  test.setTimeout(longSpecTimeoutMs);
 
   const suffix = Date.now();
   const groupName = `E2EMembership${suffix}`;

--- a/e2e/group-membership-lifecycle.spec.ts
+++ b/e2e/group-membership-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage';
 
 test.use({ storageState: '.playwright/user-a-group.json' });
 

--- a/e2e/page-header-transition.spec.ts
+++ b/e2e/page-header-transition.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage';
 
 test.use({ storageState: '.playwright/user-a-header.json' });
 

--- a/e2e/ruleset-lifecycle.spec.ts
+++ b/e2e/ruleset-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from './coverage';
+import { expect, newCoveredPage, test } from './coverage';
 
 test.use({ storageState: '.playwright/user-a-ruleset.json' });
 
@@ -15,12 +15,12 @@ test('owner can create and delete a ruleset in a two-user flow', async ({ page, 
   await expect(page.getByLabel('Edit ruleset')).toBeVisible({ timeout: 30_000 });
   await expect(page.getByText(uniqueName).first()).toBeVisible({ timeout: 30_000 });
 
-  const userBContext = await browser.newContext({ storageState: '.playwright/user-b.json' });
-  const userBPage = await userBContext.newPage();
+  const userB = await newCoveredPage(browser, { storageState: '.playwright/user-b.json' });
+  const userBPage = userB.page;
   await userBPage.goto(createdUrl);
   await expect(userBPage.getByText(uniqueName).first()).toBeVisible({ timeout: 30_000 });
   await expect(userBPage.getByLabel('Edit ruleset')).toHaveCount(0);
-  await userBContext.close();
+  await userB.close();
 
   page.once('dialog', (dialog) => dialog.accept());
   await page.getByLabel('Delete ruleset').click();

--- a/e2e/ruleset-lifecycle.spec.ts
+++ b/e2e/ruleset-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './coverage';
 
 test.use({ storageState: '.playwright/user-a-ruleset.json' });
 

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "convex-test": "^0.0.55",
     "jsdom": "^30.0.1",
     "knip": "^6.32.0",
+    "monocart-coverage-reports": "^2.12.12",
     "oxfmt": "0.62.0",
     "oxlint": "1.77.0",
     "playwright": "^1.62.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
   // what makes cross-file parallelism safe under Convex Auth token rotation.
   workers: process.env.CI ? 3 : 1,
   globalSetup: './e2e/global-setup.ts',
+  // Generates the e2e lcov report when E2E_COVERAGE=1 (no-op otherwise).
+  globalTeardown: './e2e/global-teardown.ts',
   reporter: [['list'], ['html', { open: 'never', outputFolder: 'playwright-report' }]],
   use: {
     baseURL: baseUrl,


### PR DESCRIPTION
Phase 2 of the combined-coverage effort — wayfinder map #299, resolves ticket #303.

## What

- **`e2e/coverage.ts` fixture**: per-test Chromium V8 coverage, opt-in via `E2E_COVERAGE=1` (local runs untouched). The `animation` project is excluded — its per-frame assertions can't afford collection overhead. `global-teardown.ts` assembles the cross-worker raw cache into `coverage/e2e/lcov.info`.
- **The one non-obvious bit**: vite-dev inline sourcemaps carry bare filenames, so paths remap via monocart's `info.distFile` before filtering — recipe validated on branch `prototype/combined-coverage`.
- **CI**: `e2e_docker` sets `E2E_COVERAGE=1` and uploads flag `e2e`; `codecov.yml` waits for 3 uploads now.

## Verification

Full local docker e2e run: **5/5 specs pass** with the fixture active; the real user flows cover **84.7% of 13,379 touched lines** across 150 `src/` files, all repo-relative paths.

**This PR is also the map's verification vehicle for the PR-comment display**: it's the first PR with a coverage baseline on main, so the full Codecov comparison comment (project + patch + flags) should appear below — settling the free-plan flag-rendering question from the research doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added optional end-to-end test coverage collection and reporting.
  * Improved coverage aggregation to include unit, publisher, and end-to-end results.
  * Coverage upload failures no longer interrupt verification workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->