### PR TITLE
Overhaul the Group detail page

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "bash",
       "runtimeArgs": ["-c", "bun run generate:vectors && bun run storybook"],
       "port": 6006
+    },
+    {
+      "name": "app-local",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "bun run generate:vectors && bun run app:dev --local"],
+      "port": 3000
     }
   ]
 }

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -28,6 +28,7 @@ import type * as lib_faqProfileActivity from "../lib/faqProfileActivity.js";
 import type * as lib_faqQuestionPage from "../lib/faqQuestionPage.js";
 import type * as lib_faqRulesetList from "../lib/faqRulesetList.js";
 import type * as lib_faqTags from "../lib/faqTags.js";
+import type * as lib_groupAssignPicker from "../lib/groupAssignPicker.js";
 import type * as lib_ids from "../lib/ids.js";
 import type * as lib_policy from "../lib/policy.js";
 import type * as lib_profileActivity from "../lib/profileActivity.js";
@@ -79,6 +80,7 @@ declare const fullApi: ApiFromModules<{
   "lib/faqQuestionPage": typeof lib_faqQuestionPage;
   "lib/faqRulesetList": typeof lib_faqRulesetList;
   "lib/faqTags": typeof lib_faqTags;
+  "lib/groupAssignPicker": typeof lib_groupAssignPicker;
   "lib/ids": typeof lib_ids;
   "lib/policy": typeof lib_policy;
   "lib/profileActivity": typeof lib_profileActivity;

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -23,6 +23,7 @@ import { factionDataValidator } from './lib/factionData';
 import { parseFactionInput } from './lib/factionInput';
 import {
   buildOwnedForGroupAssignRows,
+  OWNED_FOR_GROUP_ASSIGN_LIMIT,
   ownedForGroupAssignRowValidator,
 } from './lib/groupAssignPicker';
 import { requireAuthUserId } from './lib/policy';
@@ -240,7 +241,7 @@ export const listOwnedForGroupAssign = query({
     const rows = await ctx.db
       .query('factions')
       .withIndex('by_owner_deleted', (q) => q.eq('owner_id', userId).eq('is_deleted', false))
-      .take(500);
+      .take(OWNED_FOR_GROUP_ASSIGN_LIMIT);
     return await buildOwnedForGroupAssignRows(
       ctx,
       rows,

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -21,7 +21,10 @@ import {
 import { loadFactionCatalogue, selectFactionCatalogueSpotlights } from './lib/factionCatalogue';
 import { factionDataValidator } from './lib/factionData';
 import { parseFactionInput } from './lib/factionInput';
-import { projectOwnedGroupRef, resolveLiveGroupNames } from './lib/groupAssignPicker';
+import {
+  buildOwnedForGroupAssignRows,
+  ownedForGroupAssignRowValidator,
+} from './lib/groupAssignPicker';
 import { requireAuthUserId } from './lib/policy';
 import { enqueueFactionSheetPublication } from './lib/publication';
 import { nowIso, slugify } from './lib/utils';
@@ -225,36 +228,24 @@ export const listByOwner = query({
   },
 });
 
-const ownedForGroupAssignRowValidator = v.object({
-  id: v.id('factions'),
-  slug: v.string(),
-  name: v.string(),
-  groupId: v.union(v.id('groups'), v.null()),
-  groupName: v.union(v.string(), v.null()),
-});
-
 /**
  * Factions the viewer owns, with their current group's name resolved, for the group-detail "add my
  * faction to this group" picker.
  */
 export const listOwnedForGroupAssign = query({
   args: {},
-  returns: v.array(ownedForGroupAssignRowValidator),
+  returns: v.array(ownedForGroupAssignRowValidator('factions')),
   handler: async (ctx) => {
     const userId = await requireAuthUserId(ctx);
     const rows = await ctx.db
       .query('factions')
       .withIndex('by_owner_deleted', (q) => q.eq('owner_id', userId).eq('is_deleted', false))
       .take(500);
-
-    const groupNameById = await resolveLiveGroupNames(ctx, rows);
-
-    return rows.map((row) => ({
-      id: row._id,
-      slug: row.slug,
-      name: factionDataForClient(row.data).name,
-      ...projectOwnedGroupRef(row.group_id, groupNameById),
-    }));
+    return await buildOwnedForGroupAssignRows(
+      ctx,
+      rows,
+      (row) => factionDataForClient(row.data).name
+    );
   },
 });
 

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -21,6 +21,7 @@ import {
 import { loadFactionCatalogue, selectFactionCatalogueSpotlights } from './lib/factionCatalogue';
 import { factionDataValidator } from './lib/factionData';
 import { parseFactionInput } from './lib/factionInput';
+import { projectOwnedGroupRef, resolveLiveGroupNames } from './lib/groupAssignPicker';
 import { requireAuthUserId } from './lib/policy';
 import { enqueueFactionSheetPublication } from './lib/publication';
 import { nowIso, slugify } from './lib/utils';
@@ -246,30 +247,14 @@ export const listOwnedForGroupAssign = query({
       .withIndex('by_owner_deleted', (q) => q.eq('owner_id', userId).eq('is_deleted', false))
       .take(500);
 
-    const groupIds = new Set<Id<'groups'>>();
-    for (const row of rows) {
-      if (row.group_id) {
-        groupIds.add(row.group_id);
-      }
-    }
-    const groupNameById = new Map<string, string>();
-    for (const gid of groupIds) {
-      const group = await ctx.db.get('groups', gid);
-      if (group && !group.is_deleted) {
-        groupNameById.set(gid, group.name.trim());
-      }
-    }
+    const groupNameById = await resolveLiveGroupNames(ctx, rows);
 
-    return rows.map((row) => {
-      const groupId = row.group_id && groupNameById.has(row.group_id) ? row.group_id : null;
-      return {
-        id: row._id,
-        slug: row.slug,
-        name: factionDataForClient(row.data).name,
-        groupId,
-        groupName: groupId ? (groupNameById.get(groupId) ?? null) : null,
-      };
-    });
+    return rows.map((row) => ({
+      id: row._id,
+      slug: row.slug,
+      name: factionDataForClient(row.data).name,
+      ...projectOwnedGroupRef(row.group_id, groupNameById),
+    }));
   },
 });
 

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -224,6 +224,55 @@ export const listByOwner = query({
   },
 });
 
+const ownedForGroupAssignRowValidator = v.object({
+  id: v.id('factions'),
+  slug: v.string(),
+  name: v.string(),
+  groupId: v.union(v.id('groups'), v.null()),
+  groupName: v.union(v.string(), v.null()),
+});
+
+/**
+ * Factions the viewer owns, with their current group's name resolved, for the group-detail "add my
+ * faction to this group" picker.
+ */
+export const listOwnedForGroupAssign = query({
+  args: {},
+  returns: v.array(ownedForGroupAssignRowValidator),
+  handler: async (ctx) => {
+    const userId = await requireAuthUserId(ctx);
+    const rows = await ctx.db
+      .query('factions')
+      .withIndex('by_owner_deleted', (q) => q.eq('owner_id', userId).eq('is_deleted', false))
+      .take(500);
+
+    const groupIds = new Set<Id<'groups'>>();
+    for (const row of rows) {
+      if (row.group_id) {
+        groupIds.add(row.group_id);
+      }
+    }
+    const groupNameById = new Map<string, string>();
+    for (const gid of groupIds) {
+      const group = await ctx.db.get('groups', gid);
+      if (group && !group.is_deleted) {
+        groupNameById.set(gid, group.name.trim());
+      }
+    }
+
+    return rows.map((row) => {
+      const groupId = row.group_id && groupNameById.has(row.group_id) ? row.group_id : null;
+      return {
+        id: row._id,
+        slug: row.slug,
+        name: factionDataForClient(row.data).name,
+        groupId,
+        groupName: groupId ? (groupNameById.get(groupId) ?? null) : null,
+      };
+    });
+  },
+});
+
 export const listByGroup = query({
   args: {
     group_id: v.id('groups'),

--- a/convex/groupAssignPicker.test.ts
+++ b/convex/groupAssignPicker.test.ts
@@ -7,123 +7,148 @@ import { describe, expect, test } from 'vitest';
 import { assetPublishingFaction } from '../src/game/fixtures/assetPublishingFaction';
 import { api } from './_generated/api';
 import schema from './schema';
+import type { MutationCtx } from './types';
 
 const modules = import.meta.glob('./**/*.ts');
 const now = '2026-08-10T00:00:00.000Z';
 
+async function seedUsersAndGroups(ctx: MutationCtx) {
+  const ownerId = await ctx.db.insert('users', { name: 'Owner' });
+  const otherId = await ctx.db.insert('users', { name: 'Other owner' });
+
+  const targetGroupId = await ctx.db.insert('groups', {
+    name: 'Target Guild',
+    slug: 'target-guild',
+    created_at: now,
+    created_by: ownerId,
+    is_deleted: false,
+  });
+  const otherGroupId = await ctx.db.insert('groups', {
+    name: 'Other Guild',
+    slug: 'other-guild',
+    created_at: now,
+    created_by: ownerId,
+    is_deleted: false,
+  });
+  const deletedGroupId = await ctx.db.insert('groups', {
+    name: 'Deleted Guild',
+    slug: 'deleted-guild',
+    created_at: now,
+    created_by: ownerId,
+    is_deleted: true,
+  });
+
+  return { ownerId, otherId, targetGroupId, otherGroupId, deletedGroupId };
+}
+
+async function seedFactions(
+  ctx: MutationCtx,
+  seeded: Awaited<ReturnType<typeof seedUsersAndGroups>>
+) {
+  const { ownerId, otherId, otherGroupId, deletedGroupId } = seeded;
+
+  const unassignedFactionId = await ctx.db.insert('factions', {
+    owner_id: ownerId,
+    data: { ...assetPublishingFaction, name: 'Unassigned Faction' },
+    slug: 'unassigned-faction',
+    created_at: now,
+    updated_at: now,
+    is_deleted: false,
+    group_id: null,
+  });
+  const elsewhereFactionId = await ctx.db.insert('factions', {
+    owner_id: ownerId,
+    data: { ...assetPublishingFaction, name: 'Elsewhere Faction' },
+    slug: 'elsewhere-faction',
+    created_at: now,
+    updated_at: now,
+    is_deleted: false,
+    group_id: otherGroupId,
+  });
+  await ctx.db.insert('factions', {
+    owner_id: ownerId,
+    data: { ...assetPublishingFaction, name: 'Deleted Faction' },
+    slug: 'deleted-faction',
+    created_at: now,
+    updated_at: now,
+    is_deleted: true,
+    group_id: null,
+  });
+  await ctx.db.insert('factions', {
+    owner_id: otherId,
+    data: { ...assetPublishingFaction, name: 'Someone Elses Faction' },
+    slug: 'someone-elses-faction',
+    created_at: now,
+    updated_at: now,
+    is_deleted: false,
+    group_id: null,
+  });
+  const danglingGroupFactionId = await ctx.db.insert('factions', {
+    owner_id: ownerId,
+    data: { ...assetPublishingFaction, name: 'Dangling Group Faction' },
+    slug: 'dangling-group-faction',
+    created_at: now,
+    updated_at: now,
+    is_deleted: false,
+    group_id: deletedGroupId,
+  });
+
+  return { unassignedFactionId, elsewhereFactionId, danglingGroupFactionId };
+}
+
+async function seedRulesets(
+  ctx: MutationCtx,
+  seeded: Awaited<ReturnType<typeof seedUsersAndGroups>>
+) {
+  const { ownerId, otherId } = seeded;
+
+  const unassignedRulesetId = await ctx.db.insert('rulesets', {
+    name: 'UnassignedRuleset',
+    slug: 'unassigned-ruleset',
+    created_at: now,
+    updated_at: now,
+    owner_id: ownerId,
+    group_id: null,
+    is_deleted: false,
+    image_cover: null,
+  });
+  await ctx.db.insert('rulesets', {
+    name: 'DeletedRuleset',
+    slug: 'deleted-ruleset',
+    created_at: now,
+    updated_at: now,
+    owner_id: ownerId,
+    group_id: null,
+    is_deleted: true,
+    image_cover: null,
+  });
+  await ctx.db.insert('rulesets', {
+    name: 'SomeoneElsesRuleset',
+    slug: 'someone-elses-ruleset',
+    created_at: now,
+    updated_at: now,
+    owner_id: otherId,
+    group_id: null,
+    is_deleted: false,
+    image_cover: null,
+  });
+
+  return { unassignedRulesetId };
+}
+
 async function fixture() {
   const t = convexTest(schema, modules);
   const ids = await t.run(async (ctx) => {
-    const ownerId = await ctx.db.insert('users', { name: 'Owner' });
-    const otherId = await ctx.db.insert('users', { name: 'Other owner' });
-
-    const targetGroupId = await ctx.db.insert('groups', {
-      name: 'Target Guild',
-      slug: 'target-guild',
-      created_at: now,
-      created_by: ownerId,
-      is_deleted: false,
-    });
-    const otherGroupId = await ctx.db.insert('groups', {
-      name: 'Other Guild',
-      slug: 'other-guild',
-      created_at: now,
-      created_by: ownerId,
-      is_deleted: false,
-    });
-    const deletedGroupId = await ctx.db.insert('groups', {
-      name: 'Deleted Guild',
-      slug: 'deleted-guild',
-      created_at: now,
-      created_by: ownerId,
-      is_deleted: true,
-    });
-
-    const unassignedFactionId = await ctx.db.insert('factions', {
-      owner_id: ownerId,
-      data: { ...assetPublishingFaction, name: 'Unassigned Faction' },
-      slug: 'unassigned-faction',
-      created_at: now,
-      updated_at: now,
-      is_deleted: false,
-      group_id: null,
-    });
-    const elsewhereFactionId = await ctx.db.insert('factions', {
-      owner_id: ownerId,
-      data: { ...assetPublishingFaction, name: 'Elsewhere Faction' },
-      slug: 'elsewhere-faction',
-      created_at: now,
-      updated_at: now,
-      is_deleted: false,
-      group_id: otherGroupId,
-    });
-    await ctx.db.insert('factions', {
-      owner_id: ownerId,
-      data: { ...assetPublishingFaction, name: 'Deleted Faction' },
-      slug: 'deleted-faction',
-      created_at: now,
-      updated_at: now,
-      is_deleted: true,
-      group_id: null,
-    });
-    await ctx.db.insert('factions', {
-      owner_id: otherId,
-      data: { ...assetPublishingFaction, name: 'Someone Elses Faction' },
-      slug: 'someone-elses-faction',
-      created_at: now,
-      updated_at: now,
-      is_deleted: false,
-      group_id: null,
-    });
-    const danglingGroupFactionId = await ctx.db.insert('factions', {
-      owner_id: ownerId,
-      data: { ...assetPublishingFaction, name: 'Dangling Group Faction' },
-      slug: 'dangling-group-faction',
-      created_at: now,
-      updated_at: now,
-      is_deleted: false,
-      group_id: deletedGroupId,
-    });
-
-    const unassignedRulesetId = await ctx.db.insert('rulesets', {
-      name: 'UnassignedRuleset',
-      slug: 'unassigned-ruleset',
-      created_at: now,
-      updated_at: now,
-      owner_id: ownerId,
-      group_id: null,
-      is_deleted: false,
-      image_cover: null,
-    });
-    await ctx.db.insert('rulesets', {
-      name: 'DeletedRuleset',
-      slug: 'deleted-ruleset',
-      created_at: now,
-      updated_at: now,
-      owner_id: ownerId,
-      group_id: null,
-      is_deleted: true,
-      image_cover: null,
-    });
-    await ctx.db.insert('rulesets', {
-      name: 'SomeoneElsesRuleset',
-      slug: 'someone-elses-ruleset',
-      created_at: now,
-      updated_at: now,
-      owner_id: otherId,
-      group_id: null,
-      is_deleted: false,
-      image_cover: null,
-    });
+    const seeded = await seedUsersAndGroups(ctx);
+    const factionIds = await seedFactions(ctx, seeded);
+    const rulesetIds = await seedRulesets(ctx, seeded);
 
     return {
-      ownerId,
-      targetGroupId,
-      otherGroupId,
-      unassignedFactionId,
-      elsewhereFactionId,
-      danglingGroupFactionId,
-      unassignedRulesetId,
+      ownerId: seeded.ownerId,
+      targetGroupId: seeded.targetGroupId,
+      otherGroupId: seeded.otherGroupId,
+      ...factionIds,
+      ...rulesetIds,
     };
   });
 

--- a/convex/groupAssignPicker.test.ts
+++ b/convex/groupAssignPicker.test.ts
@@ -183,7 +183,9 @@ describe('factions.listOwnedForGroupAssign', () => {
 
   test('requires authentication', async () => {
     const { t } = await fixture();
-    await expect(t.query(api.factions.listOwnedForGroupAssign, {})).rejects.toThrow();
+    await expect(t.query(api.factions.listOwnedForGroupAssign, {})).rejects.toThrow(
+      /Not authenticated/
+    );
   });
 });
 
@@ -204,6 +206,8 @@ describe('rulesets.listOwnedForGroupAssign', () => {
 
   test('requires authentication', async () => {
     const { t } = await fixture();
-    await expect(t.query(api.rulesets.listOwnedForGroupAssign, {})).rejects.toThrow();
+    await expect(t.query(api.rulesets.listOwnedForGroupAssign, {})).rejects.toThrow(
+      /Not authenticated/
+    );
   });
 });

--- a/convex/groupAssignPicker.test.ts
+++ b/convex/groupAssignPicker.test.ts
@@ -1,0 +1,184 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import { convexTest } from 'convex-test';
+import { describe, expect, test } from 'vitest';
+
+import { assetPublishingFaction } from '../src/game/fixtures/assetPublishingFaction';
+import { api } from './_generated/api';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+const now = '2026-08-10T00:00:00.000Z';
+
+async function fixture() {
+  const t = convexTest(schema, modules);
+  const ids = await t.run(async (ctx) => {
+    const ownerId = await ctx.db.insert('users', { name: 'Owner' });
+    const otherId = await ctx.db.insert('users', { name: 'Other owner' });
+
+    const targetGroupId = await ctx.db.insert('groups', {
+      name: 'Target Guild',
+      slug: 'target-guild',
+      created_at: now,
+      created_by: ownerId,
+      is_deleted: false,
+    });
+    const otherGroupId = await ctx.db.insert('groups', {
+      name: 'Other Guild',
+      slug: 'other-guild',
+      created_at: now,
+      created_by: ownerId,
+      is_deleted: false,
+    });
+    const deletedGroupId = await ctx.db.insert('groups', {
+      name: 'Deleted Guild',
+      slug: 'deleted-guild',
+      created_at: now,
+      created_by: ownerId,
+      is_deleted: true,
+    });
+
+    const unassignedFactionId = await ctx.db.insert('factions', {
+      owner_id: ownerId,
+      data: { ...assetPublishingFaction, name: 'Unassigned Faction' },
+      slug: 'unassigned-faction',
+      created_at: now,
+      updated_at: now,
+      is_deleted: false,
+      group_id: null,
+    });
+    const elsewhereFactionId = await ctx.db.insert('factions', {
+      owner_id: ownerId,
+      data: { ...assetPublishingFaction, name: 'Elsewhere Faction' },
+      slug: 'elsewhere-faction',
+      created_at: now,
+      updated_at: now,
+      is_deleted: false,
+      group_id: otherGroupId,
+    });
+    await ctx.db.insert('factions', {
+      owner_id: ownerId,
+      data: { ...assetPublishingFaction, name: 'Deleted Faction' },
+      slug: 'deleted-faction',
+      created_at: now,
+      updated_at: now,
+      is_deleted: true,
+      group_id: null,
+    });
+    await ctx.db.insert('factions', {
+      owner_id: otherId,
+      data: { ...assetPublishingFaction, name: 'Someone Elses Faction' },
+      slug: 'someone-elses-faction',
+      created_at: now,
+      updated_at: now,
+      is_deleted: false,
+      group_id: null,
+    });
+    const danglingGroupFactionId = await ctx.db.insert('factions', {
+      owner_id: ownerId,
+      data: { ...assetPublishingFaction, name: 'Dangling Group Faction' },
+      slug: 'dangling-group-faction',
+      created_at: now,
+      updated_at: now,
+      is_deleted: false,
+      group_id: deletedGroupId,
+    });
+
+    const unassignedRulesetId = await ctx.db.insert('rulesets', {
+      name: 'UnassignedRuleset',
+      slug: 'unassigned-ruleset',
+      created_at: now,
+      updated_at: now,
+      owner_id: ownerId,
+      group_id: null,
+      is_deleted: false,
+      image_cover: null,
+    });
+    await ctx.db.insert('rulesets', {
+      name: 'DeletedRuleset',
+      slug: 'deleted-ruleset',
+      created_at: now,
+      updated_at: now,
+      owner_id: ownerId,
+      group_id: null,
+      is_deleted: true,
+      image_cover: null,
+    });
+    await ctx.db.insert('rulesets', {
+      name: 'SomeoneElsesRuleset',
+      slug: 'someone-elses-ruleset',
+      created_at: now,
+      updated_at: now,
+      owner_id: otherId,
+      group_id: null,
+      is_deleted: false,
+      image_cover: null,
+    });
+
+    return {
+      ownerId,
+      targetGroupId,
+      otherGroupId,
+      unassignedFactionId,
+      elsewhereFactionId,
+      danglingGroupFactionId,
+      unassignedRulesetId,
+    };
+  });
+
+  return { t, owner: t.withIdentity({ subject: ids.ownerId }), ids };
+}
+
+describe('factions.listOwnedForGroupAssign', () => {
+  test("lists only the viewer's own, live factions with the current group name resolved", async () => {
+    const { owner, ids } = await fixture();
+    const rows = await owner.query(api.factions.listOwnedForGroupAssign, {});
+
+    const bySlug = new Map(rows.map((row) => [row.slug, row]));
+    expect(bySlug.size).toBe(3);
+    expect(bySlug.get('unassigned-faction')).toMatchObject({
+      groupId: null,
+      groupName: null,
+    });
+    expect(bySlug.get('elsewhere-faction')).toMatchObject({
+      groupId: ids.otherGroupId,
+      groupName: 'Other Guild',
+    });
+    expect(bySlug.has('deleted-faction')).toBe(false);
+    expect(bySlug.has('someone-elses-faction')).toBe(false);
+  });
+
+  test('projects a group_id pointing at a soft-deleted group to unassigned', async () => {
+    const { owner } = await fixture();
+    const rows = await owner.query(api.factions.listOwnedForGroupAssign, {});
+    const danglingRow = rows.find((row) => row.slug === 'dangling-group-faction');
+    expect(danglingRow).toMatchObject({ groupId: null, groupName: null });
+  });
+
+  test('requires authentication', async () => {
+    const { t } = await fixture();
+    await expect(t.query(api.factions.listOwnedForGroupAssign, {})).rejects.toThrow();
+  });
+});
+
+describe('rulesets.listOwnedForGroupAssign', () => {
+  test("lists only the viewer's own, live rulesets", async () => {
+    const { owner } = await fixture();
+    const rows = await owner.query(api.rulesets.listOwnedForGroupAssign, {});
+
+    const bySlug = new Map(rows.map((row) => [row.slug, row]));
+    expect(bySlug.size).toBe(1);
+    expect(bySlug.get('unassigned-ruleset')).toMatchObject({
+      groupId: null,
+      groupName: null,
+    });
+    expect(bySlug.has('deleted-ruleset')).toBe(false);
+    expect(bySlug.has('someone-elses-ruleset')).toBe(false);
+  });
+
+  test('requires authentication', async () => {
+    const { t } = await fixture();
+    await expect(t.query(api.rulesets.listOwnedForGroupAssign, {})).rejects.toThrow();
+  });
+});

--- a/convex/lib/groupAssignPicker.ts
+++ b/convex/lib/groupAssignPicker.ts
@@ -1,3 +1,5 @@
+import { v } from 'convex/values';
+
 import type { Id } from '../_generated/dataModel';
 import type { QueryCtx } from '../types';
 
@@ -34,4 +36,48 @@ export function projectOwnedGroupRef(
     groupId: liveGroupId,
     groupName: liveGroupId ? (groupNameById.get(liveGroupId) ?? null) : null,
   };
+}
+
+type OwnedTableName = 'factions' | 'rulesets';
+
+/** Row shape shared by the group-detail "add my faction/ruleset to this group" pickers. */
+export function ownedForGroupAssignRowValidator<TableName extends OwnedTableName>(
+  table: TableName
+) {
+  return v.object({
+    id: v.id(table),
+    slug: v.string(),
+    name: v.string(),
+    groupId: v.union(v.id('groups'), v.null()),
+    groupName: v.union(v.string(), v.null()),
+  });
+}
+
+type OwnedForGroupAssignRow = OwnedRowWithGroup & { _id: Id<OwnedTableName>; slug: string };
+
+/**
+ * Projects already-fetched owned rows into the group-detail "add my faction/ruleset to this group"
+ * picker shape, resolving each row's current (live) group name.
+ */
+export async function buildOwnedForGroupAssignRows<Row extends OwnedForGroupAssignRow>(
+  ctx: QueryCtx,
+  rows: readonly Row[],
+  nameOf: (row: Row) => string
+): Promise<
+  {
+    id: Row['_id'];
+    slug: string;
+    name: string;
+    groupId: Id<'groups'> | null;
+    groupName: string | null;
+  }[]
+> {
+  const groupNameById = await resolveLiveGroupNames(ctx, rows);
+
+  return rows.map((row) => ({
+    id: row._id,
+    slug: row.slug,
+    name: nameOf(row),
+    ...projectOwnedGroupRef(row.group_id, groupNameById),
+  }));
 }

--- a/convex/lib/groupAssignPicker.ts
+++ b/convex/lib/groupAssignPicker.ts
@@ -1,0 +1,37 @@
+import type { Id } from '../_generated/dataModel';
+import type { QueryCtx } from '../types';
+
+type OwnedRowWithGroup = { group_id: Id<'groups'> | null };
+
+/** Live (non-deleted) group names for every distinct group_id referenced by `rows`. */
+export async function resolveLiveGroupNames(
+  ctx: QueryCtx,
+  rows: readonly OwnedRowWithGroup[]
+): Promise<Map<Id<'groups'>, string>> {
+  const groupIds = new Set<Id<'groups'>>();
+  for (const row of rows) {
+    if (row.group_id) {
+      groupIds.add(row.group_id);
+    }
+  }
+  const groupNameById = new Map<Id<'groups'>, string>();
+  for (const gid of groupIds) {
+    const group = await ctx.db.get('groups', gid);
+    if (group && !group.is_deleted) {
+      groupNameById.set(gid, group.name.trim());
+    }
+  }
+  return groupNameById;
+}
+
+/** Projects a `group_id` to `{groupId, groupName}`, nulling out references to soft-deleted groups. */
+export function projectOwnedGroupRef(
+  groupId: Id<'groups'> | null,
+  groupNameById: Map<Id<'groups'>, string>
+): { groupId: Id<'groups'> | null; groupName: string | null } {
+  const liveGroupId = groupId && groupNameById.has(groupId) ? groupId : null;
+  return {
+    groupId: liveGroupId,
+    groupName: liveGroupId ? (groupNameById.get(liveGroupId) ?? null) : null,
+  };
+}

--- a/convex/lib/groupAssignPicker.ts
+++ b/convex/lib/groupAssignPicker.ts
@@ -2,8 +2,11 @@ import { v } from 'convex/values';
 
 import type { Id } from '../_generated/dataModel';
 import type { QueryCtx } from '../types';
+import { liveGroupOrNull } from './collaborativeAccess';
 
 type OwnedRowWithGroup = { group_id: Id<'groups'> | null };
+
+export const OWNED_FOR_GROUP_ASSIGN_LIMIT = 500;
 
 /** Live (non-deleted) group names for every distinct group_id referenced by `rows`. */
 export async function resolveLiveGroupNames(
@@ -16,11 +19,12 @@ export async function resolveLiveGroupNames(
       groupIds.add(row.group_id);
     }
   }
+  const groups = await Promise.all([...groupIds].map((gid) => ctx.db.get('groups', gid)));
   const groupNameById = new Map<Id<'groups'>, string>();
-  for (const gid of groupIds) {
-    const group = await ctx.db.get('groups', gid);
-    if (group && !group.is_deleted) {
-      groupNameById.set(gid, group.name.trim());
+  for (const candidate of groups) {
+    const group = liveGroupOrNull(candidate);
+    if (group) {
+      groupNameById.set(group._id, group.name.trim());
     }
   }
   return groupNameById;

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -16,6 +16,7 @@ import {
 } from './lib/collaborativeAccessValidators';
 import {
   buildOwnedForGroupAssignRows,
+  OWNED_FOR_GROUP_ASSIGN_LIMIT,
   ownedForGroupAssignRowValidator,
 } from './lib/groupAssignPicker';
 import { requireAuthUserId } from './lib/policy';
@@ -96,7 +97,7 @@ export const listOwnedForGroupAssign = query({
     const rows = await ctx.db
       .query('rulesets')
       .withIndex('by_owner_deleted', (q) => q.eq('owner_id', userId).eq('is_deleted', false))
-      .take(500);
+      .take(OWNED_FOR_GROUP_ASSIGN_LIMIT);
     return await buildOwnedForGroupAssignRows(ctx, rows, (row) => row.name);
   },
 });

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -14,6 +14,7 @@ import {
   rulesetDetailPageValidator,
   rulesetPublicBundleValidator,
 } from './lib/collaborativeAccessValidators';
+import { projectOwnedGroupRef, resolveLiveGroupNames } from './lib/groupAssignPicker';
 import { requireAuthUserId } from './lib/policy';
 import {
   loadRulesetDetailPageBySlug,
@@ -102,30 +103,14 @@ export const listOwnedForGroupAssign = query({
       .withIndex('by_owner_deleted', (q) => q.eq('owner_id', userId).eq('is_deleted', false))
       .take(500);
 
-    const groupIds = new Set<Id<'groups'>>();
-    for (const row of rows) {
-      if (row.group_id) {
-        groupIds.add(row.group_id);
-      }
-    }
-    const groupNameById = new Map<string, string>();
-    for (const gid of groupIds) {
-      const group = await ctx.db.get('groups', gid);
-      if (group && !group.is_deleted) {
-        groupNameById.set(gid, group.name.trim());
-      }
-    }
+    const groupNameById = await resolveLiveGroupNames(ctx, rows);
 
-    return rows.map((row) => {
-      const groupId = row.group_id && groupNameById.has(row.group_id) ? row.group_id : null;
-      return {
-        id: row._id,
-        slug: row.slug,
-        name: row.name,
-        groupId,
-        groupName: groupId ? (groupNameById.get(groupId) ?? null) : null,
-      };
-    });
+    return rows.map((row) => ({
+      id: row._id,
+      slug: row.slug,
+      name: row.name,
+      ...projectOwnedGroupRef(row.group_id, groupNameById),
+    }));
   },
 });
 

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -80,6 +80,55 @@ export const detailPageBySlug = query({
   handler: async (ctx, args) => await loadRulesetDetailPageBySlug(ctx, args.slug),
 });
 
+const ownedForGroupAssignRowValidator = v.object({
+  id: v.id('rulesets'),
+  slug: v.string(),
+  name: v.string(),
+  groupId: v.union(v.id('groups'), v.null()),
+  groupName: v.union(v.string(), v.null()),
+});
+
+/**
+ * Rulesets the viewer owns, with their current group's name resolved, for the group-detail "add my
+ * ruleset to this group" picker.
+ */
+export const listOwnedForGroupAssign = query({
+  args: {},
+  returns: v.array(ownedForGroupAssignRowValidator),
+  handler: async (ctx) => {
+    const userId = await requireAuthUserId(ctx);
+    const rows = await ctx.db
+      .query('rulesets')
+      .withIndex('by_owner_deleted', (q) => q.eq('owner_id', userId).eq('is_deleted', false))
+      .take(500);
+
+    const groupIds = new Set<Id<'groups'>>();
+    for (const row of rows) {
+      if (row.group_id) {
+        groupIds.add(row.group_id);
+      }
+    }
+    const groupNameById = new Map<string, string>();
+    for (const gid of groupIds) {
+      const group = await ctx.db.get('groups', gid);
+      if (group && !group.is_deleted) {
+        groupNameById.set(gid, group.name.trim());
+      }
+    }
+
+    return rows.map((row) => {
+      const groupId = row.group_id && groupNameById.has(row.group_id) ? row.group_id : null;
+      return {
+        id: row._id,
+        slug: row.slug,
+        name: row.name,
+        groupId,
+        groupName: groupId ? (groupNameById.get(groupId) ?? null) : null,
+      };
+    });
+  },
+});
+
 export const listByFaction = query({
   args: { faction_id: v.id('factions') },
   handler: async (ctx, args) => {

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -14,7 +14,10 @@ import {
   rulesetDetailPageValidator,
   rulesetPublicBundleValidator,
 } from './lib/collaborativeAccessValidators';
-import { projectOwnedGroupRef, resolveLiveGroupNames } from './lib/groupAssignPicker';
+import {
+  buildOwnedForGroupAssignRows,
+  ownedForGroupAssignRowValidator,
+} from './lib/groupAssignPicker';
 import { requireAuthUserId } from './lib/policy';
 import {
   loadRulesetDetailPageBySlug,
@@ -81,36 +84,20 @@ export const detailPageBySlug = query({
   handler: async (ctx, args) => await loadRulesetDetailPageBySlug(ctx, args.slug),
 });
 
-const ownedForGroupAssignRowValidator = v.object({
-  id: v.id('rulesets'),
-  slug: v.string(),
-  name: v.string(),
-  groupId: v.union(v.id('groups'), v.null()),
-  groupName: v.union(v.string(), v.null()),
-});
-
 /**
  * Rulesets the viewer owns, with their current group's name resolved, for the group-detail "add my
  * ruleset to this group" picker.
  */
 export const listOwnedForGroupAssign = query({
   args: {},
-  returns: v.array(ownedForGroupAssignRowValidator),
+  returns: v.array(ownedForGroupAssignRowValidator('rulesets')),
   handler: async (ctx) => {
     const userId = await requireAuthUserId(ctx);
     const rows = await ctx.db
       .query('rulesets')
       .withIndex('by_owner_deleted', (q) => q.eq('owner_id', userId).eq('is_deleted', false))
       .take(500);
-
-    const groupNameById = await resolveLiveGroupNames(ctx, rows);
-
-    return rows.map((row) => ({
-      id: row._id,
-      slug: row.slug,
-      name: row.name,
-      ...projectOwnedGroupRef(row.group_id, groupNameById),
-    }));
+    return await buildOwnedForGroupAssignRows(ctx, rows, (row) => row.name);
   },
 });
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -97,6 +97,11 @@ export default async function globalSetup(config: FullConfig) {
       password: userPassword,
       storageStatePath: '.playwright/user-a-group.json',
     },
+    {
+      email: userAEmail,
+      password: userPassword,
+      storageStatePath: '.playwright/user-a-asset-assign.json',
+    },
     { email: userBEmail, password: userPassword, storageStatePath: '.playwright/user-b.json' },
     { email: userBEmail, password: userPassword, storageStatePath: '.playwright/user-b-faq.json' },
     {

--- a/e2e/group-asset-assign.spec.ts
+++ b/e2e/group-asset-assign.spec.ts
@@ -1,0 +1,41 @@
+import { expect, longSpecTimeoutMs, test } from './coverage';
+
+test.use({ storageState: '.playwright/user-a-group.json' });
+
+test('owner adds an owned, unassigned faction to their Group', async ({ page }) => {
+  test.setTimeout(longSpecTimeoutMs);
+
+  const suffix = Date.now();
+  const groupName = `E2EAssetAssign${suffix}`;
+  const factionName = `E2EAssetAssignFaction${suffix}`;
+
+  await test.step('owner creates the Group', async () => {
+    await page.goto('/groups/create');
+    await page.getByRole('textbox', { name: 'Group name' }).fill(groupName);
+    await page.getByRole('button', { name: 'Save group' }).click();
+    await expect(page).toHaveURL(/\/profiles\//);
+  });
+
+  await test.step('owner creates an unassigned faction', async () => {
+    await page.goto('/factions/create');
+    await page.getByRole('textbox', { name: 'Faction name' }).fill(factionName);
+    await page.getByRole('tab', { name: /^Faction leader/ }).click();
+    await page.getByRole('textbox', { name: 'Faction leader name' }).fill('Leader');
+    await page.getByRole('button', { name: 'Save faction' }).click();
+    await expect(page).toHaveURL(new RegExp(`/factions/${factionName.toLowerCase()}/edit$`));
+  });
+
+  await test.step('owner adds the faction to the Group from the picker', async () => {
+    await page.goto(`/groups/${groupName.toLowerCase()}`);
+    await expect(page.getByRole('heading', { name: groupName })).toBeVisible();
+    await expect(page.getByText(factionName)).not.toBeVisible();
+
+    await page.getByRole('button', { name: 'Add a faction you own' }).click();
+    const search = page.getByRole('combobox', { name: 'Search your factions' });
+    await search.fill(factionName);
+    await page.getByRole('option').filter({ hasText: factionName }).click();
+    await page.getByRole('button', { name: 'Add to this group' }).click();
+
+    await expect(page.getByText(factionName)).toBeVisible();
+  });
+});

--- a/e2e/group-asset-assign.spec.ts
+++ b/e2e/group-asset-assign.spec.ts
@@ -1,6 +1,6 @@
 import { expect, longSpecTimeoutMs, test } from './coverage';
 
-test.use({ storageState: '.playwright/user-a-group.json' });
+test.use({ storageState: '.playwright/user-a-asset-assign.json' });
 
 test('owner adds an owned, unassigned faction to their Group', async ({ page }) => {
   test.setTimeout(longSpecTimeoutMs);

--- a/e2e/group-asset-assign.spec.ts
+++ b/e2e/group-asset-assign.spec.ts
@@ -36,6 +36,7 @@ test('owner adds an owned, unassigned faction to their Group', async ({ page }) 
     await page.getByRole('option').filter({ hasText: factionName }).click();
     await page.getByRole('button', { name: 'Add to this group' }).click();
 
-    await expect(page.getByText(factionName)).toBeVisible();
+    await expect(page.getByRole('link', { name: factionName })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Add to this group' })).not.toBeVisible();
   });
 });

--- a/e2e/group-membership-lifecycle.spec.ts
+++ b/e2e/group-membership-lifecycle.spec.ts
@@ -30,9 +30,9 @@ test('membership lifecycle: request, approve, moderate, remove', async ({ page, 
 
   await test.step('owner approves from the roster', async () => {
     await page.goto(groupUrl);
-    await expect(page.getByText('(pending)')).toBeVisible();
+    await expect(page.getByText('Pending requests')).toBeVisible();
     await page.getByRole('button', { name: 'Approve membership' }).click();
-    await expect(page.getByText('(pending)')).not.toBeVisible();
+    await expect(page.getByText('Pending requests')).not.toBeVisible();
   });
 
   await test.step('member sees active status through the live subscription', async () => {

--- a/src/app/components/groups/AssetAssignPopover.tsx
+++ b/src/app/components/groups/AssetAssignPopover.tsx
@@ -13,9 +13,12 @@ import {
 import { Plus } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
+/**
+ * The popover's minimal structural requirement on a picked row — satisfied by the (validator-
+ * derived) `listOwnedForGroupAssign` row types, which remain the shape's authority.
+ */
 export interface AssetAssignOption {
   id: string;
-  slug: string;
   name: string;
   groupId: string | null;
   groupName: string | null;
@@ -24,6 +27,7 @@ export interface AssetAssignOption {
 export interface AssetAssignPopoverProps {
   kind: 'faction' | 'ruleset';
   disabled: boolean;
+  loading: boolean;
   currentGroupId: string;
   currentGroupName: string;
   ownedItems: AssetAssignOption[];
@@ -37,6 +41,7 @@ export interface AssetAssignPopoverProps {
 export function AssetAssignPopover({
   kind,
   disabled,
+  loading,
   currentGroupId,
   currentGroupName,
   ownedItems,
@@ -119,7 +124,7 @@ export function AssetAssignPopover({
             size="sm"
             aria-label={`Add a ${kind} you own`}
             disabled={disabled}
-            onClick={() => setOpened((current) => !current)}
+            onClick={() => handleOpenedChange(!opened)}
           >
             <Plus size={14} aria-hidden />
           </ActionIcon>
@@ -144,13 +149,19 @@ export function AssetAssignPopover({
               </Alert>
             ) : null}
 
-            {options.length === 0 ? (
+            {loading ? (
+              <Text size="sm" c="dimmed">
+                Loading your {kind}s…
+              </Text>
+            ) : null}
+            {!loading && options.length === 0 ? (
               <Text size="sm" c="dimmed">
                 {ownedItems.length === 0
                   ? `You don't own any ${kind}s yet.`
                   : `All your ${kind}s are already in this group.`}
               </Text>
-            ) : (
+            ) : null}
+            {!loading && options.length > 0 ? (
               <Stack gap="md">
                 <Select
                   label={`Search your ${kind}s`}
@@ -176,7 +187,7 @@ export function AssetAssignPopover({
                   </Button>
                 </Group>
               </Stack>
-            )}
+            ) : null}
           </Stack>
         ) : null}
       </Popover.Dropdown>

--- a/src/app/components/groups/AssetAssignPopover.tsx
+++ b/src/app/components/groups/AssetAssignPopover.tsx
@@ -13,7 +13,7 @@ import {
 import { Plus } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
-interface AssetAssignOption {
+export interface AssetAssignOption {
   id: string;
   slug: string;
   name: string;
@@ -27,7 +27,7 @@ export interface AssetAssignPopoverProps {
   currentGroupId: string;
   currentGroupName: string;
   ownedItems: AssetAssignOption[];
-  onAssign: (itemId: string) => Promise<void>;
+  onAssign: (item: AssetAssignOption) => Promise<void>;
 }
 
 /**
@@ -91,7 +91,7 @@ export function AssetAssignPopover({
     setIsAssigning(true);
     setError(null);
     try {
-      await onAssign(item.id);
+      await onAssign(item);
       setOpened(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : `Failed to add ${kind}. Please try again.`);

--- a/src/app/components/groups/AssetAssignPopover.tsx
+++ b/src/app/components/groups/AssetAssignPopover.tsx
@@ -1,0 +1,185 @@
+import {
+  ActionIcon,
+  Alert,
+  Button,
+  Group,
+  Popover,
+  Select,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import { Plus } from 'lucide-react';
+import { useMemo, useState } from 'react';
+
+interface AssetAssignOption {
+  id: string;
+  slug: string;
+  name: string;
+  groupId: string | null;
+  groupName: string | null;
+}
+
+export interface AssetAssignPopoverProps {
+  kind: 'faction' | 'ruleset';
+  disabled: boolean;
+  currentGroupId: string;
+  currentGroupName: string;
+  ownedItems: AssetAssignOption[];
+  onAssign: (itemId: string) => Promise<void>;
+}
+
+/**
+ * Reverse direction of `GroupAssignPopover`: instead of picking a group from an asset's edit page,
+ * the group is fixed and the viewer picks one of their own owned factions/rulesets to add.
+ */
+export function AssetAssignPopover({
+  kind,
+  disabled,
+  currentGroupId,
+  currentGroupName,
+  ownedItems,
+  onAssign,
+}: AssetAssignPopoverProps) {
+  const [opened, setOpened] = useState(false);
+  const [selectedId, setSelectedId] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isAssigning, setIsAssigning] = useState(false);
+
+  const assignableItems = useMemo(
+    () => ownedItems.filter((item) => item.groupId !== currentGroupId),
+    [ownedItems, currentGroupId]
+  );
+  const itemById = useMemo(
+    () => new Map(assignableItems.map((item) => [item.id, item])),
+    [assignableItems]
+  );
+  const options = useMemo(
+    () =>
+      assignableItems.map((item) => ({
+        value: item.id,
+        label: item.groupName
+          ? `${item.name} — currently in ${item.groupName}`
+          : `${item.name} — unassigned`,
+      })),
+    [assignableItems]
+  );
+
+  const handleOpenedChange = (nextOpened: boolean) => {
+    setOpened(nextOpened);
+    if (nextOpened) {
+      setSelectedId('');
+      setError(null);
+    }
+  };
+
+  const handleAssign = async () => {
+    const item = itemById.get(selectedId);
+    if (!item) {
+      setError(`Pick a ${kind} to add.`);
+      return;
+    }
+    if (item.groupId !== null) {
+      const confirmed = window.confirm(
+        `Move "${item.name}" from "${item.groupName}" to "${currentGroupName}"? It will no longer be maintained by "${item.groupName}".`
+      );
+      if (!confirmed) {
+        return;
+      }
+    }
+    setIsAssigning(true);
+    setError(null);
+    try {
+      await onAssign(item.id);
+      setOpened(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Failed to add ${kind}. Please try again.`);
+    } finally {
+      setIsAssigning(false);
+    }
+  };
+
+  return (
+    <Popover
+      opened={opened}
+      onChange={handleOpenedChange}
+      position="bottom-start"
+      width={340}
+      shadow="md"
+      withArrow
+      trapFocus
+      returnFocus
+    >
+      <Tooltip label={`Add a ${kind} you own`}>
+        <Popover.Target>
+          <ActionIcon
+            type="button"
+            variant="light"
+            size="sm"
+            aria-label={`Add a ${kind} you own`}
+            disabled={disabled}
+            onClick={() => setOpened((current) => !current)}
+          >
+            <Plus size={14} aria-hidden />
+          </ActionIcon>
+        </Popover.Target>
+      </Tooltip>
+      <Popover.Dropdown>
+        {opened ? (
+          <Stack gap="md">
+            <Stack gap={4}>
+              <Title order={3} size="h4">
+                Add a {kind}
+              </Title>
+              <Text size="sm" c="dimmed">
+                Only {kind}s you own are listed. Moving one already in another group needs
+                confirmation.
+              </Text>
+            </Stack>
+
+            {error ? (
+              <Alert color="red" title={`${kind} could not be added`} role="alert">
+                {error}
+              </Alert>
+            ) : null}
+
+            {options.length === 0 ? (
+              <Text size="sm" c="dimmed">
+                {ownedItems.length === 0
+                  ? `You don't own any ${kind}s yet.`
+                  : `All your ${kind}s are already in this group.`}
+              </Text>
+            ) : (
+              <Stack gap="md">
+                <Select
+                  label={`Search your ${kind}s`}
+                  value={selectedId || null}
+                  onChange={(value) => setSelectedId(value ?? '')}
+                  data={options}
+                  searchable
+                  clearable
+                  placeholder={`Type ${kind} name…`}
+                  nothingFoundMessage="No matches"
+                  comboboxProps={{ withinPortal: false }}
+                  disabled={disabled || isAssigning}
+                />
+                <Group justify="flex-end">
+                  <Button
+                    type="button"
+                    leftSection={<Plus size={16} aria-hidden />}
+                    onClick={() => void handleAssign()}
+                    disabled={disabled || !selectedId}
+                    loading={isAssigning}
+                  >
+                    Add to this group
+                  </Button>
+                </Group>
+              </Stack>
+            )}
+          </Stack>
+        ) : null}
+      </Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/src/app/factions/db.ts
+++ b/src/app/factions/db.ts
@@ -303,3 +303,19 @@ export async function loadFaction(slug: string): Promise<FactionDetailPageData> 
   const raw = await db.query(api.factions.getBySlug, { slug });
   return toFactionDetailPageData(raw);
 }
+
+export type OwnedFactionForGroupAssign = {
+  id: string;
+  slug: string;
+  name: string;
+  groupId: string | null;
+  groupName: string | null;
+};
+
+/** Factions the viewer owns, for the Group detail page's "add a faction" picker. */
+export function useFactionsOwnedForGroupAssign() {
+  const liveData = useQuery(api.factions.listOwnedForGroupAssign, {}) as
+    | OwnedFactionForGroupAssign[]
+    | undefined;
+  return toLiveQueryResult(liveData, true);
+}

--- a/src/app/factions/db.ts
+++ b/src/app/factions/db.ts
@@ -304,7 +304,7 @@ export async function loadFaction(slug: string): Promise<FactionDetailPageData> 
   return toFactionDetailPageData(raw);
 }
 
-export type OwnedFactionForGroupAssign = {
+type OwnedFactionForGroupAssign = {
   id: string;
   slug: string;
   name: string;

--- a/src/app/factions/db.ts
+++ b/src/app/factions/db.ts
@@ -304,18 +304,8 @@ export async function loadFaction(slug: string): Promise<FactionDetailPageData> 
   return toFactionDetailPageData(raw);
 }
 
-type OwnedFactionForGroupAssign = {
-  id: string;
-  slug: string;
-  name: string;
-  groupId: string | null;
-  groupName: string | null;
-};
-
 /** Factions the viewer owns, for the Group detail page's "add a faction" picker. */
 export function useFactionsOwnedForGroupAssign() {
-  const liveData = useQuery(api.factions.listOwnedForGroupAssign, {}) as
-    | OwnedFactionForGroupAssign[]
-    | undefined;
+  const liveData = useQuery(api.factions.listOwnedForGroupAssign, {});
   return toLiveQueryResult(liveData, true);
 }

--- a/src/app/groups/db.ts
+++ b/src/app/groups/db.ts
@@ -133,6 +133,22 @@ export function useCreateGroup() {
   };
 }
 
+export function useDeleteGroup() {
+  const mutation = useLiveMutation<{ id: string }, string>(api.groups.softDelete);
+  return {
+    ...mutation,
+    mutate: (id: string, options?: { onSuccess?: () => void; onError?: (error: Error) => void }) =>
+      mutation.mutate(
+        { id },
+        {
+          onSuccess: () => options?.onSuccess?.(),
+          onError: (error) => options?.onError?.(error),
+        }
+      ),
+    mutateAsync: async (id: string) => await mutation.mutateAsync({ id }),
+  };
+}
+
 export function useUpdateGroup() {
   const mutation = useLiveMutation<{ id: string; name: string }, GroupRow>(api.groups.update);
 

--- a/src/app/routes/_app/groups/$groupSlug/index.module.css
+++ b/src/app/routes/_app/groups/$groupSlug/index.module.css
@@ -1,19 +1,12 @@
-.memberRow {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
+.twoColumnGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(16rem, 2fr);
+  gap: var(--mantine-spacing-xl);
+  align-items: start;
 }
 
-.memberRowMain {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: var(--space-1);
-}
-
-.pendingMeta {
-  color: var(--color-muted);
-  font-size: 0.88rem;
+@media (max-width: 62em) {
+  .twoColumnGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -402,16 +402,10 @@ function OwnerLine({
   );
 }
 
-const membershipBadgeColors: Record<MembershipStatus, string> = {
-  active: 'green',
-  pending: 'yellow',
-  none: 'gray',
-};
-
-const membershipBadgeLabels: Record<MembershipStatus, string> = {
-  active: 'Active member',
-  pending: 'Pending approval',
-  none: 'Not a member',
+const membershipBadges: Record<MembershipStatus, { color: string; label: string }> = {
+  active: { color: 'green', label: 'Active member' },
+  pending: { color: 'yellow', label: 'Pending approval' },
+  none: { color: 'gray', label: 'Not a member' },
 };
 
 function MembershipStatusBadge({
@@ -428,9 +422,10 @@ function MembershipStatusBadge({
       </Badge>
     );
   }
+  const badge = membershipBadges[status];
   return (
-    <Badge color={membershipBadgeColors[status]} variant="light">
-      {membershipBadgeLabels[status]}
+    <Badge color={badge.color} variant="light">
+      {badge.label}
     </Badge>
   );
 }

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -213,6 +213,11 @@ function GroupDetailPage() {
               }
             />
           </Group>
+          {deleteGroup.error && (
+            <Text size="sm" c="red" role="alert" mt="xs">
+              Delete failed: {deleteGroup.error.message}
+            </Text>
+          )}
         </Paper>
       }
     >
@@ -269,10 +274,15 @@ function GroupDetailPage() {
             </Stack>
           </Card>
 
+          {membersModerationError && (
+            <Alert color="red" variant="light" title="Moderation failed" role="alert">
+              {membersModerationError}
+            </Alert>
+          )}
+
           <PendingRequestsPanel
             pendingMembers={pendingMembers}
             moderationBusy={membersModerationBusy}
-            moderationError={membersModerationError}
             onApprove={(membershipId) =>
               void membershipWorkflow.approve.run(membershipId).catch(() => undefined)
             }
@@ -289,7 +299,6 @@ function GroupDetailPage() {
               <MemberRoster
                 members={activeMembers}
                 moderationBusy={membersModerationBusy}
-                moderationError={membersModerationError}
                 onApprove={(membershipId) =>
                   void membershipWorkflow.approve.run(membershipId).catch(() => undefined)
                 }
@@ -321,24 +330,37 @@ function SectionHeading({ icon, children }: { icon: ReactNode; children: ReactNo
   );
 }
 
-type AssignPickerProps = Omit<AssetAssignPopoverProps, 'kind' | 'ownedItems'>;
+type AssignPickerProps = Omit<AssetAssignPopoverProps, 'kind' | 'ownedItems' | 'loading'>;
 
 /**
  * Only mounted for active members (see call sites): the owned-factions query requires
  * authentication, so it must not be called for anonymous, pending, or non-member viewers.
+ * Subscribing to a second query beyond the page query deviates from DD-013's default; that was
+ * decided explicitly for this picker (issues #348/#182: keep `detailBySlug` unchanged, expose the
+ * viewer-scoped owned lists as their own queries).
  */
 function FactionAssignPicker(props: AssignPickerProps) {
   const ownedFactionsQuery = useFactionsOwnedForGroupAssign();
   return (
-    <AssetAssignPopover kind="faction" ownedItems={ownedFactionsQuery.data ?? []} {...props} />
+    <AssetAssignPopover
+      kind="faction"
+      ownedItems={ownedFactionsQuery.data ?? []}
+      loading={ownedFactionsQuery.isLoading}
+      {...props}
+    />
   );
 }
 
-/** Same rule as `FactionAssignPicker`: only mount this for active members. */
+/** Same rules as `FactionAssignPicker`: only mount this for active members. */
 function RulesetAssignPicker(props: AssignPickerProps) {
   const ownedRulesetsQuery = useRulesetsOwnedForGroupAssign();
   return (
-    <AssetAssignPopover kind="ruleset" ownedItems={ownedRulesetsQuery.data ?? []} {...props} />
+    <AssetAssignPopover
+      kind="ruleset"
+      ownedItems={ownedRulesetsQuery.data ?? []}
+      loading={ownedRulesetsQuery.isLoading}
+      {...props}
+    />
   );
 }
 
@@ -386,19 +408,11 @@ const membershipBadgeColors: Record<MembershipStatus, string> = {
   none: 'gray',
 };
 
-function membershipBadgeColor(status: MembershipStatus) {
-  return membershipBadgeColors[status];
-}
-
 const membershipBadgeLabels: Record<MembershipStatus, string> = {
   active: 'Active member',
   pending: 'Pending approval',
   none: 'Not a member',
 };
-
-function membershipBadgeLabel(status: MembershipStatus) {
-  return membershipBadgeLabels[status];
-}
 
 function MembershipStatusBadge({
   status,
@@ -415,8 +429,8 @@ function MembershipStatusBadge({
     );
   }
   return (
-    <Badge color={membershipBadgeColor(status)} variant="light">
-      {membershipBadgeLabel(status)}
+    <Badge color={membershipBadgeColors[status]} variant="light">
+      {membershipBadgeLabels[status]}
     </Badge>
   );
 }
@@ -476,7 +490,7 @@ function MemberRow({
   moderationBusy: boolean;
   onApprove: (membershipId: string) => void;
   onReject: (membershipId: string) => void;
-  onRemove: (membershipId: string) => void;
+  onRemove?: (membershipId: string) => void;
 }) {
   const isPending = entry.status === 'pending';
   return (
@@ -521,7 +535,7 @@ function MemberRow({
             </ActionIcon>
           </Tooltip>
         )}
-        {entry.capabilities.remove && (
+        {entry.capabilities.remove && onRemove && (
           <Tooltip label="Remove member">
             <ActionIcon
               aria-label="Remove member"
@@ -542,43 +556,35 @@ function MemberRow({
 function MemberRoster({
   members,
   moderationBusy,
-  moderationError,
   onApprove,
   onReject,
   onRemove,
 }: {
   members: RosterEntry[];
   moderationBusy: boolean;
-  moderationError: string | null;
   onApprove: (membershipId: string) => void;
   onReject: (membershipId: string) => void;
   onRemove: (membershipId: string) => void;
 }) {
+  if (members.length === 0) {
+    return (
+      <Text size="sm" c="dimmed">
+        No members yet.
+      </Text>
+    );
+  }
   return (
-    <Stack gap="sm">
-      {members.length === 0 ? (
-        <Text size="sm" c="dimmed">
-          No members yet.
-        </Text>
-      ) : (
-        <Stack gap="xs">
-          {members.map((entry) => (
-            <MemberRow
-              key={entry.membershipId}
-              entry={entry}
-              moderationBusy={moderationBusy}
-              onApprove={onApprove}
-              onReject={onReject}
-              onRemove={onRemove}
-            />
-          ))}
-        </Stack>
-      )}
-      {moderationError && (
-        <Text size="sm" c="red" role="alert">
-          {moderationError}
-        </Text>
-      )}
+    <Stack gap="xs">
+      {members.map((entry) => (
+        <MemberRow
+          key={entry.membershipId}
+          entry={entry}
+          moderationBusy={moderationBusy}
+          onApprove={onApprove}
+          onReject={onReject}
+          onRemove={onRemove}
+        />
+      ))}
     </Stack>
   );
 }
@@ -590,13 +596,11 @@ function MemberRoster({
 function PendingRequestsPanel({
   pendingMembers,
   moderationBusy,
-  moderationError,
   onApprove,
   onReject,
 }: {
   pendingMembers: RosterEntry[];
   moderationBusy: boolean;
-  moderationError: string | null;
   onApprove: (membershipId: string) => void;
   onReject: (membershipId: string) => void;
 }) {
@@ -613,14 +617,8 @@ function PendingRequestsPanel({
             moderationBusy={moderationBusy}
             onApprove={onApprove}
             onReject={onReject}
-            onRemove={() => undefined}
           />
         ))}
-        {moderationError && (
-          <Text size="sm" c="red" role="alert">
-            {moderationError}
-          </Text>
-        )}
       </Stack>
     </Alert>
   );

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -40,6 +40,10 @@ import { useRulesetsOwnedForGroupAssign, useUpdateRuleset } from '@db/rulesets';
 import type { RulesetEntry } from '@db/rulesets';
 import { viewerActionsFor } from '@app/access/viewerActions';
 import { AssetAssignPopover } from '@app/components/groups/AssetAssignPopover';
+import type {
+  AssetAssignOption,
+  AssetAssignPopoverProps,
+} from '@app/components/groups/AssetAssignPopover';
 import { ProfileLink } from '@app/components/profile/ProfileLink';
 import { PageLayout } from '@app/components/shell';
 import { formatRelativeDate } from '@app/utils/formatRelativeDate';
@@ -66,8 +70,6 @@ function GroupDetailPage() {
   const deleteGroup = useDeleteGroup();
   const setFactionGroup = useSetFactionGroup();
   const updateRuleset = useUpdateRuleset();
-  const ownedFactionsQuery = useFactionsOwnedForGroupAssign();
-  const ownedRulesetsQuery = useRulesetsOwnedForGroupAssign();
 
   if (groupData.isError) {
     return (
@@ -140,15 +142,14 @@ function GroupDetailPage() {
     });
   };
 
-  const handleAssignFaction = async (factionId: string) => {
-    await setFactionGroup.mutateAsync({ id: factionId, groupId });
+  const handleAssignFaction = async (item: AssetAssignOption) => {
+    await setFactionGroup.mutateAsync({ id: item.id, groupId });
   };
 
-  const handleAssignRuleset = async (rulesetId: string) => {
-    const owned = ownedRulesetsQuery.data?.find((item) => item.id === rulesetId);
+  const handleAssignRuleset = async (item: AssetAssignOption) => {
     await updateRuleset.mutateAsync({
-      id: rulesetId,
-      input: { name: owned?.name ?? '' },
+      id: item.id,
+      input: { name: item.name },
       groupId,
     });
   };
@@ -222,12 +223,10 @@ function GroupDetailPage() {
               <Group justify="space-between" wrap="nowrap">
                 <SectionHeading icon={<FremenIcon />}>Factions maintained</SectionHeading>
                 {isActiveMember && (
-                  <AssetAssignPopover
-                    kind="faction"
+                  <FactionAssignPicker
                     disabled={setFactionGroup.isPending}
                     currentGroupId={groupId}
                     currentGroupName={group.name}
-                    ownedItems={ownedFactionsQuery.data ?? []}
                     onAssign={handleAssignFaction}
                   />
                 )}
@@ -242,12 +241,10 @@ function GroupDetailPage() {
                   Rulesets maintained
                 </SectionHeading>
                 {isActiveMember && (
-                  <AssetAssignPopover
-                    kind="ruleset"
+                  <RulesetAssignPicker
                     disabled={updateRuleset.isPending}
                     currentGroupId={groupId}
                     currentGroupName={group.name}
-                    ownedItems={ownedRulesetsQuery.data ?? []}
                     onAssign={handleAssignRuleset}
                   />
                 )}
@@ -321,6 +318,27 @@ function SectionHeading({ icon, children }: { icon: ReactNode; children: ReactNo
       </Title>
       {icon}
     </Group>
+  );
+}
+
+type AssignPickerProps = Omit<AssetAssignPopoverProps, 'kind' | 'ownedItems'>;
+
+/**
+ * Only mounted for active members (see call sites): the owned-factions query requires
+ * authentication, so it must not be called for anonymous, pending, or non-member viewers.
+ */
+function FactionAssignPicker(props: AssignPickerProps) {
+  const ownedFactionsQuery = useFactionsOwnedForGroupAssign();
+  return (
+    <AssetAssignPopover kind="faction" ownedItems={ownedFactionsQuery.data ?? []} {...props} />
+  );
+}
+
+/** Same rule as `FactionAssignPicker`: only mount this for active members. */
+function RulesetAssignPicker(props: AssignPickerProps) {
+  const ownedRulesetsQuery = useRulesetsOwnedForGroupAssign();
+  return (
+    <AssetAssignPopover kind="ruleset" ownedItems={ownedRulesetsQuery.data ?? []} {...props} />
   );
 }
 

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -362,16 +362,24 @@ function OwnerLine({
   );
 }
 
+const membershipBadgeColors: Record<MembershipStatus, string> = {
+  active: 'green',
+  pending: 'yellow',
+  none: 'gray',
+};
+
 function membershipBadgeColor(status: MembershipStatus) {
-  return status === 'active' ? 'green' : status === 'pending' ? 'yellow' : 'gray';
+  return membershipBadgeColors[status];
 }
 
+const membershipBadgeLabels: Record<MembershipStatus, string> = {
+  active: 'Active member',
+  pending: 'Pending approval',
+  none: 'Not a member',
+};
+
 function membershipBadgeLabel(status: MembershipStatus) {
-  return status === 'active'
-    ? 'Active member'
-    : status === 'pending'
-      ? 'Pending approval'
-      : 'Not a member';
+  return membershipBadgeLabels[status];
 }
 
 function MembershipStatusBadge({

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -1,18 +1,53 @@
+import {
+  ActionIcon,
+  Alert,
+  Anchor,
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Divider,
+  Group,
+  Paper,
+  Skeleton,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { ArrowLeft, Check, Pencil, UserPlus, UserRoundMinus, X } from 'lucide-react';
+import {
+  ArrowLeft,
+  BookOpen,
+  Check,
+  Crown,
+  Pencil,
+  Trash2,
+  UserPlus,
+  UserRoundMinus,
+  UsersRound,
+  X,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
 
-import { loadGroupDetailBySlug, useGroupDetailBySlug } from '@db/groups';
+import { useFactionsOwnedForGroupAssign, useSetFactionGroup } from '@db/factions';
+import type { FactionEntry } from '@db/factions';
+import { loadGroupDetailBySlug, useDeleteGroup, useGroupDetailBySlug } from '@db/groups';
+import type { GroupDetailPageData } from '@db/groups';
 import { useGroupMembershipWorkflow } from '@db/members';
+import { useRulesetsOwnedForGroupAssign, useUpdateRuleset } from '@db/rulesets';
+import type { RulesetEntry } from '@db/rulesets';
 import { viewerActionsFor } from '@app/access/viewerActions';
-import { FormTooltip } from '@app/components/form/FormTooltip';
-import { ButtonGroup, Toolbar } from '@app/components/generic/layout';
-import { Card } from '@app/components/generic/surfaces/Card';
-import { UIButton } from '@app/components/generic/ui/UIButton';
+import { AssetAssignPopover } from '@app/components/groups/AssetAssignPopover';
 import { ProfileLink } from '@app/components/profile/ProfileLink';
 import { PageLayout } from '@app/components/shell';
 import { formatRelativeDate } from '@app/utils/formatRelativeDate';
 
-import pageStyles from './index.module.css';
+import styles from './index.module.css';
+
+type RosterEntry = GroupDetailPageData['roster'][number];
+type MembershipStatus = ReturnType<typeof viewerActionsFor>['membershipStatus'];
 
 export const Route = createFileRoute('/_app/groups/$groupSlug/')({
   loader: async ({ params }) => {
@@ -24,23 +59,44 @@ export const Route = createFileRoute('/_app/groups/$groupSlug/')({
 
 function GroupDetailPage() {
   const { groupSlug } = Route.useParams();
+  const navigate = Route.useNavigate();
   const loaderData = Route.useLoaderData();
   const groupData = useGroupDetailBySlug(groupSlug, { initialData: loaderData.groupDetail });
   const membershipWorkflow = useGroupMembershipWorkflow();
+  const deleteGroup = useDeleteGroup();
+  const setFactionGroup = useSetFactionGroup();
+  const updateRuleset = useUpdateRuleset();
+  const ownedFactionsQuery = useFactionsOwnedForGroupAssign();
+  const ownedRulesetsQuery = useRulesetsOwnedForGroupAssign();
 
   if (groupData.isError) {
     return (
-      <PageLayout header={<h1>Group</h1>}>
-        <Card>
-          <p>Group not found.</p>
-        </Card>
+      <PageLayout header={<Title order={1}>Group</Title>}>
+        <Paper withBorder p="xl" radius="md">
+          <Alert color="red" title="Group could not be loaded" role="alert">
+            <Text size="sm">This group may have been deleted, or the link may be incorrect.</Text>
+          </Alert>
+        </Paper>
       </PageLayout>
     );
   }
 
   const page = groupData.data;
   if (!page) {
-    return <PageLayout header={<h1>Group</h1>}>Loading group…</PageLayout>;
+    return (
+      <PageLayout header={<Title order={1}>Group</Title>}>
+        <Box className={styles.twoColumnGrid}>
+          <Stack gap="lg">
+            <Skeleton height={140} radius="md" />
+            <Skeleton height={140} radius="md" />
+          </Stack>
+          <Stack gap="lg">
+            <Skeleton height={160} radius="md" />
+            <Skeleton height={160} radius="md" />
+          </Stack>
+        </Box>
+      </PageLayout>
+    );
   }
 
   const group = page.group;
@@ -48,9 +104,15 @@ function GroupDetailPage() {
   const viewerAccess = page.viewerAccess;
   const ownerProfile = page.owner;
   const { membershipStatus } = viewerActionsFor(viewerAccess);
+  const isOwner = viewerAccess.capabilities.rename;
+  const isActiveMember = membershipStatus === 'active';
+  const isAnonymous = viewerAccess.viewer.kind === 'anonymous';
   const factions = page.factions;
   const rulesets = page.rulesets;
   const roster = page.roster;
+
+  const activeMembers = roster.filter((member) => member.status === 'active');
+  const pendingMembers = roster.filter((member) => member.status === 'pending');
 
   const membersModerationBusy =
     membershipWorkflow.approve.isPending ||
@@ -69,215 +131,519 @@ function GroupDetailPage() {
     void membershipWorkflow.remove.run(membershipId).catch(() => undefined);
   };
 
-  const activeMembers = roster.filter((member) => member.status === 'active');
-  const pendingMembers = roster.filter((member) => member.status === 'pending');
-  const memberRows = [...activeMembers, ...pendingMembers];
+  const handleDeleteGroup = () => {
+    if (!window.confirm(`Delete group "${group.name}"? This cannot be undone.`)) {
+      return;
+    }
+    deleteGroup.mutate(groupId, {
+      onSuccess: () => void navigate({ to: '/profiles' }),
+    });
+  };
 
-  const header = <h1>{group.name}</h1>;
+  const handleAssignFaction = async (factionId: string) => {
+    await setFactionGroup.mutateAsync({ id: factionId, groupId });
+  };
+
+  const handleAssignRuleset = async (rulesetId: string) => {
+    const owned = ownedRulesetsQuery.data?.find((item) => item.id === rulesetId);
+    await updateRuleset.mutateAsync({
+      id: rulesetId,
+      input: { name: owned?.name ?? '' },
+      groupId,
+    });
+  };
 
   return (
     <PageLayout
-      header={header}
+      header={<Title order={1}>{group.name}</Title>}
       toolbar={
-        <Toolbar>
-          <Toolbar.Left>
-            <ButtonGroup>
-              <FormTooltip content="Back to profiles">
-                <UIButton variant="nav" to="/profiles" aria-label="Back to profiles">
-                  <ArrowLeft size={16} aria-hidden />
-                </UIButton>
-              </FormTooltip>
+        <Paper withBorder p="sm" radius="md">
+          <Group justify="space-between" gap="sm" wrap="wrap">
+            <Group gap="xs" wrap="wrap" role="group" aria-label="Navigation and editing">
+              <Tooltip label="Back to profiles">
+                <ActionIcon
+                  variant="light"
+                  color="gray"
+                  size="lg"
+                  aria-label="Back to profiles"
+                  renderRoot={(rootProps) => <Link {...rootProps} to="/profiles" />}
+                >
+                  <ArrowLeft size={17} aria-hidden />
+                </ActionIcon>
+              </Tooltip>
               {viewerAccess.capabilities.rename ? (
-                <FormTooltip content="Edit group settings">
-                  <UIButton
-                    variant="secondary"
-                    to="/groups/$groupSlug/edit"
-                    params={{ groupSlug }}
+                <Tooltip label="Edit group settings">
+                  <ActionIcon
+                    variant="light"
+                    color="dune"
+                    size="lg"
                     aria-label="Edit group settings"
+                    renderRoot={(rootProps) => (
+                      <Link {...rootProps} to="/groups/$groupSlug/edit" params={{ groupSlug }} />
+                    )}
                   >
-                    <Pencil size={16} aria-hidden />
-                  </UIButton>
-                </FormTooltip>
+                    <Pencil size={17} aria-hidden />
+                  </ActionIcon>
+                </Tooltip>
               ) : null}
-            </ButtonGroup>
-          </Toolbar.Left>
-        </Toolbar>
+              {viewerAccess.capabilities.delete ? (
+                <Tooltip label="Delete group">
+                  <ActionIcon
+                    type="button"
+                    variant="light"
+                    color="red"
+                    size="lg"
+                    aria-label="Delete group"
+                    disabled={deleteGroup.isPending}
+                    onClick={handleDeleteGroup}
+                  >
+                    <Trash2 size={17} aria-hidden />
+                  </ActionIcon>
+                </Tooltip>
+              ) : null}
+            </Group>
+            <RequestMembershipButton
+              canRequestMembership={viewerAccess.capabilities.requestMembership}
+              isAnonymous={isAnonymous}
+              requestPending={membershipWorkflow.request.isPending}
+              requestError={membershipWorkflow.request.error?.message ?? null}
+              onRequestMembership={() =>
+                void membershipWorkflow.request.run(groupId).catch(() => undefined)
+              }
+            />
+          </Group>
+        </Paper>
       }
     >
-      <Card>
-        <p>
-          Owner:{' '}
-          {ownerProfile?.slug ? (
-            <ProfileLink
-              slug={ownerProfile.slug}
-              username={ownerProfile.username}
-              avatar_url={ownerProfile.avatar_url}
-            />
-          ) : (
-            (ownerProfile?.username ?? group.created_by)
-          )}
-        </p>
-        <p>
-          Membership status:{' '}
-          {membershipStatus === 'active'
-            ? 'Active member'
-            : membershipStatus === 'pending'
-              ? 'Pending approval'
-              : 'Not a member'}
-        </p>
-        {membershipStatus === 'pending' && <p>Your request is awaiting approval.</p>}
-        {viewerAccess.viewer.kind === 'anonymous' && (
-          <p>
-            <Link to="/auth/login">Log in</Link> to request membership.
-          </p>
-        )}
-        {viewerAccess.capabilities.requestMembership && (
-          <FormTooltip content="Request membership">
-            <UIButton
-              type="button"
-              iconOnly
-              aria-label="Request membership"
-              disabled={membershipWorkflow.request.isPending}
-              onClick={() => void membershipWorkflow.request.run(groupId).catch(() => undefined)}
-            >
-              <UserPlus size={16} aria-hidden />
-            </UIButton>
-          </FormTooltip>
-        )}
-        {membershipWorkflow.request.isError && (
-          <p role="alert">{membershipWorkflow.request.error?.message}</p>
-        )}
-      </Card>
+      <Box className={styles.twoColumnGrid}>
+        <Stack gap="lg">
+          <Card withBorder padding="lg" radius="md">
+            <Stack gap="md">
+              <Group justify="space-between" wrap="nowrap">
+                <SectionHeading icon={<FremenIcon />}>Factions maintained</SectionHeading>
+                {isActiveMember && (
+                  <AssetAssignPopover
+                    kind="faction"
+                    disabled={setFactionGroup.isPending}
+                    currentGroupId={groupId}
+                    currentGroupName={group.name}
+                    ownedItems={ownedFactionsQuery.data ?? []}
+                    onAssign={handleAssignFaction}
+                  />
+                )}
+              </Group>
+              <FactionList factions={factions} />
+            </Stack>
+          </Card>
+          <Card withBorder padding="lg" radius="md">
+            <Stack gap="md">
+              <Group justify="space-between" wrap="nowrap">
+                <SectionHeading icon={<BookOpen size={18} aria-hidden />}>
+                  Rulesets maintained
+                </SectionHeading>
+                {isActiveMember && (
+                  <AssetAssignPopover
+                    kind="ruleset"
+                    disabled={updateRuleset.isPending}
+                    currentGroupId={groupId}
+                    currentGroupName={group.name}
+                    ownedItems={ownedRulesetsQuery.data ?? []}
+                    onAssign={handleAssignRuleset}
+                  />
+                )}
+              </Group>
+              <RulesetList rulesets={rulesets} />
+            </Stack>
+          </Card>
+        </Stack>
 
-      <Card>
-        <h3>Members</h3>
-        {memberRows.length === 0 ? (
-          <p>No members yet.</p>
-        ) : (
-          <ul>
-            {memberRows.map((entry) => {
-              const isPending = entry.status === 'pending';
+        <Stack gap="lg">
+          <Card withBorder padding="lg" radius="md">
+            <Stack gap="sm">
+              <SectionHeading icon={<Crown size={18} aria-hidden />}>Stewardship</SectionHeading>
+              <OwnerLine ownerProfile={ownerProfile} createdBy={group.created_by} />
+              <Divider />
+              <Group justify="space-between">
+                <Text size="sm" c="dimmed">
+                  Your membership
+                </Text>
+                <MembershipStatusBadge status={membershipStatus} isOwner={isOwner} />
+              </Group>
+            </Stack>
+          </Card>
 
-              return (
-                <li key={entry.membershipId}>
-                  <div className={pageStyles.memberRow}>
-                    <div className={pageStyles.memberRowMain}>
-                      {entry.user.slug ? (
-                        <ProfileLink
-                          slug={entry.user.slug}
-                          username={entry.user.username}
-                          avatar_url={entry.user.avatar_url}
-                        />
-                      ) : (
-                        <span>{entry.user.username ?? entry.user.id}</span>
-                      )}
-                      {isPending ? (
-                        <>
-                          <span className={pageStyles.pendingMeta}>(pending)</span>
-                          <span className={pageStyles.pendingMeta}>
-                            {formatRelativeDate(entry.requestedAt)}
-                          </span>
-                        </>
-                      ) : null}
-                    </div>
-                    {entry.capabilities.approve || entry.capabilities.reject ? (
-                      <ButtonGroup>
-                        {entry.capabilities.approve ? (
-                          <FormTooltip content="Approve">
-                            <UIButton
-                              type="button"
-                              variant="confirm"
-                              iconOnly
-                              aria-label="Approve membership"
-                              disabled={membersModerationBusy}
-                              onClick={() =>
-                                void membershipWorkflow.approve
-                                  .run(entry.membershipId)
-                                  .catch(() => undefined)
-                              }
-                            >
-                              <Check size={16} aria-hidden />
-                            </UIButton>
-                          </FormTooltip>
-                        ) : null}
-                        {entry.capabilities.reject ? (
-                          <FormTooltip content="Decline">
-                            <UIButton
-                              type="button"
-                              variant="critical"
-                              iconOnly
-                              aria-label="Decline membership"
-                              disabled={membersModerationBusy}
-                              onClick={() =>
-                                void membershipWorkflow.reject
-                                  .run(entry.membershipId)
-                                  .catch(() => undefined)
-                              }
-                            >
-                              <X size={16} aria-hidden />
-                            </UIButton>
-                          </FormTooltip>
-                        ) : null}
-                      </ButtonGroup>
-                    ) : null}
-                    {entry.capabilities.remove ? (
-                      <ButtonGroup>
-                        <FormTooltip content="Remove member">
-                          <UIButton
-                            type="button"
-                            variant="critical"
-                            iconOnly
-                            aria-label="Remove member"
-                            disabled={membersModerationBusy}
-                            onClick={() => handleRemoveMember(entry.membershipId)}
-                          >
-                            <UserRoundMinus size={16} aria-hidden />
-                          </UIButton>
-                        </FormTooltip>
-                      </ButtonGroup>
-                    ) : null}
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        )}
-        {membersModerationError ? <p role="alert">{membersModerationError}</p> : null}
-      </Card>
+          <PendingRequestsPanel
+            pendingMembers={pendingMembers}
+            moderationBusy={membersModerationBusy}
+            moderationError={membersModerationError}
+            onApprove={(membershipId) =>
+              void membershipWorkflow.approve.run(membershipId).catch(() => undefined)
+            }
+            onReject={(membershipId) =>
+              void membershipWorkflow.reject.run(membershipId).catch(() => undefined)
+            }
+          />
 
-      <Card>
-        <h3>Factions</h3>
-        {factions.length === 0 ? (
-          <p>No factions in this group yet.</p>
-        ) : (
-          <ul>
-            {factions.map((faction) => (
-              <li key={faction._id}>
-                <Link to="/factions/$factionId" params={{ factionId: faction.slug }}>
-                  {faction.data.name}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        )}
-      </Card>
-
-      <Card>
-        <h3>Rulesets</h3>
-        {rulesets.length === 0 ? (
-          <p>No rulesets in this group yet.</p>
-        ) : (
-          <ul>
-            {rulesets.map((ruleset) => (
-              <li key={ruleset._id}>
-                <Link to="/rulesets/$rulesetSlug" params={{ rulesetSlug: ruleset.slug }}>
-                  {ruleset.name}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        )}
-      </Card>
+          <Card withBorder padding="lg" radius="md">
+            <Stack gap="sm">
+              <SectionHeading icon={<UsersRound size={18} aria-hidden />}>
+                Members ({activeMembers.length})
+              </SectionHeading>
+              <MemberRoster
+                members={activeMembers}
+                moderationBusy={membersModerationBusy}
+                moderationError={membersModerationError}
+                onApprove={(membershipId) =>
+                  void membershipWorkflow.approve.run(membershipId).catch(() => undefined)
+                }
+                onReject={(membershipId) =>
+                  void membershipWorkflow.reject.run(membershipId).catch(() => undefined)
+                }
+                onRemove={handleRemoveMember}
+              />
+            </Stack>
+          </Card>
+        </Stack>
+      </Box>
     </PageLayout>
+  );
+}
+
+/* ---------------------------------------------------------------------- */
+/* Page-local presentation helpers.                                       */
+/* ---------------------------------------------------------------------- */
+
+function SectionHeading({ icon, children }: { icon: ReactNode; children: ReactNode }) {
+  return (
+    <Group gap="xs" wrap="nowrap">
+      <Title order={3} size="h4">
+        {children}
+      </Title>
+      {icon}
+    </Group>
+  );
+}
+
+/**
+ * Dune-specific crest for the Factions section. These faction logo files ship without root
+ * width/height (see `Token`'s `StrokedUse` pattern) — reference the `#root` fragment via `<use>`
+ * inside an own viewBox rather than a plain `<img src>`, which renders as a broken 0x0 image.
+ */
+function FremenIcon({ size = 18 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      aria-hidden
+      focusable="false"
+      style={{ display: 'block', flex: '0 0 auto', color: 'var(--mantine-color-dune-8)' }}
+    >
+      <use href="/vector/logo/fremen.svg#root" width={100} height={100} fill="currentColor" />
+    </svg>
+  );
+}
+
+function OwnerLine({
+  ownerProfile,
+  createdBy,
+}: {
+  ownerProfile: GroupDetailPageData['owner'];
+  createdBy: string;
+}) {
+  return ownerProfile?.slug ? (
+    <ProfileLink
+      slug={ownerProfile.slug}
+      username={ownerProfile.username}
+      avatar_url={ownerProfile.avatar_url}
+    />
+  ) : (
+    <Text size="sm">{ownerProfile?.username ?? createdBy}</Text>
+  );
+}
+
+function membershipBadgeColor(status: MembershipStatus) {
+  return status === 'active' ? 'green' : status === 'pending' ? 'yellow' : 'gray';
+}
+
+function membershipBadgeLabel(status: MembershipStatus) {
+  return status === 'active'
+    ? 'Active member'
+    : status === 'pending'
+      ? 'Pending approval'
+      : 'Not a member';
+}
+
+function MembershipStatusBadge({
+  status,
+  isOwner,
+}: {
+  status: MembershipStatus;
+  isOwner: boolean;
+}) {
+  if (isOwner) {
+    return (
+      <Badge color="dune" variant="light" leftSection={<Crown size={12} aria-hidden />}>
+        Owner
+      </Badge>
+    );
+  }
+  return (
+    <Badge color={membershipBadgeColor(status)} variant="light">
+      {membershipBadgeLabel(status)}
+    </Badge>
+  );
+}
+
+function RequestMembershipButton({
+  canRequestMembership,
+  isAnonymous,
+  requestPending,
+  requestError,
+  onRequestMembership,
+}: {
+  canRequestMembership: boolean;
+  isAnonymous: boolean;
+  requestPending: boolean;
+  requestError: string | null;
+  onRequestMembership: () => void;
+}) {
+  return (
+    <Stack gap={4}>
+      {isAnonymous && (
+        <Text size="sm" c="dimmed">
+          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>
+            Log in
+          </Anchor>{' '}
+          to request membership.
+        </Text>
+      )}
+      {canRequestMembership && (
+        <Button
+          type="button"
+          variant="filled"
+          leftSection={<UserPlus size={16} aria-hidden />}
+          loading={requestPending}
+          onClick={onRequestMembership}
+          w="fit-content"
+        >
+          Request membership
+        </Button>
+      )}
+      {requestError && (
+        <Text size="sm" c="red" role="alert">
+          {requestError}
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
+function MemberRow({
+  entry,
+  moderationBusy,
+  onApprove,
+  onReject,
+  onRemove,
+}: {
+  entry: RosterEntry;
+  moderationBusy: boolean;
+  onApprove: (membershipId: string) => void;
+  onReject: (membershipId: string) => void;
+  onRemove: (membershipId: string) => void;
+}) {
+  const isPending = entry.status === 'pending';
+  return (
+    <Group justify="space-between" wrap="wrap" gap="sm">
+      <Group gap="xs" wrap="nowrap" miw={0}>
+        <Avatar src={entry.user.avatar_url} radius="xl" size="sm" />
+        {entry.user.slug ? (
+          <ProfileLink slug={entry.user.slug} username={entry.user.username} avatar_url={null} />
+        ) : (
+          <Text size="sm">{entry.user.username ?? entry.user.id}</Text>
+        )}
+        {isPending && (
+          <Text size="xs" c="dimmed">
+            requested {formatRelativeDate(entry.requestedAt)}
+          </Text>
+        )}
+      </Group>
+      <Group gap={4} wrap="nowrap">
+        {entry.capabilities.approve && (
+          <Tooltip label="Approve">
+            <ActionIcon
+              aria-label="Approve membership"
+              color="confirm"
+              variant="light"
+              disabled={moderationBusy}
+              onClick={() => onApprove(entry.membershipId)}
+            >
+              <Check size={15} aria-hidden />
+            </ActionIcon>
+          </Tooltip>
+        )}
+        {entry.capabilities.reject && (
+          <Tooltip label="Decline">
+            <ActionIcon
+              aria-label="Decline membership"
+              color="red"
+              variant="light"
+              disabled={moderationBusy}
+              onClick={() => onReject(entry.membershipId)}
+            >
+              <X size={15} aria-hidden />
+            </ActionIcon>
+          </Tooltip>
+        )}
+        {entry.capabilities.remove && (
+          <Tooltip label="Remove member">
+            <ActionIcon
+              aria-label="Remove member"
+              color="red"
+              variant="light"
+              disabled={moderationBusy}
+              onClick={() => onRemove(entry.membershipId)}
+            >
+              <UserRoundMinus size={15} aria-hidden />
+            </ActionIcon>
+          </Tooltip>
+        )}
+      </Group>
+    </Group>
+  );
+}
+
+function MemberRoster({
+  members,
+  moderationBusy,
+  moderationError,
+  onApprove,
+  onReject,
+  onRemove,
+}: {
+  members: RosterEntry[];
+  moderationBusy: boolean;
+  moderationError: string | null;
+  onApprove: (membershipId: string) => void;
+  onReject: (membershipId: string) => void;
+  onRemove: (membershipId: string) => void;
+}) {
+  return (
+    <Stack gap="sm">
+      {members.length === 0 ? (
+        <Text size="sm" c="dimmed">
+          No members yet.
+        </Text>
+      ) : (
+        <Stack gap="xs">
+          {members.map((entry) => (
+            <MemberRow
+              key={entry.membershipId}
+              entry={entry}
+              moderationBusy={moderationBusy}
+              onApprove={onApprove}
+              onReject={onReject}
+              onRemove={onRemove}
+            />
+          ))}
+        </Stack>
+      )}
+      {moderationError && (
+        <Text size="sm" c="red" role="alert">
+          {moderationError}
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
+/**
+ * Pending membership requests, pulled out of the plain roster into their own highlighted,
+ * conditional panel.
+ */
+function PendingRequestsPanel({
+  pendingMembers,
+  moderationBusy,
+  moderationError,
+  onApprove,
+  onReject,
+}: {
+  pendingMembers: RosterEntry[];
+  moderationBusy: boolean;
+  moderationError: string | null;
+  onApprove: (membershipId: string) => void;
+  onReject: (membershipId: string) => void;
+}) {
+  if (pendingMembers.length === 0) {
+    return null;
+  }
+  return (
+    <Alert color="yellow" variant="light" title={`Pending requests (${pendingMembers.length})`}>
+      <Stack gap="xs">
+        {pendingMembers.map((entry) => (
+          <MemberRow
+            key={entry.membershipId}
+            entry={entry}
+            moderationBusy={moderationBusy}
+            onApprove={onApprove}
+            onReject={onReject}
+            onRemove={() => undefined}
+          />
+        ))}
+        {moderationError && (
+          <Text size="sm" c="red" role="alert">
+            {moderationError}
+          </Text>
+        )}
+      </Stack>
+    </Alert>
+  );
+}
+
+function FactionList({ factions }: { factions: FactionEntry[] }) {
+  return factions.length === 0 ? (
+    <Text size="sm" c="dimmed">
+      No factions in this group yet.
+    </Text>
+  ) : (
+    <Stack gap={6}>
+      {factions.map((faction) => (
+        <Anchor
+          key={faction._id}
+          fw={600}
+          renderRoot={(rootProps) => (
+            <Link {...rootProps} to="/factions/$factionId" params={{ factionId: faction.slug }} />
+          )}
+        >
+          {faction.data.name}
+        </Anchor>
+      ))}
+    </Stack>
+  );
+}
+
+function RulesetList({ rulesets }: { rulesets: RulesetEntry[] }) {
+  return rulesets.length === 0 ? (
+    <Text size="sm" c="dimmed">
+      No rulesets in this group yet.
+    </Text>
+  ) : (
+    <Stack gap={6}>
+      {rulesets.map((ruleset) => (
+        <Anchor
+          key={ruleset._id}
+          fw={600}
+          renderRoot={(rootProps) => (
+            <Link
+              {...rootProps}
+              to="/rulesets/$rulesetSlug"
+              params={{ rulesetSlug: ruleset.slug }}
+            />
+          )}
+        >
+          {ruleset.name}
+        </Anchor>
+      ))}
+    </Stack>
   );
 }

--- a/src/app/rulesets/db.ts
+++ b/src/app/rulesets/db.ts
@@ -283,7 +283,7 @@ export function useDeleteRuleset() {
   };
 }
 
-export type OwnedRulesetForGroupAssign = {
+type OwnedRulesetForGroupAssign = {
   id: string;
   slug: string;
   name: string;

--- a/src/app/rulesets/db.ts
+++ b/src/app/rulesets/db.ts
@@ -283,18 +283,8 @@ export function useDeleteRuleset() {
   };
 }
 
-type OwnedRulesetForGroupAssign = {
-  id: string;
-  slug: string;
-  name: string;
-  groupId: string | null;
-  groupName: string | null;
-};
-
 /** Rulesets the viewer owns, for the Group detail page's "add a ruleset" picker. */
 export function useRulesetsOwnedForGroupAssign() {
-  const liveData = useQuery(api.rulesets.listOwnedForGroupAssign, {}) as
-    | OwnedRulesetForGroupAssign[]
-    | undefined;
+  const liveData = useQuery(api.rulesets.listOwnedForGroupAssign, {});
   return toLiveQueryResult(liveData, true);
 }

--- a/src/app/rulesets/db.ts
+++ b/src/app/rulesets/db.ts
@@ -282,3 +282,19 @@ export function useDeleteRuleset() {
     mutateAsync: async (id: string) => await mutation.mutateAsync({ id }),
   };
 }
+
+export type OwnedRulesetForGroupAssign = {
+  id: string;
+  slug: string;
+  name: string;
+  groupId: string | null;
+  groupName: string | null;
+};
+
+/** Rulesets the viewer owns, for the Group detail page's "add a ruleset" picker. */
+export function useRulesetsOwnedForGroupAssign() {
+  const liveData = useQuery(api.rulesets.listOwnedForGroupAssign, {}) as
+    | OwnedRulesetForGroupAssign[]
+    | undefined;
+  return toLiveQueryResult(liveData, true);
+}


### PR DESCRIPTION
## Summary

Implements [Implement the selected Group detail overhaul](https://github.com/ndelangen/dunezone/issues/184), the final ticket on [Wayfinder: Overhaul the Group detail page](https://github.com/ndelangen/dunezone/issues/180).

Every design decision below was made and prototype-verified through the wayfinder map before landing here — nothing in this PR is a first-time judgment call:

- **Layout** — two-column (creations primary, stewardship/membership aside), chosen unranked from six structurally different concepts by human decision: [Choose the Group detail design direction](https://github.com/ndelangen/dunezone/issues/185). The existing responsive breakpoint collapses it to one column with zero changes needed: [Adapt the selected Group detail design to mobile](https://github.com/ndelangen/dunezone/issues/186).
- **Toolbar** — rebuilt on direct Mantine (`Paper`+`ActionIcon`) instead of the legacy `Toolbar`/`UIButton`/`ButtonGroup`/`FormTooltip` primitives, per [DD-015](https://github.com/ndelangen/dunezone/blob/main/docs/technical/ui-design-decisions.md). Back / owner-only rename+delete / request-membership as a primary action. **Delete-group is new UI** — the capability and mutation (`groups.softDelete`) already existed but were never surfaced anywhere.
- **Adaptive states** — dropped the redundant "OWNER" label, added a distinct "Owner" badge state, pending requests split into their own public highlighted panel, tailored loading/error states. Full decision record: [Define the adaptive Group page states](https://github.com/ndelangen/dunezone/issues/181).
- **Data contract** — unchanged, ships entirely on the existing `detailBySlug` query: [Decide the selected Group design data contract](https://github.com/ndelangen/dunezone/issues/182).
- **Entity-picker** — `AssetAssignPopover`, the reverse direction of the existing `GroupAssignPopover`: pick one of your own owned factions/rulesets and add it to this group, inline "+" per card, active-members only. Reuses existing mutations and their already-tested authorization (owner-of-asset + active-member-of-target-group) — no new capability model, only two new `listOwnedForGroupAssign` queries. Full record: [Add an entity-picker for assigning owned factions/rulesets to a group](https://github.com/ndelangen/dunezone/issues/348).

Group edit (`/groups/$groupSlug/edit`) is untouched — explicitly out of scope for this map, gets its own wayfinder effort.

## Test plan

- [x] `bun run typecheck` / `bun run lint` / `bun run format:check` — clean
- [x] Full test suite (440 tests) green, including new Convex contract tests for both `listOwnedForGroupAssign` queries (ownership scoping, live-only filtering, group-name resolution, and projecting a soft-deleted target group to unassigned)
- [x] New e2e happy path for the picker's full interaction chain (create group → create faction → add via picker → see it listed)
- [x] Updated the existing membership-lifecycle e2e's pending-state assertions for the new panel (behavior unchanged, only where it's shown)
- [x] Verified live in browser, signed in as a real user: desktop + mobile, owner view (toolbar, picker, delete confirm) and anonymous view

## Not in this PR

- Merging or deploying this — explicitly out of scope per the wayfinder map's Notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive group-management controls for editing, deleting, membership requests, stewardship, and member moderation.
  * Added searchable assignment of owned factions and rulesets to groups, including reassignment confirmation.
  * Added responsive two-column group layouts, clearer loading and error states, and dedicated asset sections.
  * Group deletion now returns to the profile page after completion.

* **Bug Fixes**
  * Improved handling of deleted or unavailable groups during asset assignment.

* **Tests**
  * Added coverage for assignment workflows, ownership filtering, authentication, and membership approvals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->