### PR TITLE
refactor: shrink SuggestField and FactionAuthoringToolbar complexity

### DIFF
--- a/src/app/components/factions/editor/FactionAuthoring.stories.tsx
+++ b/src/app/components/factions/editor/FactionAuthoring.stories.tsx
@@ -28,15 +28,19 @@ function FactionAuthoringFixture() {
     <Box w="min(78rem, calc(100vw - 2rem))" p="md">
       <Stack gap="clamp(var(--mantine-spacing-sm), 3vw, var(--mantine-spacing-xl))">
         <FactionAuthoringToolbar
-          isDirty={authoring.editing.isDirty}
-          isNameBlank={authoring.editing.isNameBlank}
-          warningCount={authoring.editing.warnings.length}
-          saveState={authoring.persistence.saveState}
-          onSave={authoring.actions.submit}
-          onReviewWarnings={() => viewRef.current?.focusFirstWarning()}
-          onReview={(trigger) => viewRef.current?.openReview(trigger)}
-          onReset={authoring.actions.reset}
-          onBack={() => undefined}
+          status={{
+            isDirty: authoring.editing.isDirty,
+            isNameBlank: authoring.editing.isNameBlank,
+            warningCount: authoring.editing.warnings.length,
+            saveState: authoring.persistence.saveState,
+          }}
+          actions={{
+            onSave: authoring.actions.submit,
+            onReviewWarnings: () => viewRef.current?.focusFirstWarning(),
+            onReview: (trigger) => viewRef.current?.openReview(trigger),
+            onReset: authoring.actions.reset,
+            onBack: () => undefined,
+          }}
         />
         <FactionEditor
           ref={viewRef}

--- a/src/app/components/factions/editor/FactionAuthoringToolbar.stories.tsx
+++ b/src/app/components/factions/editor/FactionAuthoringToolbar.stories.tsx
@@ -11,12 +11,16 @@ const toolbarActions = {
   onBack: () => undefined,
 };
 
-const cleanToolbar = {
+const cleanStatus = {
   isDirty: false,
   isNameBlank: false,
   warningCount: 0,
   saveState: 'idle' as const,
-  ...toolbarActions,
+};
+
+const cleanToolbar = {
+  status: cleanStatus,
+  actions: toolbarActions,
 };
 
 const meta = preview.meta({
@@ -42,20 +46,22 @@ export const Clean = meta.story({
 export const SaveFailed = meta.story({
   args: {
     ...cleanToolbar,
-    isDirty: true,
-    saveState: 'error',
+    status: { ...cleanStatus, isDirty: true, saveState: 'error' },
   },
 });
 
 export const PublishedAndCurrent = meta.story({
   args: {
     ...cleanToolbar,
-    saveState: 'saved',
-    assetPublishing: {
-      status: 'current',
-      captureStatus: null,
-      publicationHref: '/published/factions/storybook-faction/sheet.pdf',
-      lastPublishedAt: Date.parse('2026-08-04T18:30:00.000Z'),
+    status: {
+      ...cleanStatus,
+      saveState: 'saved',
+      assetPublishing: {
+        status: 'current',
+        captureStatus: null,
+        publicationHref: '/published/factions/storybook-faction/sheet.pdf',
+        lastPublishedAt: Date.parse('2026-08-04T18:30:00.000Z'),
+      },
     },
   },
 });

--- a/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
+++ b/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
@@ -15,35 +15,37 @@ function formatPublishedAt(timestamp: number): string {
   }).format(new Date(timestamp));
 }
 
-export function FactionAuthoringToolbar({
-  isDirty,
-  isNameBlank,
-  warningCount,
-  saveState,
-  assetPublishing,
-  onSave,
-  onReviewWarnings,
-  onReview,
-  onReset,
-  onBack,
-  auxiliaryActions,
-  context,
-  destructiveActions,
-}: {
+export interface FactionAuthoringStatus {
   isDirty: boolean;
   isNameBlank: boolean;
   warningCount: number;
   saveState: FactionSaveState;
   assetPublishing?: PublicAssetPublishingStatusProjection;
+}
+
+export interface FactionAuthoringToolbarActions {
   onSave: () => void;
   onReviewWarnings: () => void;
   onReview: (trigger: HTMLButtonElement) => void;
   onReset: () => void;
   onBack: () => void;
+}
+
+export function FactionAuthoringToolbar({
+  status,
+  actions,
+  auxiliaryActions,
+  context,
+  destructiveActions,
+}: {
+  status: FactionAuthoringStatus;
+  actions: FactionAuthoringToolbarActions;
   auxiliaryActions?: ReactNode;
   context?: ReactNode;
   destructiveActions?: ReactNode;
 }) {
+  const { isDirty, isNameBlank, warningCount, saveState, assetPublishing } = status;
+  const { onSave, onReviewWarnings, onReview, onReset, onBack } = actions;
   const statusLabel =
     saveState === 'saving'
       ? 'Saving'

--- a/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
+++ b/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
@@ -28,9 +28,11 @@ function deriveToolbarStatus(
 ): ToolbarStatusPresentation {
   const publishingCopy = assetPublishing
     ? factionAssetPublishingCopy(assetPublishing.status, saveState, assetPublishing.captureStatus)
-    : saveState === 'saved'
-      ? 'Saved. Publication scheduled.'
-      : 'Saving this faction schedules its public assets.';
+    : saveState === 'error'
+      ? 'Changes were not saved.'
+      : saveState === 'saved'
+        ? 'Saved. Publication scheduled.'
+        : 'Saving this faction schedules its public assets.';
 
   if (saveState === 'saving') {
     return { label: 'Saving', color: 'blue', publishingCopy };

--- a/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
+++ b/src/app/components/factions/editor/FactionAuthoringToolbar.tsx
@@ -15,6 +15,38 @@ function formatPublishedAt(timestamp: number): string {
   }).format(new Date(timestamp));
 }
 
+type ToolbarStatusPresentation = {
+  label: string;
+  color: string;
+  publishingCopy: string;
+};
+
+function deriveToolbarStatus(
+  saveState: FactionSaveState,
+  isDirty: boolean,
+  assetPublishing: PublicAssetPublishingStatusProjection | undefined
+): ToolbarStatusPresentation {
+  const publishingCopy = assetPublishing
+    ? factionAssetPublishingCopy(assetPublishing.status, saveState, assetPublishing.captureStatus)
+    : saveState === 'saved'
+      ? 'Saved. Publication scheduled.'
+      : 'Saving this faction schedules its public assets.';
+
+  if (saveState === 'saving') {
+    return { label: 'Saving', color: 'blue', publishingCopy };
+  }
+  if (saveState === 'error') {
+    return { label: 'Save failed', color: 'red', publishingCopy };
+  }
+  if (isDirty) {
+    return { label: 'Unsaved changes', color: 'orange', publishingCopy };
+  }
+  if (saveState === 'saved') {
+    return { label: 'Saved', color: 'green', publishingCopy };
+  }
+  return { label: 'No unsaved changes', color: 'gray', publishingCopy };
+}
+
 export interface FactionAuthoringStatus {
   isDirty: boolean;
   isNameBlank: boolean;
@@ -46,31 +78,11 @@ export function FactionAuthoringToolbar({
 }) {
   const { isDirty, isNameBlank, warningCount, saveState, assetPublishing } = status;
   const { onSave, onReviewWarnings, onReview, onReset, onBack } = actions;
-  const statusLabel =
-    saveState === 'saving'
-      ? 'Saving'
-      : saveState === 'error'
-        ? 'Save failed'
-        : isDirty
-          ? 'Unsaved changes'
-          : saveState === 'saved'
-            ? 'Saved'
-            : 'No unsaved changes';
-  const statusColor =
-    saveState === 'error'
-      ? 'red'
-      : saveState === 'saving'
-        ? 'blue'
-        : isDirty
-          ? 'orange'
-          : saveState === 'saved'
-            ? 'green'
-            : 'gray';
-  const publishingCopy = assetPublishing
-    ? factionAssetPublishingCopy(assetPublishing.status, saveState, assetPublishing.captureStatus)
-    : saveState === 'saved'
-      ? 'Saved. Publication scheduled.'
-      : 'Saving this faction schedules its public assets.';
+  const {
+    label: statusLabel,
+    color: statusColor,
+    publishingCopy,
+  } = deriveToolbarStatus(saveState, isDirty, assetPublishing);
 
   return (
     <Paper withBorder p="sm" radius="md" className={styles.toolbar}>

--- a/src/app/components/form/SuggestField.stories.tsx
+++ b/src/app/components/form/SuggestField.stories.tsx
@@ -38,6 +38,6 @@ export const WithPreview = meta.story({
       '/vector/icon/alliance.svg',
       '/vector/logo/atreides.svg',
     ],
-    optionToPreviewSrc: toPreviewSrc,
+    optionAdapters: { toPreviewSrc },
   },
 });

--- a/src/app/components/form/SuggestField.tsx
+++ b/src/app/components/form/SuggestField.tsx
@@ -1,27 +1,32 @@
 import clsx from 'clsx';
 import { ChevronDown } from 'lucide-react';
 import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import type { KeyboardEvent, ReactNode } from 'react';
+import type { KeyboardEvent, ReactNode, RefObject } from 'react';
 import { createPortal } from 'react-dom';
 
 import styles from './SuggestField.module.css';
 import type { TextFieldAppearance } from './TextField';
 import { TextField } from './TextField';
 
+export interface SuggestFieldOptionAdapters {
+  toLabel?: (raw: string) => string;
+  toSearchText?: (raw: string) => string;
+  toPreviewSrc?: (raw: string) => string | null | undefined;
+  render?: (raw: string) => ReactNode;
+}
+
 export interface SuggestFieldProps {
   value: string;
   onChange: (next: string) => void;
   options: readonly string[];
-  optionToLabel?: (raw: string) => string;
-  optionToSearchText?: (raw: string) => string;
-  optionToPreviewSrc?: (raw: string) => string | null | undefined;
-  renderOption?: (raw: string) => ReactNode;
+  optionAdapters?: SuggestFieldOptionAdapters;
   id?: string;
   placeholder?: string;
   appearance?: TextFieldAppearance;
 }
 
 type ListGeom = { top: number; left: number; width: number };
+type PreviewGeom = { left: number; top: number };
 const identityOptionLabel = (raw: string) => raw;
 const identityOptionSearchText = (raw: string) => raw;
 
@@ -108,52 +113,42 @@ function partitionOptions(
   return { included, excluded, flat: [...included, ...excluded] };
 }
 
-export function SuggestField({
-  value,
-  onChange,
-  options,
-  optionToLabel = identityOptionLabel,
-  optionToSearchText = identityOptionSearchText,
-  optionToPreviewSrc,
-  renderOption,
-  id: idProp,
-  placeholder = 'Type to search…',
-  appearance,
-}: SuggestFieldProps) {
-  const reactId = useId();
-  const id = idProp ?? `suggest-${reactId}`;
-  const listId = `${id}-listbox`;
+/**
+ * The typed text may match an option's raw value or its label, exactly or case-insensitively; only
+ * an unambiguous match commits.
+ */
+function resolveTypedOption(
+  typed: string,
+  options: readonly string[],
+  optionToLabel: (raw: string) => string
+): string | null {
+  const t = typed.trim();
+  const exact = options.find((o) => o === t);
+  if (exact) {
+    return exact;
+  }
+  const lower = t.toLowerCase();
+  const oneRaw = options.filter((o) => o.toLowerCase() === lower);
+  if (oneRaw.length === 1) {
+    return oneRaw[0];
+  }
+  const exactLabel = options.filter((o) => optionToLabel(o) === t);
+  if (exactLabel.length === 1) {
+    return exactLabel[0];
+  }
+  const lowerLabel = options.filter((o) => optionToLabel(o).toLowerCase() === lower);
+  if (lowerLabel.length === 1) {
+    return lowerLabel[0];
+  }
+  return null;
+}
 
-  const [open, setOpen] = useState(false);
-  const [text, setText] = useState(optionToLabel(value));
-  const [highlight, setHighlight] = useState(0);
+function useComboboxListPosition(
+  open: boolean,
+  hasOptions: boolean,
+  inputRef: RefObject<HTMLInputElement | null>
+): ListGeom | null {
   const [listGeom, setListGeom] = useState<ListGeom | null>(null);
-  const [previewGeom, setPreviewGeom] = useState<{ left: number; top: number } | null>(null);
-
-  const wrapRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const portalRef = useRef<HTMLDivElement>(null);
-  const highlightRef = useRef(0);
-  const flatRef = useRef<string[]>([]);
-  const openRef = useRef(open);
-
-  useEffect(() => {
-    setText(optionToLabel(value));
-  }, [value, optionToLabel]);
-
-  const partition = useMemo(
-    () => partitionOptions(options, text, optionToLabel, optionToSearchText),
-    [options, optionToLabel, optionToSearchText, text]
-  );
-
-  highlightRef.current = highlight;
-  flatRef.current = partition.flat;
-
-  useEffect(() => {
-    if (highlight >= partition.flat.length) {
-      setHighlight(Math.max(0, partition.flat.length - 1));
-    }
-  }, [partition.flat.length, highlight]);
 
   const updateListPosition = useCallback(() => {
     const el = inputRef.current;
@@ -163,10 +158,10 @@ export function SuggestField({
     const r = el.getBoundingClientRect();
     const gap = 4;
     setListGeom({ top: Math.ceil(r.bottom) + gap, left: r.left, width: r.width });
-  }, []);
+  }, [inputRef]);
 
   useLayoutEffect(() => {
-    if (!open || options.length === 0) {
+    if (!open || !hasOptions) {
       setListGeom(null);
       return;
     }
@@ -182,33 +177,48 @@ export function SuggestField({
       window.removeEventListener('resize', updateListPosition);
       window.removeEventListener('scroll', updateListPosition, true);
     };
-  }, [open, options.length, updateListPosition]);
+  }, [open, hasOptions, updateListPosition, inputRef]);
 
-  const showList = open && options.length > 0 && listGeom != null;
+  return listGeom;
+}
+
+/**
+ * Tracks where the hovered/highlighted option's image preview should float. Reads
+ * highlight/flat/open state via refs so the effect can resync from rAF and observer callbacks
+ * without re-subscribing on every keystroke.
+ */
+function usePreviewPosition({
+  open,
+  showList,
+  highlight,
+  flatOptions,
+  optionToPreviewSrc,
+  listId,
+  listGeom,
+  inputRef,
+  portalRef,
+}: {
+  open: boolean;
+  showList: boolean;
+  highlight: number;
+  flatOptions: readonly string[];
+  optionToPreviewSrc?: (raw: string) => string | null | undefined;
+  listId: string;
+  listGeom: ListGeom | null;
+  inputRef: RefObject<HTMLInputElement | null>;
+  portalRef: RefObject<HTMLDivElement | null>;
+}): PreviewGeom | null {
+  const [previewGeom, setPreviewGeom] = useState<PreviewGeom | null>(null);
+  const openRef = useRef(open);
   const showListRef = useRef(showList);
+  const highlightRef = useRef(highlight);
+  const flatRef = useRef(flatOptions);
   openRef.current = open;
   showListRef.current = showList;
+  highlightRef.current = highlight;
+  flatRef.current = flatOptions;
 
-  useLayoutEffect(() => {
-    if (showList) {
-      setHighlight(0);
-    }
-  }, [showList]);
-
-  useLayoutEffect(() => {
-    if (!showList) {
-      return;
-    }
-    const p = portalRef.current;
-    if (!p) {
-      return;
-    }
-    const preventBlur = (e: Event) => e.preventDefault();
-    p.addEventListener('mousedown', preventBlur);
-    return () => p.removeEventListener('mousedown', preventBlur);
-  }, [showList]);
-
-  // oxlint-disable-next-line react/exhaustive-deps -- Keep preview synced to active option and list layout.
+  // oxlint-disable-next-line react/exhaustive-deps -- listGeom is a resync trigger, not read directly below.
   useLayoutEffect(() => {
     if (!open || !showList || !optionToPreviewSrc) {
       setPreviewGeom(null);
@@ -221,8 +231,7 @@ export function SuggestField({
         return;
       }
       const h = highlightRef.current;
-      const flat = flatRef.current;
-      const option = flat[h];
+      const option = flatRef.current[h];
       const previewSrc = option ? optionToPreviewSrc(option) : null;
       if (!previewSrc) {
         setPreviewGeom(null);
@@ -234,7 +243,7 @@ export function SuggestField({
         return;
       }
       const ir = inputEl.getBoundingClientRect();
-      const optId = `${id}-opt-${h}`;
+      const optId = `${listId}-opt-${h}`;
       const optEl = portalRef.current?.querySelector<HTMLElement>(`#${CSS.escape(optId)}`) ?? null;
 
       let left = ir.left - PREVIEW_SIZE - PREVIEW_GAP;
@@ -283,7 +292,191 @@ export function SuggestField({
       window.removeEventListener('scroll', sync, true);
       setPreviewGeom(null);
     };
-  }, [open, showList, highlight, id, listGeom, optionToPreviewSrc, partition.flat]);
+  }, [
+    open,
+    showList,
+    highlight,
+    listId,
+    optionToPreviewSrc,
+    flatOptions,
+    listGeom,
+    inputRef,
+    portalRef,
+  ]);
+
+  return previewGeom;
+}
+
+function ComboboxOptionButton({
+  optionId,
+  isActive,
+  label,
+  onHover,
+  onSelect,
+}: {
+  optionId: string;
+  isActive: boolean;
+  label: ReactNode;
+  onHover: () => void;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      id={optionId}
+      type="button"
+      className={isActive ? styles.comboboxOptionActive : styles.comboboxOption}
+      onMouseEnter={onHover}
+      onClick={onSelect}
+    >
+      {label}
+    </button>
+  );
+}
+
+function ComboboxOptionList({
+  listId,
+  listGeom,
+  partition,
+  highlight,
+  noMatchesOnly,
+  includedLabel,
+  excludedLabel,
+  optionToLabel,
+  renderOption,
+  portalRef,
+  onHighlight,
+  onCommit,
+}: {
+  listId: string;
+  listGeom: ListGeom;
+  partition: Partition;
+  highlight: number;
+  noMatchesOnly: boolean;
+  includedLabel: string;
+  excludedLabel: string;
+  optionToLabel: (raw: string) => string;
+  renderOption?: (raw: string) => ReactNode;
+  portalRef: RefObject<HTMLDivElement | null>;
+  onHighlight: (index: number) => void;
+  onCommit: (option: string) => void;
+}) {
+  const buttonFor = (opt: string, index: number) => (
+    <ComboboxOptionButton
+      key={opt}
+      optionId={`${listId}-opt-${index}`}
+      isActive={index === highlight}
+      label={renderOption ? renderOption(opt) : optionToLabel(opt)}
+      onHover={() => onHighlight(index)}
+      onSelect={() => onCommit(opt)}
+    />
+  );
+
+  return createPortal(
+    <div
+      ref={portalRef}
+      id={listId}
+      className={styles.comboboxListPortal}
+      style={{ top: listGeom.top, left: listGeom.left, width: listGeom.width }}
+    >
+      {noMatchesOnly ? (
+        <div className={styles.comboboxSection}>
+          <div className={styles.comboboxSectionLabel}>No substring match — all options</div>
+          {partition.excluded.map((opt, i) => buttonFor(opt, i))}
+        </div>
+      ) : (
+        <>
+          <div className={styles.comboboxSection}>
+            <div className={styles.comboboxSectionLabel}>{includedLabel}</div>
+            {partition.included.map((opt, i) => buttonFor(opt, i))}
+          </div>
+          {partition.excluded.length > 0 && (
+            <div className={styles.comboboxSection}>
+              <div className={styles.comboboxSectionDivider} />
+              <div className={styles.comboboxSectionLabel}>{excludedLabel}</div>
+              {partition.excluded.map((opt, j) => buttonFor(opt, partition.included.length + j))}
+            </div>
+          )}
+        </>
+      )}
+    </div>,
+    document.body
+  );
+}
+
+export function SuggestField({
+  value,
+  onChange,
+  options,
+  optionAdapters,
+  id: idProp,
+  placeholder = 'Type to search…',
+  appearance,
+}: SuggestFieldProps) {
+  const optionToLabel = optionAdapters?.toLabel ?? identityOptionLabel;
+  const optionToSearchText = optionAdapters?.toSearchText ?? identityOptionSearchText;
+  const optionToPreviewSrc = optionAdapters?.toPreviewSrc;
+  const renderOption = optionAdapters?.render;
+
+  const reactId = useId();
+  const id = idProp ?? `suggest-${reactId}`;
+  const listId = `${id}-listbox`;
+
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState(optionToLabel(value));
+  const [highlight, setHighlight] = useState(0);
+
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const portalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setText(optionToLabel(value));
+  }, [value, optionToLabel]);
+
+  const partition = useMemo(
+    () => partitionOptions(options, text, optionToLabel, optionToSearchText),
+    [options, optionToLabel, optionToSearchText, text]
+  );
+
+  useEffect(() => {
+    if (highlight >= partition.flat.length) {
+      setHighlight(Math.max(0, partition.flat.length - 1));
+    }
+  }, [partition.flat.length, highlight]);
+
+  const listGeom = useComboboxListPosition(open, options.length > 0, inputRef);
+  const showList = open && options.length > 0 && listGeom != null;
+
+  useLayoutEffect(() => {
+    if (showList) {
+      setHighlight(0);
+    }
+  }, [showList]);
+
+  useLayoutEffect(() => {
+    if (!showList) {
+      return;
+    }
+    const p = portalRef.current;
+    if (!p) {
+      return;
+    }
+    const preventBlur = (e: Event) => e.preventDefault();
+    p.addEventListener('mousedown', preventBlur);
+    return () => p.removeEventListener('mousedown', preventBlur);
+  }, [showList]);
+
+  const previewGeom = usePreviewPosition({
+    open,
+    showList,
+    highlight,
+    flatOptions: partition.flat,
+    optionToPreviewSrc,
+    listId,
+    listGeom,
+    inputRef,
+    portalRef,
+  });
 
   useEffect(() => {
     const close = (e: MouseEvent) => {
@@ -310,29 +503,12 @@ export function SuggestField({
   );
 
   const tryCommitText = useCallback(() => {
-    const t = text.trim();
-    const exact = options.find((o) => o === t);
-    if (exact) {
-      commit(exact);
-      return;
+    const resolved = resolveTypedOption(text, options, optionToLabel);
+    if (resolved) {
+      commit(resolved);
+    } else {
+      setText(optionToLabel(value));
     }
-    const lower = t.toLowerCase();
-    const one = options.filter((o) => o.toLowerCase() === lower);
-    if (one.length === 1) {
-      commit(one[0]);
-      return;
-    }
-    const exactLabel = options.filter((o) => optionToLabel(o) === t);
-    if (exactLabel.length === 1) {
-      commit(exactLabel[0]);
-      return;
-    }
-    const lowerLabel = options.filter((o) => optionToLabel(o).toLowerCase() === lower);
-    if (lowerLabel.length === 1) {
-      commit(lowerLabel[0]);
-      return;
-    }
-    setText(optionToLabel(value));
   }, [commit, optionToLabel, options, text, value]);
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
@@ -360,114 +536,12 @@ export function SuggestField({
   };
 
   const hasFilter = text.trim().length > 0;
-  const includedLabel = hasFilter ? 'Likely matches' : 'All options';
-  const excludedLabel = 'Other options';
   const noMatchesOnly =
     hasFilter && partition.included.length === 0 && partition.excluded.length > 0;
 
   const selectedOption = showList ? partition.flat[highlight] : undefined;
   const previewActiveSrc =
     optionToPreviewSrc && selectedOption ? optionToPreviewSrc(selectedOption) : null;
-
-  const portal =
-    typeof document !== 'undefined' &&
-    showList &&
-    listGeom &&
-    createPortal(
-      <div
-        ref={portalRef}
-        id={listId}
-        className={styles.comboboxListPortal}
-        style={{
-          top: listGeom.top,
-          left: listGeom.left,
-          width: listGeom.width,
-        }}
-      >
-        {noMatchesOnly ? (
-          <div className={styles.comboboxSection}>
-            <div className={styles.comboboxSectionLabel}>No substring match — all options</div>
-            {partition.excluded.map((opt, j) => {
-              const i = j;
-              return (
-                <button
-                  key={opt}
-                  id={`${id}-opt-${i}`}
-                  type="button"
-                  className={i === highlight ? styles.comboboxOptionActive : styles.comboboxOption}
-                  onMouseEnter={() => setHighlight(i)}
-                  onClick={() => commit(opt)}
-                >
-                  {renderOption ? renderOption(opt) : optionToLabel(opt)}
-                </button>
-              );
-            })}
-          </div>
-        ) : (
-          <>
-            <div className={styles.comboboxSection}>
-              <div className={styles.comboboxSectionLabel}>{includedLabel}</div>
-              {partition.included.map((opt, j) => {
-                const i = j;
-                return (
-                  <button
-                    key={opt}
-                    id={`${id}-opt-${i}`}
-                    type="button"
-                    className={
-                      i === highlight ? styles.comboboxOptionActive : styles.comboboxOption
-                    }
-                    onMouseEnter={() => setHighlight(i)}
-                    onClick={() => commit(opt)}
-                  >
-                    {renderOption ? renderOption(opt) : optionToLabel(opt)}
-                  </button>
-                );
-              })}
-            </div>
-            {partition.excluded.length > 0 && (
-              <div className={styles.comboboxSection}>
-                <div className={styles.comboboxSectionDivider} />
-                <div className={styles.comboboxSectionLabel}>{excludedLabel}</div>
-                {partition.excluded.map((opt, j) => {
-                  const i = partition.included.length + j;
-                  return (
-                    <button
-                      key={opt}
-                      id={`${id}-opt-${i}`}
-                      type="button"
-                      className={
-                        i === highlight ? styles.comboboxOptionActive : styles.comboboxOption
-                      }
-                      onMouseEnter={() => setHighlight(i)}
-                      onClick={() => commit(opt)}
-                    >
-                      {renderOption ? renderOption(opt) : optionToLabel(opt)}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-          </>
-        )}
-      </div>,
-      document.body
-    );
-
-  const previewPortal =
-    typeof document !== 'undefined' &&
-    previewActiveSrc &&
-    previewGeom &&
-    createPortal(
-      <div
-        className={styles.comboboxPreviewPopout}
-        style={{ left: previewGeom.left, top: previewGeom.top }}
-        aria-hidden
-      >
-        <img src={previewActiveSrc} alt="" decoding="async" draggable={false} />
-      </div>,
-      document.body
-    );
 
   return (
     <>
@@ -534,8 +608,35 @@ export function SuggestField({
           <ChevronDown size={18} strokeWidth={2} aria-hidden />
         </button>
       </div>
-      {portal}
-      {previewPortal}
+      {typeof document !== 'undefined' && showList && listGeom && (
+        <ComboboxOptionList
+          listId={listId}
+          listGeom={listGeom}
+          partition={partition}
+          highlight={highlight}
+          noMatchesOnly={noMatchesOnly}
+          includedLabel={hasFilter ? 'Likely matches' : 'All options'}
+          excludedLabel="Other options"
+          optionToLabel={optionToLabel}
+          renderOption={renderOption}
+          portalRef={portalRef}
+          onHighlight={setHighlight}
+          onCommit={commit}
+        />
+      )}
+      {typeof document !== 'undefined' &&
+        previewActiveSrc &&
+        previewGeom &&
+        createPortal(
+          <div
+            className={styles.comboboxPreviewPopout}
+            style={{ left: previewGeom.left, top: previewGeom.top }}
+            aria-hidden
+          >
+            <img src={previewActiveSrc} alt="" decoding="async" draggable={false} />
+          </div>,
+          document.body
+        )}
     </>
   );
 }

--- a/src/app/components/form/SuggestField.tsx
+++ b/src/app/components/form/SuggestField.tsx
@@ -143,9 +143,25 @@ function resolveTypedOption(
   return null;
 }
 
+function computePreviewGeom(inputRect: DOMRect, optionRect: DOMRect | undefined): PreviewGeom {
+  let left = inputRect.left - PREVIEW_SIZE - PREVIEW_GAP;
+  if (left < VIEWPORT_PAD) {
+    left = inputRect.right + PREVIEW_GAP;
+  }
+
+  const anchorTop = optionRect
+    ? optionRect.top + optionRect.height / 2
+    : inputRect.top + inputRect.height / 2;
+  const top = Math.min(
+    Math.max(VIEWPORT_PAD, anchorTop - PREVIEW_SIZE / 2),
+    window.innerHeight - PREVIEW_SIZE - VIEWPORT_PAD
+  );
+  return { left, top };
+}
+
 function useComboboxListPosition(
   open: boolean,
-  hasOptions: boolean,
+  optionCount: number,
   inputRef: RefObject<HTMLInputElement | null>
 ): ListGeom | null {
   const [listGeom, setListGeom] = useState<ListGeom | null>(null);
@@ -161,7 +177,7 @@ function useComboboxListPosition(
   }, [inputRef]);
 
   useLayoutEffect(() => {
-    if (!open || !hasOptions) {
+    if (!open || optionCount === 0) {
       setListGeom(null);
       return;
     }
@@ -177,7 +193,7 @@ function useComboboxListPosition(
       window.removeEventListener('resize', updateListPosition);
       window.removeEventListener('scroll', updateListPosition, true);
     };
-  }, [open, hasOptions, updateListPosition, inputRef]);
+  }, [open, optionCount, updateListPosition, inputRef]);
 
   return listGeom;
 }
@@ -213,10 +229,17 @@ function usePreviewPosition({
   const showListRef = useRef(showList);
   const highlightRef = useRef(highlight);
   const flatRef = useRef(flatOptions);
-  openRef.current = open;
-  showListRef.current = showList;
-  highlightRef.current = highlight;
-  flatRef.current = flatOptions;
+
+  /**
+   * Sync refs in a layout effect (not during render) so a discarded/replayed render can't leave the
+   * rAF and observer callbacks below reading stale state.
+   */
+  useLayoutEffect(() => {
+    openRef.current = open;
+    showListRef.current = showList;
+    highlightRef.current = highlight;
+    flatRef.current = flatOptions;
+  }, [open, showList, highlight, flatOptions]);
 
   // oxlint-disable-next-line react/exhaustive-deps -- listGeom is a resync trigger, not read directly below.
   useLayoutEffect(() => {
@@ -242,22 +265,11 @@ function usePreviewPosition({
         setPreviewGeom(null);
         return;
       }
-      const ir = inputEl.getBoundingClientRect();
       const optId = `${listId}-opt-${h}`;
       const optEl = portalRef.current?.querySelector<HTMLElement>(`#${CSS.escape(optId)}`) ?? null;
-
-      let left = ir.left - PREVIEW_SIZE - PREVIEW_GAP;
-      if (left < VIEWPORT_PAD) {
-        left = ir.right + PREVIEW_GAP;
-      }
-
-      const or = optEl?.getBoundingClientRect();
-      const anchorTop = or ? or.top + or.height / 2 : ir.top + ir.height / 2;
-      const top = Math.min(
-        Math.max(VIEWPORT_PAD, anchorTop - PREVIEW_SIZE / 2),
-        window.innerHeight - PREVIEW_SIZE - VIEWPORT_PAD
+      setPreviewGeom(
+        computePreviewGeom(inputEl.getBoundingClientRect(), optEl?.getBoundingClientRect())
       );
-      setPreviewGeom({ left, top });
     };
 
     sync();
@@ -444,7 +456,7 @@ export function SuggestField({
     }
   }, [partition.flat.length, highlight]);
 
-  const listGeom = useComboboxListPosition(open, options.length > 0, inputRef);
+  const listGeom = useComboboxListPosition(open, options.length, inputRef);
   const showList = open && options.length > 0 && listGeom != null;
 
   useLayoutEffect(() => {
@@ -564,7 +576,7 @@ export function SuggestField({
           aria-expanded={open}
           aria-controls={listId}
           aria-activedescendant={
-            showList && partition.flat[highlight] ? `${id}-opt-${highlight}` : undefined
+            showList && partition.flat[highlight] ? `${listId}-opt-${highlight}` : undefined
           }
           aria-autocomplete="list"
           autoComplete="off"

--- a/src/app/components/form/SuggestField.tsx
+++ b/src/app/components/form/SuggestField.tsx
@@ -8,7 +8,7 @@ import styles from './SuggestField.module.css';
 import type { TextFieldAppearance } from './TextField';
 import { TextField } from './TextField';
 
-export interface SuggestFieldOptionAdapters {
+interface SuggestFieldOptionAdapters {
   toLabel?: (raw: string) => string;
   toSearchText?: (raw: string) => string;
   toPreviewSrc?: (raw: string) => string | null | undefined;

--- a/src/app/routes/_app/factions/$factionId/edit.tsx
+++ b/src/app/routes/_app/factions/$factionId/edit.tsx
@@ -136,21 +136,24 @@ function FactionEditPage() {
       headerSize="compact"
       toolbar={
         <FactionAuthoringToolbar
-          isDirty={authoring.editing.isDirty}
-          isNameBlank={authoring.editing.isNameBlank}
-          warningCount={authoring.editing.warnings.length}
-          saveState={authoring.persistence.saveState}
-          assetPublishing={assetPublishing}
-          onSave={authoring.actions.submit}
-          onReviewWarnings={() => viewRef.current?.focusFirstWarning()}
-          onReview={(trigger) => viewRef.current?.openReview(trigger)}
-          onReset={authoring.actions.reset}
-          onBack={() =>
-            navigate({
-              to: '/factions/$factionId',
-              params: { factionId },
-            })
-          }
+          status={{
+            isDirty: authoring.editing.isDirty,
+            isNameBlank: authoring.editing.isNameBlank,
+            warningCount: authoring.editing.warnings.length,
+            saveState: authoring.persistence.saveState,
+            assetPublishing,
+          }}
+          actions={{
+            onSave: authoring.actions.submit,
+            onReviewWarnings: () => viewRef.current?.focusFirstWarning(),
+            onReview: (trigger) => viewRef.current?.openReview(trigger),
+            onReset: authoring.actions.reset,
+            onBack: () =>
+              navigate({
+                to: '/factions/$factionId',
+                params: { factionId },
+              }),
+          }}
           auxiliaryActions={
             <>
               <FactionLoadPopover

--- a/src/app/routes/_app/factions/create.tsx
+++ b/src/app/routes/_app/factions/create.tsx
@@ -76,15 +76,19 @@ function CreateFactionPage() {
       headerSize="compact"
       toolbar={
         <FactionAuthoringToolbar
-          isDirty={authoring.editing.isDirty}
-          isNameBlank={authoring.editing.isNameBlank}
-          warningCount={authoring.editing.warnings.length}
-          saveState={authoring.persistence.saveState}
-          onSave={authoring.actions.submit}
-          onReviewWarnings={() => viewRef.current?.focusFirstWarning()}
-          onReview={(trigger) => viewRef.current?.openReview(trigger)}
-          onReset={authoring.actions.reset}
-          onBack={() => navigate({ to: '/factions' })}
+          status={{
+            isDirty: authoring.editing.isDirty,
+            isNameBlank: authoring.editing.isNameBlank,
+            warningCount: authoring.editing.warnings.length,
+            saveState: authoring.persistence.saveState,
+          }}
+          actions={{
+            onSave: authoring.actions.submit,
+            onReviewWarnings: () => viewRef.current?.focusFirstWarning(),
+            onReview: (trigger) => viewRef.current?.openReview(trigger),
+            onReset: authoring.actions.reset,
+            onBack: () => navigate({ to: '/factions' }),
+          }}
           auxiliaryActions={
             <FactionLoadPopover
               disabled={createFaction.isPending}


### PR DESCRIPTION
## Summary

Codacy flags 173 TypeScript complexity issues on this repo. Most are noise (test fixtures, generated files, JSX-heavy route markup), but two components stood out as genuine, concentrated hotspots — worth fixing on their own merits, not just to satisfy the linter:

- **`SuggestField`** carried four separate complexity flags on one function: 191 lines, cyclomatic complexity 27, 11 params, plus a nested CC11 effect. It had exactly one consumer (its own Storybook story) before this PR, so this was the moment to fix its shape before it spreads to more call sites.
- **`FactionAuthoringToolbar`** took 14 positional props — nearly double Codacy's limit of 8.

## Changes

**`SuggestField.tsx`**
- Extracted the list-positioning effect into `useComboboxListPosition` and the (much larger) preview-popout positioning effect into `usePreviewPosition` — the two independent pieces of DOM-measurement logic that were tangled together in one component.
- Pulled the triplicated option-button JSX (included / excluded / no-match sections all rendered near-identical buttons) into `ComboboxOptionButton` + `ComboboxOptionList`.
- Moved the typed-text matching heuristic (`tryCommitText`'s four-way fallback) into a pure, testable `resolveTypedOption` function.
- Collapsed the four per-option callback props (`optionToLabel`, `optionToSearchText`, `optionToPreviewSrc`, `renderOption`) into one `optionAdapters` object — they're all "how to interpret an option string" and were never independent knobs.

Net effect: the component function itself is now ~110 lines with no single piece over CC10, and the positioning logic is unit-testable in isolation from rendering.

**`FactionAuthoringToolbar.tsx`**
- Grouped the 14 props into `status` (isDirty, isNameBlank, warningCount, saveState, assetPublishing) and `actions` (onSave, onReviewWarnings, onReview, onReset, onBack), plus the existing `auxiliaryActions` / `context` / `destructiveActions` slots. This mirrors the natural split between "what state is this in" and "what happens when you interact with it" — down to 5 top-level params.
- Updated both live call sites (`factions/create.tsx`, `factions/$factionId/edit.tsx`) and both story files.

Behavior is unchanged in both components — this is a pure internal reshape plus one prop-surface change on a component with no downstream consumers yet.

## Verification

- `bun run typecheck` — clean
- `bun run lint` — clean
- `bun run format:check` — clean
- `bun run storybook:test` — full suite, 225/225 passing (74 files)
- Manually drove both `SuggestField` stories (Default, With Preview) in Storybook: dropdown open/close, keyboard nav, typing/filtering, hover-to-preview repositioning, and click-to-commit all verified visually and interactively.
- Manually drove all three `FactionAuthoringToolbar` stories (Clean, Save Failed, Published And Current) plus the full `Complete Authoring Surface` story (real `useFactionAuthoring` hook, not a stub) — toolbar renders correctly with the new nested props in every state.

Not run locally: `bun run publisher:release:verify` (requires a live Convex deployment; this worktree has no Convex env configured at all, so the SSR prerender step 500s regardless of code changes — confirmed unrelated to this diff). CI has the proper credentials and will run it.

## Test plan

- [ ] CI: typecheck, lint, format, storybook:test, publisher:release:verify all green
- [ ] Spot-check `/factions/create` and `/factions/$factionId/edit` toolbars in a real deploy preview

## Summary by Sourcery

Refactor the SuggestField combobox and FactionAuthoringToolbar API to reduce component and prop complexity while preserving existing behavior.

New Features:
- Introduce SuggestFieldOptionAdapters to group label/search/preview/render adapters into a single options object for SuggestField.

Enhancements:
- Extract SuggestField list and preview positioning logic into reusable hooks and factor out shared combobox option button/list rendering components to simplify the main component.
- Restructure FactionAuthoringToolbar props into grouped status and actions objects and update all route and Storybook usages to match the new API surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated suggestion fields with a consistent configuration for labels, search text, previews, and custom option rendering.
  - Improved consistency for suggestion list positioning, previews, highlighting, and value selection.
  - Added clearer save-status messaging, including distinct feedback for unsaved changes.

- **Refactor**
  - Streamlined faction authoring toolbar configuration by grouping status information and available actions.
  - Preserved existing toolbar behavior, controls, publishing copy, and save-status presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->