### PR TITLE
docs: record the deleted Group lifecycle contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,8 +7,12 @@ Dune Zone is a community catalogue for Dune board-game factions, rulesets, and t
 **Group**:
 A collaboration boundary shared by factions, rulesets, and future community assets. Active members may maintain associated content and manage membership intake, while the Group owner alone may rename the Group or remove active members.
 
+**Deleted Group**:
+A Group its owner has deleted. It survives with its memberships and asset associations intact, but the product treats it as not found for everyone, owner included — it appears nowhere, grants no collaborative access, and accepts no changes — while its name and slug remain reserved. Recovery is an administrative act, not a product capability; restoring a Group never reclaims an asset whose owner reassigned it away.
+_Avoid_: Archived group, removed group
+
 **Group-associated asset**:
-A faction, ruleset, or future community asset that its owner has assigned to a Group for collaborative maintenance. Active members may edit it, while its owner alone may delete it or change its Group association; ruleset renames are owner-only, while faction renames are collaborative.
+A faction, ruleset, or future community asset that its owner has assigned to a Group for collaborative maintenance. Active members may edit it, while its owner alone may delete it or change its Group association; ruleset renames are owner-only, while faction renames are collaborative. An asset whose Group is deleted or no longer exists presents as ungrouped; the stored association survives until its owner changes it.
 
 **FAQ question**:
 A ruleset question owned by its author, who may edit or remove it and moderate its answers regardless of the ruleset's Group association.

--- a/docs/adr/0003-group-soft-deletion-not-found.md
+++ b/docs/adr/0003-group-soft-deletion-not-found.md
@@ -1,0 +1,50 @@
+# ADR-0003: Deleted Groups are not found; stale references project to null at the read layer
+
+**Status:** Accepted (2026-08-09)
+
+## Context
+
+Group deletion used to hard-delete the row and run a bounded cleanup cascade
+that nulled ruleset associations, deleted memberships, and never touched
+factions — destroying membership data and leaving dangling faction references
+in production. The soft-deletion lifecycle
+([#188](https://github.com/ndelangen/dunezone/issues/188)) replaces this, and
+the contract below was settled in
+[#189](https://github.com/ndelangen/dunezone/issues/189).
+
+## Decision
+
+- **Deleted ⇒ not found, everywhere, no carve-outs.** A deleted Group is
+  indistinguishable from one that never existed: queries throw or exclude it,
+  and every mutation targeting it — rename, delete-again, all membership
+  actions, assigning an asset to it — behaves as not found. There is no
+  tombstone page for any role and no product-level restore; recovery is a
+  manual administrative act (flip `is_deleted` in the dashboard).
+- **Deletion preserves, never cascades.** The Group row, its memberships, and
+  the `group_id` on associated assets all survive untouched. `group_id` is the
+  sole authority on association: restoration never reclaims a reassigned
+  asset, and an untouched asset snaps back when its Group is restored.
+- **Name and slug stay reserved while deleted**, matching the faction
+  convention. This keeps the slug→row mapping unique (the faction duplicate
+  slug repair migration is the scar from breaking that) and makes restoration
+  collision-free, at the cost of a create-time error that can reveal a name is
+  held by a Group the requester cannot see.
+- **Stale references are projected, not repaired.** Historical hard deletions
+  left dangling `group_id` pointers (factions were never cleaned; ruleset and
+  membership cleanup was capped at 100 rows). The migration audits and logs
+  these but does not rewrite them. Instead, the Convex read layer owns one
+  projection rule: any group reference that does not resolve to a live Group —
+  soft-deleted or missing entirely — leaves Convex as `null`, so the UI always
+  receives an asset that presents as ungrouped and never sees a dangling id.
+
+## Considered options
+
+- Owner-facing restore and/or tombstone pages — rejected for now; without a
+  restore action a tombstone has nothing to do, and one-way deletion keeps the
+  authorization rule to a single clause.
+- Releasing the name and slug of deleted Groups — purest "never existed", but
+  it breaks slug uniqueness, invites restore collisions, and contradicts the
+  established faction convention.
+- Migration repair (nulling dangling pointers, deleting orphan memberships) —
+  rejected in favor of read-layer projection so the database keeps its history
+  and one rule covers both soft-deleted and historically vanished Groups.


### PR DESCRIPTION
Resolves the wayfinder grilling ticket [Settle the deleted Group lifecycle and recovery contract](https://github.com/ndelangen/dunezone/issues/189) by recording the settled contract in the domain docs:

- **CONTEXT.md**: adds the **Deleted Group** term and extends **Group-associated asset** with the ungrouped-presentation rule.
- **ADR-0003**: deleted ⇒ not found everywhere with zero carve-outs; no product-level restore (dashboard recovery only); name and slug stay reserved (faction parity); `group_id` is sole authority (restoration never reclaims reassigned assets); historical dangling references are audited but never repaired — the Convex read layer projects any unresolvable group reference to `null`.

Part of the [Group soft-deletion lifecycle map](https://github.com/ndelangen/dunezone/issues/188).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added glossary guidance for deleted Groups and assets associated with deleted or unavailable Groups.
  * Documented the soft-deletion behavior: deleted Groups appear as not found, while memberships, assets, and identifying names remain preserved.
  * Clarified that stale Group references appear as unavailable in application reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->