### PR TITLE
feat: Group soft deletion and deleted-state authorization

### DIFF
--- a/convex/groups.softDeletion.test.ts
+++ b/convex/groups.softDeletion.test.ts
@@ -1,0 +1,266 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import aggregateTest from '@convex-dev/aggregate/test';
+import { convexTest } from 'convex-test';
+import { describe, expect, test } from 'vitest';
+
+import { assetPublishingFaction } from '../src/game/fixtures/assetPublishingFaction';
+import { api } from './_generated/api';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+const now = '2026-08-09T00:00:00.000Z';
+
+async function softDeletionFixture() {
+  const t = convexTest(schema, modules);
+  aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileActivity');
+  aggregateTest.register(t, 'profileDiscovery');
+  const ids = await t.run(async (ctx) => {
+    const ownerId = await ctx.db.insert('users', { name: 'Group owner' });
+    const memberId = await ctx.db.insert('users', { name: 'Active member' });
+    const assetOwnerId = await ctx.db.insert('users', { name: 'Asset owner' });
+    const outsiderId = await ctx.db.insert('users', { name: 'Outsider' });
+    for (const [userId, username, slug] of [
+      [ownerId, 'Group owner', 'group-owner'],
+      [memberId, 'Active member', 'active-member'],
+      [assetOwnerId, 'Asset owner', 'asset-owner'],
+      [outsiderId, 'Outsider', 'outsider'],
+    ] as const) {
+      await ctx.db.insert('profiles', {
+        user_id: userId,
+        username,
+        avatar_url: null,
+        slug,
+        created_at: now,
+        updated_at: now,
+      });
+    }
+    const groupId = await ctx.db.insert('groups', {
+      name: 'DuneDesigners',
+      slug: 'dunedesigners',
+      created_at: now,
+      created_by: ownerId,
+      is_deleted: false,
+    });
+    const membershipIds = {
+      owner: await ctx.db.insert('group_members', {
+        group_id: groupId,
+        user_id: ownerId,
+        status: 'active',
+        requested_at: now,
+        approved_at: now,
+        approved_by: ownerId,
+      }),
+      member: await ctx.db.insert('group_members', {
+        group_id: groupId,
+        user_id: memberId,
+        status: 'active',
+        requested_at: now,
+        approved_at: now,
+        approved_by: ownerId,
+      }),
+    };
+    const factionId = await ctx.db.insert('factions', {
+      owner_id: assetOwnerId,
+      data: { ...structuredClone(assetPublishingFaction), name: 'Collaborative Faction' },
+      slug: 'collaborative-faction',
+      created_at: now,
+      updated_at: now,
+      is_deleted: false,
+      group_id: groupId,
+    });
+    const rulesetId = await ctx.db.insert('rulesets', {
+      name: 'Collaborative Ruleset',
+      slug: 'collaborative-ruleset',
+      created_at: now,
+      updated_at: now,
+      owner_id: assetOwnerId,
+      group_id: groupId,
+      is_deleted: false,
+      image_cover: null,
+    });
+    return {
+      ownerId,
+      memberId,
+      assetOwnerId,
+      outsiderId,
+      groupId,
+      membershipIds,
+      factionId,
+      rulesetId,
+    };
+  });
+  return { t, ids };
+}
+
+describe('Group soft deletion lifecycle', () => {
+  test('owner soft deletion preserves the Group row, memberships, and asset associations', async () => {
+    const { t, ids } = await softDeletionFixture();
+
+    await t.withIdentity({ subject: ids.ownerId }).mutation(api.groups.softDelete, {
+      id: ids.groupId,
+    });
+
+    await t.run(async (ctx) => {
+      const group = await ctx.db.get('groups', ids.groupId);
+      expect(group?.is_deleted).toBe(true);
+      expect(group?.name).toBe('DuneDesigners');
+      const ownerMembership = await ctx.db.get('group_members', ids.membershipIds.owner);
+      const memberMembership = await ctx.db.get('group_members', ids.membershipIds.member);
+      expect(ownerMembership?.status).toBe('active');
+      expect(memberMembership?.status).toBe('active');
+      const faction = await ctx.db.get('factions', ids.factionId);
+      const ruleset = await ctx.db.get('rulesets', ids.rulesetId);
+      expect(faction?.group_id).toBe(ids.groupId);
+      expect(ruleset?.group_id).toBe(ids.groupId);
+    });
+  });
+
+  test('only the Group owner may soft delete', async () => {
+    const { t, ids } = await softDeletionFixture();
+
+    await expect(
+      t.withIdentity({ subject: ids.memberId }).mutation(api.groups.softDelete, {
+        id: ids.groupId,
+      })
+    ).rejects.toThrow('Not authorized');
+  });
+
+  test('a deleted Group behaves as not found for every Group mutation', async () => {
+    const { t, ids } = await softDeletionFixture();
+    const owner = t.withIdentity({ subject: ids.ownerId });
+    await owner.mutation(api.groups.softDelete, { id: ids.groupId });
+
+    await expect(
+      owner.mutation(api.groups.update, { id: ids.groupId, name: 'RenamedDesigners' })
+    ).rejects.toThrow('not found');
+    await expect(owner.mutation(api.groups.softDelete, { id: ids.groupId })).rejects.toThrow(
+      'not found'
+    );
+    await expect(
+      t.withIdentity({ subject: ids.outsiderId }).mutation(api.members.request, {
+        group_id: ids.groupId,
+      })
+    ).rejects.toThrow('Group not found');
+    await expect(
+      owner.mutation(api.members.addMember, { groupId: ids.groupId, userId: ids.outsiderId })
+    ).rejects.toThrow('not found');
+  });
+
+  test('membership in a deleted Group grants no collaborative authority over assets', async () => {
+    const { t, ids } = await softDeletionFixture();
+    await t.withIdentity({ subject: ids.ownerId }).mutation(api.groups.softDelete, {
+      id: ids.groupId,
+    });
+
+    const member = t.withIdentity({ subject: ids.memberId });
+    await expect(
+      member.mutation(api.factions.update, {
+        id: ids.factionId,
+        data: { ...structuredClone(assetPublishingFaction), name: 'Collaborative Faction' },
+      })
+    ).rejects.toThrow('Not authorized');
+
+    const faction = await member.query(api.factions.getBySlug, { slug: 'collaborative-faction' });
+    expect(faction.viewerAccess.assignedGroup).toBeNull();
+    expect(faction.viewerAccess.capabilities.edit).toBe(false);
+  });
+
+  test('the asset owner may unassign or reassign while the former Group is deleted', async () => {
+    const { t, ids } = await softDeletionFixture();
+    const owner = t.withIdentity({ subject: ids.ownerId });
+    await owner.mutation(api.groups.softDelete, { id: ids.groupId });
+
+    const assetOwner = t.withIdentity({ subject: ids.assetOwnerId });
+    const unassigned = await assetOwner.mutation(api.factions.setGroup, {
+      id: ids.factionId,
+      group_id: null,
+    });
+    expect(unassigned.group_id).toBeNull();
+
+    const nextGroup = await owner.mutation(api.groups.create, { name: 'NextDesigners' });
+    await t.run(async (ctx) => {
+      await ctx.db.insert('group_members', {
+        group_id: nextGroup._id,
+        user_id: ids.assetOwnerId,
+        status: 'active',
+        requested_at: now,
+        approved_at: now,
+        approved_by: ids.ownerId,
+      });
+    });
+    const reassigned = await assetOwner.mutation(api.factions.setGroup, {
+      id: ids.factionId,
+      group_id: nextGroup._id,
+    });
+    expect(reassigned.group_id).toBe(nextGroup._id);
+  });
+
+  test('assignment to a deleted Group behaves as not found', async () => {
+    const { t, ids } = await softDeletionFixture();
+    await t.withIdentity({ subject: ids.ownerId }).mutation(api.groups.softDelete, {
+      id: ids.groupId,
+    });
+
+    const assetOwner = t.withIdentity({ subject: ids.assetOwnerId });
+    await expect(
+      assetOwner.mutation(api.factions.setGroup, { id: ids.factionId, group_id: ids.groupId })
+    ).rejects.toThrow('not found');
+    await expect(
+      assetOwner.mutation(api.rulesets.create, {
+        name: 'OrphanRuleset',
+        group_id: ids.groupId,
+        image_cover: null,
+      })
+    ).rejects.toThrow('not found');
+  });
+
+  test('a deleted Group keeps its name and slug reserved', async () => {
+    const { t, ids } = await softDeletionFixture();
+    const owner = t.withIdentity({ subject: ids.ownerId });
+    await owner.mutation(api.groups.softDelete, { id: ids.groupId });
+
+    await expect(owner.mutation(api.groups.create, { name: 'DuneDesigners' })).rejects.toThrow(
+      'Group name already exists'
+    );
+    const shadow = await owner.mutation(api.groups.create, { name: 'DUNEDESIGNERS' });
+    expect(shadow.slug).toBe('dunedesigners-2');
+  });
+
+  test('dangling references from historical hard deletions project to null', async () => {
+    const { t, ids } = await softDeletionFixture();
+    await t.run(async (ctx) => {
+      await ctx.db.delete(ids.groupId);
+    });
+
+    const assetOwner = t.withIdentity({ subject: ids.assetOwnerId });
+    const faction = await assetOwner.query(api.factions.getBySlug, {
+      slug: 'collaborative-faction',
+    });
+    expect(faction.viewerAccess.assignedGroup).toBeNull();
+    expect(faction.viewerAccess.capabilities).toMatchObject({
+      edit: true,
+      changeGroup: true,
+      delete: true,
+    });
+  });
+
+  test('a deleted Group exposes no capabilities on its detail page', async () => {
+    const { t, ids } = await softDeletionFixture();
+    await t.withIdentity({ subject: ids.ownerId }).mutation(api.groups.softDelete, {
+      id: ids.groupId,
+    });
+
+    const page = await t.withIdentity({ subject: ids.ownerId }).query(api.groups.detailBySlug, {
+      slug: 'dunedesigners',
+    });
+    expect(page.viewerAccess.capabilities).toEqual({
+      requestMembership: false,
+      rename: false,
+      delete: false,
+      addMember: false,
+    });
+  });
+});

