### PR TITLE
FAQ tag labels are browser copy, not a shared contract

### DIFF
--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
@@ -1,6 +1,7 @@
 import { Group, Input, Stack, Textarea } from '@mantine/core';
-import { FAQ_TAG_LABELS, FAQ_TAG_VALUES } from '@shared/faq/tags';
+import { FAQ_TAG_VALUES } from '@shared/faq/tags';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
@@ -1,7 +1,8 @@
 import { Button, Group, Input, Stack, TextInput, Textarea } from '@mantine/core';
 import type { FaqTag } from '@shared/faq/tags';
-import { FAQ_TAG_LABELS, FAQ_TAG_VALUES } from '@shared/faq/tags';
+import { FAQ_TAG_VALUES } from '@shared/faq/tags';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
 

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -13,13 +13,14 @@ import {
   TextInput,
   Title,
 } from '@mantine/core';
-import { FAQ_TAG_LABELS, FAQ_TAG_VALUES } from '@shared/faq/tags';
+import { FAQ_TAG_VALUES } from '@shared/faq/tags';
 import type { FaqTag } from '@shared/faq/tags';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { ProposedContent } from '@ui/block/ProposedContent';
 import { Section } from '@ui/block/Section';
 import { Eyebrow } from '@ui/content/Eyebrow';
+import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { StatusBadge } from '@ui/content/StatusBadge';
 import { TopicIcon } from '@ui/content/TopicIcon';

--- a/src/app/ui/content/faqTagLabels.ts
+++ b/src/app/ui/content/faqTagLabels.ts
@@ -1,0 +1,15 @@
+import type { FaqTag } from '@shared/faq/tags';
+
+/**
+ * How the interface writes each FAQ tag. The vocabulary itself (`FAQ_TAG_VALUES`) is a shared
+ * contract the Convex server also parses; these display strings are the browser's alone, so they
+ * live in the kit rather than in `@shared`, keyed off the shared type so a new tag forces a label.
+ */
+export const FAQ_TAG_LABELS: Record<FaqTag, string> = {
+  rules: 'Rules',
+  army_list: 'Army List',
+  strategy: 'Strategy',
+  balance: 'Balance',
+  errata: 'Errata',
+  other: 'Other',
+};

--- a/src/app/ui/list/FaqList.tsx
+++ b/src/app/ui/list/FaqList.tsx
@@ -1,8 +1,8 @@
 import { Anchor, Badge, Group, Stack, Text, Tooltip } from '@mantine/core';
-import { FAQ_TAG_LABELS } from '@shared/faq/tags';
 import type { FaqTag } from '@shared/faq/tags';
 import { Link } from '@tanstack/react-router';
 import { formatRelativeDate } from '@ui/content/dates';
+import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { SectionedSurface } from '@ui/surface/SectionedSurface';
 import Fuse from 'fuse.js';

--- a/src/shared/faq/tags.ts
+++ b/src/shared/faq/tags.ts
@@ -10,12 +10,3 @@ export const FAQ_TAG_VALUES = [
 export type FaqTag = (typeof FAQ_TAG_VALUES)[number];
 
 export const DEFAULT_FAQ_TAG: FaqTag = 'other';
-
-export const FAQ_TAG_LABELS: Record<FaqTag, string> = {
-  rules: 'Rules',
-  army_list: 'Army List',
-  strategy: 'Strategy',
-  balance: 'Balance',
-  errata: 'Errata',
-  other: 'Other',
-};


### PR DESCRIPTION
The question that started this: `src/shared/faq/` felt fragmented. The finding was narrower and clearer than "merge the files" — one file in the shared layer was carrying something that doesn't belong there.

`src/shared/faq/tags.ts` held `FAQ_TAG_LABELS` — the English display strings `'Rules'`, `'Army List'`, `'Strategy'` — beside the tag vocabulary. But the two are different species:

- **`FAQ_TAG_VALUES`** is a genuine cross-artifact contract: `convex/faq.ts`, `convex/lib/faqTags.ts`, and `convex/migrations.ts` all parse against it. It belongs in `@shared`.
- **`FAQ_TAG_LABELS`** is browser copy — four app callers, **zero** server callers. The Convex deploy was carrying UI strings it has no use for.

So the labels move to `@ui/content/faqTagLabels.ts`, beside the other data-to-words modules already in the kit (`dates.ts`, `assetPublishingStatus.ts`), keyed off the shared `FaqTag` type so a new tag still forces a label at compile time. What's left in `@shared/faq/` is pure vocabulary and pure schema — which is what the shared layer is for.

## Verification

typecheck, lint, format, knip, 447 app tests, 279 story tests — all green. No import specifier still pulls `FAQ_TAG_LABELS` from `@shared`.

## Context

This is the first of a set of small "make `src/` simple, logical and safe" cleanups. A research pass (kept local) established that the deeper proposal — relocating the faction schema out of `src/game` — is a legibility move, not a safety one (`src/game` is already fenced UI-free), so it's being treated as a separate decision rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * FAQ tag display labels are now managed separately from their underlying values.
  * FAQ labels remain consistent across FAQ lists, creation forms, detail pages, and ruleset views.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->