### PR TITLE
ci: checkout trusted github.sha in pull_request_target workflow

### DIFF
--- a/.github/workflows/cloudflare-live-drift.yml
+++ b/.github/workflows/cloudflare-live-drift.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout trusted base revision
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - name: Setup Bun

--- a/scripts/cloudflare-live-drift.test.ts
+++ b/scripts/cloudflare-live-drift.test.ts
@@ -154,7 +154,8 @@ describe('Cloudflare live drift check', () => {
     expect(workflow).toContain(
       'oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0'
     );
-    expect(workflow).toContain(`ref: $${'{'}{ github.event.pull_request.base.sha || github.sha }}`);
+    expect(workflow).toContain(`ref: $${'{'}{ github.sha }}`);
+    expect(workflow).not.toContain('github.event.pull_request.base.sha');
     expect(workflow).toContain('persist-credentials: false');
     expect(workflow).toContain(
       `CLOUDFLARE_API_TOKEN: $${'{'}{ secrets.CLOUDFLARE_READ_API_TOKEN }}`


### PR DESCRIPTION
## Summary
- The `cloudflare-live-drift` workflow runs on `pull_request_target` (it needs the read-only Cloudflare token, which fork `pull_request` runs don't get). Security scanning flagged the checkout step for using an event-payload value as the ref.
- The checkout ref was `github.event.pull_request.base.sha || github.sha`; while `base.sha` is base-branch code, it comes from the PR event payload. It now pins to `${{ github.sha }}`, which under `pull_request_target` is the trusted base branch head (and under `workflow_dispatch` the dispatched ref) — no behavior change, and no PR-derived value can influence what code runs with secrets in context.
- PR head code is never checked out or executed in this workflow; `permissions: contents: read`, `persist-credentials: false`, and pinned action SHAs were already in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Update the cloudflare-live-drift pull_request_target workflow to avoid using pull_request event payload values when checking out code.