### PR TITLE
fix: make story play assertions robust under the vitest story runner

### DIFF
--- a/src/app/components/content/FormControls/ControlBlock/ControlBlock.stories.tsx
+++ b/src/app/components/content/FormControls/ControlBlock/ControlBlock.stories.tsx
@@ -1,6 +1,6 @@
 import { Box, Select } from '@mantine/core';
 import preview from '@sb/preview';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import { ListLengthActions } from '../ListLengthActions';
 import { ControlBlock } from './ControlBlock';
@@ -79,10 +79,10 @@ export const TruncatedText = meta.story({
     await expect(description.scrollWidth).toBeGreaterThan(description.clientWidth);
 
     await userEvent.hover(title);
-    await expect(page.getByRole('tooltip')).toHaveTextContent(longTitle);
+    await waitFor(() => expect(page.getByRole('tooltip')).toHaveTextContent(longTitle));
 
     await userEvent.unhover(title);
     await userEvent.hover(description);
-    await expect(page.getByRole('tooltip')).toHaveTextContent(longDescription);
+    await waitFor(() => expect(page.getByRole('tooltip')).toHaveTextContent(longDescription));
   },
 });

--- a/src/app/components/groups/GroupAssignPopover.stories.tsx
+++ b/src/app/components/groups/GroupAssignPopover.stories.tsx
@@ -1,5 +1,5 @@
 import preview from '@sb/preview';
-import { expect, fn, userEvent, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
 import type { Id } from '../../../../convex/_generated/dataModel';
 import { GroupAssignPopover } from './GroupAssignPopover';
@@ -33,7 +33,9 @@ export const AvailableGroups = meta.story({
 
     await expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
     await expect(trigger).toHaveAttribute('aria-expanded', 'true');
-    await expect(page.getByLabelText('Search groups')).toBeVisible();
+    await waitFor(() =>
+      expect(page.getByRole('combobox', { name: 'Search groups' })).toBeVisible()
+    );
   },
 });
 
@@ -44,7 +46,7 @@ export const NoAvailableGroups = meta.story({
   play: async ({ canvasElement }) => {
     const page = within(canvasElement.ownerDocument.body);
     await userEvent.click(page.getByRole('button', { name: 'Assign group' }));
-    await expect(page.getByText('No groups are available yet.')).toBeVisible();
+    await waitFor(() => expect(page.getByText('No groups are available yet.')).toBeVisible());
   },
 });
 


### PR DESCRIPTION
Resolves ticket #304 of the combined-coverage map #299 — the last blocker before the storybook coverage flag (#305).

## What

The three story-test failures surfaced by the prototype are play-function timing/specificity issues, not component bugs:

- **GroupAssignPopover**: the search input's actual role is `combobox` (debugged empirically — a single label, one visible input), and the popover dropdown *transitions* in, so presence precedes visibility. Query by real role, `waitFor` visibility.
- **GroupAssignPopover empty state + ControlBlock tooltips**: same transition physics — assertions wrapped in `waitFor`.

No component changes; two story files, 8 lines.

## Verification

All **74 story files / 225 story tests pass with zero excludes**, stable across repeated runs (the runner config itself lands with #305; verified locally against the prototype-validated setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)