### PR TITLE
ci: normalize Vite asset hashes in Codecov bundle tracking

### DIFF
--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -213,7 +213,13 @@ jobs:
               status=1
             fi
           }
-          upload dunezone-app dist/client/public
+          # Vite emits base64-style hashes (index-De4XUz5O.js) which the
+          # analyzer's hex-only fallback regex never matches, so without a
+          # pattern every build reports all assets as deleted+added. Only the
+          # app bundle gets the pattern: the generated-media categories have
+          # stable un-hashed names, and the pattern would collapse any
+          # dash-containing name (foo-bar.png -> foo-*.png) into collisions.
+          upload dunezone-app dist/client/public --normalize-assets-pattern='[name]-[hash].js'
           upload dunezone-images dist/client/image dist/client/web
           upload dunezone-vectors dist/client/vector
           upload dunezone-objs dist/client/obj

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,11 +7,12 @@ import { configDefaults, defineConfig } from 'vitest/config';
 
 import { coverageExclude, coverageInclude } from './coverage-denominator';
 
-// Codecov's bundle-report normalizer wildcards from the first `-` to the
-// next `.`, so a dash or dot inside a base name either collapses distinct
-// files into one normalized name (lato-latin-300-normal -> lato-*) or
-// leaves the hash un-wildcarded (floating-ui.react-dom-<hash>). Keep the
-// hash as the only dash-delimited segment.
+/**
+ * Codecov's bundle-report normalizer wildcards from the first `-` to the next `.`, so a dash or dot
+ * inside a base name either collapses distinct files into one normalized name
+ * (lato-latin-300-normal -> lato-*) or leaves the hash un-wildcarded
+ * (floating-ui.react-dom-<hash>). Keep the hash as the only dash-delimited segment.
+ */
 const codecovSafeName = (name: string) => name.replace(/[-.]/g, '_');
 
 const config = defineConfig({
@@ -32,9 +33,11 @@ const config = defineConfig({
     assetsDir: 'public', // will make your static assets appear under /public/
   },
   environments: {
-    // Client-only: server chunk names never reach Codecov and TanStack
-    // Start owns the server entry layout. These mirror Vite's defaults
-    // (`<assetsDir>/[name]-[hash]...`) with the base name sanitized.
+    /**
+     * Client-only: server chunk names never reach Codecov and TanStack Start owns the server entry
+     * layout. These mirror Vite's defaults (`<assetsDir>/[name]-[hash]...`) with the base name
+     * sanitized.
+     */
     client: {
       build: {
         rollupOptions: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,13 @@ import { configDefaults, defineConfig } from 'vitest/config';
 
 import { coverageExclude, coverageInclude } from './coverage-denominator';
 
+// Codecov's bundle-report normalizer wildcards from the first `-` to the
+// next `.`, so a dash or dot inside a base name either collapses distinct
+// files into one normalized name (lato-latin-300-normal -> lato-*) or
+// leaves the hash un-wildcarded (floating-ui.react-dom-<hash>). Keep the
+// hash as the only dash-delimited segment.
+const codecovSafeName = (name: string) => name.replace(/[-.]/g, '_');
+
 const config = defineConfig({
   test: {
     exclude: [...configDefaults.exclude, 'e2e/**', '.claude/**', 'tools/**'],
@@ -21,6 +28,28 @@ const config = defineConfig({
   },
   build: {
     assetsDir: 'public', // will make your static assets appear under /public/
+  },
+  environments: {
+    // Client-only: server chunk names never reach Codecov and TanStack
+    // Start owns the server entry layout. These mirror Vite's defaults
+    // (`<assetsDir>/[name]-[hash]...`) with the base name sanitized.
+    client: {
+      build: {
+        rollupOptions: {
+          output: {
+            entryFileNames: ({ name }) => `public/${codecovSafeName(name)}-[hash].js`,
+            chunkFileNames: ({ name }) => `public/${codecovSafeName(name)}-[hash].js`,
+            assetFileNames: (asset) => {
+              const original = asset.names[0] ?? 'asset';
+              const dot = original.lastIndexOf('.');
+              const base = dot === -1 ? original : original.slice(0, dot);
+              const ext = dot === -1 ? '' : original.slice(dot);
+              return `public/${codecovSafeName(base)}-[hash]${ext}`;
+            },
+          },
+        },
+      },
+    },
   },
   publicDir: 'public',
   // Typings in the current Vite package lag behind docs/runtime support.


### PR DESCRIPTION
## Problem

Codecov bundle reports show every asset as **New** + **Deleted** on every PR (see [this comment on #333](https://github.com/ndelangen/dunezone/pull/333#issuecomment-5228662424)) instead of tracking size changes per asset.

## Root cause

`@codecov/bundle-analyzer` matches assets across builds by a *normalized* name with the content hash replaced by `*`. Without `--normalize-assets-pattern` it falls back to a hex-only regex (`/[a-f0-9]{8,}/i`) — but Vite emits base64-style hashes (`index-De4XUz5O.js`, `_app-Dw-Nh_PS.js`) that are never pure hex. Normalization never fired, so each build's hashed filenames looked like entirely new assets.

## Fix

Pass `--normalize-assets-pattern='[name]-[hash].js'` on the `dunezone-app` upload. Verified against every asset-name shape from the #333 comment (dash-containing hashes, dotted names like `Form.module-BZGiYgIy.js`, `.css` extensions): all normalize to `name-*.ext`, and old/new hashes of the same chunk produce identical normalized names. Also verified end-to-end with a `--dry-run` upload: the report now emits `"normalized": "index-*.js"` etc.

The five generated-media category uploads (images, vectors, objs, pages, fonts) deliberately do **not** get the pattern: their filenames are stable un-hashed names, and the pattern's regex would collapse any legitimately dash-named file (`foo-bar.png` → `foo-*.png`), colliding distinct assets.

## Known limitation

Vite names route chunks by basename, so several distinct routes normalize to e.g. `edit-*.js`. They now track as changed rather than deleted+added, but Codecov can't distinguish which `edit` route is which. If that matters later, a `chunkFileNames` function including the parent directory would disambiguate — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code coverage reporting for application bundles.
  * Ensured hashed JavaScript asset filenames are normalized correctly during coverage uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->