### PR TITLE
feat: per-category bundle analysis

### DIFF
--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -185,14 +185,29 @@ jobs:
         run: bun run app:build
         env:
           VITE_CONVEX_URL: https://example.convex.cloud
-      - name: Upload bundle stats to Codecov
+      - name: Upload bundle stats to Codecov (per category)
         # @codecov/vite-plugin only peers with Vite <=6 (no rolldown support),
         # so the bundler-agnostic analyzer runs on the finished client build
-        # instead. Not tokenless — skipped on fork PRs where the secret is
-        # absent; never fails the build.
+        # instead. One bundle per asset category: dist/client is ~96% generated
+        # media, and a single blob would let an image regeneration bury an
+        # app-code regression. dunezone-app (compiled JS/CSS) is the one that
+        # tracks dependency/code bloat. Not tokenless — skipped on fork PRs
+        # where the secret is absent; never fails the build.
         if: ${{ env.CODECOV_TOKEN != '' }}
         continue-on-error: true
-        run: bunx @codecov/bundle-analyzer ./dist/client --bundle-name=dunezone-client --upload-token="$CODECOV_TOKEN"
+        run: |
+          set -euo pipefail
+          upload() {
+            local name="$1"
+            shift
+            bunx @codecov/bundle-analyzer "$@" --bundle-name="$name" --upload-token="$CODECOV_TOKEN"
+          }
+          upload dunezone-app dist/client/public
+          upload dunezone-images dist/client/image dist/client/web
+          upload dunezone-vectors dist/client/vector
+          upload dunezone-objs dist/client/obj
+          upload dunezone-pages dist/client/page
+          upload dunezone-fonts dist/client/font
 
   publisher_release:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -35,3 +35,8 @@ flags:
 comment:
   after_n_builds: 4
   layout: "diff, flags, files"
+  # Bundle section: list only categories that actually changed, so the
+  # per-category split (app/images/vectors/objs/pages/fonts) surfaces real
+  # movement instead of restating six static sizes on every PR.
+  require_bundle_changes: true
+  bundle_change_threshold: "10Kb"

--- a/docs/research/combined-coverage-codecov.md
+++ b/docs/research/combined-coverage-codecov.md
@@ -358,8 +358,12 @@ Two further Codecov integrations, verified against primary sources before adopti
   has been unanswered since July 2025; nothing supports rolldown. Adopted instead:
   [`@codecov/bundle-analyzer`](https://github.com/codecov/codecov-javascript-bundler-plugins/tree/main/packages/bundle-analyzer)
   (same official monorepo), which analyzes the finished `dist/client` post-build — bundler-
-  agnostic, coarser per-module attribution than the in-bundler plugin would give. Uploads as
-  bundle `dunezone-client` from the `generate_and_build` job; not tokenless, so fork PRs skip it.
+  agnostic, coarser per-module attribution than the in-bundler plugin would give. Uploaded from the
+  `generate_and_build` job as one bundle per asset category (`dunezone-app` = compiled JS/CSS,
+  plus `-images`, `-vectors`, `-objs`, `-pages`, `-fonts`): `dist/client` is ~96% generated media
+  (84MB total vs ~3MB compiled app), and a single blob would let an image regeneration bury an
+  app-code regression. The PR comment lists only categories that moved
+  (`require_bundle_changes` + `bundle_change_threshold`). Not tokenless, so fork PRs skip it.
   Storybook/worker bundles can be added later with their own `--bundle-name`s.
 - **Test Analytics**: every suite emits JUnit XML (Vitest: `--reporter=junit`
   `--outputFile.junit=...` alongside the default reporter; Playwright: a `junit` entry in the


### PR DESCRIPTION
Follow-up to #319: the single `dunezone-client` bundle measured the whole 84MB static site, of which ~96% is generated media — an image regeneration would bury a real app-code regression, and the total was meaningless for tracking bloat.

## What

- **Six category bundles** instead of one blob: `dunezone-app` (compiled JS/CSS, ~2.8MB — the one that matters for dependency bloat), `dunezone-images` (image+web, ~59MB), `dunezone-vectors`, `dunezone-objs`, `dunezone-pages`, `dunezone-fonts`.
- **PR comment shows movement, not totals**: `require_bundle_changes: true` + `bundle_change_threshold: "10Kb"` — only categories that actually changed appear, so an app-bundle jump reads clearly instead of drowning in six static sizes.
- `dunezone-client` stops receiving uploads (its history remains in the UI until it ages out).

All six verified with `--dry-run` against a real build. Doc updated (§9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added more detailed Codecov bundle analysis for application code and generated asset categories.
  * Reports now highlight changed categories and require changes above the configured 10 KB threshold.
  * Bundle uploads remain non-blocking and are skipped when required authentication is unavailable.

* **Documentation**
  * Updated coverage documentation to describe category-specific bundle reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->