### PR TITLE
feat: Group lifecycle backfill and historical hard-delete audit

### DIFF
--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -130,6 +130,16 @@
       "id": "faction_decal_retune_v1",
       "phase": "widen",
       "requires": []
+    },
+    {
+      "id": "groups_soft_delete_backfill_v1",
+      "phase": "widen",
+      "requires": []
+    },
+    {
+      "id": "groups_soft_delete_verify_v1",
+      "phase": "widen",
+      "requires": ["groups_soft_delete_backfill_v1"]
     }
   ]
 }

--- a/convex/migrations.groupsSoftDelete.test.ts
+++ b/convex/migrations.groupsSoftDelete.test.ts
@@ -1,0 +1,130 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import migrationsTest from '@convex-dev/migrations/test';
+import { convexTest } from 'convex-test';
+import { describe, expect, test } from 'vitest';
+
+import { internal } from './_generated/api';
+import type { Id } from './_generated/dataModel';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+const now = '2026-08-09T00:00:00.000Z';
+
+async function migrationFixture() {
+  const t = convexTest(schema, modules);
+  migrationsTest.register(t);
+  const ids = await t.run(async (ctx) => {
+    const ownerId = await ctx.db.insert('users', { name: 'Migration owner' });
+    const legacyGroupId = await ctx.db.insert('groups', {
+      name: 'LegacyGroup',
+      slug: 'legacygroup',
+      created_at: now,
+      created_by: ownerId,
+    });
+    const deletedGroupId = await ctx.db.insert('groups', {
+      name: 'DeletedGroup',
+      slug: 'deletedgroup',
+      created_at: now,
+      created_by: ownerId,
+      is_deleted: true,
+    });
+    return { ownerId, legacyGroupId, deletedGroupId };
+  });
+  return { t, ids };
+}
+
+describe('Group soft-delete backfill and audit', () => {
+  test('backfill marks pre-lifecycle Groups active and never resurrects deleted ones', async () => {
+    const { t, ids } = await migrationFixture();
+
+    await t.mutation(internal.migrations.groups_soft_delete_backfill_v1, {
+      cursor: null,
+      dryRun: false,
+      oneBatchOnly: true,
+    });
+    await t.mutation(internal.migrations.groups_soft_delete_verify_v1, {
+      cursor: null,
+      dryRun: false,
+      oneBatchOnly: true,
+    });
+
+    await t.run(async (ctx) => {
+      const legacy = await ctx.db.get('groups', ids.legacyGroupId);
+      const deleted = await ctx.db.get('groups', ids.deletedGroupId);
+      expect(legacy?.is_deleted).toBe(false);
+      expect(deleted?.is_deleted).toBe(true);
+    });
+  });
+
+  test('verify fails while any Group is missing its lifecycle state', async () => {
+    const { t } = await migrationFixture();
+
+    await expect(
+      t.mutation(internal.migrations.groups_soft_delete_verify_v1, {
+        cursor: null,
+        dryRun: false,
+        oneBatchOnly: true,
+      })
+    ).rejects.toThrow('missing its lifecycle state');
+  });
+
+  test('audit counts dangling group references without repairing them', async () => {
+    const { t, ids } = await migrationFixture();
+    const vanishedRefs = await t.run(async (ctx) => {
+      const vanishedGroupId = await ctx.db.insert('groups', {
+        name: 'VanishedGroup',
+        slug: 'vanishedgroup',
+        created_at: now,
+        created_by: ids.ownerId,
+      });
+      const factionId = await ctx.db.insert('factions', {
+        owner_id: ids.ownerId,
+        data: { name: 'Orphaned Faction' },
+        slug: 'orphaned-faction',
+        created_at: now,
+        updated_at: now,
+        is_deleted: false,
+        group_id: vanishedGroupId,
+      });
+      const membershipId = await ctx.db.insert('group_members', {
+        group_id: vanishedGroupId,
+        user_id: ids.ownerId,
+        status: 'active',
+        requested_at: now,
+        approved_at: now,
+        approved_by: ids.ownerId,
+      });
+      const rulesetId = await ctx.db.insert('rulesets', {
+        name: 'GroupedRuleset',
+        slug: 'groupedruleset',
+        created_at: now,
+        updated_at: now,
+        owner_id: ids.ownerId,
+        group_id: ids.legacyGroupId,
+        is_deleted: false,
+        image_cover: null,
+      });
+      await ctx.db.delete(vanishedGroupId);
+      return { vanishedGroupId, factionId, membershipId, rulesetId };
+    });
+
+    const audit = await t.query(internal.migrations.groupsLifecycleAudit, {});
+
+    expect(audit.groups).toMatchObject({ total: 2, missingLifecycleFlag: 1, deleted: 1 });
+    expect(audit.factions).toMatchObject({ dangling: 1, danglingIds: [vanishedRefs.factionId] });
+    expect(audit.memberships).toMatchObject({
+      dangling: 1,
+      danglingIds: [vanishedRefs.membershipId],
+    });
+    expect(audit.rulesets).toMatchObject({ dangling: 0, withGroupReference: 1 });
+
+    await t.run(async (ctx) => {
+      const faction = await ctx.db.get('factions', vanishedRefs.factionId);
+      const membership = await ctx.db.get('group_members', vanishedRefs.membershipId);
+      expect(faction?.group_id).toBe(vanishedRefs.vanishedGroupId as Id<'groups'>);
+      expect(membership?.group_id).toBe(vanishedRefs.vanishedGroupId as Id<'groups'>);
+    });
+  });
+});

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -465,8 +465,8 @@ export const groupsLifecycleAudit = internalQuery({
     const memberships = await ctx.db.query('group_members').take(AUDIT_SCAN_LIMIT);
 
     /**
-     * Every distinct referenced Group is resolved by primary key, so a reference is judged
-     * against the actual row — never against a truncated Group scan window.
+     * Every distinct referenced Group is resolved by primary key, so a reference is judged against
+     * the actual row — never against a truncated Group scan window.
      */
     const referencedIds = new Set<Id<'groups'>>();
     for (const row of [...factions, ...rulesets, ...memberships]) {

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -459,10 +459,30 @@ export const groupsLifecycleAudit = internalQuery({
   args: {},
   handler: async (ctx) => {
     const groups = await ctx.db.query('groups').take(AUDIT_SCAN_LIMIT);
-    const groupIds = new Set<Id<'groups'>>(groups.map((group) => group._id));
+
+    const factions = await ctx.db.query('factions').take(AUDIT_SCAN_LIMIT);
+    const rulesets = await ctx.db.query('rulesets').take(AUDIT_SCAN_LIMIT);
+    const memberships = await ctx.db.query('group_members').take(AUDIT_SCAN_LIMIT);
+
+    /**
+     * Every distinct referenced Group is resolved by primary key, so a reference is judged
+     * against the actual row — never against a truncated Group scan window.
+     */
+    const referencedIds = new Set<Id<'groups'>>();
+    for (const row of [...factions, ...rulesets, ...memberships]) {
+      if (row.group_id !== null) {
+        referencedIds.add(row.group_id);
+      }
+    }
+    const resolvesToRow = new Map<Id<'groups'>, boolean>();
+    for (const groupId of referencedIds) {
+      resolvesToRow.set(groupId, (await ctx.db.get('groups', groupId)) !== null);
+    }
 
     function danglingReport(rows: { _id: string; group_id: Id<'groups'> | null }[]) {
-      const dangling = rows.filter((row) => row.group_id !== null && !groupIds.has(row.group_id));
+      const dangling = rows.filter(
+        (row) => row.group_id !== null && resolvesToRow.get(row.group_id) === false
+      );
       return {
         scanned: rows.length,
         truncated: rows.length === AUDIT_SCAN_LIMIT,
@@ -471,10 +491,6 @@ export const groupsLifecycleAudit = internalQuery({
         danglingIds: dangling.slice(0, AUDIT_ID_SAMPLE_LIMIT).map((row) => row._id),
       };
     }
-
-    const factions = await ctx.db.query('factions').take(AUDIT_SCAN_LIMIT);
-    const rulesets = await ctx.db.query('rulesets').take(AUDIT_SCAN_LIMIT);
-    const memberships = await ctx.db.query('group_members').take(AUDIT_SCAN_LIMIT);
 
     return {
       groups: {

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -5,7 +5,7 @@ import { v } from 'convex/values';
 import { DEFAULT_FAQ_TAG } from '../src/app/faq/tags';
 import { components, internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
-import { query } from './_generated/server';
+import { internalQuery, query } from './_generated/server';
 import { internalMutation, mutation } from './functions';
 import { DECAL_ID_RENAMES, DECAL_SCALE_FACTORS } from './lib/decalRetune';
 import {
@@ -49,6 +49,8 @@ const MIGRATION_IDS: Record<string, MigrationRef> = {
   profile_activity_questions_v1: internal.migrations.profile_activity_questions_v1,
   profile_activity_answers_v1: internal.migrations.profile_activity_answers_v1,
   faction_decal_retune_v1: internal.migrations.faction_decal_retune_v1,
+  groups_soft_delete_backfill_v1: internal.migrations.groups_soft_delete_backfill_v1,
+  groups_soft_delete_verify_v1: internal.migrations.groups_soft_delete_verify_v1,
 };
 
 type MigrationId = keyof typeof MIGRATION_IDS;
@@ -419,6 +421,75 @@ export const faction_decal_retune_v1 = migrations.define({
   },
 });
 
+/**
+ * Marks every pre-lifecycle Group active (wayfinder #191). Rows that already carry the flag —
+ * including soft-deleted ones — are never touched, so the backfill can never resurrect a Group.
+ */
+export const groups_soft_delete_backfill_v1 = migrations.define({
+  table: 'groups',
+  batchSize: 50,
+  migrateOne: async (_ctx, row) => {
+    if (row.is_deleted !== undefined) {
+      return;
+    }
+    return { is_deleted: false };
+  },
+});
+
+/** Successful completion proves every Group carries a lifecycle state; #194 narrows on it. */
+export const groups_soft_delete_verify_v1 = migrations.define({
+  table: 'groups',
+  batchSize: 50,
+  migrateOne: async (_ctx, row) => {
+    if (row.is_deleted === undefined) {
+      throw new Error(`Group ${row._id} is missing its lifecycle state`);
+    }
+  },
+});
+
+const AUDIT_SCAN_LIMIT = 4096;
+const AUDIT_ID_SAMPLE_LIMIT = 50;
+
+/**
+ * Read-only evidence for the historical hard-delete audit (wayfinder #191, ADR-0003): counts group
+ * references that no longer resolve to a Group row. Repairs nothing — dangling references stay in
+ * place and the read layer projects them to null.
+ */
+export const groupsLifecycleAudit = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const groups = await ctx.db.query('groups').take(AUDIT_SCAN_LIMIT);
+    const groupIds = new Set<Id<'groups'>>(groups.map((group) => group._id));
+
+    function danglingReport(rows: { _id: string; group_id: Id<'groups'> | null }[]) {
+      const dangling = rows.filter((row) => row.group_id !== null && !groupIds.has(row.group_id));
+      return {
+        scanned: rows.length,
+        truncated: rows.length === AUDIT_SCAN_LIMIT,
+        withGroupReference: rows.filter((row) => row.group_id !== null).length,
+        dangling: dangling.length,
+        danglingIds: dangling.slice(0, AUDIT_ID_SAMPLE_LIMIT).map((row) => row._id),
+      };
+    }
+
+    const factions = await ctx.db.query('factions').take(AUDIT_SCAN_LIMIT);
+    const rulesets = await ctx.db.query('rulesets').take(AUDIT_SCAN_LIMIT);
+    const memberships = await ctx.db.query('group_members').take(AUDIT_SCAN_LIMIT);
+
+    return {
+      groups: {
+        total: groups.length,
+        truncated: groups.length === AUDIT_SCAN_LIMIT,
+        missingLifecycleFlag: groups.filter((group) => group.is_deleted === undefined).length,
+        deleted: groups.filter((group) => group.is_deleted === true).length,
+      },
+      factions: danglingReport(factions),
+      rulesets: danglingReport(rulesets),
+      memberships: danglingReport(memberships),
+    };
+  },
+});
+
 export const run = migrations.runner();
 
 export const runDeployMigrations = migrations.runner([
@@ -437,6 +508,8 @@ export const runDeployMigrations = migrations.runner([
   internal.migrations.statistics_answers_v1,
   internal.migrations.profile_discovery_profiles_v1,
   internal.migrations.faction_decal_retune_v1,
+  internal.migrations.groups_soft_delete_backfill_v1,
+  internal.migrations.groups_soft_delete_verify_v1,
 ]);
 
 export const runRequired = mutation({


### PR DESCRIPTION
Implements the wayfinder ticket [Backfill Groups and audit historical hard-delete fallout](https://github.com/ndelangen/dunezone/issues/191) on the [Group soft-deletion lifecycle map](https://github.com/ndelangen/dunezone/issues/188).

## What changed

- **`groups_soft_delete_backfill_v1`** (widen, auto-run on deploy): marks every pre-lifecycle Group `is_deleted: false`. Rows that already carry the flag are never touched, so the backfill cannot resurrect a soft-deleted Group. Resumable + idempotent via `@convex-dev/migrations`.
- **`groups_soft_delete_verify_v1`** (widen, requires the backfill): throws on any Group missing its lifecycle state — successful completion is the evidence #194's narrow guard will require.
- **`groupsLifecycleAudit`** (internal, read-only): counts group references that no longer resolve to a Group row — factions, rulesets, memberships — with bounded scans and sampled ids. Per ADR-0003 it repairs **nothing**; dangling references stay in place and the read layer projects them to null.
- Guard manifest gains both widen entries, so `migrations:deploy` starts them in production and `dev-strict` enforces them locally.

## Evidence

- Seam suite `convex/migrations.groupsSoftDelete.test.ts`: backfill marks unmarked rows and preserves deleted ones; verify fails while unmarked rows remain; audit counts dangling faction/membership references without repairing them.
- Full local validation green: typecheck, lint/format, 436 tests / 68 files.
- CI `e2e_docker` exercises the dev-strict migration preflight with the updated manifest.

After merge, the production deploy auto-runs both migrations; the audit will be run against production and its counts recorded on the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for completing group lifecycle data during migration while preserving existing deletion states.
  * Added lifecycle verification to detect groups with incomplete deletion information.
  * Added read-only auditing for groups and dangling faction, ruleset, and membership references.

* **Tests**
  * Added coverage for migration backfills, verification failures, and lifecycle reference auditing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->