--- a/convex/groups.softDeletion.test.ts
+++ b/convex/groups.softDeletion.test.ts
@@ -256,11 +256,6 @@ describe('Group soft deletion lifecycle', () => {
     const page = await t.withIdentity({ subject: ids.ownerId }).query(api.groups.detailBySlug, {
       slug: 'dunedesigners',
     });
-    expect(page.viewerAccess.capabilities).toEqual({
-      requestMembership: false,
-      rename: false,
-      delete: false,
-      addMember: false,
-    });
+    expect(Object.values(page.viewerAccess.capabilities).some(Boolean)).toBe(false);
   });
 });

--- a/convex/groups.ts
+++ b/convex/groups.ts
@@ -120,6 +120,7 @@ export const create = mutation({
       slug,
       created_by: userId,
       created_at: now,
+      is_deleted: false,
     });
     await ctx.db.insert('group_members', {
       group_id: _id,
@@ -170,28 +171,11 @@ export const update = mutation({
   },
 });
 
-export const remove = mutation({
+export const softDelete = mutation({
   args: { id: v.id('groups') },
   handler: async (ctx, args) => {
     const { subject: group } = await requireGroupCapability(ctx, args.id, 'delete');
-    await ctx.db.delete(group._id);
-
-    const rulesetsWithGroup = await ctx.db
-      .query('rulesets')
-      .withIndex('by_group_deleted', (q) => q.eq('group_id', group._id).eq('is_deleted', false))
-      .take(100);
-    for (const ruleset of rulesetsWithGroup) {
-      await ctx.db.patch(ruleset._id, { group_id: null });
-    }
-
-    const memberships = await ctx.db
-      .query('group_members')
-      .withIndex('by_group', (q) => q.eq('group_id', group._id))
-      .take(100);
-    for (const membership of memberships) {
-      await ctx.db.delete(membership._id);
-    }
-
+    await ctx.db.patch(group._id, { is_deleted: true });
     return args.id;
   },
 });

--- a/convex/lib/collaborativeAccess.ts
+++ b/convex/lib/collaborativeAccess.ts
@@ -76,6 +76,15 @@ type LoadedCollaborativeAccess = LoadedGroupAccess | LoadedFactionAccess | Loade
 
 type AnyCtx = QueryCtx | MutationCtx;
 
+/**
+ * The one projection rule for group references: a reference that does not resolve to a live Group —
+ * soft-deleted or missing entirely (historical hard deletions left dangling ids) — projects to null
+ * (ADR-0003).
+ */
+function liveGroupOrNull(group: Doc<'groups'> | null): Doc<'groups'> | null {
+  return group === null || group.is_deleted ? null : group;
+}
+
 async function requireAuthenticatedViewerId(ctx: AnyCtx) {
   const viewerId = (await getAuthUserId(ctx)) as Id<'users'> | null;
   if (!viewerId) {
@@ -125,7 +134,7 @@ function groupAccessFromLoaded(
     viewerId,
     viewerAccess: evaluateCollaborativeAccess({
       kind: 'group',
-      group: { eligible: true },
+      group: { eligible: !subject.is_deleted },
       viewer: viewerFacts(viewerId, subject.created_by, viewerMembership),
     }) as Extract<CollaborativeAccess, { kind: 'group' }>,
   };
@@ -200,7 +209,7 @@ export async function loadCollaborativeAccess(
   const viewerId = (await getAuthUserId(ctx)) as Id<'users'> | null;
 
   if (subject.kind === 'group') {
-    const row = await ctx.db.get('groups', subject.id);
+    const row = liveGroupOrNull(await ctx.db.get('groups', subject.id));
     if (!row) {
       throw new Error(`Group with id ${subject.id} not found`);
     }
@@ -213,7 +222,9 @@ export async function loadCollaborativeAccess(
     if (!row) {
       throw new Error(`Faction with id ${subject.id} not found`);
     }
-    const assignedGroup = row.group_id ? await ctx.db.get('groups', row.group_id) : null;
+    const assignedGroup = liveGroupOrNull(
+      row.group_id ? await ctx.db.get('groups', row.group_id) : null
+    );
     const viewerMembership = await membershipFor(ctx, assignedGroup?._id ?? null, viewerId);
     return factionAccessFromLoaded(row, assignedGroup, viewerId, viewerMembership);
   }
@@ -222,7 +233,7 @@ export async function loadCollaborativeAccess(
   if (!row) {
     throw new Error(`Ruleset with id ${subject.id} not found`);
   }
-  const assignedGroup = row.group_id ? await ctx.db.get(row.group_id) : null;
+  const assignedGroup = liveGroupOrNull(row.group_id ? await ctx.db.get(row.group_id) : null);
   const viewerMembership = await membershipFor(ctx, assignedGroup?._id ?? null, viewerId);
   return rulesetAccessFromLoaded(row, assignedGroup, viewerId, viewerMembership);
 }
@@ -242,7 +253,9 @@ export async function collaborativeAccessFor(
 
 export async function loadRulesetAccessForLoadedSubject(ctx: AnyCtx, ruleset: Doc<'rulesets'>) {
   const viewerId = (await getAuthUserId(ctx)) as Id<'users'> | null;
-  const assignedGroup = ruleset.group_id ? await ctx.db.get('groups', ruleset.group_id) : null;
+  const assignedGroup = liveGroupOrNull(
+    ruleset.group_id ? await ctx.db.get('groups', ruleset.group_id) : null
+  );
   const viewerMembership = await membershipFor(ctx, assignedGroup?._id ?? null, viewerId);
   return rulesetAccessFromLoaded(ruleset, assignedGroup, viewerId, viewerMembership);
 }
@@ -295,7 +308,7 @@ export async function requireAssignableGroup(ctx: MutationCtx, groupId: Id<'grou
 
 export async function requireMembershipRequest(ctx: MutationCtx, groupId: Id<'groups'>) {
   const viewerId = await requireAuthenticatedViewerId(ctx);
-  const group = await ctx.db.get('groups', groupId);
+  const group = liveGroupOrNull(await ctx.db.get('groups', groupId));
   if (!group) {
     throw new Error('Group not found');
   }
@@ -459,8 +472,9 @@ export async function loadAssetAccessBundle(
   const groupById = new Map<Id<'groups'>, Doc<'groups'>>();
   const groups = await Promise.all([...groupIds].map((groupId) => ctx.db.get('groups', groupId)));
   for (const group of groups) {
-    if (group) {
-      groupById.set(group._id, group);
+    const live = liveGroupOrNull(group);
+    if (live) {
+      groupById.set(live._id, live);
     }
   }
   const assignedGroup = subject.row.group_id ? (groupById.get(subject.row.group_id) ?? null) : null;
@@ -524,6 +538,7 @@ export async function loadGroupAccessBundle(ctx: QueryCtx, group: Doc<'groups'>)
   }
 
   const actorIsActive =
+    !group.is_deleted &&
     access.viewerAccess.viewer.kind === 'authenticated' &&
     access.viewerAccess.viewer.membership === 'active';
   const actorIsOwner = access.viewerAccess.capabilities.rename;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -37,6 +37,8 @@ export default defineSchema({
     slug: v.string(),
     created_at: v.string(),
     created_by: v.id('users'),
+    // Widen phase (#190): optional until the #191 backfill marks every row, narrowed in #194.
+    is_deleted: v.optional(v.boolean()),
   })
     .index('by_name', ['name'])
     .index('by_slug', ['slug'])

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -24,7 +24,7 @@ Convex schema and indexes are defined in [`convex/schema.ts`](../convex/schema.t
 
 **Tables**: factions, groups, group_members, profiles
 
-**Pattern**: Domain data is stored in Convex documents, validated with Zod in domain hooks and with function validators in Convex functions. Factions and rulesets use soft delete; groups use hard delete.
+**Pattern**: Domain data is stored in Convex documents, validated with Zod in domain hooks and with function validators in Convex functions. Factions, rulesets, and groups use soft delete.
 
 ## Domain File Pattern
 
@@ -117,14 +117,18 @@ export const updateSomething = mutation({
 
 ## Soft Delete Pattern
 
-Factions and rulesets use `is_deleted` flags instead of hard deletes:
+Factions, rulesets, and groups use `is_deleted` flags instead of hard deletes:
 
 - Queries filter deleted rows in Convex query handlers
 - Delete mutation sets `is_deleted: true`
+- Deleting a group never cascades: memberships and asset `group_id` associations survive
+- A group reference that does not resolve to a live group (soft-deleted, or a dangling id from
+  historical hard deletions) is projected to `null` inside the Convex layer
+  (`liveGroupOrNull` in [`convex/lib/collaborativeAccess.ts`](../convex/lib/collaborativeAccess.ts)),
+  so clients never see a deleted group or a dangling reference
+- Deleted names and slugs stay reserved (see ADR-0003)
 
 **Example**: [`src/app/factions/db.ts`](../src/app/factions/db.ts)
-
-Groups use hard delete (actual row removal).
 
 ## Convex `useQuery` in domain hooks (`src/app/**/db.ts`)
 


### PR DESCRIPTION
Implements the wayfinder ticket [Implement Group soft deletion and deleted-state authorization](https://github.com/ndelangen/dunezone/issues/190), the widen phase of the [Group soft-deletion lifecycle map](https://github.com/ndelangen/dunezone/issues/188) under the contract settled in [#189](https://github.com/ndelangen/dunezone/issues/189).

## What changed

- **Schema (widen)**: `groups.is_deleted` is an optional boolean so pre-migration rows stay readable. `create` writes `false`; the #191 backfill marks existing rows; #194 narrows.
- **`groups.remove` → `groups.softDelete`**: owner-only, patches `is_deleted: true`, and retires the bounded cascade — memberships and faction/ruleset `group_id` associations survive untouched. (No client or test referenced `groups.remove`.)
- **One projection rule** (`liveGroupOrNull` in `convex/lib/collaborativeAccess.ts`): a group reference that doesn't resolve to a live Group — soft-deleted, or dangling from historical hard deletions — projects to `null`. Consequences, all centralized:
  - A deleted Group is **not found** as a mutation subject: rename, delete-again, and all membership mutations.
  - Membership in a deleted Group grants **no collaborative capability** on associated assets; asset owners keep unassign/reassign authority.
  - A deleted Group is rejected as an assignment target and excluded from assignable-group lists.
- **Names and slugs stay reserved** while deleted: uniqueness checks intentionally still consider deleted rows (faction-convention parity, per ADR-0003 in #340).
- **Docs**: `docs/data-layer.md` no longer says Groups hard-delete.

## Evidence

- New seam suite `convex/groups.softDeletion.test.ts` (9 tests) covers: preservation on delete, owner-only delete, deleted ⇒ not-found for group/membership mutations, no member authority over assets, asset-owner unassign/reassign, deleted assignment target rejected, name+slug reservation, dangling-reference projection, and zero capabilities on the (pre-cutover) detail page.
- Full validation: typecheck, oxlint + format, and the complete vitest suite (433 tests / 67 files) pass locally.

## Out of scope (later map tickets)

- Production backfill + dangling-reference audit (#191)
- Product-surface cutover — lists, routes, profile summaries (#192)
- Deploy/verify (#193) and narrow + compat removal (#194)

Merge order note: #340 (ADR-0003 + CONTEXT.md) documents the contract this implements; ideally it lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Groups can now be soft-deleted while preserving memberships and asset associations.
  * Deleted groups no longer grant collaborative access or roster-management capabilities.
  * Assets can be reassigned to active groups but not deleted ones.

* **Bug Fixes**
  * Prevented deleted groups from appearing in assignment lists or accepting membership requests.
  * Added owner-only authorization for group deletion.
  * Historical references to deleted groups now display as unavailable rather than causing errors.

* **Documentation**
  * Updated data-layer documentation to describe group soft deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->