### PR TITLE
fix: exclude test files from every coverage flag's denominator

### DIFF
--- a/coverage-denominator.ts
+++ b/coverage-denominator.ts
@@ -13,6 +13,10 @@ export const coverageInclude = [coverageIncludeSrc, 'convex/**/*.ts', 'workers/*
 
 export const coverageExclude = [
   ...coverageConfigDefaults.exclude,
+  // Vitest 4 only auto-excludes the current run's own test glob, so the
+  // storybook run (tests = *.stories.*) counted every *.test.* file as an
+  // uncovered source file. Exclude test files from every flag explicitly.
+  '**/*.{test,spec}.{ts,tsx}',
   // Local publisher build output (gitignored, but present on dev machines).
   'workers/publisher/dist/**',
   '**/*.stories.{ts,tsx}',

--- a/coverage-denominator.ts
+++ b/coverage-denominator.ts
@@ -17,9 +17,11 @@ export const coverageInclude = [coverageIncludeSrc, 'convex/**/*.ts', 'workers/*
 
 export const coverageExclude = [
   ...coverageConfigDefaults.exclude,
-  // Vitest 4 only auto-excludes the current run's own test glob, so the
-  // storybook run (tests = *.stories.*) counted every *.test.* file as an
-  // uncovered source file. Exclude test files from every flag explicitly.
+  /*
+   * Vitest 4 only auto-excludes the current run's own test glob, so the
+   * storybook run (tests = *.stories.*) counted every *.test.* file as an
+   * uncovered source file. Exclude test files from every flag explicitly.
+   */
   '**/*.{test,spec}.{ts,tsx}',
   // Local publisher build output (gitignored, but present on dev machines).
   'workers/publisher/dist/**',


### PR DESCRIPTION
## Why

Codecov shows test files like `src/app/access/viewerActions.test.ts` at 0% line coverage, dragging down the combined number.

The Codecov API confirms the `storybook` flag is the only upload containing them. The shared exclude list in `coverage-denominator.ts` relied on spreading `coverageConfigDefaults.exclude`, but Vitest 4 emptied that array — v4 only auto-excludes files matching the *current run's* test glob. The unit run's tests are `*.test.ts` (auto-excluded there), but the storybook run's tests are `*.stories.tsx`, so every `src/**/*.test.{ts,tsx}` file landed in its denominator as an ordinary uncovered source file.

## What

One explicit entry in `coverageExclude`: `'**/*.{test,spec}.{ts,tsx}'`. All three vitest configs (unit, publisher, storybook) import this list, so every flag gets the exclusion.

## Verification

Ran `storybook:test --coverage.enabled=true TopicIcon` locally both ways: without the fix the lcov lists **28** `*.test.*` files; with the fix it lists **0**, with 212 real source files unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)