### PR TITLE
fix: bundle uploads continue past individual category failures

### DIFF
--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -196,11 +196,18 @@ jobs:
         if: ${{ env.CODECOV_TOKEN != '' }}
         continue-on-error: true
         run: |
-          set -euo pipefail
+          set -uo pipefail
+          # Each category uploads independently: one transient failure must
+          # not suppress the remaining bundles. Aggregate status surfaces as a
+          # warning; continue-on-error keeps the job green either way.
+          status=0
           upload() {
             local name="$1"
             shift
-            bunx @codecov/bundle-analyzer "$@" --bundle-name="$name" --upload-token="$CODECOV_TOKEN"
+            if ! bunx @codecov/bundle-analyzer "$@" --bundle-name="$name" --upload-token="$CODECOV_TOKEN"; then
+              echo "::warning::bundle upload failed: $name"
+              status=1
+            fi
           }
           upload dunezone-app dist/client/public
           upload dunezone-images dist/client/image dist/client/web
@@ -208,6 +215,7 @@ jobs:
           upload dunezone-objs dist/client/obj
           upload dunezone-pages dist/client/page
           upload dunezone-fonts dist/client/font
+          exit "$status"
 
   publisher_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to the review comments on #322 (merged before the fix landed):

- **Fixed**: `set -e` aborted the upload script at the first failed category — one transient analyzer failure would silently suppress all later bundles. Each category now uploads independently, failures emit a warning annotation, and the step exits with aggregate status (still `continue-on-error`, so never blocking).
- **Declined** (reasoned on the thread): `fetch-depth: 0` — the analyzer resolves commit identity from CI env vars, verified working in the #322 run logs (6/6 uploads attributed correctly); a full-history clone of this media-heavy repo is a real cost for a speculative benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bundle uploads now continue independently when one upload fails.
  * Upload failures are reported as warnings while still producing an overall failure status.
  * Verification workflows can complete remaining checks before reporting the final result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->