### PR TITLE
chore: prune comment noise, normalize multi-line comments to block comments

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,10 +1,17 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript", "unicorn", "oxc", "react", "jsx-a11y", "vitest", "import", "jsdoc"],
+  "jsPlugins": ["./scripts/oxlint-prefer-block-comments.mjs"],
   "categories": {
     "correctness": "error"
   },
   "overrides": [
+    {
+      "files": ["**/*.generated.ts", "**/*.gen.ts", "**/worker-configuration.d.ts"],
+      "rules": {
+        "local/prefer-block-comments": "off"
+      }
+    },
     {
       "files": ["convex/lib/collaborativeAccess.ts"],
       "rules": {
@@ -29,6 +36,7 @@
   ],
   "rules": {
     "curly": ["error", "all"],
+    "local/prefer-block-comments": "error",
     "eqeqeq": ["error", "smart"],
     "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
     "jsdoc/check-tag-names": [

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -10,8 +10,8 @@ import '../src/app/styles/mantine-shell-compatibility.css';
 import { appContentTheme } from '../src/app/theme';
 import * as sizes from '../src/game/data/sizes';
 
-// Storybook has no backend or auth context. Connected components must opt into
-// deterministic, per-story return values from these network-incapable mocks.
+/* Storybook has no backend or auth context. Connected components must opt into
+   deterministic, per-story return values from these network-incapable mocks. */
 sb.mock(import('convex/react'));
 sb.mock(import('convex/browser'));
 

--- a/.storybook/vite.config.ts
+++ b/.storybook/vite.config.ts
@@ -6,8 +6,10 @@ export default defineConfig({
     assetsDir: 'public',
   },
   define: {
-    // Never copy a developer or production deployment URL into the public catalogue.
-    // The global manual mock ignores this inert value when app database modules load.
+    /**
+     * Never copy a developer or production deployment URL into the public catalogue. The global
+     * manual mock ignores this inert value when app database modules load.
+     */
     'import.meta.env.VITE_CONVEX_URL': JSON.stringify('storybook-disconnected'),
   },
   publicDir: false,

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -1,5 +1,5 @@
-// Applies the project's Storybook annotations (decorators, parameters) to
-// stories running as Vitest browser-mode tests.
+/* Applies the project's Storybook annotations (decorators, parameters) to
+   stories running as Vitest browser-mode tests. */
 import { setProjectAnnotations } from '@storybook/tanstack-react';
 import { beforeAll } from 'vitest';
 

--- a/convex/lib/profileDetail.ts
+++ b/convex/lib/profileDetail.ts
@@ -30,8 +30,8 @@ export async function loadProfileDetailBySlug(ctx: QueryCtx, slug: string) {
   const groups = groupsWithNulls.filter(
     (group): group is NonNullable<(typeof groupsWithNulls)[number]> => group !== null
   );
-  // Public profile callers count and render only resolvable active Groups. A dangling
-  // membership cannot become a safe identity summary.
+  /* Public profile callers count and render only resolvable active Groups. A dangling
+   * membership cannot become a safe identity summary. */
   const groupSummaries = groups.map((group) => ({
     id: group._id,
     name: group.name,

--- a/coverage-denominator.ts
+++ b/coverage-denominator.ts
@@ -1,12 +1,16 @@
-// Single authority for the coverage denominator, imported by vite.config.ts
-// (unit/publisher flags) and vitest.storybook.config.ts (storybook flag).
-// Decided in https://github.com/ndelangen/dunezone/issues/301; corrections
-// recorded in docs/research/combined-coverage-codecov.md §8.
+/*
+ * Single authority for the coverage denominator, imported by vite.config.ts
+ * (unit/publisher flags) and vitest.storybook.config.ts (storybook flag).
+ * @see https://github.com/ndelangen/dunezone/issues/301 (decision)
+ * @see docs/research/combined-coverage-codecov.md §8 (corrections)
+ */
 import { coverageConfigDefaults } from 'vitest/config';
 
-// Extension-scoped rather than bare globs: bare `src/**` pulled non-code
-// files (local publisher dist output, tsconfig.json) into the denominator.
-// A new source extension (.js, .mts) must be added here to be counted.
+/**
+ * Extension-scoped rather than bare globs: bare `src/**` pulled non-code files (local publisher
+ * dist output, tsconfig.json) into the denominator. A new source extension (.js, .mts) must be
+ * added here to be counted.
+ */
 export const coverageIncludeSrc = 'src/**/*.{ts,tsx}';
 
 export const coverageInclude = [coverageIncludeSrc, 'convex/**/*.ts', 'workers/**/*.ts'];

--- a/e2e/coverage.ts
+++ b/e2e/coverage.ts
@@ -1,9 +1,11 @@
-// Chromium V8 coverage for the e2e suite, opt-in via E2E_COVERAGE=1.
-// Design: docs/research/combined-coverage-codecov.md §4; recipe validated on
-// branch prototype/combined-coverage. Each test collects V8 entries and feeds
-// them to monocart-coverage-reports, which persists raw data to the shared
-// outputDir cache across Playwright workers; global-teardown.ts generates the
-// final lcov report.
+/*
+ * Chromium V8 coverage for the e2e suite, opt-in via E2E_COVERAGE=1. Each test
+ * collects V8 entries and feeds them to monocart-coverage-reports, which
+ * persists raw data to the shared outputDir cache across Playwright workers;
+ * global-teardown.ts generates the final lcov report.
+ * @see docs/research/combined-coverage-codecov.md §4 (recipe validated on
+ * branch prototype/combined-coverage)
+ */
 import { test as base, expect } from '@playwright/test';
 import type { BrowserContext, BrowserContextOptions, Page } from '@playwright/test';
 import MCR from 'monocart-coverage-reports';
@@ -11,21 +13,26 @@ import type { CoverageReportOptions } from 'monocart-coverage-reports';
 
 export const coverageEnabled = process.env.E2E_COVERAGE === '1';
 
-// V8 collection costs the long specs real headroom in CI: faction-lifecycle
-// ran 78s of its 90s budget on a green coverage run and over it on a slower
-// runner. Coverage runs get 1.5x.
+/**
+ * V8 collection costs the long specs real headroom in CI: faction-lifecycle ran 78s of its 90s
+ * budget on a green coverage run and over it on a slower runner. Coverage runs get 1.5x.
+ */
 export const longSpecTimeoutMs = coverageEnabled ? 135_000 : 90_000;
 
 export const mcrOptions: CoverageReportOptions = {
   name: 'e2e coverage',
   outputDir: 'coverage/e2e',
   reports: [['lcovonly'], ['console-summary']],
-  // Only modules served from the app's /src tree; dev-server dep bundles and
-  // vite client internals are not ours to count.
+  /**
+   * Only modules served from the app's /src tree; dev-server dep bundles and vite client internals
+   * are not ours to count.
+   */
   entryFilter: (entry) => entry.url.includes('/src/'),
-  // Vite dev inline sourcemaps carry bare filenames ("AppShell.tsx");
-  // info.distFile holds the served path, which IS the repo path for
-  // transform-in-place dev modules. Remap first, then filter.
+  /**
+   * Vite dev inline sourcemaps carry bare filenames ("AppShell.tsx"); info.distFile holds the
+   * served path, which IS the repo path for transform-in-place dev modules. Remap first, then
+   * filter.
+   */
   sourcePath: (filePath, info) => {
     const served = (info as { distFile?: string } | undefined)?.distFile ?? filePath;
     const i = served.indexOf('src/');
@@ -34,14 +41,18 @@ export const mcrOptions: CoverageReportOptions = {
   sourceFilter: (sourcePath) => sourcePath.startsWith('src/'),
 };
 
-// The animation project asserts per-frame samples and runs isolated;
-// V8 precise coverage adds in-page overhead it cannot afford.
+/**
+ * The animation project asserts per-frame samples and runs isolated; V8 precise coverage adds
+ * in-page overhead it cannot afford.
+ */
 const shouldCollect = () => coverageEnabled && test.info().project.name !== 'animation';
 
 const startCollecting = (page: Page) => page.coverage.startJSCoverage({ resetOnNavigation: false });
 
-// Collection must happen while the page's CDP session is alive — after the
-// context closes, the coverage is unrecoverable.
+/**
+ * Collection must happen while the page's CDP session is alive — after the context closes, the
+ * coverage is unrecoverable.
+ */
 async function collectInto(page: Page): Promise<void> {
   const entries = await page.coverage.stopJSCoverage();
   await MCR(mcrOptions).add(entries);

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -74,9 +74,11 @@ export default async function globalSetup(config: FullConfig) {
   }
 
   await mkdir('.playwright', { recursive: true });
-  // Each spec file gets its own session: Convex Auth rotates refresh tokens,
-  // so two parallel workers sharing a storage state would invalidate each
-  // other's session mid-run. Logins are independent, so they run concurrently.
+  /**
+   * Each spec file gets its own session: Convex Auth rotates refresh tokens, so two parallel
+   * workers sharing a storage state would invalidate each other's session mid-run. Logins are
+   * independent, so they run concurrently.
+   */
   const sessions: Credentials[] = [
     { email: userAEmail, password: userPassword, storageStatePath: '.playwright/user-a.json' },
     {
@@ -103,9 +105,10 @@ export default async function globalSetup(config: FullConfig) {
       storageStatePath: '.playwright/user-b-group.json',
     },
   ];
-  // The first login runs alone: it warms the vite dev server's on-demand
-  // module transforms. Eight cold first-loads at once starve each other and
-  // time out before the login form renders.
+  /*
+   * The first login runs alone: it warms the vite dev server's on-demand module transforms.
+   * Eight cold first-loads at once starve each other and time out before the login form renders.
+   */
   const [first, ...rest] = sessions;
   await loginWithLocalAuth(baseUrl, first);
   await Promise.all(rest.map((credentials) => loginWithLocalAuth(baseUrl, credentials)));

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,5 +1,7 @@
-// Generates the e2e lcov report from the raw coverage cache the workers
-// wrote via e2e/coverage.ts. No-op unless E2E_COVERAGE=1.
+/*
+ * Generates the e2e lcov report from the raw coverage cache the workers wrote via
+ * e2e/coverage.ts. No-op unless E2E_COVERAGE=1.
+ */
 import MCR from 'monocart-coverage-reports';
 
 import { coverageEnabled, mcrOptions } from './coverage';

--- a/knip.ts
+++ b/knip.ts
@@ -1,33 +1,38 @@
 import type { KnipConfig } from 'knip';
 
 const config: KnipConfig = {
-  // The authoring tool is a self-contained workspace with its own conventions and
-  // test/typecheck gates; it is extraction-destined (see wayfinder #298).
+  /**
+   * The authoring tool is a self-contained workspace with its own conventions and test/typecheck
+   * gates; it is extraction-destined (see wayfinder #298).
+   */
   ignoreWorkspaces: ['tools/svg-authoring'],
   workspaces: {
     '.': {
       entry: [
-        // TanStack Start file-based routing: routes are loaded by the router
-        // plugin, not imported anywhere knip can see.
+        /* TanStack Start file-based routing: routes are loaded by the router
+           plugin, not imported anywhere knip can see. */
         'src/app/router.tsx',
         'src/app/routes/**/*.tsx',
         // Built via workers/publisher/vite.config.ts (publisher-capture.html input).
         'src/app/capture/publisher-entry.tsx',
         // Worker entry, referenced from workers/publisher/wrangler.jsonc.
         'workers/publisher/index.ts',
-        // Standalone scripts run ad hoc with `bun run ./scripts/...`.
-        // Deliberately not scripts/lib/** — helpers there must be imported to count as used.
+        /* Standalone scripts run ad hoc with `bun run ./scripts/...`. Deliberately
+           not scripts/lib/** — helpers there must be imported to count as used. */
         'scripts/*.{ts,mjs}',
       ],
-      // Non-default vite config locations (custom `config` overrides the plugin
-      // default, so the root config must be listed too). The .storybook one is
-      // referenced by string from .storybook/main.ts (viteConfigPath).
+      /**
+       * Non-default vite config locations (custom `config` overrides the plugin default, so the
+       * root config must be listed too). The .storybook one is referenced by string from
+       * .storybook/main.ts (viteConfigPath).
+       */
       vite: {
         config: ['vite.config.ts', 'workers/publisher/vite.config.ts', '.storybook/vite.config.ts'],
       },
-      // Dev-toggle devtools: imported only from commented-out code in
-      // src/app/routes/__root.tsx and vite.config.ts, kept for flipping on
-      // during debugging.
+      /**
+       * Dev-toggle devtools: imported only from commented-out code in src/app/routes/__root.tsx and
+       * vite.config.ts, kept for flipping on during debugging.
+       */
       ignoreDependencies: [
         '@tanstack/react-devtools',
         '@tanstack/react-router-devtools',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,9 +10,11 @@ export default defineConfig({
     timeout: 10_000,
   },
   fullyParallel: false,
-  // Spec files run in parallel workers; tests within a file stay ordered.
-  // Every spec file carries its own auth session (see global-setup), which is
-  // what makes cross-file parallelism safe under Convex Auth token rotation.
+  /**
+   * Spec files run in parallel workers; tests within a file stay ordered. Every spec file carries
+   * its own auth session (see global-setup), which is what makes cross-file parallelism safe under
+   * Convex Auth token rotation.
+   */
   workers: process.env.CI ? 3 : 1,
   globalSetup: './e2e/global-setup.ts',
   // Generates the e2e lcov report when E2E_COVERAGE=1 (no-op otherwise).
@@ -31,8 +33,8 @@ export default defineConfig({
     video: 'retain-on-failure',
   },
   projects: [
-    // Runs alone, before everything else: this spec asserts on per-frame
-    // animation samples, which starve when parallel workers compete for CPU.
+    /* Runs alone, before everything else: this spec asserts on per-frame
+       animation samples, which starve when parallel workers compete for CPU. */
     {
       name: 'animation',
       testMatch: /page-header-transition\.spec\.ts/,

--- a/scripts/db-sync-data-schema.ts
+++ b/scripts/db-sync-data-schema.ts
@@ -21,16 +21,13 @@ type SchemaConfig = z.infer<typeof schemaConfigSchema>;
 
 const mySchemas: SchemaConfig[] = [];
 
-// Scan from current working directory (project root when script is run)
-// Pattern is relative to cwd - no "../" needed, just change the root if needed
-// Use absolute paths for easier imports
+// Glob is cwd-relative; run this script from the project root.
 for await (const file of glob.scan({
   onlyFiles: true,
 })) {
   const { name } = parse(file);
   const module = await import(file);
 
-  // Use standardized 'schema' export
   if (!module.schema || !(module.schema instanceof z.ZodObject)) {
     console.warn(`⚠ No 'schema' export found in ${file} or it's not a ZodObject, skipping`);
     continue;
@@ -213,13 +210,10 @@ function simplifyRedundantCombinators(node: unknown): unknown {
   return out;
 }
 
-// Helper function: Derive constraint name from table name
-// Column name is always 'data'
 function deriveConstraintName(name: string): string {
   return `${name}_data_schema_check`;
 }
 
-// Helper function: Extract timestamp from migration filename
 function extractTimestamp(filename: string): number | null {
   const match = filename.match(/^(\d{14})_/);
   if (!match) {
@@ -228,7 +222,6 @@ function extractTimestamp(filename: string): number | null {
   return parseInt(match[1], 10);
 }
 
-// Helper function: Find latest validation migration for a specific constraint
 async function findLatestValidationMigration(
   constraintName: string,
   migrationsDir: string
@@ -247,7 +240,6 @@ async function findLatestValidationMigration(
     const filePath = join(migrationsDir, file);
     const content = await readFile(filePath, 'utf-8');
 
-    // Check if migration contains the constraint name
     if (content.includes(constraintName)) {
       const timestamp = extractTimestamp(file);
       if (timestamp !== null) {
@@ -266,9 +258,11 @@ async function findLatestValidationMigration(
     return null;
   }
 
-  // Prefer newest on disk (so a just-written migration wins over an older file with a
-  // higher numeric prefix, e.g. 20260321133000 vs 20260320012157 on the next run).
-  // Tie-break: higher filename timestamp (stable clones where mtimes are identical).
+  /*
+   * Prefer newest on disk so a just-written migration wins over an older file with a higher
+   * numeric prefix (e.g. 20260321133000 vs 20260320012157 on the next run). Tie-break: higher
+   * filename timestamp (stable clones where mtimes are identical).
+   */
   matchingMigrations.sort((a, b) => {
     if (b.mtimeMs !== a.mtimeMs) {
       return b.mtimeMs - a.mtimeMs;
@@ -281,14 +275,12 @@ async function findLatestValidationMigration(
   };
 }
 
-// Helper function: Extract JSON schema from migration SQL
 function extractSchemaFromMigration(
   migrationContent: string,
   constraintName: string,
   columnName: string
 ): object | null {
-  // Look for extensions.jsonb_matches_schema('...'::json, column_name) pattern
-  // We need to find the constraint that matches our constraintName and extract the JSON literal
+  // Matches this constraint's `jsonb_matches_schema('<json>'::json, column)` CHECK and captures the JSON literal.
   const constraintRegex = new RegExp(
     `ADD CONSTRAINT ${constraintName}[\\s\\S]*?CHECK\\s*\\(\\s*extensions\\.jsonb_matches_schema\\s*\\(\\s*'([^']*(?:''[^']*)*)'::json\\s*,\\s*${columnName}\\s*\\)\\s*\\)`,
     'i'
@@ -299,7 +291,7 @@ function extractSchemaFromMigration(
     return null;
   }
 
-  // Unescape SQL string (handle '' -> ')
+  // Unescape the SQL string literal ('' -> ')
   const jsonString = match[1].replace(/''/g, "'");
 
   try {
@@ -339,21 +331,19 @@ function canonicalizeSchemaForComparison(node: unknown): unknown {
   return sorted;
 }
 
-// Helper function: Compare two JSON schemas (deep equality, order-insensitive combinator arrays)
 function compareSchemas(schema1: object, schema2: object): boolean {
   const a = canonicalizeSchemaForComparison(schema1);
   const b = canonicalizeSchemaForComparison(schema2);
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
-// Helper function: Generate migration SQL
 function generateMigrationSQL(
   config: SchemaConfig,
   jsonSchema: object,
   includeExtension: boolean
 ): string {
   const schemaJsonString = JSON.stringify(jsonSchema, null, 2);
-  // Escape single quotes for SQL ('' -> '')
+  // Escape single quotes for the SQL string literal (' -> '')
   const escapedSchema = schemaJsonString.replace(/'/g, "''");
   const constraintName = deriveConstraintName(config.name);
   const columnName = 'data';
@@ -385,7 +375,6 @@ function generateMigrationSQL(
   return lines.join('\n');
 }
 
-// Helper function: Generate timestamp for migration filename
 function generateMigrationTimestamp(): string {
   const now = new Date();
   const year = now.getFullYear();
@@ -403,22 +392,19 @@ function generateMigrationTimestamp(): string {
 const migrationsDir = './supabase/migrations';
 let extensionIncluded = false;
 
-// Process each schema
 for (const config of mySchemas) {
   const constraintName = deriveConstraintName(config.name);
   const columnName = 'data';
 
-  // Step 1: Generate JSON schema in memory (same steps as written migrations)
+  // Apply the same transforms used in written migrations so comparison is apples-to-apples.
   let newSchema = z.toJSONSchema(config.schema, { unrepresentable: 'any' }) as object;
   if (RELAX_STRING_ENUMS.has(config.name)) {
     newSchema = relaxStringEnumsInJsonSchema(newSchema) as object;
   }
   newSchema = simplifyRedundantCombinators(newSchema) as object;
 
-  // Step 2: Find latest validation migration for this schema
   const latestMigration = await findLatestValidationMigration(constraintName, migrationsDir);
 
-  // Step 3: Compare schemas if migration exists
   if (latestMigration) {
     const extractedRaw = extractSchemaFromMigration(
       latestMigration.content,
@@ -441,10 +427,8 @@ for (const config of mySchemas) {
     }
   }
 
-  // Step 4: Generate migration SQL
   const migrationSQL = generateMigrationSQL(config, newSchema, !extensionIncluded);
 
-  // Step 5: Write migration file
   const timestamp = generateMigrationTimestamp();
   const migrationFilename = `${timestamp}_${config.name}_data_validation.sql`;
   const migrationPath = join(migrationsDir, migrationFilename);
@@ -452,7 +436,6 @@ for (const config of mySchemas) {
   await writeFile(migrationPath, migrationSQL);
   console.log(`✓ Generated migration: ${migrationFilename}`);
 
-  // Mark extension as included for subsequent migrations
   if (!extensionIncluded) {
     extensionIncluded = true;
   }

--- a/scripts/generate-images.ts
+++ b/scripts/generate-images.ts
@@ -99,9 +99,11 @@ async function generateOne(sourceAbsolute: string): Promise<MapEntry> {
     sizes.push(sizeName);
   }
 
-  // Safety net at the canonical name: same extension as the key so any
-  // unresolved reference (including the publisher capture, where a 404 is
-  // fatal) keeps rendering. Never upscaled, capped per rule.
+  /**
+   * Safety net at the canonical name: same extension as the key so any unresolved reference
+   * (including the publisher capture, where a 404 is fatal) keeps rendering. Never upscaled, capped
+   * per rule.
+   */
   const safetyFormat =
     canonicalExtension === 'png' ? 'png' : canonicalExtension === 'webp' ? 'webp' : 'jpeg';
   await encode(rule.safetyCapPx, path.join(outDirectory, path.basename(relative)), safetyFormat);

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -3,16 +3,17 @@ import { join, relative } from 'node:path';
 import { recursiveReaddirFiles } from 'recursive-readdir-files';
 
 async function getFiles(path: string, root: 'public' | 'media' = 'public') {
-  // Image enums read the media/ sources (public/image is generated output),
-  // but keys keep their canonical /image/... shape — they are opaque asset
-  // ids stored on faction documents, resolved via resolveAsset at render time.
+  /*
+   * Image enums read the media/ sources (public/image is generated output), but keys keep their
+   * canonical /image/... shape — they are opaque asset ids stored on faction documents, resolved
+   * via resolveAsset at render time.
+   */
   const dir = join(import.meta.dirname, '..', root, path);
   return (await recursiveReaddirFiles(dir))
     .map((f) => relative(join(dir, '..', '..'), f.path))
     .filter((f) => f.match(/\.(png|jpg|pdf|svg)$/));
 }
 
-// images
 const leaders = await getFiles('/image/leader', 'media');
 const planet = await getFiles('/image/planet', 'media');
 const texture = await getFiles('/image/texture', 'media');

--- a/scripts/oxlint-prefer-block-comments.mjs
+++ b/scripts/oxlint-prefer-block-comments.mjs
@@ -1,0 +1,68 @@
+/**
+ * Local oxlint JS plugin: multi-line comments must be block comments, not stacked `//` lines (the
+ * repo comment convention; see PR #333). Loaded via `jsPlugins` in .oxlintrc.json — requires
+ * oxlint's ESLint-compatible plugin support (alpha).
+ *
+ * @see https://oxc.rs/docs/guide/usage/linter/js-plugins.html
+ */
+
+/* Directive-ish lines are exempt: merging them into a block comment would break
+   the tooling that reads them. Triple-slash (`/ <reference`) and shebang-style
+   (`!`) values are excluded by prefix. */
+const DIRECTIVE =
+  /^(\/|!|\s*(eslint|oxlint|prettier-ignore|biome-ignore|@ts-|ts-|v8 ignore|c8 ignore|istanbul ignore|#region|#endregion|@vitest-environment))/;
+
+const preferBlockComments = {
+  meta: {
+    type: 'layout',
+    docs: {
+      description: 'Require block comments for comments spanning multiple lines',
+    },
+    messages: {
+      stacked:
+        'Multi-line comments use a block comment (/* … */ or /** … */), not stacked // lines.',
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    return {
+      Program() {
+        const lines = sourceCode.lines;
+        // Own-line comment: nothing but whitespace before it on its line.
+        const ownLine = (c) =>
+          lines[c.loc.start.line - 1].slice(0, c.loc.start.column).trim() === '';
+        let run = [];
+        const flush = () => {
+          if (run.length >= 2) {
+            context.report({
+              loc: { start: run[0].loc.start, end: run[run.length - 1].loc.end },
+              messageId: 'stacked',
+            });
+          }
+          run = [];
+        };
+        for (const comment of sourceCode.getAllComments()) {
+          const chainable =
+            comment.type === 'Line' && !DIRECTIVE.test(comment.value) && ownLine(comment);
+          if (!chainable) {
+            flush();
+            continue;
+          }
+          const previous = run[run.length - 1];
+          if (previous && comment.loc.start.line === previous.loc.end.line + 1) {
+            run.push(comment);
+          } else {
+            flush();
+            run.push(comment);
+          }
+        }
+        flush();
+      },
+    };
+  },
+};
+
+export default {
+  meta: { name: 'local' },
+  rules: { 'prefer-block-comments': preferBlockComments },
+};

--- a/scripts/verify-vectors.ts
+++ b/scripts/verify-vectors.ts
@@ -90,10 +90,12 @@ for (const relative of sourceRelatives) {
     failures.push(`${relative}: carries baked paint but its category inherits paint`);
   }
 
-  // 7. authoring stamp (#298; hard since #311 — the in-repo tool emits it, legacy sources are
-  // batch-stamped, so a missing stamp means the file never went through the authoring pipeline).
-  // Checked as an attribute of the root <svg> tag, not as a substring: a mention in a comment or
-  // text node must not satisfy the gate.
+  /*
+   * 7. authoring stamp (#298; hard since #311 — the in-repo tool emits it, legacy sources are
+   * batch-stamped, so a missing stamp means the file never went through the authoring pipeline).
+   * Checked as an attribute of the root <svg> tag, not as a substring: a mention in a comment or
+   * text node must not satisfy the gate.
+   */
   const source = readFileSync(path.join(mediaRoot, relative), 'utf8');
   if (!rootTagCarriesStamp(source)) {
     failures.push(
@@ -115,8 +117,10 @@ if (existsSync(mapPath)) {
     }
   }
 } else {
-  // Consumers hard-reference the map's fragment API; its absence is a failure even if the
-  // media source vanished too (the per-source check only fires while a source exists).
+  /*
+   * Consumers hard-reference the map's fragment API; its absence is a failure even if the media
+   * source vanished too (the per-source check only fires while a source exists).
+   */
   failures.push('background/map.svg: missing generated map (place-id API unavailable)');
 }
 

--- a/src/app/collaborativeAccessCallers.architecture.test.ts
+++ b/src/app/collaborativeAccessCallers.architecture.test.ts
@@ -5,8 +5,10 @@ import * as groupsApi from '../../convex/groups';
 import * as membersApi from '../../convex/members';
 import * as rulesetsApi from '../../convex/rulesets';
 
-// ADR-0001: the former source-text assertions are fully retired. The server-policy layering rule
-// lives in .oxlintrc.json (no-restricted-imports); wire guarantees live in the returns validators.
+/*
+ * ADR-0001: the former source-text assertions are fully retired. The server-policy layering rule
+ * lives in .oxlintrc.json (no-restricted-imports); wire guarantees live in the returns validators.
+ */
 describe('collaborative-access caller contract', () => {
   test('the narrowed Convex registry exposes only canonical collaborative-access transport', () => {
     expect(Object.keys(membersApi).sort()).toEqual(

--- a/src/app/components/form/Form.module.css
+++ b/src/app/components/form/Form.module.css
@@ -97,7 +97,6 @@
   margin-bottom: 0;
   background: rgba(255, 255, 255, 0.5);
   padding: var(--space-2);
-  /* box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12); */
 }
 
 .unitToolbarLeading,

--- a/src/app/components/form/PrefixedField.tsx
+++ b/src/app/components/form/PrefixedField.tsx
@@ -57,5 +57,3 @@ export function PrefixedField({
     </div>
   );
 }
-
-/** @deprecated Use `PrefixedField` instead. */

--- a/src/app/components/generic/layout/ButtonGroup.module.css
+++ b/src/app/components/generic/layout/ButtonGroup.module.css
@@ -1,4 +1,3 @@
-/** Horizontal row of buttons or actions; prefer over ad-hoc flex containers for inline button groups. */
 .root {
   display: flex;
   align-items: center;

--- a/src/app/components/generic/layout/Stack.module.css
+++ b/src/app/components/generic/layout/Stack.module.css
@@ -1,4 +1,3 @@
-/** Vertical flex stack; prefer over chaining margin-bottom on children. */
 .root {
   display: flex;
   flex-direction: column;

--- a/src/app/components/shell/PageLayout.architecture.test.ts
+++ b/src/app/components/shell/PageLayout.architecture.test.ts
@@ -17,9 +17,11 @@ function listRouteFiles(directory: string): string[] {
 }
 
 describe('PageLayout route contract', () => {
-  // Allowlisted source-scan (ADR-0001): "every terminal visual route mounts PageLayout" is a real
-  // structural rule with no type-level or lint-level expression. Everything else this file once
-  // asserted (import spellings, chunk-split literals, ghost components) was retired per ADR-0001.
+  /*
+   * Allowlisted source-scan (ADR-0001): "every terminal visual route mounts PageLayout" is a real
+   * structural rule with no type-level or lint-level expression. Everything else this file once
+   * asserted (import spellings, chunk-split literals, ghost components) was retired per ADR-0001.
+   */
   it('keeps terminal visual routes on PageLayout', () => {
     const routes = listRouteFiles(appRoutesDirectory).map((path) => ({
       relativePath: relative(appRoutesDirectory, path),

--- a/src/app/routes/_app/factions/FactionDetail.module.css
+++ b/src/app/routes/_app/factions/FactionDetail.module.css
@@ -48,7 +48,6 @@
   gap: var(--mantine-spacing-md);
   min-width: 0;
   margin: calc(var(--mantine-spacing-xs) - var(--lane-bleed)) calc(-1 * var(--lane-bleed));
-  /* margin-right: 0; */
   -webkit-mask-image: linear-gradient(
     to right,
     transparent,

--- a/src/game/assets/card/Decals.tsx
+++ b/src/game/assets/card/Decals.tsx
@@ -33,9 +33,11 @@ export function FrontDecals({
   const decalsMask = `${prefix}decals-mask`;
   const decalsFilter = `${prefix}decals-filter`;
 
-  // Square slot for square-normalized decal files (#307): stored scales were retuned by
-  // clamp(originalRatio, 1, 763/439) when the old 763×439 slot was retired, so art renders
-  // pixel-identically.
+  /**
+   * Square slot for square-normalized decal files (#307): stored scales were retuned by
+   * clamp(originalRatio, 1, 763/439) when the old 763×439 slot was retired, so art renders
+   * pixel-identically.
+   */
   const decalSize = { width: 439, height: 439 };
   const stroked = { filter: `url(#${decalsFilter})` };
   const empty = {};

--- a/src/game/assets/card/Spice.stories.ts
+++ b/src/game/assets/card/Spice.stories.ts
@@ -61,8 +61,6 @@ export const BightOfTheCliff = meta.story({
   },
 });
 
-// Spice blows
-
 export const BrokenLand = meta.story({
   args: {
     name: 'Broken Land',

--- a/src/game/assets/faction/alliance/Alliance.tsx
+++ b/src/game/assets/faction/alliance/Alliance.tsx
@@ -32,14 +32,12 @@ export const AllianceCard: FC<z.infer<typeof FactionRender.alliance>> = ({
     <div className={styles.card}>
       <div className={styles.decal_bg_1} />
 
-      {/* decals */}
       {decals.length > 0 && (
         <svg {...card} viewBox={`0 0 ${card.width} ${card.height}`} className={unique.overlay}>
           <FrontDecals {...{ decals, prefix }} />
         </svg>
       )}
 
-      {/* troop */}
       <svg className={unique.troop} viewBox="0 0 300 300">
         <StrokedUse
           x="50"

--- a/src/game/components/block/Fan.module.css
+++ b/src/game/components/block/Fan.module.css
@@ -6,7 +6,6 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  /* overflow: hidden; */
 
   & svg {
     height: auto;

--- a/src/game/components/block/Outline.tsx
+++ b/src/game/components/block/Outline.tsx
@@ -1,5 +1,3 @@
-// import styled from '@emotion/styled';
-// import * as colors from '../presets/colors';
 import type { FC, PropsWithChildren } from 'react';
 
 import styles from './Outline.module.css';

--- a/src/game/css-modules.d.ts
+++ b/src/game/css-modules.d.ts
@@ -1,16 +1,1 @@
 /* oxlint-disable unicorn/no-empty-file -- Placeholder enhanced by typescript-plugin-css-modules. */
-// // Base declaration for CSS modules
-// // The typescript-plugin-css-modules plugin will enhance this with actual class names
-// // from your CSS files, providing type safety and autocomplete
-// declare module '*.module.css' {
-//   const classes: { readonly [key: string]: string };
-//   export default classes;
-// }
-
-// // Augment the module to support namespace imports (import * as styles)
-// // This works because bundlers transform namespace imports to access the default export
-// declare module '*.module.css' {
-//   const classes: { readonly [key: string]: string };
-//   namespace classes {}
-//   export = classes;
-// }

--- a/src/game/data/planetCatalogue.test.ts
+++ b/src/game/data/planetCatalogue.test.ts
@@ -14,9 +14,9 @@ describe('curated planet image catalogue', () => {
   });
 
   it('only references keys backed by media sources', () => {
-    // Keys are opaque asset ids; their ground truth is the media/ source tree.
-    // public/image is generated output and may not exist when tests run —
-    // fetchability of the generated files is verified by `bun run verify:images`.
+    /* Keys are opaque asset ids; their ground truth is the media/ source tree. public/image is
+       generated output and may not exist when tests run — fetchability of the generated files is
+       verified by `bun run verify:images`. */
     for (const { image } of CURATED_PLANET_IMAGES) {
       expect(existsSync(join(import.meta.dirname, '../../..', 'media', image))).toBe(true);
     }

--- a/src/shared/vectorNormalize.ts
+++ b/src/shared/vectorNormalize.ts
@@ -133,8 +133,8 @@ function bake(element: SvgElementLike, parent: Matrix): void {
   }
 
   const k = scaleOf(matrix);
-  // A stroked element without an explicit width uses the SVG default of 1 user unit — after
-  // coordinate baking that implicit 1 must become an explicit 1×k or strokes fatten by 1/k.
+  /* A stroked element without an explicit width uses the SVG default of 1 user unit — after
+     coordinate baking that implicit 1 must become an explicit 1×k or strokes fatten by 1/k. */
   const stroke = element.getAttribute('stroke');
   if (stroke && stroke !== 'none' && !element.getAttribute('stroke-width')) {
     element.setAttribute('stroke-width', String(round(k)));

--- a/tools/svg-authoring/e2e/normalize-pipeline.spec.ts
+++ b/tools/svg-authoring/e2e/normalize-pipeline.spec.ts
@@ -11,8 +11,8 @@ function badgeFor(page: import("@playwright/test").Page, name: string) {
     .getByTestId("viewbox-badge");
 }
 
-// Scale/aspect normalization moved to the dunezone build generator; the tool
-// authors sources with a ratio-based crop margin and a provenance stamp.
+/* Scale/aspect normalization moved to the dunezone build generator; the tool
+   authors sources with a ratio-based crop margin and a provenance stamp. */
 test.describe("Stage 2 — ratio crop margin + provenance", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");

--- a/tools/svg-authoring/e2e/persistence-and-presets.spec.ts
+++ b/tools/svg-authoring/e2e/persistence-and-presets.spec.ts
@@ -79,8 +79,8 @@ test.describe("Stage 4 — persistence, presets, heavy optimize", () => {
     await page.getByTestId("toggle-optimizePaths").click();
     await page.getByTestId("run-pipeline").click();
 
-    // The pipeline runs asynchronously (SVGO loads lazily); wait for the
-    // observable result (crop changes the viewBox) before exporting.
+    /* The pipeline runs asynchronously (SVGO loads lazily); wait for the
+       observable result (crop changes the viewBox) before exporting. */
     await expect(
       row(page, "pasted-1.svg").getByTestId("viewbox-badge"),
     ).toHaveText("10 10 20 20", { timeout: 10_000 });

--- a/tools/svg-authoring/src/components/feature/PipelinePanel.tsx
+++ b/tools/svg-authoring/src/components/feature/PipelinePanel.tsx
@@ -55,8 +55,8 @@ function NumberField({
         value={Number.isFinite(value) ? value : ""}
         onChange={(e) => {
           const n = Number(e.target.value);
-          // Browser min/step are hints, not validation: never store NaN or
-          // negatives in step configuration.
+          /* Browser min/step are hints, not validation: never store NaN or
+             negatives in step configuration. */
           if (Number.isFinite(n) && n >= min) onChange(n);
         }}
         className="w-24"

--- a/tools/svg-authoring/src/hooks/usePersistence.ts
+++ b/tools/svg-authoring/src/hooks/usePersistence.ts
@@ -29,9 +29,9 @@ export function usePersistence(): { hydrated: boolean } {
 
     loadSession()
       .then((docs) => {
-        // Restore only while the workspace is still pristine: a whole-array
-        // replace must never discard documents the user added while the
-        // IndexedDB read was in flight.
+        /* Restore only while the workspace is still pristine: a whole-array
+           replace must never discard documents the user added while the
+           IndexedDB read was in flight. */
         if (docs && docs.length > 0 && useAppStore.getState().docs.length === 0) {
           useAppStore.setState({ docs, previewId: docs[0].id });
         }

--- a/tools/svg-authoring/src/lib/download.ts
+++ b/tools/svg-authoring/src/lib/download.ts
@@ -61,15 +61,16 @@ export function replaceExtension(name: string, ext: string): string {
 function dedupeName(name: string, seen: Map<string, number>): string {
   /* Reserve every emitted candidate, not only originals: a.svg, a-1.svg, a.svg
      must yield a.svg, a-1.svg, a-2.svg — never a colliding second a-1.svg. */
-  const emitted = seen;
-  let candidate = name;
-  let count = emitted.get(name) ?? 0;
-  while (emitted.has(candidate) && emitted.get(candidate)! > 0) {
+  const dot = name.lastIndexOf(".");
+  const variant = (n: number) =>
+    n === 0 ? name : dot === -1 ? `${name}-${n}` : `${name.slice(0, dot)}-${n}${name.slice(dot)}`;
+  let count = seen.get(name) ?? 0;
+  let candidate = variant(count);
+  while (seen.has(candidate) && seen.get(candidate)! > 0) {
     count += 1;
-    const dot = name.lastIndexOf(".");
-    candidate = dot === -1 ? `${name}-${count}` : `${name.slice(0, dot)}-${count}${name.slice(dot)}`;
+    candidate = variant(count);
   }
-  emitted.set(name, count + 1);
-  emitted.set(candidate, (emitted.get(candidate) ?? 0) + 1);
+  seen.set(name, count + 1);
+  if (candidate !== name) seen.set(candidate, (seen.get(candidate) ?? 0) + 1);
   return candidate;
 }

--- a/tools/svg-authoring/src/lib/download.ts
+++ b/tools/svg-authoring/src/lib/download.ts
@@ -59,8 +59,8 @@ export function replaceExtension(name: string, ext: string): string {
 }
 
 function dedupeName(name: string, seen: Map<string, number>): string {
-  // Reserve every emitted candidate, not only originals: a.svg, a-1.svg, a.svg
-  // must yield a.svg, a-1.svg, a-2.svg — never a colliding second a-1.svg.
+  /* Reserve every emitted candidate, not only originals: a.svg, a-1.svg, a.svg
+     must yield a.svg, a-1.svg, a-2.svg — never a colliding second a-1.svg. */
   const emitted = seen;
   let candidate = name;
   let count = emitted.get(name) ?? 0;

--- a/tools/svg-authoring/src/lib/obj/__tests__/svgToObj.test.ts
+++ b/tools/svg-authoring/src/lib/obj/__tests__/svgToObj.test.ts
@@ -140,8 +140,6 @@ describe("svgToObj", () => {
       weld: false,
     });
     expect(countLines(welded, "v ")).toBeLessThan(countLines(raw, "v "));
-    // Welded faces reference shared vertex indices, so the highest index used
-    // is far smaller than 3 * triangleCount.
     expect(countLines(welded, "v ")).toBeGreaterThan(0);
   });
 

--- a/tools/svg-authoring/src/lib/persistence/prefs.ts
+++ b/tools/svg-authoring/src/lib/persistence/prefs.ts
@@ -22,8 +22,8 @@ export function loadPrefs(): StepsState | null {
   try {
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object") return null;
-    // Drop structurally invalid entries so pipeline code can rely on
-    // steps[stepId].config being an object.
+    /* Drop structurally invalid entries so pipeline code can rely on
+       steps[stepId].config being an object. */
     const valid: StepsState = {};
     for (const [id, state] of Object.entries(parsed as Record<string, unknown>)) {
       if (

--- a/tools/svg-authoring/src/lib/pipeline/steps/mirrorFlip.ts
+++ b/tools/svg-authoring/src/lib/pipeline/steps/mirrorFlip.ts
@@ -53,9 +53,9 @@ export const mirrorFlip: PipelineStep<FlipConfig> = {
         const transform = mirrorTransform(doc.flip, cx, cy);
 
         if (!transform) {
-          // No flip desired: unwrap any existing flip group; if there is none the
-          // document is untouched — return it verbatim so serialization cannot
-          // reformat a no-op.
+          /* No flip desired: unwrap any existing flip group; if there is none the
+             document is untouched — return it verbatim so serialization cannot
+             reformat a no-op. */
           if (existing && existing.parentNode === el) {
             while (existing.firstChild) {
               el.insertBefore(existing.firstChild, existing);

--- a/tools/svg-authoring/src/lib/pipeline/steps/optimizePaths.ts
+++ b/tools/svg-authoring/src/lib/pipeline/steps/optimizePaths.ts
@@ -104,8 +104,8 @@ export const optimizePaths: PipelineStep<OptimizeConfig> = {
       }
 
       if (config.level === "heavy") {
-        // SVGO must be preloaded by the caller (store) before running. If it
-        // is not yet available we degrade gracefully to medium.
+        /* SVGO must be preloaded by the caller (store) before running. If it
+           is not yet available we degrade gracefully to medium. */
         if (getSvgo()) {
           return { ...doc, current: optimizeWithSvgo(doc.current, precision) };
         }

--- a/tools/svg-authoring/src/lib/svg/meta.ts
+++ b/tools/svg-authoring/src/lib/svg/meta.ts
@@ -13,9 +13,6 @@ function parseLength(value: string | null): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-/**
- * Read layout metadata directly off an SVG root element.
- */
 export function readMeta(svg: SVGSVGElement): SvgMeta {
   const viewBox = parseViewBox(svg.getAttribute("viewBox"));
   let width = parseLength(svg.getAttribute("width"));

--- a/tools/svg-authoring/src/store/useAppStore.ts
+++ b/tools/svg-authoring/src/store/useAppStore.ts
@@ -176,8 +176,8 @@ export const useAppStore = create<AppState>((set, get) => ({
         /* heavy optimize will degrade to medium */
       }
     }
-    // Read state AFTER the potentially slow await so edits made while SVGO
-    // loaded are not overwritten by a stale snapshot.
+    /* Read state AFTER the potentially slow await so edits made while SVGO
+       loaded are not overwritten by a stale snapshot. */
     const { docs, steps } = get();
     const next = runStep(docs, step, steps[stepId].config, ctx());
     set({ docs: next });
@@ -191,15 +191,15 @@ export const useAppStore = create<AppState>((set, get) => ({
         /* heavy optimize will degrade to medium */
       }
     }
-    // Read state AFTER the potentially slow await so edits made while SVGO
-    // loaded are not overwritten by a stale snapshot.
+    /* Read state AFTER the potentially slow await so edits made while SVGO
+       loaded are not overwritten by a stale snapshot. */
     const { docs, steps } = get();
     const invocations: StepInvocation[] = PIPELINE_STEPS.filter(
       (s) => steps[s.id]?.enabled,
     ).map((s) => ({ step: s, config: steps[s.id].config }));
     if (invocations.length === 0) return;
-    // The pipeline is a pure function of (original, flip flags, config): reset
-    // selected docs to their source first so repeated runs are deterministic.
+    /* The pipeline is a pure function of (original, flip flags, config): reset
+       selected docs to their source first so repeated runs are deterministic. */
     const reset = docs.map((d) =>
       d.selected ? { ...d, current: d.original } : d,
     );

--- a/tools/svg-authoring/vite.config.ts
+++ b/tools/svg-authoring/vite.config.ts
@@ -9,8 +9,8 @@ export default defineConfig({
     port: 3000,
   },
   optimizeDeps: {
-    // Pre-bundle the lazily imported, heavy deps so the dev dep-optimizer
-    // doesn't kick in mid-session (which makes dynamic imports fail to fetch).
+    /** Pre-bundle the lazily imported, heavy deps so the dev dep-optimizer
+     *  doesn't kick in mid-session (which makes dynamic imports fail to fetch). */
     include: [
       "svgo/browser",
       "three",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,8 +13,10 @@ const config = defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text-summary', 'lcov'],
-      // Whole-codebase denominator; anything not listed (scripts/, e2e/,
-      // docs/, .storybook/) is out by omission.
+      /**
+       * Whole-codebase denominator; anything not listed (scripts/, e2e/, docs/, .storybook/) is out
+       * by omission.
+       */
       include: coverageInclude,
       exclude: coverageExclude,
     },
@@ -31,8 +33,10 @@ const config = defineConfig({
     // devtools(),
     tanstackStart({
       srcDirectory: './src/app',
-      // The Worker release assembly consumes `dist/client`. Prerender must run or there is no SPA
-      // shell; do not crawl the authenticated app.
+      /**
+       * The Worker release assembly consumes `dist/client`. Prerender must run or there is no SPA
+       * shell; do not crawl the authenticated app.
+       */
       prerender: {
         concurrency: Math.max(1, os.cpus().length),
         crawlLinks: false,

--- a/vitest.storybook.config.ts
+++ b/vitest.storybook.config.ts
@@ -1,7 +1,9 @@
-// Runs every story as a Vitest browser-mode test in Chromium via
-// @storybook/addon-vitest. Coverage is opt-in (--coverage) and uploads as the
-// `storybook` Codecov flag. Design: docs/research/combined-coverage-codecov.md
-// §3; validated on branch prototype/combined-coverage.
+/*
+ * Runs every story as a Vitest browser-mode test in Chromium via
+ * @storybook/addon-vitest. Coverage is opt-in (--coverage) and uploads as the
+ * `storybook` Codecov flag. Validated on branch prototype/combined-coverage.
+ * @see docs/research/combined-coverage-codecov.md §3
+ */
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import viteReact from '@vitejs/plugin-react';
 import { playwright } from '@vitest/browser-playwright';
@@ -10,15 +12,16 @@ import { defineConfig } from 'vitest/config';
 import { coverageExclude, coverageIncludeSrc } from './coverage-denominator';
 
 export default defineConfig({
-  // Mirrors .storybook/vite.config.ts — the addon does not load the custom
-  // builder viteConfigPath on its own; without the react plugin every story
-  // fails on CJS interop (react-dom flushSync).
+  /**
+   * Mirrors .storybook/vite.config.ts — the addon does not load the custom builder viteConfigPath
+   * on its own; without the react plugin every story fails on CJS interop (react-dom flushSync).
+   */
   define: {
     'import.meta.env.VITE_CONVEX_URL': JSON.stringify('storybook-disconnected'),
   },
   resolve: {
-    // Typings in the current Vite package lag behind docs/runtime support
-    // (same cast as .storybook/vite.config.ts).
+    /* Typings in the current Vite package lag behind docs/runtime support
+       (same cast as .storybook/vite.config.ts). */
     ...({ tsconfigPaths: true } as Record<string, unknown>),
   },
   plugins: [viteReact(), storybookTest({ configDir: '.storybook' })],

--- a/workers/publisher/browser.ts
+++ b/workers/publisher/browser.ts
@@ -208,9 +208,11 @@ export class PublisherBrowserSession {
   }
 
   async close(): Promise<void> {
-    // Browser.close() owns the provider session lifecycle and closes all contexts. Closing the
-    // context concurrently races the CDP connection teardown and can turn a normal provider close
-    // into a rejected close promise even though the session has already ended.
+    /*
+     * Browser.close() owns the provider session lifecycle and closes all contexts. Closing the
+     * context concurrently races the CDP connection teardown and can turn a normal provider close
+     * into a rejected close promise even though the session has already ended.
+     */
     await this.browser.close();
   }
 }

--- a/workers/publisher/capture-contract-regression.ts
+++ b/workers/publisher/capture-contract-regression.ts
@@ -175,8 +175,10 @@ async function checkPublisherPdf(browser: Browser): Promise<void> {
         PUBLISHER_RENDERER_CONTRACT.pdf.pageSizeToleranceMm,
       `Production-shaped capture produced ${inspection.pageHeightMm.toFixed(2)} mm tall pages`
     );
-    // In-place recompression contract (#257): portraits downsampled losslessly,
-    // page structure untouched, output under the published ceiling.
+    /*
+     * In-place recompression contract (#257): portraits downsampled losslessly, page structure
+     * untouched, output under the published ceiling.
+     */
     const recompressed = await recompressCapturedPdf(new Uint8Array(pdf));
     invariant(
       recompressed.swappedImages > 0,

--- a/workers/publisher/executor.ts
+++ b/workers/publisher/executor.ts
@@ -85,9 +85,11 @@ export async function executeItemList(
         assertCapturedSize(captured, config.pdfMaxBytes);
         result.rendered += 1;
 
-        // In-place recompression (#257): lossless-downsample the big RGB
-        // portrait rasters; everything else byte-untouched. A recompression
-        // failure never blocks publishing — the capture is stored as-is.
+        /*
+         * In-place recompression (#257): lossless-downsample the big RGB portrait rasters;
+         * everything else byte-untouched. A recompression failure never blocks publishing — the
+         * capture is stored as-is.
+         */
         let publishedBytes = captured.bytes;
         try {
           const recompressed = await recompressCapturedPdf(captured.bytes);

--- a/workers/publisher/pdf-recompress.test.ts
+++ b/workers/publisher/pdf-recompress.test.ts
@@ -10,7 +10,7 @@ function noisyPixels(count: number): Uint8Array {
   const bytes = new Uint8Array(count);
   let state = 0x12_34_56_78;
   for (let index = 0; index < count; index += 1) {
-    // xorshift32 (Math.imul keeps 32-bit semantics): incompressible like grain.
+    // xorshift32; Math.imul keeps 32-bit semantics.
     state ^= state << 13;
     state ^= state >>> 17;
     state = Math.imul(state ^ (state << 5), 1);

--- a/workers/publisher/renderer-manifest-build.test.ts
+++ b/workers/publisher/renderer-manifest-build.test.ts
@@ -210,8 +210,10 @@ describe('current Renderer manifest digest', () => {
   });
 
   test('encoder output changes alone do not move the identity', () => {
-    // The same ingredients must yield the same digest regardless of what the
-    // encoder produced — generated output is not part of the identity at all.
+    /*
+     * The same ingredients must yield the same digest regardless of what the encoder produced —
+     * generated output is not part of the identity at all.
+     */
     expect(digest().digest).toBe(digest().digest);
     expect(isRendererManifestAsset('image/leader/official/alia-small.webp')).toBe(false);
   });

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -5,12 +5,12 @@
 export const rendererManifest = {
   schemaVersion: 2,
   rendererIdentity:
-    'faction-sheet/sha256:d2eb83f6a6a572feb0b84cbc27450d500d49a7d9fae2a98be1bc34e876a6a802',
-  digest: 'd2eb83f6a6a572feb0b84cbc27450d500d49a7d9fae2a98be1bc34e876a6a802',
+    'faction-sheet/sha256:04bc8af6467ecd48eeb00282f43e11d7c1577856c072e57099fddad426509039',
+  digest: '04bc8af6467ecd48eeb00282f43e11d7c1577856c072e57099fddad426509039',
   components: {
     sources: '551dfdfd69a8a986f98be4e2edad9cd79cf03290845821d59986522d173fbd36',
-    toolchain: 'd50d78e5f4145a62d1fa4b8cfcca209791eeda9a55c0fbd2f5d60f0b4e2ef888',
-    code: 'd04edf8149b266746de799590c04deb8366130d54b3e8e9fab1d97fd2a864c41',
+    toolchain: 'a9d66c69040fffeadd0766d2a37756f785d33b1b7240d1bda5d6eeb081dd51ab',
+    code: 'a83b7ec22d0f502a1b7adb0e9ebafe61b92b5fdbc09562416867f9b356219d40',
     contract: '2920714c87493d104342355dda2b956202259513c78ce6195670034f31a656a6',
   },
   contract: {


### PR DESCRIPTION
## What

A comment-only sweep across the whole codebase (app, convex, workers, scripts, tools/svg-authoring, e2e, root configs, CI): 48 source files + the regenerated renderer manifest. Zero code changes.

- **Deleted noise**: comments restating adjacent code ("Helper function: …", "Step 2", `{/* decals */}`), section banners, dead commented-out code (`css-modules.d.ts` placeholder block, emotion imports in `Outline.tsx`, stray commented-out CSS props), a dangling `@deprecated` JSDoc attached to nothing, and one stale test comment describing an assertion that doesn't exist.
- **Normalized format**: multi-line stacked `//` runs are now block comments (`/** */` above declarations, `/* */` elsewhere); references inside block comments use `@see` (issue links, doc paths).
- **Tightened wording** on kept comments; all why/contract notes (renderer identity, capture lifecycle, recompression #257, Convex Auth token rotation, coverage denominator) preserved. One factual fix: the SQL escape comment in `db-sync-data-schema.ts` said `'' -> ''`; it now correctly says `' -> ''`.
- **Renderer manifest regenerated**: comment edits in identity-ingredient files legitimately move the toolchain/code hashes; `publisher:release:verify` is green with the committed manifest.

## Deliberately kept

- Dev-toggle commented-out devtools in `__root.tsx` / `vite.config.ts` — `knip.ts` documents them as intentional (`ignoreDependencies` would strand otherwise).
- `@see docs/research/…` references (3 files) — the paths are gitignored-local now, but they still say where the design rationale lives.
- Domain grouping markers in `objects.ts` (`//sand`, `//rock`, …) — not derivable from the names.

## Verification

- `oxlint --deny-warnings`, `oxfmt --check` clean
- `typecheck`, `publisher:typecheck`, `tool:typecheck` clean
- vitest: 424/424 main, 62/62 tools
- `publisher:release:verify` green (manifest committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated filename handling to preserve extensions and prevent duplicate suffixed names.
* **Documentation**
  * Clarified and standardized documentation across application, tooling, testing, and configuration areas.
  * Improved explanations for asset generation, processing pipelines, persistence, validation, and data workflows.
* **Maintenance**
  * Added automated checks to encourage consistent block-comment formatting.
  * Removed obsolete comments and inactive code notes.
  * No other runtime behavior, configuration, styling, or public interfaces changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Enforcement

The multi-line-block convention is now a lint rule: a local oxlint JS plugin (`scripts/oxlint-prefer-block-comments.mjs`, wired via `jsPlugins` in `.oxlintrc.json`) errors on stacked own-line `//` runs of 2+ lines. Directive comments (pragmas, triple-slash, shebang-style) never chain, and generated files (`*.generated.ts`, `*.gen.ts`, `worker-configuration.d.ts`) are exempt. oxlint has no built-in `multiline-comment-style` and oxfmt has no comment options, so a custom rule is the enforcement point. Also fixes a real bug the review surfaced: `dedupeName` in the svg-authoring tool skipped suffix numbers (`a-3.svg`, `a-5.svg` for duplicates); it now numbers sequentially as its comment documents.
