### PR TITLE
fix: /__icons renders Dune SVGs correctly, plus catalog UX rework

### DIFF
--- a/src/app/routes/_app/[_]_icons.tsx
+++ b/src/app/routes/_app/[_]_icons.tsx
@@ -1,11 +1,9 @@
 import {
-  Badge,
   Card,
-  Center,
+  Chip,
   Group,
-  Image,
-  Pagination,
   Paper,
+  SegmentedControl,
   SimpleGrid,
   Stack,
   Tabs,
@@ -16,7 +14,7 @@ import {
 import { createFileRoute } from '@tanstack/react-router';
 import { icons, Search } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { PageLayout } from '@app/components/shell';
 import { TOPIC_ICON_TOPICS, TopicIcon } from '@app/components/topics/TopicIcon';
@@ -31,7 +29,7 @@ import {
   TROOP_MODIFIER,
 } from '@game/data/generated';
 
-const PAGE_SIZE = 120;
+const BATCH_SIZE = 60;
 
 const DUNE_GROUPS = [
   { name: 'Background', paths: Object.keys(BACKGROUND.enum) },
@@ -43,12 +41,23 @@ const DUNE_GROUPS = [
   { name: 'Troop modifier', paths: Object.keys(TROOP_MODIFIER.enum) },
 ] as const;
 
+const ALL_DUNE_CATEGORY = 'all';
+type DuneCategory = (typeof DUNE_GROUPS)[number]['name'] | typeof ALL_DUNE_CATEGORY;
+
+type SortMode = 'name' | 'size-asc' | 'size-desc';
+const SORT_OPTIONS: { label: string; value: SortMode }[] = [
+  { label: 'Name', value: 'name' },
+  { label: 'Size ↑', value: 'size-asc' },
+  { label: 'Size ↓', value: 'size-desc' },
+];
+
 type CatalogSource = 'topics' | 'lucide' | 'dune';
 
 type CatalogEntry =
   | { source: 'topics'; name: TopicIconTopic; searchText: string }
   | { source: 'lucide'; name: string; icon: LucideIcon; searchText: string }
   | { source: 'dune'; name: string; group: string; path: string; searchText: string };
+type DuneCatalogEntry = Extract<CatalogEntry, { source: 'dune' }>;
 
 const TOPIC_ENTRIES: CatalogEntry[] = TOPIC_ICON_TOPICS.map((name) => ({
   source: 'topics',
@@ -88,6 +97,93 @@ const ENTRIES_BY_SOURCE: Record<CatalogSource, CatalogEntry[]> = {
   dune: DUNE_ENTRIES,
 };
 
+/**
+ * Grows `visibleCount` in `BATCH_SIZE` steps as a sentinel element at the bottom of the grid enters
+ * the viewport, and resets it whenever `resetKey` changes (new search, tab, or category).
+ */
+function useInfiniteReveal(total: number, resetKey: string) {
+  const [visibleCount, setVisibleCount] = useState(BATCH_SIZE);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setVisibleCount(BATCH_SIZE);
+  }, [resetKey]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setVisibleCount((count) => Math.min(count + BATCH_SIZE, total));
+        }
+      },
+      { rootMargin: '600px' }
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [total]);
+
+  return { visibleCount: Math.min(visibleCount, total), sentinelRef };
+}
+
+/** Shared across mounts so navigating away from and back to the Dune SVGs tab re-fetches nothing. */
+const svgByteSizeCache = new Map<string, number>();
+
+function formatBytes(bytes: number): string {
+  return bytes < 1024 ? `${bytes} B` : `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+/**
+ * Byte size isn't in the generated manifest, so it's measured client-side, once, from the same
+ * static files `<use>` already renders. Fetches every uncached Dune SVG in parallel the first time
+ * the Dune SVGs tab opens, and bumps `version` in batches so cards and sort fill in progressively
+ * rather than waiting on all ~500 requests to land.
+ */
+function useDuneSvgSizes(enabled: boolean) {
+  const [version, setVersion] = useState(0);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || startedRef.current) {
+      return;
+    }
+    startedRef.current = true;
+
+    const missing = DUNE_ENTRIES.filter(
+      (entry): entry is DuneCatalogEntry =>
+        entry.source === 'dune' && !svgByteSizeCache.has(entry.path)
+    );
+    let completed = 0;
+    let cancelled = false;
+
+    for (const entry of missing) {
+      fetch(entry.path)
+        .then((response) => response.arrayBuffer())
+        .then((buffer) => {
+          svgByteSizeCache.set(entry.path, buffer.byteLength);
+        })
+        .catch(() => {
+          // Leave unmeasured — size display/sort just treats it as unknown.
+        })
+        .finally(() => {
+          completed += 1;
+          if (!cancelled && (completed % 32 === 0 || completed === missing.length)) {
+            setVersion((v) => v + 1);
+          }
+        });
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return version;
+}
+
 export const Route = createFileRoute('/_app/__icons')({
   codeSplitGroupings: [['component']],
   component: IconsPage,
@@ -95,23 +191,46 @@ export const Route = createFileRoute('/_app/__icons')({
 
 function IconsPage() {
   const [source, setSource] = useState<CatalogSource>('topics');
+  const [category, setCategory] = useState<DuneCategory>(ALL_DUNE_CATEGORY);
+  const [sortMode, setSortMode] = useState<SortMode>('name');
   const [query, setQuery] = useState('');
-  const [page, setPage] = useState(1);
+
+  const sizesVersion = useDuneSvgSizes(source === 'dune');
+  const measuredSizeCount = source === 'dune' ? svgByteSizeCache.size : 0;
 
   const filteredEntries = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     const sourceEntries = ENTRIES_BY_SOURCE[source];
+    const categoryFiltered =
+      source === 'dune' && category !== ALL_DUNE_CATEGORY
+        ? sourceEntries.filter((entry) => entry.source === 'dune' && entry.group === category)
+        : sourceEntries;
     return normalizedQuery.length === 0
-      ? sourceEntries
-      : sourceEntries.filter((entry) => entry.searchText.includes(normalizedQuery));
-  }, [query, source]);
+      ? categoryFiltered
+      : categoryFiltered.filter((entry) => entry.searchText.includes(normalizedQuery));
+  }, [query, source, category]);
 
-  const pageCount = Math.max(1, Math.ceil(filteredEntries.length / PAGE_SIZE));
-  const currentPage = Math.min(page, pageCount);
-  const visibleEntries = filteredEntries.slice(
-    (currentPage - 1) * PAGE_SIZE,
-    currentPage * PAGE_SIZE
+  const sortedEntries = useMemo(() => {
+    if (source !== 'dune' || sortMode === 'name') {
+      return filteredEntries;
+    }
+    const direction = sortMode === 'size-asc' ? 1 : -1;
+    return filteredEntries.slice().sort((a, b) => {
+      const sizeA =
+        a.source === 'dune' ? (svgByteSizeCache.get(a.path) ?? Number.POSITIVE_INFINITY) : 0;
+      const sizeB =
+        b.source === 'dune' ? (svgByteSizeCache.get(b.path) ?? Number.POSITIVE_INFINITY) : 0;
+      return (sizeA - sizeB) * direction;
+    });
+    // sizesVersion isn't read directly, but its change means the cache this sort reads has grown.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filteredEntries, sortMode, source, sizesVersion]);
+
+  const { visibleCount, sentinelRef } = useInfiniteReveal(
+    sortedEntries.length,
+    `${source}:${category}:${sortMode}:${query.trim().toLowerCase()}`
   );
+  const visibleEntries = sortedEntries.slice(0, visibleCount);
 
   return (
     <PageLayout
@@ -135,7 +254,6 @@ function IconsPage() {
               value={query}
               onChange={(event) => {
                 setQuery(event.currentTarget.value);
-                setPage(1);
               }}
             />
             <Tabs
@@ -145,7 +263,6 @@ function IconsPage() {
                   return;
                 }
                 setSource(value as CatalogSource);
-                setPage(1);
               }}
             >
               <Tabs.List grow>
@@ -154,6 +271,43 @@ function IconsPage() {
                 <Tabs.Tab value="dune">Dune SVGs ({DUNE_ENTRIES.length})</Tabs.Tab>
               </Tabs.List>
             </Tabs>
+            {source === 'dune' ? (
+              <Chip.Group
+                value={category}
+                onChange={(value) => {
+                  setCategory(value as DuneCategory);
+                }}
+              >
+                <Group gap="xs">
+                  <Chip value={ALL_DUNE_CATEGORY} size="xs" variant="light">
+                    All ({DUNE_ENTRIES.length})
+                  </Chip>
+                  {DUNE_GROUPS.map((group) => (
+                    <Chip key={group.name} value={group.name} size="xs" variant="light">
+                      {group.name} ({group.paths.length})
+                    </Chip>
+                  ))}
+                </Group>
+              </Chip.Group>
+            ) : null}
+            {source === 'dune' ? (
+              <Group gap="sm" align="center">
+                <Text size="xs" c="dimmed">
+                  Sort
+                </Text>
+                <SegmentedControl
+                  size="xs"
+                  value={sortMode}
+                  onChange={(value) => setSortMode(value as SortMode)}
+                  data={SORT_OPTIONS}
+                />
+                {measuredSizeCount < DUNE_ENTRIES.length ? (
+                  <Text size="xs" c="dimmed">
+                    measuring sizes… {measuredSizeCount}/{DUNE_ENTRIES.length}
+                  </Text>
+                ) : null}
+              </Group>
+            ) : null}
           </Stack>
         </Paper>
       }
@@ -165,15 +319,18 @@ function IconsPage() {
               ? 'Canonical topics'
               : source === 'lucide'
                 ? 'Lucide'
-                : 'Dune SVGs'}
+                : category === ALL_DUNE_CATEGORY
+                  ? 'Dune SVGs'
+                  : `Dune SVGs — ${category}`}
           </Title>
           <Text size="sm" c="dimmed">
-            {filteredEntries.length} {filteredEntries.length === 1 ? 'match' : 'matches'}
+            showing {visibleEntries.length} of {sortedEntries.length}{' '}
+            {sortedEntries.length === 1 ? 'match' : 'matches'}
           </Text>
         </Group>
 
         {visibleEntries.length > 0 ? (
-          <SimpleGrid cols={{ base: 2, xs: 3, sm: 4, md: 6, lg: 8 }} spacing="md">
+          <SimpleGrid cols={{ base: 2, xs: 3, sm: 4, md: 5 }} spacing="xs">
             {visibleEntries.map((entry) => (
               <IconCatalogCard entry={entry} key={catalogEntryKey(entry)} />
             ))}
@@ -186,42 +343,48 @@ function IconsPage() {
           </Paper>
         )}
 
-        {pageCount > 1 ? (
-          <Center>
-            <Pagination
-              value={currentPage}
-              onChange={setPage}
-              total={pageCount}
-              withEdges
-              aria-label="Icon catalog pages"
-            />
-          </Center>
+        {visibleCount < sortedEntries.length ? (
+          <div ref={sentinelRef} style={{ height: 1 }} aria-hidden />
         ) : null}
       </Stack>
     </PageLayout>
   );
 }
 
+/** Square, fills the card's full width — `<svg width="100%" height="100%">` scales to fit it. */
+const iconSlotStyle = {
+  width: '100%',
+  aspectRatio: '1 / 1',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+} as const;
+
 function IconCatalogCard({ entry }: { entry: CatalogEntry }) {
+  const sizeBytes = entry.source === 'dune' ? svgByteSizeCache.get(entry.path) : undefined;
+
   return (
-    <Card withBorder padding="sm" radius="md">
-      <Stack align="center" gap="sm">
-        <Center h={52}>
+    <Card withBorder padding={6} radius="md">
+      <Stack align="center" gap={2}>
+        <div style={iconSlotStyle}>
           {entry.source === 'topics' ? (
-            <TopicIcon topic={entry.name} size={36} />
+            <TopicIcon topic={entry.name} size={64} />
           ) : entry.source === 'lucide' ? (
-            <entry.icon size={36} strokeWidth={1.75} aria-hidden />
+            <entry.icon size={64} strokeWidth={1.75} aria-hidden />
           ) : (
-            <Image src={entry.path} alt="" aria-hidden h={44} w={44} fit="contain" />
+            <svg viewBox="0 0 100 100" width="100%" height="100%" aria-hidden>
+              <use xlinkHref={`${entry.path}#root`} fill="currentColor" />
+            </svg>
           )}
-        </Center>
-        <Text size="xs" fw={600} ta="center" lineClamp={2} title={entry.name}>
+        </div>
+        <Text size="10px" fw={600} ta="center" lineClamp={1} title={entry.name}>
           {entry.name}
         </Text>
         {entry.source === 'dune' ? (
-          <Badge variant="light" size="xs">
+          <Text size="9px" c="dimmed" ta="center">
             {entry.group}
-          </Badge>
+            {sizeBytes !== undefined ? ` · ${formatBytes(sizeBytes)}` : ''}
+          </Text>
         ) : null}
       </Stack>
     </Card>

--- a/src/app/routes/_app/[_]_icons.tsx
+++ b/src/app/routes/_app/[_]_icons.tsx
@@ -111,8 +111,11 @@ const ENTRIES_BY_SOURCE: Record<CatalogSource, CatalogEntry[]> = {
 function useInfiniteReveal(total: number, resetKey: string) {
   const [visibleCount, setVisibleCount] = useState(BATCH_SIZE);
   const totalRef = useRef(total);
-  totalRef.current = total;
   const observerRef = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    totalRef.current = total;
+  }, [total]);
 
   useEffect(() => {
     setVisibleCount(BATCH_SIZE);
@@ -185,9 +188,12 @@ function useDuneSvgSizes(enabled: boolean) {
     for (const entry of missing) {
       fetch(entry.path, { method: 'HEAD' })
         .then((response) => {
-          const contentLength = response.headers.get('content-length');
-          if (contentLength) {
-            svgByteSizeCache.set(entry.path, Number.parseInt(contentLength, 10));
+          /* fetch() resolves (doesn't reject) on HTTP errors — a 404 page's own Content-Length
+             would otherwise get cached as if it were the SVG's size. */
+          const header = response.ok ? response.headers.get('content-length') : null;
+          const contentLength = header === null ? Number.NaN : Number(header);
+          if (Number.isSafeInteger(contentLength) && contentLength >= 0) {
+            svgByteSizeCache.set(entry.path, contentLength);
           }
         })
         .catch(() => {

--- a/src/app/routes/_app/[_]_icons.tsx
+++ b/src/app/routes/_app/[_]_icons.tsx
@@ -14,7 +14,7 @@ import {
 import { createFileRoute } from '@tanstack/react-router';
 import { icons, Search } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { PageLayout } from '@app/components/shell';
 import { TOPIC_ICON_TOPICS, TopicIcon } from '@app/components/topics/TopicIcon';
@@ -100,31 +100,43 @@ const ENTRIES_BY_SOURCE: Record<CatalogSource, CatalogEntry[]> = {
 /**
  * Grows `visibleCount` in `BATCH_SIZE` steps as a sentinel element at the bottom of the grid enters
  * the viewport, and resets it whenever `resetKey` changes (new search, tab, or category).
+ *
+ * The sentinel is conditionally rendered (only while more entries remain), so a plain `useRef` +
+ * effect keyed on `total` can miss it: if a reset's clamped visible count happens to already equal
+ * the new total, the sentinel skips rendering on that exact commit, the effect observes nothing,
+ * and — because `total` doesn't change again on the next render — never re-fires once the sentinel
+ * does appear. A callback ref sidesteps this: it (dis)connects the observer exactly when the
+ * sentinel DOM node itself mounts or unmounts, independent of render timing.
  */
 function useInfiniteReveal(total: number, resetKey: string) {
   const [visibleCount, setVisibleCount] = useState(BATCH_SIZE);
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const totalRef = useRef(total);
+  totalRef.current = total;
+  const observerRef = useRef<IntersectionObserver | null>(null);
 
   useEffect(() => {
     setVisibleCount(BATCH_SIZE);
   }, [resetKey]);
 
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel) {
+  const sentinelRef = useCallback((node: HTMLDivElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!node) {
       return;
     }
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries[0]?.isIntersecting) {
-          setVisibleCount((count) => Math.min(count + BATCH_SIZE, total));
+          setVisibleCount((count) => Math.min(count + BATCH_SIZE, totalRef.current));
         }
       },
       { rootMargin: '600px' }
     );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [total]);
+    observer.observe(node);
+    observerRef.current = observer;
+  }, []);
+
+  useEffect(() => () => observerRef.current?.disconnect(), []);
 
   return { visibleCount: Math.min(visibleCount, total), sentinelRef };
 }
@@ -138,13 +150,25 @@ function formatBytes(bytes: number): string {
 
 /**
  * Byte size isn't in the generated manifest, so it's measured client-side, once, from the same
- * static files `<use>` already renders. Fetches every uncached Dune SVG in parallel the first time
- * the Dune SVGs tab opens, and bumps `version` in batches so cards and sort fill in progressively
- * rather than waiting on all ~500 requests to land.
+ * static files `<use>` already renders. Uses `HEAD` + `Content-Length` rather than downloading each
+ * body, so measuring all ~500 files costs headers only, not the SVG payloads themselves. Fetches
+ * every uncached Dune SVG in parallel the first time the Dune SVGs tab opens, and bumps `version`
+ * in batches so cards and sort fill in progressively rather than waiting on every request to land.
  */
 function useDuneSvgSizes(enabled: boolean) {
   const [version, setVersion] = useState(0);
   const startedRef = useRef(false);
+  const unmountedRef = useRef(false);
+
+  /* Tracks real unmount only — separate from the `[enabled]` effect below, whose cleanup fires on
+     every tab switch away from Dune, not just on unmount. Sharing one flag between the two used to
+     mean leaving mid-scan permanently stopped `setVersion` from ever firing again for that page
+     load, even though the in-flight fetches kept populating the cache in the background. */
+  useEffect(() => {
+    return () => {
+      unmountedRef.current = true;
+    };
+  }, []);
 
   useEffect(() => {
     if (!enabled || startedRef.current) {
@@ -157,28 +181,25 @@ function useDuneSvgSizes(enabled: boolean) {
         entry.source === 'dune' && !svgByteSizeCache.has(entry.path)
     );
     let completed = 0;
-    let cancelled = false;
 
     for (const entry of missing) {
-      fetch(entry.path)
-        .then((response) => response.arrayBuffer())
-        .then((buffer) => {
-          svgByteSizeCache.set(entry.path, buffer.byteLength);
+      fetch(entry.path, { method: 'HEAD' })
+        .then((response) => {
+          const contentLength = response.headers.get('content-length');
+          if (contentLength) {
+            svgByteSizeCache.set(entry.path, Number.parseInt(contentLength, 10));
+          }
         })
         .catch(() => {
           // Leave unmeasured — size display/sort just treats it as unknown.
         })
         .finally(() => {
           completed += 1;
-          if (!cancelled && (completed % 32 === 0 || completed === missing.length)) {
+          if (!unmountedRef.current && (completed % 32 === 0 || completed === missing.length)) {
             setVersion((v) => v + 1);
           }
         });
     }
-
-    return () => {
-      cancelled = true;
-    };
   }, [enabled]);
 
   return version;
@@ -211,15 +232,21 @@ function IconsPage() {
   }, [query, source, category]);
 
   const sortedEntries = useMemo(() => {
-    if (source !== 'dune' || sortMode === 'name') {
+    if (source !== 'dune') {
       return filteredEntries;
+    }
+    if (sortMode === 'name') {
+      return filteredEntries.slice().sort((a, b) => a.name.localeCompare(b.name));
     }
     const direction = sortMode === 'size-asc' ? 1 : -1;
     return filteredEntries.slice().sort((a, b) => {
-      const sizeA =
-        a.source === 'dune' ? (svgByteSizeCache.get(a.path) ?? Number.POSITIVE_INFINITY) : 0;
-      const sizeB =
-        b.source === 'dune' ? (svgByteSizeCache.get(b.path) ?? Number.POSITIVE_INFINITY) : 0;
+      const sizeA = a.source === 'dune' ? svgByteSizeCache.get(a.path) : undefined;
+      const sizeB = b.source === 'dune' ? svgByteSizeCache.get(b.path) : undefined;
+      /* Unmeasured entries sort after measured ones regardless of direction — multiplying
+         Infinity by -1 for descending order would otherwise put them first, not last. */
+      if (sizeA === undefined || sizeB === undefined) {
+        return sizeA === sizeB ? 0 : sizeA === undefined ? 1 : -1;
+      }
       return (sizeA - sizeB) * direction;
     });
     // sizesVersion isn't read directly, but its change means the cache this sort reads has grown.


### PR DESCRIPTION
## Summary

- **Fix**: the vector train (#307) stripped baked fill/stroke from `inherit`-policy categories (`generic`, `logo`, `troop`, `troop_modifier`). The `/__icons` catalog's Dune SVGs tab rendered those with a plain `<img src>`, so they fell back to unstyled black fill — nearly invisible on the dark theme. Switched to the `<svg><use href="...#root" fill="currentColor"/></svg>` pattern production already uses in `Token.tsx`, `Troop.tsx`, and `Spice.tsx`.
- **Category filter chips** — Background/Decal/Generic/Icon/Logo/Troop/Troop modifier, each with a live count.
- **File size + sort** — byte size isn't in the generated path manifest, so it's measured client-side (fetched once per file, cached) and shown per card, with a Name / Size ↑ / Size ↓ sort control.
- **Infinite scroll** — replaced page-number `Pagination` with an `IntersectionObserver`-driven loader.
- **Bigger icons** — each card's icon now fills a 100%-square `aspect-ratio` box (all these SVGs share a `0 0 100 100` viewBox) instead of a small fixed pixel size, so the art dominates the card instead of the chrome around it.

All changes are contained to [src/app/routes/_app/[_]_icons.tsx](src/app/routes/_app/[_]_icons.tsx) — a debug-only route, no production rendering paths touched.

## Test plan

- [x] `bun run lint` clean
- [x] `bun run format:check` clean
- [x] `tsc --noEmit` clean
- [x] Verified live against the hosted dev Convex deployment: category filters, sort (confirmed size-desc ordering against actual KB values), infinite-scroll counter, and icon rendering (before/after comparison showing the fix resolves the black-silhouette bug) all checked manually in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve the /__icons debug catalog UX and fix Dune SVG rendering for inherit-policy categories.

New Features:
- Add category chips for Dune SVGs with per-category counts and an "All" view.
- Introduce client-side measurement and display of Dune SVG file sizes with name/size sort modes.
- Implement infinite scrolling for the icon catalog using an intersection observer instead of pagination.

Bug Fixes:
- Render Dune SVG icons via inline <svg><use> with currentColor fill to match production and avoid black silhouettes in dark mode.

Enhancements:
- Enlarge icon previews so artwork fills a square slot and reduce card chrome for better visual emphasis.
- Refine Dune SVG tab heading and match-count display to reflect category filters and visible items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added infinite scrolling with progressive batches of icons.
  * Added filtering by source and category, plus sorting by name or size.
  * Added result counts and loading indicators for additional icons.
  * Dune SVGs now render inline and display measured file sizes when available.
  * Expanded icon cards with larger previews and a denser grid layout.
* **Bug Fixes**
  * Search and browsing results now reset correctly when filters or sorting options change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->