### PR TITLE
Fix vector-train review findings and the blocked deploy (#308)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,8 +3,8 @@
   "configurations": [
     {
       "name": "storybook",
-      "runtimeExecutable": "bun",
-      "runtimeArgs": ["run", "storybook"],
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "bun run generate:vectors && bun run storybook"],
       "port": 6006
     }
   ]

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as http from "../http.js";
 import type * as lib_applicationTriggers from "../lib/applicationTriggers.js";
 import type * as lib_collaborativeAccess from "../lib/collaborativeAccess.js";
 import type * as lib_collaborativeAccessValidators from "../lib/collaborativeAccessValidators.js";
+import type * as lib_decalRetune from "../lib/decalRetune.js";
 import type * as lib_factionCatalogue from "../lib/factionCatalogue.js";
 import type * as lib_factionData from "../lib/factionData.js";
 import type * as lib_factionInput from "../lib/factionInput.js";
@@ -70,6 +71,7 @@ declare const fullApi: ApiFromModules<{
   "lib/applicationTriggers": typeof lib_applicationTriggers;
   "lib/collaborativeAccess": typeof lib_collaborativeAccess;
   "lib/collaborativeAccessValidators": typeof lib_collaborativeAccessValidators;
+  "lib/decalRetune": typeof lib_decalRetune;
   "lib/factionCatalogue": typeof lib_factionCatalogue;
   "lib/factionData": typeof lib_factionData;
   "lib/factionInput": typeof lib_factionInput;

--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -125,6 +125,11 @@
       "id": "profile_activity_answers_v1",
       "phase": "widen",
       "requires": []
+    },
+    {
+      "id": "faction_decal_retune_v1",
+      "phase": "widen",
+      "requires": []
     }
   ]
 }

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -407,7 +407,8 @@ export const faction_decal_retune_v1 = migrations.define({
           : entry.scale;
       if (id !== entry.id || scale !== entry.scale) {
         changed = true;
-        return { ...entry, id, scale };
+        // Convex rejects `undefined` values — never introduce an own `scale: undefined` key.
+        return scale === undefined ? { ...entry, id } : { ...entry, id, scale };
       }
       return decal;
     });

--- a/scripts/verify-vectors.ts
+++ b/scripts/verify-vectors.ts
@@ -104,6 +104,10 @@ if (existsSync(mapPath)) {
       failures.push(`background/map.svg: place-id #${placeId} was dropped by optimization`);
     }
   }
+} else {
+  // Consumers hard-reference the map's fragment API; its absence is a failure even if the
+  // media source vanished too (the per-source check only fires while a source exists).
+  failures.push('background/map.svg: missing generated map (place-id API unavailable)');
 }
 
 // 6. no orphans


### PR DESCRIPTION
Follow-up to #312, which merged before its review comments were addressed (my auto-merge misfire — the bot reviews landed after arming). The deploy then failed at the exact-checkout preflight, so **production never shipped the train** and stays consistent (old site + old data; only Convex functions updated, which is harmless).

All four review findings verified and fixed, plus the deploy blocker:

1. **Critical (CodeRabbit): `faction_decal_retune_v1` was missing from `convex/migration-guards.json`** — the deploy's `migrations:deploy` step is manifest-driven, so the decal retune would never have run and cards would have rendered wrong against the new square slot. Added as a widen entry.
2. **Deploy blocker: uncommitted Convex codegen** — `convex deploy` regenerated `convex/_generated/api.d.ts` on the runner, tripping the tracked-source preflight. Committed.
3. **Migration robustness**: never writes an own `scale: undefined` key (Convex rejects `undefined`).
4. **verify:vectors**: missing generated map is now a loud failure even when the media source is gone too.
5. **DX**: local Storybook launcher runs `generate:vectors` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)