### PR TITLE
perf(e2e): run Playwright against the production build instead of vite dev

### DIFF
--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -510,9 +510,10 @@ jobs:
         run: timeout 120 bash -c 'until [ -f /tmp/convex-pull.done ]; do sleep 1; done' || true
       # The phases below are one flow (scripts/e2e-local.sh), split into steps
       # so the Actions UI shows per-phase timing. State crosses step boundaries
-      # via files under .playwright/ (admin key, app URL, vite pid); the vite
-      # dev server backgrounded in "Start app server" keeps running into the
-      # Playwright step, same as the image pre-pull above.
+      # via files under .playwright/ (admin key, app URL, app server pid); the
+      # static server backgrounded in "Start app server" (production build,
+      # scripts/e2e-serve-dist.mjs) keeps running into the Playwright step,
+      # same as the image pre-pull above.
       - name: Boot Convex backend
         run: bun run e2e:local up
         env:
@@ -565,4 +566,5 @@ jobs:
           path: |
             ${{ github.workspace }}/playwright-report
             ${{ github.workspace }}/test-results
-            ${{ github.workspace }}/.playwright/vite.log
+            ${{ github.workspace }}/.playwright/app.log
+            ${{ github.workspace }}/.playwright/build.log

--- a/e2e/coverage.ts
+++ b/e2e/coverage.ts
@@ -4,6 +4,9 @@
 // them to monocart-coverage-reports, which persists raw data to the shared
 // outputDir cache across Playwright workers; global-teardown.ts generates the
 // final lcov report.
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { test as base, expect } from '@playwright/test';
 import type { BrowserContext, BrowserContextOptions, Page } from '@playwright/test';
 import MCR from 'monocart-coverage-reports';
@@ -20,18 +23,29 @@ export const mcrOptions: CoverageReportOptions = {
   name: 'e2e coverage',
   outputDir: 'coverage/e2e',
   reports: [['lcovonly'], ['console-summary']],
-  // Only modules served from the app's /src tree; dev-server dep bundles and
-  // vite client internals are not ours to count.
-  entryFilter: (entry) => entry.url.includes('/src/'),
-  // Vite dev inline sourcemaps carry bare filenames ("AppShell.tsx");
-  // info.distFile holds the served path, which IS the repo path for
-  // transform-in-place dev modules. Remap first, then filter.
+  // Built chunks are served under /public/ (vite build.assetsDir) and map
+  // back to src/ via their sourcemaps; the /src/ arm keeps dev-server runs
+  // working (transform-in-place module URLs). Everything else — dep bundles,
+  // vite client internals — is not ours to count.
+  entryFilter: (entry) =>
+    entry.url.includes('/src/') || /\/public\/[^?]*\.js$/.test(entry.url.split('?')[0] ?? ''),
+  // Two shapes arrive here. Built chunks: filePath is the sourcemap-resolved
+  // repo path ("src/app/..."), info.distFile the chunk. Dev modules: filePath
+  // is a bare filename ("AppShell.tsx"), info.distFile the served repo path.
+  // Whichever candidate contains src/ wins.
   sourcePath: (filePath, info) => {
-    const served = (info as { distFile?: string } | undefined)?.distFile ?? filePath;
-    const i = served.indexOf('src/');
-    return i >= 0 ? served.slice(i) : served;
+    for (const candidate of [filePath, (info as { distFile?: string } | undefined)?.distFile]) {
+      const i = candidate?.indexOf('src/') ?? -1;
+      if (i >= 0 && candidate) {
+        return candidate.slice(i);
+      }
+    }
+    return filePath;
   },
-  sourceFilter: (sourcePath) => sourcePath.startsWith('src/'),
+  // The on-disk check drops dependency sourcemaps whose sources also start
+  // with src/ (e.g. lucide-react ships src/utils/*.mjs) and synthetic
+  // modules (route-split virtuals, unmapped chunks) that have no repo file.
+  sourceFilter: (sourcePath) => sourcePath.startsWith('src/') && existsSync(resolve(sourcePath)),
 };
 
 // The animation project asserts per-frame samples and runs isolated;

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -106,13 +106,23 @@ export default async function globalSetup(config: FullConfig) {
     },
   ];
   /*
-   * The first login runs alone as a smoke test of the served build — one clean failure with a
-   * trace beats eight interleaved ones. (It predates the static server, when it also warmed vite
-   * dev's on-demand transforms.)
+   * Logins for the SAME user run sequentially: concurrent sign-ins write the same Convex Auth
+   * user doc, and the static build made logins fast enough to overlap in that mutation window
+   * (one of three simultaneous user-B logins timed out in CI). Distinct users don't contend, so
+   * their chains run in parallel. (The dev server's transform latency used to stagger this race
+   * away; the old first-login-alone warmup went with it.)
    */
