### PR TITLE
fix: faction editor no longer reverts to stale values after save; local/hosted dev launch configs

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,23 @@
       "runtimeExecutable": "bash",
       "runtimeArgs": ["-c", "bun run generate:vectors && bun run storybook"],
       "port": 6006
+    },
+    {
+      "name": "app-hosted",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": [
+        "-c",
+        "bun run migrations:dev-strict && bunx convex dev --start 'bun run app:dev'"
+      ],
+      "port": 3000,
+      "autoPort": false
+    },
+    {
+      "name": "app-local",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "APP_DEV_PORT=3100 bun run app:dev --local"],
+      "port": 3100,
+      "autoPort": false
     }
   ]
 }

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -14,16 +14,15 @@
         "-c",
         "bun run generate:vectors && bun run migrations:dev-strict && bunx convex dev --start 'bun run app:dev'"
       ],
+      "env": { "APP_DEV_PORT": "3000" },
       "port": 3000,
       "autoPort": false
     },
     {
       "name": "app-local",
       "runtimeExecutable": "bash",
-      "runtimeArgs": [
-        "-c",
-        "bun run generate:vectors && APP_DEV_PORT=3100 bun run app:dev --local"
-      ],
+      "runtimeArgs": ["-c", "bun run generate:vectors && bun run app:dev --local"],
+      "env": { "APP_DEV_PORT": "3100" },
       "port": 3100,
       "autoPort": false
     }

--- a/e2e/faction-lifecycle.spec.ts
+++ b/e2e/faction-lifecycle.spec.ts
@@ -118,6 +118,16 @@ test('owner can author a faction through its complete lifecycle', async ({ page 
     await expect(page).toHaveURL(new RegExp(`/factions/${factionAName.toLowerCase()}/edit$`));
     await expect(page.getByText('Saved', { exact: true })).toBeVisible();
 
+    /*
+     * Without a reload: the editor must keep showing the just-saved draft, not
+     * snap back to the values it loaded the page with.
+     */
+    await page.getByRole('tab', { name: /^Faction leader/ }).click();
+    await expect(page.getByRole('textbox', { name: 'Faction leader name' })).toHaveValue(
+      importedLeaderName
+    );
+    await page.getByRole('tab', { name: 'Identity & Appearance', exact: true }).click();
+
     const savedFactionName = page.getByRole('textbox', { name: 'Faction name' });
     await savedFactionName.fill(`${factionAName} local`);
     await page.getByRole('button', { name: 'Reset unsaved edits' }).click();

--- a/src/app/components/factions/editor/useFactionAuthoring.ts
+++ b/src/app/components/factions/editor/useFactionAuthoring.ts
@@ -56,7 +56,17 @@ export function useFactionAuthoring({
   sessionRef.current ??= createFactionAuthoringSession({
     initialData,
     form: {
-      reset: (values, options) => form.reset(values, options),
+      reset: (values, options) => {
+        if (!options?.keepDefaultValues) {
+          /*
+           * form.reset(values) adopts `values` as the form's defaultValues, but useForm
+           * re-applies the hook's defaultValues on every render and overwrites an
+           * untouched form whenever the two disagree — keep the hook's copy in step.
+           */
+          initialBaselineRef.current = structuredClone(values);
+        }
+        form.reset(values, options);
+      },
       markLoadedDraftDirty: () =>
         form.setFieldMeta('name', (meta) => ({ ...meta, isDirty: true, isTouched: true })),
     },


### PR DESCRIPTION
## Faction editor save-reset fix (the important part)

**Symptom:** edit a field in the faction editor, hit Save faction — the status flips to Saved but every field snaps back to the values from page load. The save *does* persist; the editor just stops showing it, so the edit looks lost, and a second save would overwrite the real data with the stale on-screen values.

**Root cause:** the authoring session calls `form.reset(canonical)` with the saved server data, which also adopts it as the form's `defaultValues`. But `useForm` re-applies the hook's own `defaultValues` option on every render, and form-core's `update()` overwrites an *untouched* form whenever the two disagree — and a form is always untouched right after reset. The next render (triggered by the mutation state flip) therefore clobbered the form back to the mount-time baseline. Fix in `useFactionAuthoring`: keep the hook's baseline ref in step whenever the session resets without `keepDefaultValues`. This also covers the same latent clobber in "Reset unsaved edits" and source switching once the saved baseline diverges from the mount baseline.

**Why QA missed it:** the e2e lifecycle spec asserted post-save values only after `page.reload()` — testing the database, never the in-session editor. The spec now asserts the editor keeps the just-saved draft *before* any reload.

**Receipts:** the new assertion ran red against the unfixed build (expected `Imported Leader …`, received the page-load `Leader A …`), and green after the fix (2 passed). Also verified live against a dev deployment: field keeps the edited value after save and the deployment query returns the same value. `typecheck`, `lint`, `format:check` clean; all 41 editor unit tests pass.

## Dev server launch configs

`.claude/launch.json` gains two preview entries: `app-hosted` (port 3000: strict migrations, then `convex dev --start 'bun run app:dev'` so functions and vite are both watched) and `app-local` (port 3100 via `APP_DEV_PORT` so both can run simultaneously; the existing disposable local Convex flow). Ports pinned with `autoPort: false` since auth callbacks depend on a stable `SITE_URL` origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved faction editor resets so imported leader information remains available when saving or resetting a loaded draft.
  * Enhanced draft lifecycle behavior to preserve form values consistently during editing, resetting, and reloading.
  * Reduced the risk of losing imported faction details when switching between draft states.

* **Testing**
  * Added coverage confirming imported faction leader values remain available without requiring a page reload.
  * Expanded lifecycle checks for saving, resetting, and reloading loaded drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->