### PR TITLE
feat: narrow the Group lifecycle schema and retire migration scaffolding

### DIFF
--- a/convex/collaborationPermissions.test.ts
+++ b/convex/collaborationPermissions.test.ts
@@ -24,6 +24,7 @@ async function collaborationFixture() {
       slug: 'dune-designers',
       created_at: '2026-08-04T00:00:00.000Z',
       created_by: ownerId,
+      is_deleted: false,
     });
     await ctx.db.insert('group_members', {
       group_id: groupId,

--- a/convex/collaborativeAccess.test.ts
+++ b/convex/collaborativeAccess.test.ts
@@ -28,6 +28,7 @@ async function groupAccessFixture() {
       slug: 'dune-designers',
       created_at: now,
       created_by: ownerId,
+      is_deleted: false,
     });
     for (const [userId, username, slug] of [
       [ownerId, 'Group owner', 'group-owner'],
@@ -239,6 +240,7 @@ describe('collaborative access public projections', () => {
           slug,
           created_at: now,
           created_by: ids.ownerId,
+          is_deleted: false,
         });
       const activeGroupId = await insertGroup('Active target', 'active-target');
       const pendingGroupId = await insertGroup('Pending target', 'pending-target');
@@ -525,6 +527,7 @@ describe('collaborative access public projections', () => {
         slug: 'membership-history',
         created_at: now,
         created_by: ids.ownerId,
+        is_deleted: false,
       });
       for (let index = 0; index < 500; index += 1) {
         await ctx.db.insert('group_members', {
@@ -550,6 +553,7 @@ describe('collaborative access public projections', () => {
           slug: `active-history-${index}`,
           created_at: now,
           created_by: ids.ownerId,
+          is_deleted: false,
         });
         await ctx.db.insert('group_members', {
           group_id: groupId,
@@ -826,6 +830,7 @@ describe('collaborative access moderation commands', () => {
           slug,
           created_at: now,
           created_by: ids.ownerId,
+          is_deleted: false,
         });
       const active = await insertGroup('Active command target', 'active-command-target');
       const pending = await insertGroup('Pending command target', 'pending-command-target');

--- a/convex/faq.test.ts
+++ b/convex/faq.test.ts
@@ -225,6 +225,7 @@ describe('FAQ lifecycle', () => {
         slug: 'faq-maintainers',
         created_at: '2026-08-05T00:00:00.000Z',
         created_by: rulesetOwnerId,
+        is_deleted: false,
       });
       await ctx.db.insert('group_members', {
         group_id: groupId,

--- a/convex/groups.ts
+++ b/convex/groups.ts
@@ -87,10 +87,9 @@ export const detailBySlug = query({
 export const list = query({
   args: {},
   handler: async (ctx) => {
-    // neq(true), not eq(false): pre-backfill rows without the flag stay live (widen window).
     return await ctx.db
       .query('groups')
-      .filter((q) => q.neq(q.field('is_deleted'), true))
+      .filter((q) => q.eq(q.field('is_deleted'), false))
       .take(500);
   },
 });
@@ -101,7 +100,7 @@ export const listByCreator = query({
     return await ctx.db
       .query('groups')
       .withIndex('by_created_by', (q) => q.eq('created_by', args.created_by))
-      .filter((q) => q.neq(q.field('is_deleted'), true))
+      .filter((q) => q.eq(q.field('is_deleted'), false))
       .take(500);
   },
 });

--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -140,6 +140,11 @@
       "id": "groups_soft_delete_verify_v1",
       "phase": "widen",
       "requires": ["groups_soft_delete_backfill_v1"]
+    },
+    {
+      "id": "groups_soft_delete_narrow",
+      "phase": "narrow",
+      "requires": ["groups_soft_delete_backfill_v1", "groups_soft_delete_verify_v1"]
     }
   ]
 }

--- a/convex/migrations.groupsSoftDelete.test.ts
+++ b/convex/migrations.groupsSoftDelete.test.ts
@@ -6,81 +6,33 @@ import { convexTest } from 'convex-test';
 import { describe, expect, test } from 'vitest';
 
 import { internal } from './_generated/api';
-import type { Id } from './_generated/dataModel';
 import schema from './schema';
 
 const modules = import.meta.glob('./**/*.ts');
 const now = '2026-08-09T00:00:00.000Z';
 
-async function migrationFixture() {
-  const t = convexTest(schema, modules);
-  migrationsTest.register(t);
-  const ids = await t.run(async (ctx) => {
-    const ownerId = await ctx.db.insert('users', { name: 'Migration owner' });
-    const legacyGroupId = await ctx.db.insert('groups', {
-      name: 'LegacyGroup',
-      slug: 'legacygroup',
-      created_at: now,
-      created_by: ownerId,
-    });
-    const deletedGroupId = await ctx.db.insert('groups', {
-      name: 'DeletedGroup',
-      slug: 'deletedgroup',
-      created_at: now,
-      created_by: ownerId,
-      is_deleted: true,
-    });
-    return { ownerId, legacyGroupId, deletedGroupId };
-  });
-  return { t, ids };
-}
-
-describe('Group soft-delete backfill and audit', () => {
-  test('backfill marks pre-lifecycle Groups active and never resurrects deleted ones', async () => {
-    const { t, ids } = await migrationFixture();
-
-    await t.mutation(internal.migrations.groups_soft_delete_backfill_v1, {
-      cursor: null,
-      dryRun: false,
-      oneBatchOnly: true,
-    });
-    await t.mutation(internal.migrations.groups_soft_delete_verify_v1, {
-      cursor: null,
-      dryRun: false,
-      oneBatchOnly: true,
-    });
-
-    await t.run(async (ctx) => {
-      const legacy = await ctx.db.get('groups', ids.legacyGroupId);
-      const deleted = await ctx.db.get('groups', ids.deletedGroupId);
-      expect(legacy?.is_deleted).toBe(false);
-      expect(deleted?.is_deleted).toBe(true);
-    });
-  });
-
-  test('verify fails while any Group is missing its lifecycle state', async () => {
-    const { t } = await migrationFixture();
-
-    await expect(
-      t.mutation(internal.migrations.groups_soft_delete_verify_v1, {
-        cursor: null,
-        dryRun: false,
-        oneBatchOnly: true,
-      })
-    ).rejects.toThrow('missing its lifecycle state');
-  });
-
+describe('Group lifecycle audit', () => {
   test('audit counts dangling group references without repairing them', async () => {
-    const { t, ids } = await migrationFixture();
-    const vanishedRefs = await t.run(async (ctx) => {
+    const t = convexTest(schema, modules);
+    migrationsTest.register(t);
+    const ids = await t.run(async (ctx) => {
+      const ownerId = await ctx.db.insert('users', { name: 'Migration owner' });
+      const deletedGroupId = await ctx.db.insert('groups', {
+        name: 'DeletedGroup',
+        slug: 'deletedgroup',
+        created_at: now,
+        created_by: ownerId,
+        is_deleted: true,
+      });
       const vanishedGroupId = await ctx.db.insert('groups', {
         name: 'VanishedGroup',
         slug: 'vanishedgroup',
         created_at: now,
-        created_by: ids.ownerId,
+        created_by: ownerId,
+        is_deleted: false,
       });
       const factionId = await ctx.db.insert('factions', {
-        owner_id: ids.ownerId,
+        owner_id: ownerId,
         data: { name: 'Orphaned Faction' },
         slug: 'orphaned-faction',
         created_at: now,
@@ -90,19 +42,19 @@ describe('Group soft-delete backfill and audit', () => {
       });
       const membershipId = await ctx.db.insert('group_members', {
         group_id: vanishedGroupId,
-        user_id: ids.ownerId,
+        user_id: ownerId,
         status: 'active',
         requested_at: now,
         approved_at: now,
-        approved_by: ids.ownerId,
+        approved_by: ownerId,
       });
       const rulesetId = await ctx.db.insert('rulesets', {
         name: 'GroupedRuleset',
         slug: 'groupedruleset',
         created_at: now,
         updated_at: now,
-        owner_id: ids.ownerId,
-        group_id: ids.legacyGroupId,
+        owner_id: ownerId,
+        group_id: deletedGroupId,
         is_deleted: false,
         image_cover: null,
       });
@@ -112,19 +64,16 @@ describe('Group soft-delete backfill and audit', () => {
 
     const audit = await t.query(internal.migrations.groupsLifecycleAudit, {});
 
-    expect(audit.groups).toMatchObject({ total: 2, missingLifecycleFlag: 1, deleted: 1 });
-    expect(audit.factions).toMatchObject({ dangling: 1, danglingIds: [vanishedRefs.factionId] });
-    expect(audit.memberships).toMatchObject({
-      dangling: 1,
-      danglingIds: [vanishedRefs.membershipId],
-    });
+    expect(audit.groups).toMatchObject({ total: 1, deleted: 1 });
+    expect(audit.factions).toMatchObject({ dangling: 1, danglingIds: [ids.factionId] });
+    expect(audit.memberships).toMatchObject({ dangling: 1, danglingIds: [ids.membershipId] });
     expect(audit.rulesets).toMatchObject({ dangling: 0, withGroupReference: 1 });
 
     await t.run(async (ctx) => {
-      const faction = await ctx.db.get('factions', vanishedRefs.factionId);
-      const membership = await ctx.db.get('group_members', vanishedRefs.membershipId);
-      expect(faction?.group_id).toBe(vanishedRefs.vanishedGroupId as Id<'groups'>);
-      expect(membership?.group_id).toBe(vanishedRefs.vanishedGroupId as Id<'groups'>);
+      const faction = await ctx.db.get('factions', ids.factionId);
+      const membership = await ctx.db.get('group_members', ids.membershipId);
+      expect(faction?.group_id).toBe(ids.vanishedGroupId);
+      expect(membership?.group_id).toBe(ids.vanishedGroupId);
     });
   });
 });

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -421,30 +421,18 @@ export const faction_decal_retune_v1 = migrations.define({
   },
 });
 
-/**
- * Marks every pre-lifecycle Group active (wayfinder #191). Rows that already carry the flag —
- * including soft-deleted ones — are never touched, so the backfill can never resurrect a Group.
- */
+/** Retains the completed Group lifecycle backfill identity through the schema-narrowing release. */
 export const groups_soft_delete_backfill_v1 = migrations.define({
   table: 'groups',
   batchSize: 50,
-  migrateOne: async (_ctx, row) => {
-    if (row.is_deleted !== undefined) {
-      return;
-    }
-    return { is_deleted: false };
-  },
+  migrateOne: async () => undefined,
 });
 
-/** Successful completion proves every Group carries a lifecycle state; #194 narrows on it. */
+/** Retains the completed lifecycle verification identity; the narrowed schema now enforces it. */
 export const groups_soft_delete_verify_v1 = migrations.define({
   table: 'groups',
   batchSize: 50,
-  migrateOne: async (_ctx, row) => {
-    if (row.is_deleted === undefined) {
-      throw new Error(`Group ${row._id} is missing its lifecycle state`);
-    }
-  },
+  migrateOne: async () => undefined,
 });
 
 const AUDIT_SCAN_LIMIT = 4096;
@@ -496,8 +484,7 @@ export const groupsLifecycleAudit = internalQuery({
       groups: {
         total: groups.length,
         truncated: groups.length === AUDIT_SCAN_LIMIT,
-        missingLifecycleFlag: groups.filter((group) => group.is_deleted === undefined).length,
-        deleted: groups.filter((group) => group.is_deleted === true).length,
+        deleted: groups.filter((group) => group.is_deleted).length,
       },
       factions: danglingReport(factions),
       rulesets: danglingReport(rulesets),

--- a/convex/profiles.detail.test.ts
+++ b/convex/profiles.detail.test.ts
@@ -56,18 +56,21 @@ async function seedProfileDetail(t: ReturnType<typeof convexTest>): Promise<Seed
       slug: 'sietch-tabr',
       created_at: at(1),
       created_by: userId,
+      is_deleted: false,
     });
     const pendingGroupId = await ctx.db.insert('groups', {
       name: 'Pending Sietch',
       slug: 'pending-sietch',
       created_at: at(1),
       created_by: userId,
+      is_deleted: false,
     });
     const removedGroupId = await ctx.db.insert('groups', {
       name: 'Removed Sietch',
       slug: 'removed-sietch',
       created_at: at(1),
       created_by: userId,
+      is_deleted: false,
     });
     await ctx.db.insert('group_members', {
       group_id: activeGroupId,
@@ -99,6 +102,7 @@ async function seedProfileDetail(t: ReturnType<typeof convexTest>): Promise<Seed
       slug: 'arrakeen-guild',
       created_at: at(1),
       created_by: userId,
+      is_deleted: false,
     });
     await ctx.db.insert('group_members', {
       group_id: laterGroupId,
@@ -113,6 +117,7 @@ async function seedProfileDetail(t: ReturnType<typeof convexTest>): Promise<Seed
       slug: 'ghost-sietch',
       created_at: at(1),
       created_by: userId,
+      is_deleted: false,
     });
     await ctx.db.insert('group_members', {
       group_id: ghostGroupId,

--- a/convex/profiles.test.ts
+++ b/convex/profiles.test.ts
@@ -31,6 +31,7 @@ test('profile list includes activity counts', async () => {
       slug: 'sietch-tabr',
       created_at: '2026-07-19T00:00:00.000Z',
       created_by: userId,
+      is_deleted: false,
     });
     await ctx.db.insert('group_members', {
       group_id: groupId,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -37,8 +37,7 @@ export default defineSchema({
     slug: v.string(),
     created_at: v.string(),
     created_by: v.id('users'),
-    // Widen phase (#190): optional until the #191 backfill marks every row, narrowed in #194.
-    is_deleted: v.optional(v.boolean()),
+    is_deleted: v.boolean(),
   })
     .index('by_name', ['name'])
     .index('by_slug', ['slug'])


### PR DESCRIPTION
Implements the final wayfinder ticket [Remove Group hard-delete compatibility and close the migration](https://github.com/ndelangen/dunezone/issues/194) on the [Group soft-deletion lifecycle map](https://github.com/ndelangen/dunezone/issues/188).

## What changed

- **Schema narrow**: `groups.is_deleted` is now **required**. The new narrow guard `groups_soft_delete_narrow` gates the deploy on `groups_soft_delete_backfill_v1` + `groups_soft_delete_verify_v1` — `narrow-check --prod` already returns `ok: true` against the live deployment, so the gate will pass.
- **Scaffolding retired**: the backfill and verify migrations become identity no-ops, retained through the narrowing release per the repo convention (`rulesets_remove_homepage_counts_v1` precedent).
- **Compat tolerance removed**: list queries drop the widen-window `neq(true)` for plain `eq(false)`; the audit drops the now-impossible `missingLifecycleFlag` count but keeps standing dangling-reference detection (per ADR-0003, dangling refs are preserved and projected, so the audit stays useful).
- **Tests**: fixtures carry the required flag; the two pre-lifecycle migration tests are retired as inexpressible under the narrowed schema (the schema itself now enforces what they proved). 435 tests / 68 files green.
- No runtime or doc path describes Group hard deletion anymore: the cascade died in #341, the docs were rewritten in #341/#340, and no production code deletes group or membership rows (verified by grep; only the `IS_TEST` reset helper does).

## Verification

- Full local validation: typecheck, lint/format, complete suite.
- `bun run scripts/migration-guards.ts narrow-check --prod` → `ok: true` (both lifecycle migrations `success + isDone` in `prod:exuberant-finch-263`).
- CI exercises `migration_static_narrow`, the Docker e2e dev-strict flow, and publisher release verification.

Closing this merges the last child of the map; the map itself closes with final deployment evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Narrow the Group lifecycle schema to require an explicit soft-deletion flag and retire the temporary migration scaffolding now that the backfill and verification are complete.

Enhancements:
- Update Group queries to filter strictly on non-deleted groups using the required lifecycle flag.
- Simplify the Group lifecycle audit to reflect that all groups now carry a deletion state and continue reporting dangling references.

Tests:
- Refresh test fixtures and lifecycle-related tests to assume the required Group deletion flag and drop pre-lifecycle migration behaviors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group listings now exclude soft-deleted groups consistently.
  * Group lifecycle reporting now accurately identifies deleted groups.

* **Refactor**
  * Group deletion status is now required and consistently initialized across workflows.
  * Migration safeguards and audit behavior were updated to support the finalized deletion model.

* **Tests**
  * Updated collaboration, access, FAQ, profile, and migration coverage to reflect group deletion states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->