-  const [first, ...rest] = sessions;
-  await loginWithLocalAuth(baseUrl, first);
-  await Promise.all(rest.map((credentials) => loginWithLocalAuth(baseUrl, credentials)));
+  const byUser = new Map<string, Credentials[]>();
+  for (const session of sessions) {
+    byUser.set(session.email, [...(byUser.get(session.email) ?? []), session]);
+  }
+  await Promise.all(
+    [...byUser.values()].map(async (chain) => {
+      for (const credentials of chain) {
+        await loginWithLocalAuth(baseUrl, credentials);
+      }
+    })
+  );
 
   execSync(`npx convex run e2e:seedBaseline '${JSON.stringify({ ownerEmail: userAEmail })}'`, {
     stdio: 'inherit',

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -103,9 +103,9 @@ export default async function globalSetup(config: FullConfig) {
       storageStatePath: '.playwright/user-b-group.json',
     },
   ];
-  // The first login runs alone: it warms the vite dev server's on-demand
-  // module transforms. Eight cold first-loads at once starve each other and
-  // time out before the login form renders.
+  // The first login runs alone as a smoke test of the served build — one
+  // clean failure with a trace beats eight interleaved ones. (It predates the
+  // static server, when it also warmed vite dev's on-demand transforms.)
   const [first, ...rest] = sessions;
   await loginWithLocalAuth(baseUrl, first);
   await Promise.all(rest.map((credentials) => loginWithLocalAuth(baseUrl, credentials)));

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -2,6 +2,7 @@
  * Generates the e2e lcov report from the raw coverage cache the workers wrote via
  * e2e/coverage.ts. No-op unless E2E_COVERAGE=1.
  */
+import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
@@ -16,6 +17,10 @@ import { coverageEnabled, mcrOptions } from './coverage';
  * invariant is enforced on the final report: drop every lcov record outside src/.
  */
 async function dropNonSrcRecords(lcovPath: string): Promise<void> {
+  if (!existsSync(lcovPath)) {
+    // Nothing was generated — e.g. globalSetup failed before any test collected coverage.
+    return;
+  }
   const lcov = await readFile(lcovPath, 'utf8');
   const records = lcov.split('end_of_record\n');
   const kept = records.filter((record) => !record.includes('SF:') || record.includes('SF:src/'));

--- a/e2e/global-teardown.ts
+++ b/e2e/global-teardown.ts
@@ -1,12 +1,28 @@
 // Generates the e2e lcov report from the raw coverage cache the workers
 // wrote via e2e/coverage.ts. No-op unless E2E_COVERAGE=1.
+import { readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
 import MCR from 'monocart-coverage-reports';
 
 import { coverageEnabled, mcrOptions } from './coverage';
+
+// mcrOptions.sourceFilter only sees entries monocart could unpack via
+// sourcemap; built chunks with no usable map (the TanStack shell virtual
+// entry, CSS-module JS proxies with empty mappings) pass through as raw
+// dist paths. Codecov must only ever see repo paths, so the invariant is
+// enforced on the final report: drop every lcov record outside src/.
+async function dropNonSrcRecords(lcovPath: string): Promise<void> {
+  const lcov = await readFile(lcovPath, 'utf8');
+  const records = lcov.split('end_of_record\n');
+  const kept = records.filter((record) => !record.includes('SF:') || record.includes('SF:src/'));
+  await writeFile(lcovPath, kept.join('end_of_record\n'));
+}
 
 export default async function globalTeardown(): Promise<void> {
   if (!coverageEnabled) {
     return;
   }
   await MCR(mcrOptions).generate();
+  await dropNonSrcRecords(join(mcrOptions.outputDir ?? 'coverage/e2e', 'lcov.info'));
 }

--- a/scripts/e2e-local.sh
+++ b/scripts/e2e-local.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # CI runs each phase as its own workflow step so the Actions UI shows
 # per-phase timing: up | provision | serve | test | down.
 # Values that must cross phase boundaries (admin key, resolved app URL,
-# vite pid, JWT material) live as files under .playwright/.
+# app server pid, JWT material) live as files under .playwright/.
 PHASE="${1:-all}"
 case "$PHASE" in
   all|up|provision|serve|test|down) ;;
@@ -24,7 +24,7 @@ JWT_KEY_PATH=""
 JWKS_PATH=""
 ADMIN_KEY_FILE="$ROOT_DIR/.playwright/admin-key"
 APP_URL_FILE="$ROOT_DIR/.playwright/app-url"
-APP_PID_FILE="$ROOT_DIR/.playwright/vite.pid"
+APP_PID_FILE="$ROOT_DIR/.playwright/app.pid"
 
 if [[ ! -f "$ENV_FILE" ]]; then
   if [[ "$PHASE" == "down" ]]; then
@@ -168,8 +168,10 @@ print_app_diagnostics() {
       echo "  - app process is NOT running (pid=$APP_PID)"
     fi
   fi
-  echo "  - recent vite.log:"
-  tail -n 120 "$ROOT_DIR/.playwright/vite.log" || true
+  echo "  - recent app.log:"
+  tail -n 120 "$ROOT_DIR/.playwright/app.log" || true
+  echo "  - recent build.log:"
+  tail -n 40 "$ROOT_DIR/.playwright/build.log" || true
 }
 
 load_app_pid() {
@@ -179,11 +181,11 @@ load_app_pid() {
 }
 
 phase_up() {
-  # A previous phased run that never reached `down` leaves vite holding the
-  # app port, and the rm -rf below deletes its pid file — reap it now. Only
-  # kill a pid that is still a vite process; pids get recycled.
+  # A previous phased run that never reached `down` leaves the app server
+  # holding the port, and the rm -rf below deletes its pid file — reap it now.
+  # Only kill a pid that is still our server; pids get recycled.
   load_app_pid
-  if [[ -n "$APP_PID" ]] && ps -p "$APP_PID" -o command= 2>/dev/null | grep -q vite; then
+  if [[ -n "$APP_PID" ]] && ps -p "$APP_PID" -o command= 2>/dev/null | grep -Eq 'e2e-serve-dist|vite'; then
     kill "$APP_PID" >/dev/null 2>&1 || true
   fi
   APP_PID=""
@@ -244,9 +246,22 @@ phase_serve() {
   export_runtime_env
 
   mkdir -p "$ROOT_DIR/.playwright"
-  echo "Starting app server for Playwright..."
+  # E2E runs against the production build, served statically — vite dev's
+  # on-demand transforms dominated slow-spec wall clock. VITE_* env is baked
+  # at build time, so it must be set on the build, not the server. Sourcemaps
+  # let e2e/coverage.ts map V8 coverage of chunks back to src/; minify off
+  # keeps that mapping near-exact (validated on prototype/e2e-coverage-build-serve).
+  echo "Building app (vite build --sourcemap --minify false)..."
   VITE_E2E_LOCAL_AUTH="$VITE_E2E_LOCAL_AUTH" VITE_CONVEX_URL="$VITE_CONVEX_URL" \
-    npx vite dev --port "$E2E_APP_PORT" >"$ROOT_DIR/.playwright/vite.log" 2>&1 &
+    npx vite build --sourcemap --minify false >"$ROOT_DIR/.playwright/build.log" 2>&1 || {
+      echo "vite build failed."
+      tail -n 60 "$ROOT_DIR/.playwright/build.log" || true
+      exit 1
+    }
+
+  echo "Starting app server for Playwright..."
+  E2E_APP_PORT="$E2E_APP_PORT" \
+    node "$ROOT_DIR/scripts/e2e-serve-dist.mjs" >"$ROOT_DIR/.playwright/app.log" 2>&1 &
   APP_PID=$!
   printf '%s' "$APP_PID" >"$APP_PID_FILE"
 

--- a/scripts/e2e-serve-dist.mjs
+++ b/scripts/e2e-serve-dist.mjs
@@ -7,9 +7,10 @@
  */
 import { readFileSync, existsSync, statSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { join, extname, normalize } from 'node:path';
+import { join, extname, normalize, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const ROOT = join(new URL('..', import.meta.url).pathname, 'dist', 'client');
+const ROOT = join(fileURLToPath(new URL('..', import.meta.url)), 'dist', 'client');
 const PORT = Number(process.env.E2E_APP_PORT ?? process.argv[2] ?? 6001);
 
 const MIME = {
@@ -38,9 +39,13 @@ if (!existsSync(join(ROOT, '_shell.html'))) {
 
 const server = createServer((req, res) => {
   const urlPath = decodeURIComponent(new URL(req.url ?? '/', 'http://localhost').pathname);
-  // normalize() collapses any ../ so requests cannot escape dist/client.
+  /*
+   * normalize() collapses any ../ (including percent-encoded ones — the pathname is decoded
+   * above) and the ROOT + sep prefix check rejects what remains, including sibling-directory
+   * escapes like /%2e%2e%2fclient-server/ which a bare ROOT prefix would let through.
+   */
   let file = normalize(join(ROOT, urlPath));
-  if (!file.startsWith(ROOT) || !existsSync(file) || statSync(file).isDirectory()) {
+  if (!file.startsWith(ROOT + sep) || !existsSync(file) || statSync(file).isDirectory()) {
     file = join(ROOT, '_shell.html');
   }
   try {

--- a/scripts/e2e-serve-dist.mjs
+++ b/scripts/e2e-serve-dist.mjs
@@ -1,0 +1,57 @@
+import { readFileSync, existsSync, statSync } from 'node:fs';
+// Static server for the e2e suite: serves the production client build
+// (dist/client) with the same SPA semantics as the Cloudflare Worker release
+// assembly — any path that is not a file on disk falls back to the prerendered
+// _shell.html. Replaces `vite dev` in scripts/e2e-local.sh phase_serve so e2e
+// tests exercise built, bundled code instead of on-demand dev transforms
+// (which dominated slow-spec wall clock; see prototype/e2e-coverage-build-serve).
+import { createServer } from 'node:http';
+import { join, extname, normalize } from 'node:path';
+
+const ROOT = join(new URL('..', import.meta.url).pathname, 'dist', 'client');
+const PORT = Number(process.env.E2E_APP_PORT ?? process.argv[2] ?? 6001);
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.map': 'application/json',
+  '.json': 'application/json',
+  '.css': 'text/css',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.avif': 'image/avif',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.txt': 'text/plain',
+  '.webmanifest': 'application/manifest+json',
+};
+
+if (!existsSync(join(ROOT, '_shell.html'))) {
+  console.error(`[e2e-serve-dist] ${ROOT}/_shell.html missing — run vite build first`);
+  process.exit(1);
+}
+
+const server = createServer((req, res) => {
+  const urlPath = decodeURIComponent(new URL(req.url ?? '/', 'http://localhost').pathname);
+  // normalize() collapses any ../ so requests cannot escape dist/client.
+  let file = normalize(join(ROOT, urlPath));
+  if (!file.startsWith(ROOT) || !existsSync(file) || statSync(file).isDirectory()) {
+    file = join(ROOT, '_shell.html');
+  }
+  try {
+    const body = readFileSync(file);
+    res.writeHead(200, { 'content-type': MIME[extname(file)] ?? 'application/octet-stream' });
+    res.end(body);
+  } catch {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`[e2e-serve-dist] serving dist/client on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Why

E2E spec durations tracked route-visit count almost perfectly: every first navigation paid vite dev's on-demand module transforms inside the test budget, multiplied by 3-worker CPU contention in CI. `faction-lifecycle` (7 gotos + reload across ~5 route trees) ran **108s** in CI with coverage on.

## What

- **`phase_serve` builds once, serves statically.** `vite build --sourcemap --minify false` (~5s including the build) + `scripts/e2e-serve-dist.mjs`, a dependency-free static server for `dist/client` with the same `_shell.html` SPA fallback the Worker release assembly uses. E2E now tests built, bundled code — the thing that ships.
- **Coverage pipeline is mode-agnostic** (validated on branch `prototype/e2e-coverage-build-serve`): `sourcePath` prefers the sourcemap-resolved `src/` path over `distFile`; `entryFilter` accepts built `/public/` chunks; `sourceFilter` requires the source to exist on disk (dependency sourcemaps — e.g. lucide — also ship `src/`-prefixed sources); `global-teardown` drops any non-`src/` record from the final lcov, because chunks without usable sourcemaps (virtual shell entry, empty-mappings CSS-module proxies) bypass monocart's `sourceFilter`.
- CI workflow: comment + artifact log paths only; the phase steps are unchanged.

## Receipts (local, 1 worker, coverage on, same machine)

| Spec | CI dev (reported) | local dev | local build |
|---|---|---|---|
| ruleset-lifecycle | 20.6s | 4.8s | 2.9s |
| faq-happy-path | 37.9s | 6.0s | 4.1s |
| group-membership | 46.7s | 6.8s | 5.2s |
| faction-lifecycle | 108s | 25.7s | 22.0s |
| **suite wall** | — | **66s** | **47s** |

Local dev→build is ~1.3x on uncontended hardware; the CI delta should be larger and this PR's run is the measurement.

## ⚠️ Deliberate Codecov e2e-flag repricing

The e2e flag steps down **82.22% → 67.86%** lines (144 → 134 files). Dev-mode coverage counted CSS-served-as-JS modules (~100%-covered noise) and untree-shaken barrel files; the built bundle measures shipped code. Full-suite DA-line-merged lcov diff, dev vs build, on identical test runs. Files leaving the report: 7 CSS files, 3 barrel `index.ts`, `profiles/db.ts` (tree-shaken).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end testing against production-style application builds.
  * Enhanced coverage reports to include valid application sources while excluding dependencies and generated files.
  * Added safer handling for missing or invalid asset paths.
  * Improved collection of application and build logs.

* **Chores**
  * Added a dedicated static server for testing built application assets.
  * Added clearer diagnostics for build and application-server failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->