### PR TITLE
Layout components own spacing and lay out through named slots (DD-003)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,13 @@ Rules between categories:
 - **Receivers vs producers.** Layouts and Surfaces *receive* built content through slots. Blocks,
   Lists and Content *produce* content from data. Controls *change* data. A component doing two of
   these is two components.
+- **Layouts own spacing and lay out through named slots.** A Layout arranges its slots; a leaf never
+  carries page margin/padding. Every Layout is a custom component built on Mantine primitives that
+  takes **named compound slots** (`<TriptychLayout><TriptychLayout.Left>…</TriptychLayout.Left>…`),
+  never fewer than two, and is responsive **by container query, not media query** — so it lays out by
+  the room it is given. `PageLayout` is the one exemption from the container-query rule: it is the
+  shell's page frame, viewport-scoped in concert with `AppHeader` (see DD-003 and DD-018).
+  `containerQueries.test.ts` guards it.
 - **Knowledge points one way.** Content knows the theme. Blocks know Content. Lists know their
   item shape. Layouts and Surfaces know nothing about their contents. No component fetches, and none
   navigates on its own behalf.

--- a/docs/technical/ui-design-decisions.md
+++ b/docs/technical/ui-design-decisions.md
@@ -52,17 +52,39 @@ This document records durable UI decisions for consistency across features.
 - Changed on: 2026-03-25
 - Superseded on: 2026-07-19 by DD-015. The legacy generic/form/layout hierarchy is replaced by the Mantine, shared-content, domain, shell, and renderer ownership model.
 
-## DD-003: Layout spacing uses reusable wrappers, flex + gap, and grid
-- Status: superseded
-- Context: Margin-led spacing in leaf components causes inconsistent layout behavior.
-- Rule: Handle spacing and alignment in reusable parent layout wrappers. Prefer flexbox + `gap` for one-dimensional layout and CSS Grid for two-dimensional layout.
+## DD-003: Layout components own spacing, and lay out through named slots
+- Status: accepted
+- Context: Margin-led spacing scattered through leaf components produces inconsistent layout and
+  buries every page in nested `<Stack><Group><Grid>…`. The original rule — parent-owned spacing,
+  flex+`gap`/grid — was only half-retired by DD-015: DD-015 replaced the specific legacy
+  `generic/layout` *wrappers* with Mantine's `Stack`/`Group`/`Grid`, but stated in the same breath
+  that "parent-owned spacing remains useful". This entry reinstates that surviving principle and
+  strengthens it into a Layout-component discipline, because the kit had already grown custom
+  layouts (`PageLayout`, `TriptychLayout`, `AtlasLayout`, `AsymmetricSplitLayout`) with no rule
+  written down for them.
+- Rule:
+  - **Spacing is owned by the Layout, not the leaf.** A leaf control never carries page
+    margin/padding; a Layout arranges its slots. Margin only for unavoidable third-party constraints.
+  - **Layout components are custom, built on Mantine primitives.** A recurring layout situation
+    becomes a named component so a page composes `<TriptychLayout>` instead of re-nesting flex/grid
+    at the call site.
+  - **Responsive by container query, not media query.** A Layout lays out by the room it is given,
+    so it stays context-independent. Guarded by
+    [`containerQueries.test.ts`](../../src/app/ui/layout/containerQueries.test.ts).
+  - **Every Layout lays out through named slots**, as compound children —
+    `<TriptychLayout><TriptychLayout.Left>…</TriptychLayout.Left>…</TriptychLayout>` — so the
+    composition reads top-down and large content never rides inside a prop value.
+  - **No single-slot Layout.** One slot is a passthrough, not a layout; a Layout earns its existence
+    by arranging two or more.
 - Examples:
-  - Use stack/row/grid-style wrappers to orchestrate spacing.
-  - Keep leaf controls focused on control concerns, not page spacing.
+  - `PageLayout` (`.Header`/`.Toolbar`/`.Content`), `TriptychLayout` (`.Left`/`.Center`/`.Right`),
+    `AtlasLayout` (`.Sidebar`/`.Content`), `AsymmetricSplitLayout` (`.Wide`/`.Narrow`).
 - Exceptions:
-  - Margin may be used only for unavoidable third-party constraints and should be documented in implementation notes.
-- Changed on: 2026-03-25
-- Superseded on: 2026-07-19 by DD-015. Flex, `gap`, grid, and parent-owned spacing remain useful, but new reusable legacy layout wrappers are no longer the default.
+  - **`PageLayout` uses `@media`, not a container query, and it is the one exemption.** It is the
+    shell's page frame — its children join `AppHeader`'s grid through `display: contents`, and it is
+    sized against the viewport in concert with the shell through the `data-page-layout-*` bridge
+    (DD-018). It is genuinely viewport-scoped, not a container. The guard excepts it by name.
+- Changed on: 2026-08-13
 
 ## DD-004: Avoid custom CSS and prohibit CSS composes
 - Status: superseded

--- a/src/app/routes/_app/[_]_icons.tsx
+++ b/src/app/routes/_app/[_]_icons.tsx
@@ -257,9 +257,8 @@ function IconsPage() {
   const visibleEntries = sortedEntries.slice(0, visibleCount);
 
   return (
-    <PageLayout
-      headerSize="compact"
-      header={
+    <PageLayout>
+      <PageLayout.Header size="compact">
         <Stack align="center" gap="xs">
           <Title order={1}>Icon catalog</Title>
           <Text ta="center" maw={680}>
@@ -267,8 +266,8 @@ function IconsPage() {
             in this project.
           </Text>
         </Stack>
-      }
-      toolbar={
+      </PageLayout.Header>
+      <PageLayout.Toolbar>
         <Paper withBorder p="md" radius="md" mb="xl">
           <Stack gap="md">
             <TextInput
@@ -334,43 +333,44 @@ function IconsPage() {
             ) : null}
           </Stack>
         </Paper>
-      }
-    >
-      <Stack gap="lg">
-        <Group justify="space-between" align="baseline" gap="sm">
-          <Title order={2} size="h3">
-            {source === 'topics'
-              ? 'Canonical topics'
-              : source === 'lucide'
-                ? 'Lucide'
-                : category === ALL_DUNE_CATEGORY
-                  ? 'Dune SVGs'
-                  : `Dune SVGs — ${category}`}
-          </Title>
-          <Text size="sm" c="dimmed">
-            showing {visibleEntries.length} of {sortedEntries.length}{' '}
-            {sortedEntries.length === 1 ? 'match' : 'matches'}
-          </Text>
-        </Group>
-
-        {visibleEntries.length > 0 ? (
-          <SimpleGrid cols={{ base: 2, xs: 3, sm: 4, md: 5 }} spacing="xs">
-            {visibleEntries.map((entry) => (
-              <IconCatalogCard entry={entry} key={catalogEntryKey(entry)} />
-            ))}
-          </SimpleGrid>
-        ) : (
-          <Surface padding="xl">
-            <Text ta="center" c="dimmed">
-              No icons match “{query.trim()}”.
+      </PageLayout.Toolbar>
+      <PageLayout.Content>
+        <Stack gap="lg">
+          <Group justify="space-between" align="baseline" gap="sm">
+            <Title order={2} size="h3">
+              {source === 'topics'
+                ? 'Canonical topics'
+                : source === 'lucide'
+                  ? 'Lucide'
+                  : category === ALL_DUNE_CATEGORY
+                    ? 'Dune SVGs'
+                    : `Dune SVGs — ${category}`}
+            </Title>
+            <Text size="sm" c="dimmed">
+              showing {visibleEntries.length} of {sortedEntries.length}{' '}
+              {sortedEntries.length === 1 ? 'match' : 'matches'}
             </Text>
-          </Surface>
-        )}
+          </Group>
 
-        {visibleCount < sortedEntries.length ? (
-          <div ref={sentinelRef} style={{ height: 1 }} aria-hidden />
-        ) : null}
-      </Stack>
+          {visibleEntries.length > 0 ? (
+            <SimpleGrid cols={{ base: 2, xs: 3, sm: 4, md: 5 }} spacing="xs">
+              {visibleEntries.map((entry) => (
+                <IconCatalogCard entry={entry} key={catalogEntryKey(entry)} />
+              ))}
+            </SimpleGrid>
+          ) : (
+            <Surface padding="xl">
+              <Text ta="center" c="dimmed">
+                No icons match “{query.trim()}”.
+              </Text>
+            </Surface>
+          )}
+
+          {visibleCount < sortedEntries.length ? (
+            <div ref={sentinelRef} style={{ height: 1 }} aria-hidden />
+          ) : null}
+        </Stack>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/[_]_jobs.tsx
+++ b/src/app/routes/_app/[_]_jobs.tsx
@@ -42,9 +42,8 @@ function PublicationJobsPage() {
   const pickupMutation = useSetPublicationPickupEnabled();
 
   return (
-    <PageLayout
-      headerSize="compact"
-      header={
+    <PageLayout>
+      <PageLayout.Header size="compact">
         <Stack align="center" gap="xs">
           <BriefcaseBusiness size={32} strokeWidth={1.6} aria-hidden />
           <Title order={1}>Publication jobs</Title>
@@ -53,175 +52,181 @@ function PublicationJobsPage() {
             pending work.
           </Text>
         </Stack>
-      }
-    >
-      {result === undefined ? (
-        <Center py="xl">
-          <Loader aria-label="Loading publication jobs" />
-        </Center>
-      ) : result.access === 'unauthenticated' ? (
-        <Alert icon={<AlertCircle size={18} />} title="Sign in required" color="yellow">
-          Sign in with an administrator account to inspect publication jobs.
-        </Alert>
-      ) : result.access === 'not_authorized' ? (
-        <Alert icon={<AlertCircle size={18} />} title="Not authorized" color="red">
-          Your account does not have permission to view publication jobs.
-        </Alert>
-      ) : (
-        <Stack gap="lg">
-          <Surface padding="lg">
-            <Stack gap="lg">
-              <Group justify="space-between" align="flex-start" wrap="wrap">
-                <div>
-                  <Text fw={700}>Publisher pickup</Text>
-                  <Text size="sm" c="dimmed" maw={620}>
-                    Turning this off only prevents the next cron run from picking up pending jobs.
-                    It does not interrupt work already in progress.
-                  </Text>
-                </div>
-                <Switch
-                  size="lg"
-                  checked={result.settings?.publicationPickupEnabled ?? false}
-                  disabled={result.settings === null || pickupMutation.isPending}
-                  label={result.settings?.publicationPickupEnabled ? 'Enabled' : 'Disabled'}
-                  onChange={(event) =>
-                    pickupMutation.mutate({ enabled: event.currentTarget.checked })
-                  }
-                />
-              </Group>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        {result === undefined ? (
+          <Center py="xl">
+            <Loader aria-label="Loading publication jobs" />
+          </Center>
+        ) : result.access === 'unauthenticated' ? (
+          <Alert icon={<AlertCircle size={18} />} title="Sign in required" color="yellow">
+            Sign in with an administrator account to inspect publication jobs.
+          </Alert>
+        ) : result.access === 'not_authorized' ? (
+          <Alert icon={<AlertCircle size={18} />} title="Not authorized" color="red">
+            Your account does not have permission to view publication jobs.
+          </Alert>
+        ) : (
+          <Stack gap="lg">
+            <Surface padding="lg">
+              <Stack gap="lg">
+                <Group justify="space-between" align="flex-start" wrap="wrap">
+                  <div>
+                    <Text fw={700}>Publisher pickup</Text>
+                    <Text size="sm" c="dimmed" maw={620}>
+                      Turning this off only prevents the next cron run from picking up pending jobs.
+                      It does not interrupt work already in progress.
+                    </Text>
+                  </div>
+                  <Switch
+                    size="lg"
+                    checked={result.settings?.publicationPickupEnabled ?? false}
+                    disabled={result.settings === null || pickupMutation.isPending}
+                    label={result.settings?.publicationPickupEnabled ? 'Enabled' : 'Disabled'}
+                    onChange={(event) =>
+                      pickupMutation.mutate({ enabled: event.currentTarget.checked })
+                    }
+                  />
+                </Group>
 
-              {pickupMutation.isError ? (
-                <Alert color="red" title="Could not update publisher pickup">
-                  {pickupMutation.error?.message}
-                </Alert>
-              ) : null}
+                {pickupMutation.isError ? (
+                  <Alert color="red" title="Could not update publisher pickup">
+                    {pickupMutation.error?.message}
+                  </Alert>
+                ) : null}
 
-              <Group gap="xl" align="flex-start" wrap="wrap">
-                <Count label="Pending" value={result.counts.pending} color="yellow" />
-                <Count label="In progress" value={result.counts.inProgress} color="blue" />
-                <Count label="Error" value={result.counts.error} color="red" />
-                <div>
-                  <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
-                    Renderer revisions
-                  </Text>
-                  <Group gap="xs" mt={4}>
-                    {result.settings
-                      ? Object.entries(result.settings.rendererRevisions).map(
-                          ([type, revision]) => (
-                            <Badge variant="light" key={type}>
-                              {formatAssetType(type)} · {revision}
-                            </Badge>
+                <Group gap="xl" align="flex-start" wrap="wrap">
+                  <Count label="Pending" value={result.counts.pending} color="yellow" />
+                  <Count label="In progress" value={result.counts.inProgress} color="blue" />
+                  <Count label="Error" value={result.counts.error} color="red" />
+                  <div>
+                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                      Renderer revisions
+                    </Text>
+                    <Group gap="xs" mt={4}>
+                      {result.settings
+                        ? Object.entries(result.settings.rendererRevisions).map(
+                            ([type, revision]) => (
+                              <Badge variant="light" key={type}>
+                                {formatAssetType(type)} · {revision}
+                              </Badge>
+                            )
                           )
-                        )
-                      : 'Not initialized'}
-                  </Group>
-                </div>
-              </Group>
-            </Stack>
-          </Surface>
+                        : 'Not initialized'}
+                    </Group>
+                  </div>
+                </Group>
+              </Stack>
+            </Surface>
 
-          <Surface>
-            <Group p="md" justify="space-between" align="end" wrap="wrap">
-              <Group align="end">
-                <Select
-                  label="Status"
-                  clearable
-                  placeholder="All statuses"
-                  value={status ?? null}
-                  data={[
-                    { value: 'error', label: 'Error' },
-                    { value: 'in_progress', label: 'In progress' },
-                    { value: 'pending', label: 'Pending' },
-                  ]}
-                  onChange={(value) => {
-                    setStatus((value as PublicationJobStatus | null) ?? undefined);
-                    setPage(1);
-                  }}
-                />
-                <Select
-                  label="Asset type"
-                  clearable
-                  placeholder="All asset types"
-                  value={assetType ?? null}
-                  data={Object.keys(result.settings?.rendererRevisions ?? {}).map((value) => ({
-                    value,
-                    label: formatAssetType(value),
-                  }))}
-                  onChange={(value) => {
-                    setAssetType(value ?? undefined);
-                    setPage(1);
-                  }}
-                />
+            <Surface>
+              <Group p="md" justify="space-between" align="end" wrap="wrap">
+                <Group align="end">
+                  <Select
+                    label="Status"
+                    clearable
+                    placeholder="All statuses"
+                    value={status ?? null}
+                    data={[
+                      { value: 'error', label: 'Error' },
+                      { value: 'in_progress', label: 'In progress' },
+                      { value: 'pending', label: 'Pending' },
+                    ]}
+                    onChange={(value) => {
+                      setStatus((value as PublicationJobStatus | null) ?? undefined);
+                      setPage(1);
+                    }}
+                  />
+                  <Select
+                    label="Asset type"
+                    clearable
+                    placeholder="All asset types"
+                    value={assetType ?? null}
+                    data={Object.keys(result.settings?.rendererRevisions ?? {}).map((value) => ({
+                      value,
+                      label: formatAssetType(value),
+                    }))}
+                    onChange={(value) => {
+                      setAssetType(value ?? undefined);
+                      setPage(1);
+                    }}
+                  />
+                </Group>
+                <Text size="sm" c="dimmed">
+                  {result.total} {result.total === 1 ? 'job' : 'jobs'}
+                </Text>
               </Group>
-              <Text size="sm" c="dimmed">
-                {result.total} {result.total === 1 ? 'job' : 'jobs'}
-              </Text>
-            </Group>
 
-            <Table.ScrollContainer minWidth={980}>
-              <Table striped highlightOnHover verticalSpacing="sm">
-                <Table.Thead>
-                  <Table.Tr>
-                    <Table.Th>Status</Table.Th>
-                    <Table.Th>Asset</Table.Th>
-                    <Table.Th>Attempts</Table.Th>
-                    <Table.Th>Lease expires</Table.Th>
-                    <Table.Th>Last error</Table.Th>
-                    <Table.Th>Updated</Table.Th>
-                    <Table.Th>Job ID</Table.Th>
-                  </Table.Tr>
-                </Table.Thead>
-                <Table.Tbody>
-                  {result.jobs.length > 0 ? (
-                    result.jobs.map((job) => (
-                      <Table.Tr key={job.id}>
-                        <Table.Td>
-                          <JobStatusBadge status={job.status} />
-                        </Table.Td>
-                        <Table.Td>
-                          <Text fw={600}>{formatAssetType(job.assetType)}</Text>
-                          <Code>{job.assetId}</Code>
-                        </Table.Td>
-                        <Table.Td>{job.attemptCounter}</Table.Td>
-                        <Table.Td>{formatDate(job.expiresAt)}</Table.Td>
-                        <Table.Td>
-                          <Text size="sm" c={job.error ? 'red' : 'dimmed'} maw={280} lineClamp={3}>
-                            {job.error ?? '—'}
+              <Table.ScrollContainer minWidth={980}>
+                <Table striped highlightOnHover verticalSpacing="sm">
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>Status</Table.Th>
+                      <Table.Th>Asset</Table.Th>
+                      <Table.Th>Attempts</Table.Th>
+                      <Table.Th>Lease expires</Table.Th>
+                      <Table.Th>Last error</Table.Th>
+                      <Table.Th>Updated</Table.Th>
+                      <Table.Th>Job ID</Table.Th>
+                    </Table.Tr>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {result.jobs.length > 0 ? (
+                      result.jobs.map((job) => (
+                        <Table.Tr key={job.id}>
+                          <Table.Td>
+                            <JobStatusBadge status={job.status} />
+                          </Table.Td>
+                          <Table.Td>
+                            <Text fw={600}>{formatAssetType(job.assetType)}</Text>
+                            <Code>{job.assetId}</Code>
+                          </Table.Td>
+                          <Table.Td>{job.attemptCounter}</Table.Td>
+                          <Table.Td>{formatDate(job.expiresAt)}</Table.Td>
+                          <Table.Td>
+                            <Text
+                              size="sm"
+                              c={job.error ? 'red' : 'dimmed'}
+                              maw={280}
+                              lineClamp={3}
+                            >
+                              {job.error ?? '—'}
+                            </Text>
+                          </Table.Td>
+                          <Table.Td>{formatDate(job.updatedAt)}</Table.Td>
+                          <Table.Td>
+                            <Code>{job.id}</Code>
+                          </Table.Td>
+                        </Table.Tr>
+                      ))
+                    ) : (
+                      <Table.Tr>
+                        <Table.Td colSpan={7}>
+                          <Text ta="center" c="dimmed" py="lg">
+                            No publication jobs match these filters.
                           </Text>
                         </Table.Td>
-                        <Table.Td>{formatDate(job.updatedAt)}</Table.Td>
-                        <Table.Td>
-                          <Code>{job.id}</Code>
-                        </Table.Td>
                       </Table.Tr>
-                    ))
-                  ) : (
-                    <Table.Tr>
-                      <Table.Td colSpan={7}>
-                        <Text ta="center" c="dimmed" py="lg">
-                          No publication jobs match these filters.
-                        </Text>
-                      </Table.Td>
-                    </Table.Tr>
-                  )}
-                </Table.Tbody>
-              </Table>
-            </Table.ScrollContainer>
-          </Surface>
+                    )}
+                  </Table.Tbody>
+                </Table>
+              </Table.ScrollContainer>
+            </Surface>
 
-          {result.total > PAGE_SIZE ? (
-            <Center>
-              <Pagination
-                value={result.page}
-                onChange={setPage}
-                total={Math.ceil(result.total / result.pageSize)}
-                withEdges
-                aria-label="Publication job pages"
-              />
-            </Center>
-          ) : null}
-        </Stack>
-      )}
+            {result.total > PAGE_SIZE ? (
+              <Center>
+                <Pagination
+                  value={result.page}
+                  onChange={setPage}
+                  total={Math.ceil(result.total / result.pageSize)}
+                  withEdges
+                  aria-label="Publication job pages"
+                />
+              </Center>
+            ) : null}
+          </Stack>
+        )}
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/admin/migrations.tsx
+++ b/src/app/routes/_app/admin/migrations.tsx
@@ -33,94 +33,104 @@ function AdminMigrationsPage() {
 
   if (!profile.data?._id) {
     return (
-      <PageLayout header={<h1>Migration activity</h1>}>
-        <Surface padding="lg">
-          <p>
-            <Link to="/auth/login">Log in</Link> to view migration activity.
-          </p>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>
+          <h1>Migration activity</h1>
+        </PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="lg">
+            <p>
+              <Link to="/auth/login">Log in</Link> to view migration activity.
+            </p>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   return (
-    <PageLayout header={<h1>Migration activity</h1>}>
-      <Stack gap="sm">
-        {dashboardQuery.isPending && <p>Loading migration dashboard…</p>}
-        <Surface padding="lg">
-          <Stack gap="xs">
-            <h2>Live migration status</h2>
-            <Group gap="xs" wrap="nowrap">
-              <IconAction
-                label="Sync migration status"
-                tooltip="Sync status snapshot to migration_runs table"
-                variant="filled"
-                color="confirm"
-                size="lg"
-                disabled={syncRuns.isPending}
-                onClick={() => syncRuns.mutate({})}
-                icon={<RefreshCw size={16} aria-hidden />}
-              />
-            </Group>
-            <table>
-              <thead>
-                <tr>
-                  <th align="left">Migration</th>
-                  <th align="left">State</th>
-                  <th align="left">Done</th>
-                  <th align="left">Processed</th>
-                  <th align="left">Started</th>
-                  <th align="left">Ended</th>
-                  <th align="left">Error</th>
-                </tr>
-              </thead>
-              <tbody>
-                {(dashboard?.statuses ?? []).map((row) => (
-                  <tr key={row.name}>
-                    <td>{row.name}</td>
-                    <td>{row.state}</td>
-                    <td>{row.isDone ? 'yes' : 'no'}</td>
-                    <td>{row.processed}</td>
-                    <td>{formatDate(row.latestStart)}</td>
-                    <td>{formatDate(row.latestEnd)}</td>
-                    <td>{row.error ?? '-'}</td>
+    <PageLayout>
+      <PageLayout.Header>
+        <h1>Migration activity</h1>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Stack gap="sm">
+          {dashboardQuery.isPending && <p>Loading migration dashboard…</p>}
+          <Surface padding="lg">
+            <Stack gap="xs">
+              <h2>Live migration status</h2>
+              <Group gap="xs" wrap="nowrap">
+                <IconAction
+                  label="Sync migration status"
+                  tooltip="Sync status snapshot to migration_runs table"
+                  variant="filled"
+                  color="confirm"
+                  size="lg"
+                  disabled={syncRuns.isPending}
+                  onClick={() => syncRuns.mutate({})}
+                  icon={<RefreshCw size={16} aria-hidden />}
+                />
+              </Group>
+              <table>
+                <thead>
+                  <tr>
+                    <th align="left">Migration</th>
+                    <th align="left">State</th>
+                    <th align="left">Done</th>
+                    <th align="left">Processed</th>
+                    <th align="left">Started</th>
+                    <th align="left">Ended</th>
+                    <th align="left">Error</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </Stack>
-        </Surface>
+                </thead>
+                <tbody>
+                  {(dashboard?.statuses ?? []).map((row) => (
+                    <tr key={row.name}>
+                      <td>{row.name}</td>
+                      <td>{row.state}</td>
+                      <td>{row.isDone ? 'yes' : 'no'}</td>
+                      <td>{row.processed}</td>
+                      <td>{formatDate(row.latestStart)}</td>
+                      <td>{formatDate(row.latestEnd)}</td>
+                      <td>{row.error ?? '-'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </Stack>
+          </Surface>
 
-        <Surface padding="lg">
-          <Stack gap="xs">
-            <h2>Recorded snapshots</h2>
-            <table>
-              <thead>
-                <tr>
-                  <th align="left">Migration ID</th>
-                  <th align="left">State</th>
-                  <th align="left">Done</th>
-                  <th align="left">Processed</th>
-                  <th align="left">Updated</th>
-                  <th align="left">Error</th>
-                </tr>
-              </thead>
-              <tbody>
-                {(dashboard?.snapshots ?? []).map((row) => (
-                  <tr key={row._id}>
-                    <td>{row.migration_id}</td>
-                    <td>{row.state}</td>
-                    <td>{row.is_done ? 'yes' : 'no'}</td>
-                    <td>{row.processed}</td>
-                    <td>{row.updated_at}</td>
-                    <td>{row.error ?? '-'}</td>
+          <Surface padding="lg">
+            <Stack gap="xs">
+              <h2>Recorded snapshots</h2>
+              <table>
+                <thead>
+                  <tr>
+                    <th align="left">Migration ID</th>
+                    <th align="left">State</th>
+                    <th align="left">Done</th>
+                    <th align="left">Processed</th>
+                    <th align="left">Updated</th>
+                    <th align="left">Error</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </Stack>
-        </Surface>
-      </Stack>
+                </thead>
+                <tbody>
+                  {(dashboard?.snapshots ?? []).map((row) => (
+                    <tr key={row._id}>
+                      <td>{row.migration_id}</td>
+                      <td>{row.state}</td>
+                      <td>{row.is_done ? 'yes' : 'no'}</td>
+                      <td>{row.processed}</td>
+                      <td>{row.updated_at}</td>
+                      <td>{row.error ?? '-'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </Stack>
+          </Surface>
+        </Stack>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/assets/create.tsx
+++ b/src/app/routes/_app/assets/create.tsx
@@ -8,8 +8,10 @@ export const Route = createFileRoute('/_app/assets/create')({
 function CreateAssetsPage() {
   return (
     <PageLayout>
-      <h2>Create a new faction</h2>
-      <p>This page has no Page.Head, so the header is collapsed (tiny).</p>
+      <PageLayout.Content>
+        <h2>Create a new faction</h2>
+        <p>This page has no Page.Head, so the header is collapsed (tiny).</p>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/assets/index.tsx
+++ b/src/app/routes/_app/assets/index.tsx
@@ -8,8 +8,10 @@ export const Route = createFileRoute('/_app/assets/')({
 function AssetsPage() {
   return (
     <PageLayout>
-      <h2>Assets</h2>
-      <p>This page has no Page.Head, so the header is collapsed (tiny).</p>
+      <PageLayout.Content>
+        <h2>Assets</h2>
+        <p>This page has no Page.Head, so the header is collapsed (tiny).</p>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/auth/error.tsx
+++ b/src/app/routes/_app/auth/error.tsx
@@ -16,11 +16,20 @@ function AuthErrorPage() {
   const params = Route.useSearch();
 
   return (
-    <PageLayout header={<h1>Sign-in error</h1>}>
-      <Surface padding="lg">
-        <h2>Sorry, something went wrong.</h2>
-        {params?.error ? <p>Code error: {params.error}</p> : <p>An unspecified error occurred.</p>}
-      </Surface>
+    <PageLayout>
+      <PageLayout.Header>
+        <h1>Sign-in error</h1>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Surface padding="lg">
+          <h2>Sorry, something went wrong.</h2>
+          {params?.error ? (
+            <p>Code error: {params.error}</p>
+          ) : (
+            <p>An unspecified error occurred.</p>
+          )}
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/auth/index.tsx
+++ b/src/app/routes/_app/auth/index.tsx
@@ -7,27 +7,28 @@ export const Route = createFileRoute('/_app/auth/')({
 
 function AuthLandingPage() {
   return (
-    <PageLayout
-      header={
+    <PageLayout>
+      <PageLayout.Header>
         <h1>
           <span>TANSTACK</span> <span>AUTH</span>
         </h1>
-      }
-    >
-      <p>The framework for next generation AI applications</p>
-      <p>
-        Full-stack framework powered by TanStack Router for React and Solid. Build modern
-        applications with server functions, streaming, and type safety.
-      </p>
-      <div>
-        <Link to="/auth/login">Sign in</Link>
-        <a href="https://tanstack.com/start" target="_blank" rel="noopener noreferrer">
-          Documentation
-        </a>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <p>The framework for next generation AI applications</p>
         <p>
-          Begin your TanStack Start journey by editing <code>/src/routes/index.tsx</code>
+          Full-stack framework powered by TanStack Router for React and Solid. Build modern
+          applications with server functions, streaming, and type safety.
         </p>
-      </div>
+        <div>
+          <Link to="/auth/login">Sign in</Link>
+          <a href="https://tanstack.com/start" target="_blank" rel="noopener noreferrer">
+            Documentation
+          </a>
+          <p>
+            Begin your TanStack Start journey by editing <code>/src/routes/index.tsx</code>
+          </p>
+        </div>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/auth/login.tsx
+++ b/src/app/routes/_app/auth/login.tsx
@@ -181,18 +181,23 @@ function LoginPage() {
   const profile = useCurrentProfile();
 
   return (
-    <PageLayout header={<h1>Sign in</h1>}>
-      <Surface padding="lg">
-        {profile.data ? (
-          <Stack gap="sm">
-            <h2>You're signed in</h2>
-            <p>{profile.data.username ?? 'Player'}</p>
-            <Link to="/">Go to home</Link>
-          </Stack>
-        ) : (
-          <SignInPanel />
-        )}
-      </Surface>
+    <PageLayout>
+      <PageLayout.Header>
+        <h1>Sign in</h1>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Surface padding="lg">
+          {profile.data ? (
+            <Stack gap="sm">
+              <h2>You're signed in</h2>
+              <p>{profile.data.username ?? 'Player'}</p>
+              <Link to="/">Go to home</Link>
+            </Stack>
+          ) : (
+            <SignInPanel />
+          )}
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/factions/$factionId/edit.tsx
+++ b/src/app/routes/_app/factions/$factionId/edit.tsx
@@ -74,46 +74,55 @@ function FactionEditPage() {
 
   if (viewerAccess?.viewer.kind === 'anonymous') {
     return (
-      <PageLayout header={header} headerSize="compact">
-        <Surface padding="xl">
-          <Stack gap="sm">
-            <Text>
-              <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>
-                Log in
-              </Anchor>{' '}
-              to edit factions.
-            </Text>
-            <Anchor
-              renderRoot={(rootProps) => (
-                <Link {...rootProps} to="/factions/$factionId" params={{ factionId }} />
-              )}
-            >
-              Back to faction
-            </Anchor>
-          </Stack>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header size="compact">{header}</PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="xl">
+            <Stack gap="sm">
+              <Text>
+                <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>
+                  Log in
+                </Anchor>{' '}
+                to edit factions.
+              </Text>
+              <Anchor
+                renderRoot={(rootProps) => (
+                  <Link {...rootProps} to="/factions/$factionId" params={{ factionId }} />
+                )}
+              >
+                Back to faction
+              </Anchor>
+            </Stack>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   if (!faction) {
     return (
-      <PageLayout header={header} headerSize="compact">
-        <Text>Loading faction…</Text>
+      <PageLayout>
+        <PageLayout.Header size="compact">{header}</PageLayout.Header>
+        <PageLayout.Content>
+          <Text>Loading faction…</Text>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   if (!viewerAccess?.capabilities.edit) {
     return (
-      <PageLayout header={header} headerSize="compact">
-        <Surface padding="xl">
-          <Text>
-            {faction.group_id
-              ? 'Only the faction owner or an active member of its group can edit this faction.'
-              : 'Only the faction owner can edit this faction.'}
-          </Text>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header size="compact">{header}</PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="xl">
+            <Text>
+              {faction.group_id
+                ? 'Only the faction owner or an active member of its group can edit this faction.'
+                : 'Only the faction owner can edit this faction.'}
+            </Text>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
@@ -123,10 +132,9 @@ function FactionEditPage() {
   const canAssignGroup = viewerAccess.capabilities.changeGroup;
 
   return (
-    <PageLayout
-      header={header}
-      headerSize="compact"
-      toolbar={
+    <PageLayout>
+      <PageLayout.Header size="compact">{header}</PageLayout.Header>
+      <PageLayout.Toolbar>
         <FactionAuthoringToolbar
           status={{
             isDirty: authoring.editing.isDirty,
@@ -231,16 +239,17 @@ function FactionEditPage() {
             ) : null
           }
         />
-      }
-    >
-      <FactionEditor
-        key={faction._id}
-        ref={viewRef}
-        form={authoring.form}
-        errors={authoring.persistence.errors}
-        isNameBlank={authoring.editing.isNameBlank}
-        warnings={authoring.editing.warnings}
-      />
+      </PageLayout.Toolbar>
+      <PageLayout.Content>
+        <FactionEditor
+          key={faction._id}
+          ref={viewRef}
+          form={authoring.form}
+          errors={authoring.persistence.errors}
+          isNameBlank={authoring.editing.isNameBlank}
+          warnings={authoring.editing.warnings}
+        />
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/factions/$factionId/index.tsx
+++ b/src/app/routes/_app/factions/$factionId/index.tsx
@@ -59,41 +59,43 @@ export const Route = createFileRoute('/_app/factions/$factionId/')({
 
 function FactionDetailPending() {
   return (
-    <PageLayout
-      header={
+    <PageLayout>
+      <PageLayout.Header>
         <Stack align="center" gap="xs">
           <Title order={1}>Faction</Title>
           <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>
             Back to factions
           </Anchor>
         </Stack>
-      }
-    >
-      <Surface padding="xl">
-        <Stack gap="xs">
-          <Title order={2}>Loading faction</Title>
-          <Text c="dimmed">The faction details are still loading.</Text>
-        </Stack>
-      </Surface>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Surface padding="xl">
+          <Stack gap="xs">
+            <Title order={2}>Loading faction</Title>
+            <Text c="dimmed">The faction details are still loading.</Text>
+          </Stack>
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }
 
 function FactionDetailError({ error }: ErrorComponentProps) {
   return (
-    <PageLayout
-      header={
+    <PageLayout>
+      <PageLayout.Header>
         <Stack align="center" gap="xs">
           <Title order={1}>Faction</Title>
           <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>
             Back to factions
           </Anchor>
         </Stack>
-      }
-    >
-      <Alert color="red" title="Faction could not be loaded" role="alert">
-        <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
-      </Alert>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Alert color="red" title="Faction could not be loaded" role="alert">
+          <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
+        </Alert>
+      </PageLayout.Content>
     </PageLayout>
   );
 }
@@ -111,22 +113,23 @@ function FactionDetailPage() {
 
   if (!page) {
     return (
-      <PageLayout
-        header={
+      <PageLayout>
+        <PageLayout.Header>
           <Stack align="center" gap="xs">
             <Title order={1}>Faction</Title>
             <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>
               Back to factions
             </Anchor>
           </Stack>
-        }
-      >
-        <Surface padding="xl">
-          <Stack gap="xs">
-            <Title order={2}>Loading faction</Title>
-            <Text c="dimmed">The faction details are still loading.</Text>
-          </Stack>
-        </Surface>
+        </PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="xl">
+            <Stack gap="xs">
+              <Title order={2}>Loading faction</Title>
+              <Text c="dimmed">The faction details are still loading.</Text>
+            </Stack>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
@@ -144,9 +147,8 @@ function FactionDetailPage() {
   const publishingStatus = assetPublishing.captureStatus ?? assetPublishing.status;
 
   return (
-    <PageLayout
-      headerSize="compact"
-      header={
+    <PageLayout>
+      <PageLayout.Header size="compact">
         <Group wrap="nowrap" align="center" gap="lg" className={styles.pageHead}>
           <div className={styles.factionSymbol} role="img" aria-label={`${data.name} symbol`}>
             <FactionToken logo={data.logo} background={data.background} />
@@ -172,8 +174,8 @@ function FactionDetailPage() {
             </Group>
           </Stack>
         </Group>
-      }
-      toolbar={
+      </PageLayout.Header>
+      <PageLayout.Toolbar>
         <Toolbar>
           <Toolbar.Left>
             <Group gap="xs" wrap="wrap" role="group" aria-label="Navigation and editing">
@@ -233,378 +235,379 @@ function FactionDetailPage() {
             </Group>
           </Toolbar.Right>
         </Toolbar>
-      }
-    >
-      <Flex
-        direction={{ base: 'column-reverse', md: 'row' }}
-        gap="xl"
-        align={{ base: 'stretch', md: 'flex-start' }}
-      >
-        <Box miw={0} style={{ flex: '1 1 auto' }}>
-          <Stack gap="xl">
-            <Section icon={<TopicIcon topic="leaders" size={20} />} title="Leaders">
-              <div className={styles.horizontalLane}>
-                {/* Position disambiguates: an author may field two identical leaders, and a
-                    faction's lists carry no ids of their own. */}
-                {data.leaders.map((leader, index) => (
-                  <article
-                    className={styles.leaderTile}
-                    key={`${leader.name}-${leader.image}-${index}`}
-                    title={`${leader.name}, strength ${leader.strength ?? 'not specified'}`}
-                  >
-                    <LeaderToken {...leader} background={data.background} logo={data.logo} />
-                  </article>
-                ))}
-              </div>
-            </Section>
-
-            <Section icon={<TopicIcon topic="troops" size={20} />} title="Troops">
-              <div className={styles.horizontalLane}>
-                {data.troops.map((troop, index) => (
-                  <Surface
-                    as="article"
-                    padding="sm"
-                    className={styles.troopTile}
-                    key={`${troop.name}-${troop.image}-${index}`}
-                  >
-                    <Group wrap="nowrap" gap="md">
-                      <div className={styles.troopToken}>
-                        <TroopToken
-                          background={data.background}
-                          image={troop.image}
-                          hue={troop.hue}
-                          star={troop.star}
-                          striped={troop.striped}
-                        />
-                      </div>
-                      <Stack gap={4} miw={0} style={{ flex: '1 1 auto' }}>
-                        <Group gap="xs" wrap="nowrap" justify="space-between">
-                          <Text fw={700} lh={1.2}>
-                            {troop.name}
-                          </Text>
-                          <Badge variant="filled" color="grey" size="lg">
-                            ×{troop.count}
-                          </Badge>
-                        </Group>
-                        {troop.description ? (
-                          <Text size="xs" c="dimmed">
-                            {troop.description}
-                          </Text>
-                        ) : null}
-                      </Stack>
-                    </Group>
-                  </Surface>
-                ))}
-              </div>
-            </Section>
-
-            {planets.length > 0 ? (
-              <Section icon={<MapPin size={20} aria-hidden />} title="Planets">
+      </PageLayout.Toolbar>
+      <PageLayout.Content>
+        <Flex
+          direction={{ base: 'column-reverse', md: 'row' }}
+          gap="xl"
+          align={{ base: 'stretch', md: 'flex-start' }}
+        >
+          <Box miw={0} style={{ flex: '1 1 auto' }}>
+            <Stack gap="xl">
+              <Section icon={<TopicIcon topic="leaders" size={20} />} title="Leaders">
                 <div className={styles.horizontalLane}>
-                  {planets.map((planet, index) => (
+                  {/* Position disambiguates: an author may field two identical leaders, and a
+                    faction's lists carry no ids of their own. */}
+                  {data.leaders.map((leader, index) => (
+                    <article
+                      className={styles.leaderTile}
+                      key={`${leader.name}-${leader.image}-${index}`}
+                      title={`${leader.name}, strength ${leader.strength ?? 'not specified'}`}
+                    >
+                      <LeaderToken {...leader} background={data.background} logo={data.logo} />
+                    </article>
+                  ))}
+                </div>
+              </Section>
+
+              <Section icon={<TopicIcon topic="troops" size={20} />} title="Troops">
+                <div className={styles.horizontalLane}>
+                  {data.troops.map((troop, index) => (
                     <Surface
                       as="article"
-                      padding="md"
-                      className={styles.planetTile}
-                      key={`${planet.name}-${planet.image}-${index}`}
+                      padding="sm"
+                      className={styles.troopTile}
+                      key={`${troop.name}-${troop.image}-${index}`}
                     >
-                      <Stack gap="xs">
-                        <Text fw={700}>{planet.name}</Text>
-                        <Text size="xs" c="dimmed">
-                          {planet.description}
-                        </Text>
-                      </Stack>
+                      <Group wrap="nowrap" gap="md">
+                        <div className={styles.troopToken}>
+                          <TroopToken
+                            background={data.background}
+                            image={troop.image}
+                            hue={troop.hue}
+                            star={troop.star}
+                            striped={troop.striped}
+                          />
+                        </div>
+                        <Stack gap={4} miw={0} style={{ flex: '1 1 auto' }}>
+                          <Group gap="xs" wrap="nowrap" justify="space-between">
+                            <Text fw={700} lh={1.2}>
+                              {troop.name}
+                            </Text>
+                            <Badge variant="filled" color="grey" size="lg">
+                              ×{troop.count}
+                            </Badge>
+                          </Group>
+                          {troop.description ? (
+                            <Text size="xs" c="dimmed">
+                              {troop.description}
+                            </Text>
+                          ) : null}
+                        </Stack>
+                      </Group>
                     </Surface>
                   ))}
                 </div>
               </Section>
-            ) : null}
 
-            <Section icon={<TopicIcon topic="advantages" size={20} />} title="Advantages">
-              {data.rules.advantages.length > 0 ? (
-                <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
-                  {data.rules.advantages.map((advantage, index) => (
-                    <Card
-                      key={`${advantage.title ?? 'advantage'}-${advantage.text}-${index}`}
-                      title={advantage.title ?? `Advantage ${index + 1}`}
-                    >
-                      <Stack gap="sm">
-                        <Text size="sm">{advantage.text}</Text>
-                        {advantage.karama ? (
-                          <Group gap="xs" wrap="nowrap" align="flex-start">
-                            <TopicIcon topic="karama" size={16} />
-                            <Text size="sm" c="dimmed">
-                              {advantage.karama}
-                            </Text>
-                          </Group>
-                        ) : null}
-                      </Stack>
-                    </Card>
-                  ))}
-                </SimpleGrid>
-              ) : (
-                <Surface padding="lg">
-                  <Text c="dimmed">No faction advantages have been added yet.</Text>
-                </Surface>
-              )}
+              {planets.length > 0 ? (
+                <Section icon={<MapPin size={20} aria-hidden />} title="Planets">
+                  <div className={styles.horizontalLane}>
+                    {planets.map((planet, index) => (
+                      <Surface
+                        as="article"
+                        padding="md"
+                        className={styles.planetTile}
+                        key={`${planet.name}-${planet.image}-${index}`}
+                      >
+                        <Stack gap="xs">
+                          <Text fw={700}>{planet.name}</Text>
+                          <Text size="xs" c="dimmed">
+                            {planet.description}
+                          </Text>
+                        </Stack>
+                      </Surface>
+                    ))}
+                  </div>
+                </Section>
+              ) : null}
+
+              <Section icon={<TopicIcon topic="advantages" size={20} />} title="Advantages">
+                {data.rules.advantages.length > 0 ? (
+                  <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+                    {data.rules.advantages.map((advantage, index) => (
+                      <Card
+                        key={`${advantage.title ?? 'advantage'}-${advantage.text}-${index}`}
+                        title={advantage.title ?? `Advantage ${index + 1}`}
+                      >
+                        <Stack gap="sm">
+                          <Text size="sm">{advantage.text}</Text>
+                          {advantage.karama ? (
+                            <Group gap="xs" wrap="nowrap" align="flex-start">
+                              <TopicIcon topic="karama" size={16} />
+                              <Text size="sm" c="dimmed">
+                                {advantage.karama}
+                              </Text>
+                            </Group>
+                          ) : null}
+                        </Stack>
+                      </Card>
+                    ))}
+                  </SimpleGrid>
+                ) : (
+                  <Surface padding="lg">
+                    <Text c="dimmed">No faction advantages have been added yet.</Text>
+                  </Surface>
+                )}
+              </Section>
+
+              <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
+                <Card icon={<TopicIcon topic="alliance" size={20} />} title="Alliance">
+                  <Text size="sm">{data.rules.alliance.text}</Text>
+                </Card>
+                <Card
+                  icon={<TopicIcon topic="fate" size={20} />}
+                  title={data.rules.fate.title || 'Fate'}
+                >
+                  <Text size="sm">{data.rules.fate.text}</Text>
+                </Card>
+              </SimpleGrid>
+            </Stack>
+          </Box>
+
+          <Stack
+            gap="md"
+            component="aside"
+            aria-label="Faction details"
+            w={{ base: '100%', md: '15rem' }}
+            miw={0}
+            style={{ flex: '0 0 auto' }}
+          >
+            <Section icon={<TopicIcon topic="hero" size={20} />} title="Faction leader">
+              <div className={styles.loreHeroToken}>
+                <LeaderToken
+                  {...data.hero}
+                  strength={undefined}
+                  background={data.background}
+                  logo={data.logo}
+                />
+              </div>
             </Section>
 
-            <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
-              <Card icon={<TopicIcon topic="alliance" size={20} />} title="Alliance">
-                <Text size="sm">{data.rules.alliance.text}</Text>
-              </Card>
-              <Card
-                icon={<TopicIcon topic="fate" size={20} />}
-                title={data.rules.fate.title || 'Fate'}
-              >
-                <Text size="sm">{data.rules.fate.text}</Text>
-              </Card>
-            </SimpleGrid>
-          </Stack>
-        </Box>
-
-        <Stack
-          gap="md"
-          component="aside"
-          aria-label="Faction details"
-          w={{ base: '100%', md: '15rem' }}
-          miw={0}
-          style={{ flex: '0 0 auto' }}
-        >
-          <Section icon={<TopicIcon topic="hero" size={20} />} title="Faction leader">
-            <div className={styles.loreHeroToken}>
-              <LeaderToken
-                {...data.hero}
-                strength={undefined}
-                background={data.background}
-                logo={data.logo}
-              />
-            </div>
-          </Section>
-
-          <Section icon={<TopicIcon topic="setup" size={20} />} title="Setup">
-            <Surface padding="lg">
-              <Stack gap="lg">
-                <Box>
-                  <Title order={3} size="h4">
-                    Components
-                  </Title>
-                  <Box mt="sm">
-                    <Stats
-                      items={[
-                        {
-                          key: 'spice',
-                          icon: <TopicIcon topic="spice" size={17} />,
-                          value: data.rules.spiceCount,
-                          label: `${data.rules.spiceCount} spice`,
-                        },
-                        {
-                          key: 'leaders',
-                          icon: <TopicIcon topic="leaders" size={17} />,
-                          value: data.leaders.length,
-                          label: `${data.leaders.length} ${data.leaders.length === 1 ? 'leader' : 'leaders'}`,
-                        },
-                        {
-                          key: 'troops',
-                          icon: <TopicIcon topic="troops" size={17} />,
-                          value: troopCount,
-                          label: `${troopCount} ${troopCount === 1 ? 'troop' : 'troops'}`,
-                        },
-                      ]}
-                    />
-                  </Box>
-                  <Stack gap="xs" mt="lg">
-                    <Title order={4} size="h5">
-                      Preferred TTS color
+            <Section icon={<TopicIcon topic="setup" size={20} />} title="Setup">
+              <Surface padding="lg">
+                <Stack gap="lg">
+                  <Box>
+                    <Title order={3} size="h4">
+                      Components
                     </Title>
-                    {data.colors.length > 0 ? (
-                      <Group gap="sm">
-                        {data.colors.map((color) => (
-                          <Tooltip key={color} label={`${color} TTS color`}>
-                            <ColorSwatch
-                              color={TTS_COLOR_SWATCHES[color]}
-                              size={18}
-                              aria-label={`${color} TTS color`}
-                            />
-                          </Tooltip>
-                        ))}
-                      </Group>
-                    ) : (
-                      <Text size="sm" c="dimmed">
-                        None specified.
-                      </Text>
-                    )}
-                  </Stack>
-                </Box>
-                <Divider />
-                <Box>
-                  <Title order={3} size="h4">
-                    At start
-                  </Title>
-                  <Text size="sm" mt="xs">
-                    {data.rules.startText}
-                  </Text>
-                </Box>
-                <Divider />
-                <Box>
-                  <Title order={3} size="h4">
-                    Revival
-                  </Title>
-                  <Text size="sm" mt="xs">
-                    {data.rules.revivalText}
-                  </Text>
-                </Box>
-              </Stack>
-            </Surface>
-          </Section>
-
-          <Card icon={<UsersRound size={20} aria-hidden />} title="Stewardship">
-            {!assignedGroup ? (
-              <Text size="sm" c="dimmed">
-                No maintaining group.
-              </Text>
-            ) : (
-              <Stack gap="sm">
-                <Box>
-                  <Eyebrow>Maintaining group</Eyebrow>
-                  {assignedGroup.slug ? (
-                    <Anchor
-                      fw={600}
-                      renderRoot={(rootProps) => (
-                        <Link
-                          {...rootProps}
-                          to="/groups/$groupSlug"
-                          params={{ groupSlug: assignedGroup.slug }}
-                        />
+                    <Box mt="sm">
+                      <Stats
+                        items={[
+                          {
+                            key: 'spice',
+                            icon: <TopicIcon topic="spice" size={17} />,
+                            value: data.rules.spiceCount,
+                            label: `${data.rules.spiceCount} spice`,
+                          },
+                          {
+                            key: 'leaders',
+                            icon: <TopicIcon topic="leaders" size={17} />,
+                            value: data.leaders.length,
+                            label: `${data.leaders.length} ${data.leaders.length === 1 ? 'leader' : 'leaders'}`,
+                          },
+                          {
+                            key: 'troops',
+                            icon: <TopicIcon topic="troops" size={17} />,
+                            value: troopCount,
+                            label: `${troopCount} ${troopCount === 1 ? 'troop' : 'troops'}`,
+                          },
+                        ]}
+                      />
+                    </Box>
+                    <Stack gap="xs" mt="lg">
+                      <Title order={4} size="h5">
+                        Preferred TTS color
+                      </Title>
+                      {data.colors.length > 0 ? (
+                        <Group gap="sm">
+                          {data.colors.map((color) => (
+                            <Tooltip key={color} label={`${color} TTS color`}>
+                              <ColorSwatch
+                                color={TTS_COLOR_SWATCHES[color]}
+                                size={18}
+                                aria-label={`${color} TTS color`}
+                              />
+                            </Tooltip>
+                          ))}
+                        </Group>
+                      ) : (
+                        <Text size="sm" c="dimmed">
+                          None specified.
+                        </Text>
                       )}
+                    </Stack>
+                  </Box>
+                  <Divider />
+                  <Box>
+                    <Title order={3} size="h4">
+                      At start
+                    </Title>
+                    <Text size="sm" mt="xs">
+                      {data.rules.startText}
+                    </Text>
+                  </Box>
+                  <Divider />
+                  <Box>
+                    <Title order={3} size="h4">
+                      Revival
+                    </Title>
+                    <Text size="sm" mt="xs">
+                      {data.rules.revivalText}
+                    </Text>
+                  </Box>
+                </Stack>
+              </Surface>
+            </Section>
+
+            <Card icon={<UsersRound size={20} aria-hidden />} title="Stewardship">
+              {!assignedGroup ? (
+                <Text size="sm" c="dimmed">
+                  No maintaining group.
+                </Text>
+              ) : (
+                <Stack gap="sm">
+                  <Box>
+                    <Eyebrow>Maintaining group</Eyebrow>
+                    {assignedGroup.slug ? (
+                      <Anchor
+                        fw={600}
+                        renderRoot={(rootProps) => (
+                          <Link
+                            {...rootProps}
+                            to="/groups/$groupSlug"
+                            params={{ groupSlug: assignedGroup.slug }}
+                          />
+                        )}
+                      >
+                        {assignedGroup.name}
+                      </Anchor>
+                    ) : (
+                      <Text fw={600}>{assignedGroup.name}</Text>
+                    )}
+                  </Box>
+                  <Group justify="space-between" gap="xs">
+                    <Text size="sm" c="dimmed">
+                      Your membership
+                    </Text>
+                    <StatusBadge
+                      tone={
+                        membershipStatus === 'active'
+                          ? 'positive'
+                          : membershipStatus === 'pending'
+                            ? 'pending'
+                            : 'neutral'
+                      }
                     >
-                      {assignedGroup.name}
-                    </Anchor>
-                  ) : (
-                    <Text fw={600}>{assignedGroup.name}</Text>
-                  )}
-                </Box>
-                <Group justify="space-between" gap="xs">
-                  <Text size="sm" c="dimmed">
-                    Your membership
-                  </Text>
-                  <StatusBadge
-                    tone={
-                      membershipStatus === 'active'
-                        ? 'positive'
+                      {membershipStatus === 'active'
+                        ? 'Active'
                         : membershipStatus === 'pending'
-                          ? 'pending'
+                          ? 'Pending'
+                          : 'Not a member'}
+                    </StatusBadge>
+                  </Group>
+                  {viewerAccess?.viewer.kind === 'anonymous' ? (
+                    <Text size="sm">
+                      <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>
+                        Log in
+                      </Anchor>{' '}
+                      to join.
+                    </Text>
+                  ) : null}
+                  {canRequestMembership ? (
+                    <Button
+                      type="button"
+                      variant="light"
+                      leftSection={<UserPlus size={16} aria-hidden />}
+                      loading={membershipWorkflow.request.isPending}
+                      onClick={() =>
+                        void membershipWorkflow.request.run(assignedGroup.id).catch(() => undefined)
+                      }
+                    >
+                      Request membership
+                    </Button>
+                  ) : null}
+                </Stack>
+              )}
+              {membershipWorkflow.request.isError ? (
+                <Alert color="red" title="Membership request failed" role="alert">
+                  {membershipWorkflow.request.error?.message}
+                </Alert>
+              ) : null}
+            </Card>
+
+            <Card
+              icon={<FileText size={20} aria-hidden />}
+              title="Files"
+              action={
+                <StatusBadge
+                  live
+                  tone={
+                    publishingStatus === 'current'
+                      ? 'positive'
+                      : publishingStatus === 'scheduled'
+                        ? 'pending'
+                        : publishingStatus === 'in_progress'
+                          ? 'progress'
                           : 'neutral'
-                    }
-                  >
-                    {membershipStatus === 'active'
-                      ? 'Active'
-                      : membershipStatus === 'pending'
-                        ? 'Pending'
-                        : 'Not a member'}
-                  </StatusBadge>
-                </Group>
-                {viewerAccess?.viewer.kind === 'anonymous' ? (
-                  <Text size="sm">
-                    <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>
-                      Log in
-                    </Anchor>{' '}
-                    to join.
-                  </Text>
-                ) : null}
-                {canRequestMembership ? (
-                  <Button
-                    type="button"
-                    variant="light"
-                    leftSection={<UserPlus size={16} aria-hidden />}
-                    loading={membershipWorkflow.request.isPending}
-                    onClick={() =>
-                      void membershipWorkflow.request.run(assignedGroup.id).catch(() => undefined)
-                    }
-                  >
-                    Request membership
-                  </Button>
-                ) : null}
-              </Stack>
-            )}
-            {membershipWorkflow.request.isError ? (
-              <Alert color="red" title="Membership request failed" role="alert">
-                {membershipWorkflow.request.error?.message}
-              </Alert>
-            ) : null}
-          </Card>
-
-          <Card
-            icon={<FileText size={20} aria-hidden />}
-            title="Files"
-            action={
-              <StatusBadge
-                live
-                tone={
-                  publishingStatus === 'current'
-                    ? 'positive'
+                  }
+                >
+                  {publishingStatus === 'in_progress'
+                    ? 'In progress'
                     : publishingStatus === 'scheduled'
-                      ? 'pending'
-                      : publishingStatus === 'in_progress'
-                        ? 'progress'
-                        : 'neutral'
-                }
-              >
-                {publishingStatus === 'in_progress'
-                  ? 'In progress'
-                  : publishingStatus === 'scheduled'
-                    ? 'Scheduled'
-                    : publishingStatus === 'current'
-                      ? 'Current'
-                      : 'Unavailable'}
-              </StatusBadge>
-            }
-          >
-            <Stack gap="sm">
-              <Text size="sm" c="dimmed">
-                {factionAssetPublishingCopy(
-                  assetPublishing.status,
-                  'idle',
-                  assetPublishing.captureStatus
-                )}
-              </Text>
-              <Anchor
-                fw={600}
-                renderRoot={(rootProps) => (
-                  <Link
-                    {...rootProps}
-                    to="/preview/sheet/$factionSlug"
-                    params={{ factionSlug: factionId }}
-                    search={{ mode: 'db' }}
-                  />
-                )}
-              >
-                Preview faction sheet
-              </Anchor>
-            </Stack>
-          </Card>
+                      ? 'Scheduled'
+                      : publishingStatus === 'current'
+                        ? 'Current'
+                        : 'Unavailable'}
+                </StatusBadge>
+              }
+            >
+              <Stack gap="sm">
+                <Text size="sm" c="dimmed">
+                  {factionAssetPublishingCopy(
+                    assetPublishing.status,
+                    'idle',
+                    assetPublishing.captureStatus
+                  )}
+                </Text>
+                <Anchor
+                  fw={600}
+                  renderRoot={(rootProps) => (
+                    <Link
+                      {...rootProps}
+                      to="/preview/sheet/$factionSlug"
+                      params={{ factionSlug: factionId }}
+                      search={{ mode: 'db' }}
+                    />
+                  )}
+                >
+                  Preview faction sheet
+                </Anchor>
+              </Stack>
+            </Card>
 
-          <Card icon={<TopicIcon topic="rulesets" size={20} />} title="Rulesets">
-            {rulesets.length === 0 ? (
-              <Text size="sm" c="dimmed">
-                Not in a ruleset yet.
-              </Text>
-            ) : (
-              <Links>
-                {rulesets.map((ruleset) => (
-                  <Links.Item
-                    key={ruleset.id}
-                    to="/rulesets/$rulesetSlug"
-                    params={{ rulesetSlug: ruleset.slug }}
-                  >
-                    {ruleset.name}
-                  </Links.Item>
-                ))}
-              </Links>
-            )}
-          </Card>
-        </Stack>
-      </Flex>
+            <Card icon={<TopicIcon topic="rulesets" size={20} />} title="Rulesets">
+              {rulesets.length === 0 ? (
+                <Text size="sm" c="dimmed">
+                  Not in a ruleset yet.
+                </Text>
+              ) : (
+                <Links>
+                  {rulesets.map((ruleset) => (
+                    <Links.Item
+                      key={ruleset.id}
+                      to="/rulesets/$rulesetSlug"
+                      params={{ rulesetSlug: ruleset.slug }}
+                    >
+                      {ruleset.name}
+                    </Links.Item>
+                  ))}
+                </Links>
+              )}
+            </Card>
+          </Stack>
+        </Flex>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/factions/create.tsx
+++ b/src/app/routes/_app/factions/create.tsx
@@ -53,29 +53,31 @@ function CreateFactionPage() {
 
   if (!ownerUserId) {
     return (
-      <PageLayout header={header} headerSize="compact">
-        <Surface padding="xl">
-          <Stack gap="sm">
-            <Text>
-              <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>
-                Log in
-              </Anchor>{' '}
-              to create a faction.
-            </Text>
-            <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>
-              Back to factions
-            </Anchor>
-          </Stack>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header size="compact">{header}</PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="xl">
+            <Stack gap="sm">
+              <Text>
+                <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>
+                  Log in
+                </Anchor>{' '}
+                to create a faction.
+              </Text>
+              <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>
+                Back to factions
+              </Anchor>
+            </Stack>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   return (
-    <PageLayout
-      header={header}
-      headerSize="compact"
-      toolbar={
+    <PageLayout>
+      <PageLayout.Header size="compact">{header}</PageLayout.Header>
+      <PageLayout.Toolbar>
         <FactionAuthoringToolbar
           status={{
             isDirty: authoring.editing.isDirty,
@@ -102,16 +104,17 @@ function CreateFactionPage() {
             </Text>
           }
         />
-      }
-    >
-      <FactionEditor
-        key="create"
-        ref={viewRef}
-        form={authoring.form}
-        errors={authoring.persistence.errors}
-        isNameBlank={authoring.editing.isNameBlank}
-        warnings={authoring.editing.warnings}
-      />
+      </PageLayout.Toolbar>
+      <PageLayout.Content>
+        <FactionEditor
+          key="create"
+          ref={viewRef}
+          form={authoring.form}
+          errors={authoring.persistence.errors}
+          isNameBlank={authoring.editing.isNameBlank}
+          warnings={authoring.editing.warnings}
+        />
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/factions/index.tsx
+++ b/src/app/routes/_app/factions/index.tsx
@@ -53,10 +53,12 @@ function FactionsPage() {
   const hasFactions = data.factions.length > 0;
 
   return (
-    <PageLayout
-      header={<CatalogueHeader spotlights={hasFactions ? data.spotlights : undefined} />}
-      toolbar={
-        hasFactions ? (
+    <PageLayout>
+      <PageLayout.Header>
+        <CatalogueHeader spotlights={hasFactions ? data.spotlights : undefined} />
+      </PageLayout.Header>
+      <PageLayout.Toolbar>
+        {hasFactions ? (
           <CatalogueToolbar
             draftQuery={session.query.value}
             onDraftQueryChange={session.query.change}
@@ -67,50 +69,61 @@ function FactionsPage() {
             totalCount={data.factions.length}
             onSearchChange={session.changeSearch}
           />
-        ) : undefined
-      }
-    >
-      {hasFactions ? (
-        session.visibleFactions.length > 0 ? (
-          <FactionList
-            factions={session.visibleFactions}
-            selectedRulesetSlug={session.search.ruleset}
-          />
+        ) : undefined}
+      </PageLayout.Toolbar>
+      <PageLayout.Content>
+        {hasFactions ? (
+          session.visibleFactions.length > 0 ? (
+            <FactionList
+              factions={session.visibleFactions}
+              selectedRulesetSlug={session.search.ruleset}
+            />
+          ) : (
+            <FilteredEmptyState onReset={session.reset} />
+          )
         ) : (
-          <FilteredEmptyState onReset={session.reset} />
-        )
-      ) : (
-        <Surface padding="xl">
-          <Title order={2}>There are no factions</Title>
-          <Text c="dimmed" mt="xs">
-            Create the first faction to begin the collection.
-          </Text>
-        </Surface>
-      )}
+          <Surface padding="xl">
+            <Title order={2}>There are no factions</Title>
+            <Text c="dimmed" mt="xs">
+              Create the first faction to begin the collection.
+            </Text>
+          </Surface>
+        )}
+      </PageLayout.Content>
     </PageLayout>
   );
 }
 
 function FactionCataloguePending() {
   return (
-    <PageLayout header={<CatalogueHeader />}>
-      <Surface padding="xl">
-        <Stack align="center" gap="sm">
-          <Loader size="sm" />
-          <Title order={2}>Loading factions</Title>
-          <Text c="dimmed">The faction catalogue is still loading.</Text>
-        </Stack>
-      </Surface>
+    <PageLayout>
+      <PageLayout.Header>
+        <CatalogueHeader />
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Surface padding="xl">
+          <Stack align="center" gap="sm">
+            <Loader size="sm" />
+            <Title order={2}>Loading factions</Title>
+            <Text c="dimmed">The faction catalogue is still loading.</Text>
+          </Stack>
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }
 
 function FactionCatalogueError({ error }: ErrorComponentProps) {
   return (
-    <PageLayout header={<CatalogueHeader />}>
-      <Alert color="red" title="Faction catalogue could not be loaded" role="alert">
-        <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
-      </Alert>
+    <PageLayout>
+      <PageLayout.Header>
+        <CatalogueHeader />
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Alert color="red" title="Faction catalogue could not be loaded" role="alert">
+          <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
+        </Alert>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/future-plans/index.tsx
+++ b/src/app/routes/_app/future-plans/index.tsx
@@ -150,8 +150,8 @@ const FUTURE_PLANS: FuturePlan[] = [
 
 function FuturePlansPage() {
   return (
-    <PageLayout
-      header={
+    <PageLayout>
+      <PageLayout.Header>
         <SimpleGrid className={styles.hero} cols={{ base: 1, md: 2 }} spacing="xl">
           <Stack gap="xs">
             <Eyebrow tone="inverse">Our ambitions</Eyebrow>
@@ -162,119 +162,119 @@ function FuturePlansPage() {
             should go next.
           </Text>
         </SimpleGrid>
-      }
-    >
-      <AtlasLayout
-        className={styles.atlasFrame}
-        sidebarClassName={styles.atlasSidebar}
-        sidebar={
-          <Stack component="aside" gap="md">
-            <Badge color="gray" variant="filled" w="fit-content">
-              All planned
-            </Badge>
-            <Eyebrow>The territory</Eyebrow>
-            <nav aria-label="Future plan themes">
-              <Bullets gap="none">
-                {FUTURE_PLANS.map((plan) => (
-                  <Bullets.Item
-                    key={plan.number}
-                    icon={plan.icon}
-                    title={plan.shortTitle}
-                    trailing={<ArrowRight size={16} aria-hidden />}
-                    renderLink={(content) => (
-                      <Anchor className={styles.indexLink} href={`#atlas-${plan.number}`}>
-                        {content}
-                      </Anchor>
-                    )}
-                  />
-                ))}
-              </Bullets>
-            </nav>
-            <Anchor href={GITHUB_BACKLOG} target="_blank" rel="noopener noreferrer" fw={700}>
-              Follow the development backlog <ArrowRight size={15} aria-hidden />
-            </Anchor>
-          </Stack>
-        }
-      >
-        <Stack gap={0}>
-          {FUTURE_PLANS.map((plan) => (
-            <Stack
-              component="article"
-              id={`atlas-${plan.number}`}
-              className={styles.entry}
-              gap="xl"
-              key={plan.number}
-            >
-              <Grid gap="lg" align="flex-start">
-                <Grid.Col span={{ base: 12, sm: 2 }}>
-                  <Text className={styles.coordinate}>{plan.number}</Text>
-                </Grid.Col>
-                <Grid.Col span={{ base: 12, sm: 10 }}>
-                  <Eyebrow tone="accent">Planned territory</Eyebrow>
-                  <Title order={2}>{plan.title}</Title>
-                  <Text className={styles.statement} c="dimmed" mt="sm">
-                    {plan.statement}
-                  </Text>
-                </Grid.Col>
-              </Grid>
-              <Box ml={{ base: 0, sm: '16.6667%' }}>
-                <Bullets gap="xl" columns={{ base: 1, sm: 3 }}>
-                  {plan.capabilities.map((capability) => (
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <AtlasLayout className={styles.atlasFrame}>
+          <AtlasLayout.Sidebar className={styles.atlasSidebar}>
+            <Stack component="aside" gap="md">
+              <Badge color="gray" variant="filled" w="fit-content">
+                All planned
+              </Badge>
+              <Eyebrow>The territory</Eyebrow>
+              <nav aria-label="Future plan themes">
+                <Bullets gap="none">
+                  {FUTURE_PLANS.map((plan) => (
                     <Bullets.Item
-                      key={capability.title}
-                      icon={capability.icon}
-                      title={capability.title}
-                      detail={capability.detail}
+                      key={plan.number}
+                      icon={plan.icon}
+                      title={plan.shortTitle}
+                      trailing={<ArrowRight size={16} aria-hidden />}
+                      renderLink={(content) => (
+                        <Anchor className={styles.indexLink} href={`#atlas-${plan.number}`}>
+                          {content}
+                        </Anchor>
+                      )}
                     />
                   ))}
                 </Bullets>
-              </Box>
+              </nav>
+              <Anchor href={GITHUB_BACKLOG} target="_blank" rel="noopener noreferrer" fw={700}>
+                Follow the development backlog <ArrowRight size={15} aria-hidden />
+              </Anchor>
             </Stack>
-          ))}
+          </AtlasLayout.Sidebar>
+          <AtlasLayout.Content>
+            <Stack gap={0}>
+              {FUTURE_PLANS.map((plan) => (
+                <Stack
+                  component="article"
+                  id={`atlas-${plan.number}`}
+                  className={styles.entry}
+                  gap="xl"
+                  key={plan.number}
+                >
+                  <Grid gap="lg" align="flex-start">
+                    <Grid.Col span={{ base: 12, sm: 2 }}>
+                      <Text className={styles.coordinate}>{plan.number}</Text>
+                    </Grid.Col>
+                    <Grid.Col span={{ base: 12, sm: 10 }}>
+                      <Eyebrow tone="accent">Planned territory</Eyebrow>
+                      <Title order={2}>{plan.title}</Title>
+                      <Text className={styles.statement} c="dimmed" mt="sm">
+                        {plan.statement}
+                      </Text>
+                    </Grid.Col>
+                  </Grid>
+                  <Box ml={{ base: 0, sm: '16.6667%' }}>
+                    <Bullets gap="xl" columns={{ base: 1, sm: 3 }}>
+                      {plan.capabilities.map((capability) => (
+                        <Bullets.Item
+                          key={capability.title}
+                          icon={capability.icon}
+                          title={capability.title}
+                          detail={capability.detail}
+                        />
+                      ))}
+                    </Bullets>
+                  </Box>
+                </Stack>
+              ))}
 
-          <Paper
-            component="section"
-            className={styles.contribution}
-            radius="lg"
-            p={{ base: 'xl', md: 48 }}
-          >
-            <SimpleGrid cols={{ base: 1, md: 3 }} spacing="xl" verticalSpacing="xl">
-              <ThemeIcon size={72} radius="50%" variant="light" color="dune" aria-hidden>
-                <Lightbulb />
-              </ThemeIcon>
-              <Stack gap="xs">
-                <Eyebrow tone="accent">And more…</Eyebrow>
-                <Title order={2}>Put a new destination on the map</Title>
-                <Text c="dimmed">
-                  Open an idea for the community to discuss, or pick up an issue and help build the
-                  route there.
-                </Text>
-              </Stack>
-              <Stack justify="center" gap="sm">
-                <Button
-                  component="a"
-                  href={GITHUB_IDEAS}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  leftSection={<MessageCirclePlus size={17} aria-hidden />}
-                >
-                  Suggest an idea
-                </Button>
-                <Button
-                  component="a"
-                  href={GITHUB_REPOSITORY}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  color="confirm"
-                  leftSection={<Code2 size={17} aria-hidden />}
-                >
-                  Help build Dune Zone
-                </Button>
-              </Stack>
-            </SimpleGrid>
-          </Paper>
-        </Stack>
-      </AtlasLayout>
+              <Paper
+                component="section"
+                className={styles.contribution}
+                radius="lg"
+                p={{ base: 'xl', md: 48 }}
+              >
+                <SimpleGrid cols={{ base: 1, md: 3 }} spacing="xl" verticalSpacing="xl">
+                  <ThemeIcon size={72} radius="50%" variant="light" color="dune" aria-hidden>
+                    <Lightbulb />
+                  </ThemeIcon>
+                  <Stack gap="xs">
+                    <Eyebrow tone="accent">And more…</Eyebrow>
+                    <Title order={2}>Put a new destination on the map</Title>
+                    <Text c="dimmed">
+                      Open an idea for the community to discuss, or pick up an issue and help build
+                      the route there.
+                    </Text>
+                  </Stack>
+                  <Stack justify="center" gap="sm">
+                    <Button
+                      component="a"
+                      href={GITHUB_IDEAS}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      leftSection={<MessageCirclePlus size={17} aria-hidden />}
+                    >
+                      Suggest an idea
+                    </Button>
+                    <Button
+                      component="a"
+                      href={GITHUB_REPOSITORY}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      color="confirm"
+                      leftSection={<Code2 size={17} aria-hidden />}
+                    >
+                      Help build Dune Zone
+                    </Button>
+                  </Stack>
+                </SimpleGrid>
+              </Paper>
+            </Stack>
+          </AtlasLayout.Content>
+        </AtlasLayout>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/groups/$groupSlug/edit.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/edit.tsx
@@ -99,13 +99,18 @@ function GroupEditPage() {
   const editPage = groupData.data;
   if (groupData.isError || !editPage) {
     return (
-      <PageLayout header={<h1>Edit group</h1>}>
-        <Surface padding="lg">
-          <p>Group not found.</p>
-          <p>
-            <Link to="/profiles">Back to profiles</Link>
-          </p>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>
+          <h1>Edit group</h1>
+        </PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="lg">
+            <p>Group not found.</p>
+            <p>
+              <Link to="/profiles">Back to profiles</Link>
+            </p>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
@@ -142,41 +147,53 @@ function GroupEditPage() {
 
   if (viewerAccess.viewer.kind === 'anonymous') {
     return (
-      <PageLayout header={header} toolbar={toolbar}>
-        <Surface padding="lg">
-          <p>
-            <Link to="/auth/login">Log in</Link> to edit group settings.
-          </p>
-          <p>
-            <Link to="/groups/$groupSlug" params={{ groupSlug: group.slug }}>
-              Back to group
-            </Link>
-          </p>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>{header}</PageLayout.Header>
+        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
+        <PageLayout.Content>
+          <Surface padding="lg">
+            <p>
+              <Link to="/auth/login">Log in</Link> to edit group settings.
+            </p>
+            <p>
+              <Link to="/groups/$groupSlug" params={{ groupSlug: group.slug }}>
+                Back to group
+              </Link>
+            </p>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   if (!viewerAccess.capabilities.rename) {
     return (
-      <PageLayout header={header} toolbar={toolbar}>
-        <Surface padding="lg">
-          <p>Only the owner can edit the group settings.</p>
-          <p>
-            <Link to="/groups/$groupSlug" params={{ groupSlug: group.slug }}>
-              Back to group
-            </Link>
-          </p>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>{header}</PageLayout.Header>
+        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
+        <PageLayout.Content>
+          <Surface padding="lg">
+            <p>Only the owner can edit the group settings.</p>
+            <p>
+              <Link to="/groups/$groupSlug" params={{ groupSlug: group.slug }}>
+                Back to group
+              </Link>
+            </p>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   return (
-    <PageLayout header={header} toolbar={toolbar}>
-      <Surface padding="lg">
-        <GroupSettings key={group.slug} initial={group} />
-      </Surface>
+    <PageLayout>
+      <PageLayout.Header>{header}</PageLayout.Header>
+      <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
+      <PageLayout.Content>
+        <Surface padding="lg">
+          <GroupSettings key={group.slug} initial={group} />
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -78,12 +78,17 @@ function GroupDetailPage() {
 
   if (groupData.isError) {
     return (
-      <PageLayout header={<Title order={1}>Group</Title>}>
-        <Surface padding="xl">
-          <Alert color="red" title="Group could not be loaded" role="alert">
-            <Text size="sm">This group may have been deleted, or the link may be incorrect.</Text>
-          </Alert>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>
+          <Title order={1}>Group</Title>
+        </PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="xl">
+            <Alert color="red" title="Group could not be loaded" role="alert">
+              <Text size="sm">This group may have been deleted, or the link may be incorrect.</Text>
+            </Alert>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
@@ -91,17 +96,22 @@ function GroupDetailPage() {
   const page = groupData.data;
   if (!page) {
     return (
-      <PageLayout header={<Title order={1}>Group</Title>}>
-        <Box className={styles.twoColumnGrid}>
-          <Stack gap="lg">
-            <Skeleton height={140} radius="md" />
-            <Skeleton height={140} radius="md" />
-          </Stack>
-          <Stack gap="lg">
-            <Skeleton height={160} radius="md" />
-            <Skeleton height={160} radius="md" />
-          </Stack>
-        </Box>
+      <PageLayout>
+        <PageLayout.Header>
+          <Title order={1}>Group</Title>
+        </PageLayout.Header>
+        <PageLayout.Content>
+          <Box className={styles.twoColumnGrid}>
+            <Stack gap="lg">
+              <Skeleton height={140} radius="md" />
+              <Skeleton height={140} radius="md" />
+            </Stack>
+            <Stack gap="lg">
+              <Skeleton height={160} radius="md" />
+              <Skeleton height={160} radius="md" />
+            </Stack>
+          </Box>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
@@ -161,9 +171,11 @@ function GroupDetailPage() {
   };
 
   return (
-    <PageLayout
-      header={<Title order={1}>{group.name}</Title>}
-      toolbar={
+    <PageLayout>
+      <PageLayout.Header>
+        <Title order={1}>{group.name}</Title>
+      </PageLayout.Header>
+      <PageLayout.Toolbar>
         <>
           <Toolbar>
             <Toolbar.Left>
@@ -219,81 +231,66 @@ function GroupDetailPage() {
             </Text>
           )}
         </>
-      }
-    >
-      <Box className={styles.twoColumnGrid}>
-        <Stack gap="lg">
-          <Card
-            icon={<FremenIcon />}
-            title="Factions maintained"
-            action={
-              isActiveMember ? (
-                <FactionAssignPicker
-                  disabled={setFactionGroup.isPending}
-                  currentGroupId={groupId}
-                  currentGroupName={group.name}
-                  onAssign={handleAssignFaction}
-                />
-              ) : undefined
-            }
-          >
-            <FactionList factions={factions} />
-          </Card>
-          <Card
-            icon={<BookOpen size={18} aria-hidden />}
-            title="Rulesets maintained"
-            action={
-              isActiveMember ? (
-                <RulesetAssignPicker
-                  disabled={updateRuleset.isPending}
-                  currentGroupId={groupId}
-                  currentGroupName={group.name}
-                  onAssign={handleAssignRuleset}
-                />
-              ) : undefined
-            }
-          >
-            <RulesetList rulesets={rulesets} />
-          </Card>
-        </Stack>
+      </PageLayout.Toolbar>
+      <PageLayout.Content>
+        <Box className={styles.twoColumnGrid}>
+          <Stack gap="lg">
+            <Card
+              icon={<FremenIcon />}
+              title="Factions maintained"
+              action={
+                isActiveMember ? (
+                  <FactionAssignPicker
+                    disabled={setFactionGroup.isPending}
+                    currentGroupId={groupId}
+                    currentGroupName={group.name}
+                    onAssign={handleAssignFaction}
+                  />
+                ) : undefined
+              }
+            >
+              <FactionList factions={factions} />
+            </Card>
+            <Card
+              icon={<BookOpen size={18} aria-hidden />}
+              title="Rulesets maintained"
+              action={
+                isActiveMember ? (
+                  <RulesetAssignPicker
+                    disabled={updateRuleset.isPending}
+                    currentGroupId={groupId}
+                    currentGroupName={group.name}
+                    onAssign={handleAssignRuleset}
+                  />
+                ) : undefined
+              }
+            >
+              <RulesetList rulesets={rulesets} />
+            </Card>
+          </Stack>
 
-        <Stack gap="lg">
-          <Card icon={<Crown size={18} aria-hidden />} title="Stewardship">
-            <Stack gap="sm">
-              <OwnerLine ownerProfile={ownerProfile} createdBy={group.created_by} />
-              <Divider />
-              <Group justify="space-between">
-                <Text size="sm" c="dimmed">
-                  Your membership
-                </Text>
-                <MembershipStatusBadge status={membershipStatus} isOwner={isOwner} />
-              </Group>
-            </Stack>
-          </Card>
+          <Stack gap="lg">
+            <Card icon={<Crown size={18} aria-hidden />} title="Stewardship">
+              <Stack gap="sm">
+                <OwnerLine ownerProfile={ownerProfile} createdBy={group.created_by} />
+                <Divider />
+                <Group justify="space-between">
+                  <Text size="sm" c="dimmed">
+                    Your membership
+                  </Text>
+                  <MembershipStatusBadge status={membershipStatus} isOwner={isOwner} />
+                </Group>
+              </Stack>
+            </Card>
 
-          {membersModerationError && (
-            <Alert color="red" variant="light" title="Moderation failed" role="alert">
-              {membersModerationError}
-            </Alert>
-          )}
+            {membersModerationError && (
+              <Alert color="red" variant="light" title="Moderation failed" role="alert">
+                {membersModerationError}
+              </Alert>
+            )}
 
-          <PendingRequestsPanel
-            pendingMembers={pendingMembers}
-            moderationBusy={membersModerationBusy}
-            onApprove={(membershipId) =>
-              void membershipWorkflow.approve.run(membershipId).catch(() => undefined)
-            }
-            onReject={(membershipId) =>
-              void membershipWorkflow.reject.run(membershipId).catch(() => undefined)
-            }
-          />
-
-          <Card
-            icon={<UsersRound size={18} aria-hidden />}
-            title={`Members (${activeMembers.length})`}
-          >
-            <MemberRoster
-              members={activeMembers}
+            <PendingRequestsPanel
+              pendingMembers={pendingMembers}
               moderationBusy={membersModerationBusy}
               onApprove={(membershipId) =>
                 void membershipWorkflow.approve.run(membershipId).catch(() => undefined)
@@ -301,11 +298,27 @@ function GroupDetailPage() {
               onReject={(membershipId) =>
                 void membershipWorkflow.reject.run(membershipId).catch(() => undefined)
               }
-              onRemove={handleRemoveMember}
             />
-          </Card>
-        </Stack>
-      </Box>
+
+            <Card
+              icon={<UsersRound size={18} aria-hidden />}
+              title={`Members (${activeMembers.length})`}
+            >
+              <MemberRoster
+                members={activeMembers}
+                moderationBusy={membersModerationBusy}
+                onApprove={(membershipId) =>
+                  void membershipWorkflow.approve.run(membershipId).catch(() => undefined)
+                }
+                onReject={(membershipId) =>
+                  void membershipWorkflow.reject.run(membershipId).catch(() => undefined)
+                }
+                onRemove={handleRemoveMember}
+              />
+            </Card>
+          </Stack>
+        </Box>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/groups/create.tsx
+++ b/src/app/routes/_app/groups/create.tsx
@@ -26,15 +26,18 @@ function GroupCreatePage() {
 
   if (!profile.data?._id || !profile.data.slug) {
     return (
-      <PageLayout header={groupCreateHeader}>
-        <Surface padding="lg">
-          <p>
-            <Link to="/auth/login">Log in</Link> to start a group.
-          </p>
-          <p>
-            <Link to="/profiles">Back to profiles</Link>
-          </p>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>{groupCreateHeader}</PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="lg">
+            <p>
+              <Link to="/auth/login">Log in</Link> to start a group.
+            </p>
+            <p>
+              <Link to="/profiles">Back to profiles</Link>
+            </p>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
@@ -43,9 +46,9 @@ function GroupCreatePage() {
   const canSubmit = !createGroup.isPending && name.trim().length > 0;
 
   return (
-    <PageLayout
-      header={groupCreateHeader}
-      toolbar={
+    <PageLayout>
+      <PageLayout.Header>{groupCreateHeader}</PageLayout.Header>
+      <PageLayout.Toolbar>
         <Toolbar>
           <Toolbar.Left>
             <Group gap="xs" wrap="nowrap">
@@ -76,52 +79,53 @@ function GroupCreatePage() {
             </Group>
           </Toolbar.Left>
         </Toolbar>
-      }
-    >
-      <Surface padding="lg">
-        <Stack
-          component="form"
-          gap="sm"
-          id={GROUP_CREATE_FORM_ID}
-          onSubmit={(e) => {
-            e.preventDefault();
-            const nextName = name.trim();
-            if (!nextName) {
-              return;
-            }
-            setSubmitError(null);
-            createGroup.mutate(
-              { input: { name: nextName } },
-              {
-                onSuccess: () => {
-                  setSubmitError(null);
-                  navigate({
-                    to: '/profiles/$profileSlug',
-                    params: { profileSlug: profileRow.slug },
-                  });
-                },
-                onError: (error) => setSubmitError(error.message),
+      </PageLayout.Toolbar>
+      <PageLayout.Content>
+        <Surface padding="lg">
+          <Stack
+            component="form"
+            gap="sm"
+            id={GROUP_CREATE_FORM_ID}
+            onSubmit={(e) => {
+              e.preventDefault();
+              const nextName = name.trim();
+              if (!nextName) {
+                return;
               }
-            );
-          }}
-        >
-          <TextInput
-            label="Group name"
-            error={submitError ?? createGroup.error?.message}
-            name="name"
-            required
-            minLength={1}
-            title="Group name may only contain letters and numbers"
-            value={name}
-            onChange={(event) => {
-              setName(event.target.value);
-              if (submitError) {
-                setSubmitError(null);
-              }
+              setSubmitError(null);
+              createGroup.mutate(
+                { input: { name: nextName } },
+                {
+                  onSuccess: () => {
+                    setSubmitError(null);
+                    navigate({
+                      to: '/profiles/$profileSlug',
+                      params: { profileSlug: profileRow.slug },
+                    });
+                  },
+                  onError: (error) => setSubmitError(error.message),
+                }
+              );
             }}
-          />
-        </Stack>
-      </Surface>
+          >
+            <TextInput
+              label="Group name"
+              error={submitError ?? createGroup.error?.message}
+              name="name"
+              required
+              minLength={1}
+              title="Group name may only contain letters and numbers"
+              value={name}
+              onChange={(event) => {
+                setName(event.target.value);
+                if (submitError) {
+                  setSubmitError(null);
+                }
+              }}
+            />
+          </Stack>
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/index.tsx
+++ b/src/app/routes/_app/index.tsx
@@ -58,8 +58,8 @@ function IndexPage() {
   ];
 
   return (
-    <PageLayout
-      header={
+    <PageLayout>
+      <PageLayout.Header>
         <Stack className={styles.hero} align="center" justify="center" gap="sm">
           <Eyebrow tone="inverse">A game of conquest, diplomacy &amp; betrayal</Eyebrow>
           <Title order={1} className={styles.heroTitle}>
@@ -81,239 +81,257 @@ function IndexPage() {
             </CallToAction>
           </Group>
         </Stack>
-      }
-    >
-      <Stack gap="xl">
-        <TriptychLayout
-          className={styles.storyLayout}
-          left={
-            <Box className={styles.storyColumn}>
-              <Stack justify="space-between" h="100%" gap="xl">
-                <Box>
-                  <Badge color="dune">Start here</Badge>
-                  <Title order={2} mt="sm" className={styles.storyTitle}>
-                    A game where every player breaks the rules differently
-                  </Title>
-                  <Text c="dimmed" size="lg" mt="md" className={styles.storyCopy}>
-                    Dune turns conquest into conversation. Your strongest weapon may be an alliance,
-                    a threat, a promise—or knowing exactly when to betray one.
-                  </Text>
-                </Box>
-                <Group>
-                  <Button renderRoot={(props) => <Link {...props} to="/rulesets" />}>
-                    Discover Dune
-                  </Button>
-                  <Button
-                    component="a"
-                    href="https://treachery.online/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    variant="subtle"
-                    rightSection={<ExternalLink size={15} aria-hidden />}
-                  >
-                    Play online
-                  </Button>
-                </Group>
-              </Stack>
-            </Box>
-          }
-          center={<AnimatedLeaderToken />}
-          centerClassName={styles.storyPreview}
-          right={
-            <Box className={styles.storyColumn}>
-              <Stack gap="md">
-                <Badge color="confirm" w="fit-content">
-                  Make it yours
-                </Badge>
-                <Title order={2}>Your idea belongs at the table</Title>
-                <Text c="dimmed">
-                  Remix a familiar edition, learn from community homebrew, or invent a faction
-                  nobody has seen before. Watch every piece take shape, then preview, print, and
-                  share it with friends.
-                </Text>
-                <Group mt="sm">
-                  <CallToAction
-                    direction="forward"
-                    renderRoot={(rootProps) => <Link {...rootProps} to="/factions/create" />}
-                  >
-                    Start creating
-                  </CallToAction>
-                  <Button
-                    variant="subtle"
-                    color="confirm"
-                    renderRoot={(props) => <Link {...props} to="/factions" />}
-                  >
-                    Browse homebrew
-                  </Button>
-                </Group>
-              </Stack>
-            </Box>
-          }
-        />
-
-        <Surface className={styles.communityBand}>
-          <SimpleGrid cols={{ base: 1, md: 2 }} spacing="xl" verticalSpacing="xl">
-            <Stack gap="sm">
-              <Eyebrow tone="accent">Built by people around the table</Eyebrow>
-              <Title order={2}>A living game needs a living community</Title>
-              <Text c="dimmed">
-                Find the people making factions, answering edge cases, and bringing new players into
-                the fold.
-              </Text>
-            </Stack>
-            <Stack gap="md">
-              <SimpleGrid cols={{ base: 2, sm: 5 }} spacing="sm">
-                {metrics.map((metric) => (
-                  <Box key={metric.label}>
-                    <Text fw={900} size="xl">
-                      {metric.value}
-                    </Text>
-                    <Text size="xs" c="dimmed">
-                      {metric.label}
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Stack gap="xl">
+          <TriptychLayout className={styles.storyLayout}>
+            <TriptychLayout.Left>
+              <Box className={styles.storyColumn}>
+                <Stack justify="space-between" h="100%" gap="xl">
+                  <Box>
+                    <Badge color="dune">Start here</Badge>
+                    <Title order={2} mt="sm" className={styles.storyTitle}>
+                      A game where every player breaks the rules differently
+                    </Title>
+                    <Text c="dimmed" size="lg" mt="md" className={styles.storyCopy}>
+                      Dune turns conquest into conversation. Your strongest weapon may be an
+                      alliance, a threat, a promise—or knowing exactly when to betray one.
                     </Text>
                   </Box>
-                ))}
-              </SimpleGrid>
-              <Group justify="space-between" align="center">
-                {data.community.newestMembers.length > 0 ? (
-                  <Avatar.Group>
-                    {data.community.newestMembers.map((member) => (
-                      <Link
-                        key={member.id}
-                        to="/profiles/$profileSlug"
-                        params={{ profileSlug: member.slug }}
-                        className={styles.avatarLink}
-                        aria-label={`View ${member.username} profile`}
-                      >
-                        <Avatar src={member.avatarUrl} alt={member.username} />
-                      </Link>
-                    ))}
-                  </Avatar.Group>
-                ) : (
-                  <Text size="sm" c="dimmed">
-                    New makers will appear here.
+                  <Group>
+                    <Button renderRoot={(props) => <Link {...props} to="/rulesets" />}>
+                      Discover Dune
+                    </Button>
+                    <Button
+                      component="a"
+                      href="https://treachery.online/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      variant="subtle"
+                      rightSection={<ExternalLink size={15} aria-hidden />}
+                    >
+                      Play online
+                    </Button>
+                  </Group>
+                </Stack>
+              </Box>
+            </TriptychLayout.Left>
+            <TriptychLayout.Center className={styles.storyPreview}>
+              <AnimatedLeaderToken />
+            </TriptychLayout.Center>
+            <TriptychLayout.Right>
+              <Box className={styles.storyColumn}>
+                <Stack gap="md">
+                  <Badge color="confirm" w="fit-content">
+                    Make it yours
+                  </Badge>
+                  <Title order={2}>Your idea belongs at the table</Title>
+                  <Text c="dimmed">
+                    Remix a familiar edition, learn from community homebrew, or invent a faction
+                    nobody has seen before. Watch every piece take shape, then preview, print, and
+                    share it with friends.
                   </Text>
-                )}
-                <Button variant="subtle" renderRoot={(props) => <Link {...props} to="/profiles" />}>
-                  Meet the community
-                </Button>
-              </Group>
-              <Group gap="xs">
-                <Anchor
-                  href="https://discord.com/invite/dune-tabletop-624609341886169117"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Discord
-                </Anchor>
-                <Text c="dimmed">·</Text>
-                <Anchor
-                  href="https://www.reddit.com/r/DuneBoardGame/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Reddit
-                </Anchor>
-                <Text c="dimmed">·</Text>
-                <Anchor
-                  href="https://boardgamegeek.com/boardgame/283355/dune/forums/69"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  BoardGameGeek
-                </Anchor>
-              </Group>
-            </Stack>
-          </SimpleGrid>
-        </Surface>
+                  <Group mt="sm">
+                    <CallToAction
+                      direction="forward"
+                      renderRoot={(rootProps) => <Link {...rootProps} to="/factions/create" />}
+                    >
+                      Start creating
+                    </CallToAction>
+                    <Button
+                      variant="subtle"
+                      color="confirm"
+                      renderRoot={(props) => <Link {...props} to="/factions" />}
+                    >
+                      Browse homebrew
+                    </Button>
+                  </Group>
+                </Stack>
+              </Box>
+            </TriptychLayout.Right>
+          </TriptychLayout>
 
-        <AsymmetricSplitLayout
-          className={styles.discoveryLayout}
-          wide={
-            <Section
-              className={styles.discoveryColumn}
-              eyebrow="From the catalogue"
-              title="New ideas are arriving"
-              action={
-                <Anchor component={Link} to="/factions" fw={700} className={styles.headingLink}>
-                  See every faction <ArrowRight size={15} aria-hidden />
-                </Anchor>
-              }
-            >
+          <Surface className={styles.communityBand}>
+            <SimpleGrid cols={{ base: 1, md: 2 }} spacing="xl" verticalSpacing="xl">
               <Stack gap="sm">
-                {data.spotlights.newArrival ? (
-                  <FactionCatalogueSpotlight
-                    faction={data.spotlights.newArrival}
-                    label="New arrival"
-                    meta={`Created ${formatFactionCatalogueDate(data.spotlights.newArrival.created_at)}`}
-                  />
-                ) : null}
-                {data.spotlights.freshlyUpdated ? (
-                  <FactionCatalogueSpotlight
-                    faction={data.spotlights.freshlyUpdated}
-                    label="Freshly updated"
-                    meta={`Updated ${formatFactionCatalogueDate(data.spotlights.freshlyUpdated.updated_at)}`}
-                  />
-                ) : null}
-                {!data.spotlights.newArrival && !data.spotlights.freshlyUpdated ? (
-                  <Text c="dimmed">The catalogue is waiting for its first faction.</Text>
-                ) : null}
+                <Eyebrow tone="accent">Built by people around the table</Eyebrow>
+                <Title order={2}>A living game needs a living community</Title>
+                <Text c="dimmed">
+                  Find the people making factions, answering edge cases, and bringing new players
+                  into the fold.
+                </Text>
               </Stack>
-            </Section>
-          }
-          narrow={
-            <Section
-              className={styles.discoveryColumn}
-              eyebrow="Planned"
-              title="What we’ll make next"
-              action={
-                <Anchor component={Link} to="/future-plans" fw={700} className={styles.headingLink}>
-                  Future plans <ArrowRight size={15} aria-hidden />
-                </Anchor>
-              }
-            >
               <Stack gap="md">
-                <Bullets>
-                  <Bullets.Item icon={<BookOpen size={20} />} title="Web-native rulebooks" />
-                  <Bullets.Item icon={<Printer size={20} />} title="PDF and TTS output" />
-                  <Bullets.Item icon={<Trophy size={20} />} title="Results and leaderboards" />
-                  <Bullets.Item
-                    icon={<MessageCircle size={20} />}
-                    title="An Atreides card tracker"
-                  />
-                </Bullets>
-                <Anchor component={Link} to="/future-plans" fw={700}>
-                  What should we make after that?
-                </Anchor>
+                <SimpleGrid cols={{ base: 2, sm: 5 }} spacing="sm">
+                  {metrics.map((metric) => (
+                    <Box key={metric.label}>
+                      <Text fw={900} size="xl">
+                        {metric.value}
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        {metric.label}
+                      </Text>
+                    </Box>
+                  ))}
+                </SimpleGrid>
+                <Group justify="space-between" align="center">
+                  {data.community.newestMembers.length > 0 ? (
+                    <Avatar.Group>
+                      {data.community.newestMembers.map((member) => (
+                        <Link
+                          key={member.id}
+                          to="/profiles/$profileSlug"
+                          params={{ profileSlug: member.slug }}
+                          className={styles.avatarLink}
+                          aria-label={`View ${member.username} profile`}
+                        >
+                          <Avatar src={member.avatarUrl} alt={member.username} />
+                        </Link>
+                      ))}
+                    </Avatar.Group>
+                  ) : (
+                    <Text size="sm" c="dimmed">
+                      New makers will appear here.
+                    </Text>
+                  )}
+                  <Button
+                    variant="subtle"
+                    renderRoot={(props) => <Link {...props} to="/profiles" />}
+                  >
+                    Meet the community
+                  </Button>
+                </Group>
+                <Group gap="xs">
+                  <Anchor
+                    href="https://discord.com/invite/dune-tabletop-624609341886169117"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Discord
+                  </Anchor>
+                  <Text c="dimmed">·</Text>
+                  <Anchor
+                    href="https://www.reddit.com/r/DuneBoardGame/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Reddit
+                  </Anchor>
+                  <Text c="dimmed">·</Text>
+                  <Anchor
+                    href="https://boardgamegeek.com/boardgame/283355/dune/forums/69"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    BoardGameGeek
+                  </Anchor>
+                </Group>
               </Stack>
-            </Section>
-          }
-        />
-      </Stack>
+            </SimpleGrid>
+          </Surface>
+
+          <AsymmetricSplitLayout className={styles.discoveryLayout}>
+            <AsymmetricSplitLayout.Wide>
+              <Section
+                className={styles.discoveryColumn}
+                eyebrow="From the catalogue"
+                title="New ideas are arriving"
+                action={
+                  <Anchor component={Link} to="/factions" fw={700} className={styles.headingLink}>
+                    See every faction <ArrowRight size={15} aria-hidden />
+                  </Anchor>
+                }
+              >
+                <Stack gap="sm">
+                  {data.spotlights.newArrival ? (
+                    <FactionCatalogueSpotlight
+                      faction={data.spotlights.newArrival}
+                      label="New arrival"
+                      meta={`Created ${formatFactionCatalogueDate(data.spotlights.newArrival.created_at)}`}
+                    />
+                  ) : null}
+                  {data.spotlights.freshlyUpdated ? (
+                    <FactionCatalogueSpotlight
+                      faction={data.spotlights.freshlyUpdated}
+                      label="Freshly updated"
+                      meta={`Updated ${formatFactionCatalogueDate(data.spotlights.freshlyUpdated.updated_at)}`}
+                    />
+                  ) : null}
+                  {!data.spotlights.newArrival && !data.spotlights.freshlyUpdated ? (
+                    <Text c="dimmed">The catalogue is waiting for its first faction.</Text>
+                  ) : null}
+                </Stack>
+              </Section>
+            </AsymmetricSplitLayout.Wide>
+            <AsymmetricSplitLayout.Narrow>
+              <Section
+                className={styles.discoveryColumn}
+                eyebrow="Planned"
+                title="What we’ll make next"
+                action={
+                  <Anchor
+                    component={Link}
+                    to="/future-plans"
+                    fw={700}
+                    className={styles.headingLink}
+                  >
+                    Future plans <ArrowRight size={15} aria-hidden />
+                  </Anchor>
+                }
+              >
+                <Stack gap="md">
+                  <Bullets>
+                    <Bullets.Item icon={<BookOpen size={20} />} title="Web-native rulebooks" />
+                    <Bullets.Item icon={<Printer size={20} />} title="PDF and TTS output" />
+                    <Bullets.Item icon={<Trophy size={20} />} title="Results and leaderboards" />
+                    <Bullets.Item
+                      icon={<MessageCircle size={20} />}
+                      title="An Atreides card tracker"
+                    />
+                  </Bullets>
+                  <Anchor component={Link} to="/future-plans" fw={700}>
+                    What should we make after that?
+                  </Anchor>
+                </Stack>
+              </Section>
+            </AsymmetricSplitLayout.Narrow>
+          </AsymmetricSplitLayout>
+        </Stack>
+      </PageLayout.Content>
     </PageLayout>
   );
 }
 
 function HomepagePending() {
   return (
-    <PageLayout header={<Title order={1}>Make Dune your own</Title>}>
-      <Surface>
-        <Stack align="center" gap="sm">
-          <Loader size="sm" />
-          <Title order={2}>Setting the table</Title>
-          <Text c="dimmed">The latest work from the community is loading.</Text>
-        </Stack>
-      </Surface>
+    <PageLayout>
+      <PageLayout.Header>
+        <Title order={1}>Make Dune your own</Title>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Surface>
+          <Stack align="center" gap="sm">
+            <Loader size="sm" />
+            <Title order={2}>Setting the table</Title>
+            <Text c="dimmed">The latest work from the community is loading.</Text>
+          </Stack>
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }
 
 function HomepageError({ error }: ErrorComponentProps) {
   return (
-    <PageLayout header={<Title order={1}>Make Dune your own</Title>}>
-      <Alert color="red" title="The homepage could not be loaded" role="alert">
-        <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
-      </Alert>
+    <PageLayout>
+      <PageLayout.Header>
+        <Title order={1}>Make Dune your own</Title>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Alert color="red" title="The homepage could not be loaded" role="alert">
+          <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
+        </Alert>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/privacy/index.tsx
+++ b/src/app/routes/_app/privacy/index.tsx
@@ -9,8 +9,8 @@ export const Route = createFileRoute('/_app/privacy/')({
 
 function PrivacyPage() {
   return (
-    <PageLayout
-      header={
+    <PageLayout>
+      <PageLayout.Header>
         <SimpleGrid cols={{ base: 1, sm: 2 }} maw="58rem" spacing="xl" w="100%">
           <Stack gap="sm" justify="center">
             <Text fw={700} size="xs" tt="uppercase">
@@ -37,186 +37,189 @@ function PrivacyPage() {
             </Stack>
           </Paper>
         </SimpleGrid>
-      }
-    >
-      <Stack gap="xl">
-        <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Stack gap="xl">
+          <SimpleGrid cols={{ base: 1, md: 2 }} spacing="lg">
+            <Surface padding="xl">
+              <Stack gap="md">
+                <Title order={2}>What we keep private</Title>
+                <Text>We need a small amount of private information to run your account:</Text>
+                <List spacing="sm">
+                  <List.Item>
+                    Your email address, if Google or Discord gives it to us when you sign in.
+                  </List.Item>
+                  <List.Item>
+                    Whether you signed in with Google or Discord, and the account ID they give us.
+                  </List.Item>
+                  <List.Item>
+                    The sign-in records needed to keep you logged in and protect your account.
+                  </List.Item>
+                  <List.Item>
+                    Basic technical details such as your IP address, browser, when you visited, and
+                    errors that happened.
+                  </List.Item>
+                </List>
+                <Text>
+                  Your email address is only used for your account and sign-in. It will not appear
+                  on your profile or anywhere else on the public website.
+                </Text>
+              </Stack>
+            </Surface>
+
+            <Surface padding="xl">
+              <Stack gap="md">
+                <Title order={2}>What everyone can see</Title>
+                <Text>Your public profile can show:</Text>
+                <List spacing="sm">
+                  <List.Item>Your screen name, profile picture, and profile link.</List.Item>
+                  <List.Item>
+                    When you joined and when your public work was created or changed.
+                  </List.Item>
+                  <List.Item>Your active group memberships.</List.Item>
+                  <List.Item>
+                    The factions, groups, and rulesets you create, own, or help maintain.
+                  </List.Item>
+                  <List.Item>
+                    The questions you ask, the answers you give, and whether an answer was picked.
+                  </List.Item>
+                  <List.Item>
+                    Activity totals and the links between you and the things you contribute.
+                  </List.Item>
+                </List>
+                <Text>
+                  The first time you sign in, we use the name and picture from Google or Discord to
+                  set up your public profile.
+                </Text>
+              </Stack>
+            </Surface>
+          </SimpleGrid>
+
           <Surface padding="xl">
             <Stack gap="md">
-              <Title order={2}>What we keep private</Title>
-              <Text>We need a small amount of private information to run your account:</Text>
+              <Title order={2}>Your choices</Title>
               <List spacing="sm">
                 <List.Item>
-                  Your email address, if Google or Discord gives it to us when you sign in.
+                  You can change your screen name and profile picture in your profile settings.
                 </List.Item>
                 <List.Item>
-                  Whether you signed in with Google or Discord, and the account ID they give us.
+                  Changing your screen name may also change the link to your profile.
                 </List.Item>
-                <List.Item>
-                  The sign-in records needed to keep you logged in and protect your account.
-                </List.Item>
-                <List.Item>
-                  Basic technical details such as your IP address, browser, when you visited, and
-                  errors that happened.
-                </List.Item>
+                <List.Item>Do not share anything here that you want to keep private.</List.Item>
               </List>
+            </Stack>
+          </Surface>
+
+          <Surface padding="xl">
+            <Stack gap="md">
+              <Title order={2}>Your data rights</Title>
+              <Text>We follow the GDPR rules that protect your personal data.</Text>
               <Text>
-                Your email address is only used for your account and sign-in. It will not appear on
-                your profile or anywhere else on the public website.
+                You can ask us what personal data we have about you. You can also ask us to correct
+                it, give you a copy, or delete it.
+              </Text>
+              <Text fw={700}>
+                If you ask us to delete your data, we will remove your account, profile,
+                contributions, memberships, sign-in details, and any other personal data we control.
+              </Text>
+              <Text>
+                We may first ask you to prove that the account is yours. It can take a little longer
+                for deleted data to disappear from backups and security logs. We cannot delete
+                copies that other people made while your work was public.
+              </Text>
+              <Text>
+                To make a request, contact the Dune Zone site owner. Do not include your password or
+                other private sign-in details in your message.
               </Text>
             </Stack>
           </Surface>
 
           <Surface padding="xl">
             <Stack gap="md">
-              <Title order={2}>What everyone can see</Title>
-              <Text>Your public profile can show:</Text>
-              <List spacing="sm">
-                <List.Item>Your screen name, profile picture, and profile link.</List.Item>
-                <List.Item>
-                  When you joined and when your public work was created or changed.
-                </List.Item>
-                <List.Item>Your active group memberships.</List.Item>
-                <List.Item>
-                  The factions, groups, and rulesets you create, own, or help maintain.
-                </List.Item>
-                <List.Item>
-                  The questions you ask, the answers you give, and whether an answer was picked.
-                </List.Item>
-                <List.Item>
-                  Activity totals and the links between you and the things you contribute.
-                </List.Item>
-              </List>
+              <Title order={2}>What we do with the data</Title>
               <Text>
-                The first time you sign in, we use the name and picture from Google or Discord to
-                set up your public profile.
+                We only use the data to let you sign in, run the website, show who made each
+                contribution, keep the website safe, and fix problems.
+              </Text>
+              <Text>
+                Google or Discord handles sign-in. Convex stores the data. Cloudflare helps deliver
+                the website. They receive the information they need to do those jobs.
+              </Text>
+              <Text>
+                We do not sell your data. Your profile and contributions are free for people to
+                view, but we do not sell access to them.
               </Text>
             </Stack>
           </Surface>
-        </SimpleGrid>
 
-        <Surface padding="xl">
-          <Stack gap="md">
-            <Title order={2}>Your choices</Title>
-            <List spacing="sm">
-              <List.Item>
-                You can change your screen name and profile picture in your profile settings.
-              </List.Item>
-              <List.Item>
-                Changing your screen name may also change the link to your profile.
-              </List.Item>
-              <List.Item>Do not share anything here that you want to keep private.</List.Item>
-            </List>
-          </Stack>
-        </Surface>
+          <Surface padding="xl">
+            <Stack gap="md">
+              <Title order={2}>Code of conduct</Title>
+              <Text>Be kind and treat other people with respect.</Text>
+              <Text>We do not allow:</Text>
+              <List spacing="sm">
+                <List.Item>Harassment, bullying, threats, or hateful behaviour.</List.Item>
+                <List.Item>
+                  Attacks on people because of who they are, where they come from, or what they
+                  believe.
+                </List.Item>
+                <List.Item>Sharing someone else&apos;s private information.</List.Item>
+                <List.Item>
+                  Spam, scams, impersonation, or attempts to damage the website.
+                </List.Item>
+                <List.Item>Illegal content or anything that puts another person at risk.</List.Item>
+              </List>
+              <Text fw={700}>These rules are not optional.</Text>
+              <Text>
+                We may remove content and suspend or delete accounts when these rules are broken. We
+                will not knowingly allow a violation to remain on Dune Zone.
+              </Text>
+            </Stack>
+          </Surface>
 
-        <Surface padding="xl">
-          <Stack gap="md">
-            <Title order={2}>Your data rights</Title>
-            <Text>We follow the GDPR rules that protect your personal data.</Text>
-            <Text>
-              You can ask us what personal data we have about you. You can also ask us to correct
-              it, give you a copy, or delete it.
-            </Text>
-            <Text fw={700}>
-              If you ask us to delete your data, we will remove your account, profile,
-              contributions, memberships, sign-in details, and any other personal data we control.
-            </Text>
-            <Text>
-              We may first ask you to prove that the account is yours. It can take a little longer
-              for deleted data to disappear from backups and security logs. We cannot delete copies
-              that other people made while your work was public.
-            </Text>
-            <Text>
-              To make a request, contact the Dune Zone site owner. Do not include your password or
-              other private sign-in details in your message.
-            </Text>
-          </Stack>
-        </Surface>
+          <Surface padding="xl">
+            <Stack gap="md">
+              <Title order={2}>Copyright</Title>
+              <Text>
+                Do not upload or publish something if doing so would infringe another person&apos;s
+                copyright.
+              </Text>
+              <Text>
+                Only share work that you made, have permission to use, or are allowed to use by law.
+                We may remove work that breaks this rule.
+              </Text>
+              <Text>
+                We view original, non-commercial fan-made game assets that transform existing
+                material into something new as fair use. That is our view, not a promise that every
+                derivative work is legally fair use. Each work and each use is different.
+              </Text>
+              <Text>
+                Uploading an official image, scan, book, rules text, or other person&apos;s work
+                without meaningful changes is not allowed unless you have permission or another
+                clear legal right to use it.
+              </Text>
+            </Stack>
+          </Surface>
 
-        <Surface padding="xl">
-          <Stack gap="md">
-            <Title order={2}>What we do with the data</Title>
-            <Text>
-              We only use the data to let you sign in, run the website, show who made each
-              contribution, keep the website safe, and fix problems.
-            </Text>
-            <Text>
-              Google or Discord handles sign-in. Convex stores the data. Cloudflare helps deliver
-              the website. They receive the information they need to do those jobs.
-            </Text>
-            <Text>
-              We do not sell your data. Your profile and contributions are free for people to view,
-              but we do not sell access to them.
-            </Text>
-          </Stack>
-        </Surface>
+          <Surface padding="xl">
+            <Stack gap="md">
+              <Title order={2}>A free hobby project</Title>
+              <Text>Dune Zone is a hobby project. You can use it free of charge.</Text>
+              <Text>
+                We will do our best to keep it working, but there is no uptime guarantee. The
+                website may be slow, unavailable, or stop running without notice.
+              </Text>
+              <Text>
+                Please do not use Dune Zone as the only place where you keep something important.
+              </Text>
+            </Stack>
+          </Surface>
 
-        <Surface padding="xl">
-          <Stack gap="md">
-            <Title order={2}>Code of conduct</Title>
-            <Text>Be kind and treat other people with respect.</Text>
-            <Text>We do not allow:</Text>
-            <List spacing="sm">
-              <List.Item>Harassment, bullying, threats, or hateful behaviour.</List.Item>
-              <List.Item>
-                Attacks on people because of who they are, where they come from, or what they
-                believe.
-              </List.Item>
-              <List.Item>Sharing someone else&apos;s private information.</List.Item>
-              <List.Item>Spam, scams, impersonation, or attempts to damage the website.</List.Item>
-              <List.Item>Illegal content or anything that puts another person at risk.</List.Item>
-            </List>
-            <Text fw={700}>These rules are not optional.</Text>
-            <Text>
-              We may remove content and suspend or delete accounts when these rules are broken. We
-              will not knowingly allow a violation to remain on Dune Zone.
-            </Text>
-          </Stack>
-        </Surface>
-
-        <Surface padding="xl">
-          <Stack gap="md">
-            <Title order={2}>Copyright</Title>
-            <Text>
-              Do not upload or publish something if doing so would infringe another person&apos;s
-              copyright.
-            </Text>
-            <Text>
-              Only share work that you made, have permission to use, or are allowed to use by law.
-              We may remove work that breaks this rule.
-            </Text>
-            <Text>
-              We view original, non-commercial fan-made game assets that transform existing material
-              into something new as fair use. That is our view, not a promise that every derivative
-              work is legally fair use. Each work and each use is different.
-            </Text>
-            <Text>
-              Uploading an official image, scan, book, rules text, or other person&apos;s work
-              without meaningful changes is not allowed unless you have permission or another clear
-              legal right to use it.
-            </Text>
-          </Stack>
-        </Surface>
-
-        <Surface padding="xl">
-          <Stack gap="md">
-            <Title order={2}>A free hobby project</Title>
-            <Text>Dune Zone is a hobby project. You can use it free of charge.</Text>
-            <Text>
-              We will do our best to keep it working, but there is no uptime guarantee. The website
-              may be slow, unavailable, or stop running without notice.
-            </Text>
-            <Text>
-              Please do not use Dune Zone as the only place where you keep something important.
-            </Text>
-          </Stack>
-        </Surface>
-
-        <Text c="dimmed" size="sm">
-          Last updated 27 July 2026. If anything changes, we will update this page.
-        </Text>
-      </Stack>
+          <Text c="dimmed" size="sm">
+            Last updated 27 July 2026. If anything changes, we will update this page.
+          </Text>
+        </Stack>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/profiles/$profileSlug/edit.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/edit.tsx
@@ -116,11 +116,13 @@ function ProfileSettingsPage() {
   if (!profile.data) {
     return (
       <PageLayout>
-        <Surface padding="lg">
-          <p>
-            <Link to="/auth/login">Log in</Link> to edit your profile.
-          </p>
-        </Surface>
+        <PageLayout.Content>
+          <Surface padding="lg">
+            <p>
+              <Link to="/auth/login">Log in</Link> to edit your profile.
+            </p>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
@@ -128,14 +130,16 @@ function ProfileSettingsPage() {
   if (profile.data.slug !== profileSlug) {
     return (
       <PageLayout>
-        <Surface padding="lg">
-          <p>You can only edit your own profile.</p>
-          <p>
-            <Link to="/profiles/$profileSlug/edit" params={{ profileSlug: profile.data.slug }}>
-              Go to your profile settings
-            </Link>
-          </p>
-        </Surface>
+        <PageLayout.Content>
+          <Surface padding="lg">
+            <p>You can only edit your own profile.</p>
+            <p>
+              <Link to="/profiles/$profileSlug/edit" params={{ profileSlug: profile.data.slug }}>
+                Go to your profile settings
+              </Link>
+            </p>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
@@ -171,10 +175,13 @@ function ProfileSettingsPage() {
   );
 
   return (
-    <PageLayout toolbar={toolbar}>
-      <Surface padding="lg">
-        <ProfileSettings key={profile.data.slug} initial={profile.data} />
-      </Surface>
+    <PageLayout>
+      <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
+      <PageLayout.Content>
+        <Surface padding="lg">
+          <ProfileSettings key={profile.data.slug} initial={profile.data} />
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/profiles/$profileSlug/index.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/index.tsx
@@ -49,13 +49,18 @@ function ProfileDetailPage() {
 
   if (!page) {
     return (
-      <PageLayout header={<h1>Profile</h1>}>
-        <Surface padding="lg">
-          <p>Profile not found.</p>
-          <p>
-            <Link to="/profiles">Back to profiles</Link>
-          </p>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>
+          <h1>Profile</h1>
+        </PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="lg">
+            <p>Profile not found.</p>
+            <p>
+              <Link to="/profiles">Back to profiles</Link>
+            </p>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
@@ -126,8 +131,8 @@ function ProfileDetailPage() {
   );
 
   return (
-    <PageLayout
-      header={
+    <PageLayout>
+      <PageLayout.Header size="compact">
         <div className={styles.identityRow}>
           {page.profile.avatar_url ? (
             <img
@@ -147,145 +152,148 @@ function ProfileDetailPage() {
             </p>
           </Stack>
         </div>
-      }
-      headerSize="compact"
-      toolbar={toolbar}
-    >
-      <div className={styles.contentColumns}>
-        <Stack gap="md" className={styles.mainColumn}>
-          <Section icon={<Shield size={20} aria-hidden />} title="Factions created">
-            {page.factions.length > 0 ? (
-              <FactionList factions={page.factions} />
-            ) : (
-              <Surface padding="lg">
-                <Text size="sm" c="dimmed">
-                  No factions created yet.
-                </Text>
-              </Surface>
-            )}
-          </Section>
-
-          <Section icon={<TopicIcon topic="rulesets" size={20} />} title="Rulesets maintained">
-            <Surface padding="lg">
-              <ProposedContent label="Proposed content · page query required">
-                <Text size="sm" c="dimmed">
-                  Rulesets owned or maintained by this contributor would appear here.
-                </Text>
-              </ProposedContent>
-            </Surface>
-          </Section>
-
-          <Section icon={<MessageCircleReply size={20} aria-hidden />} title="Answers contributed">
-            {page.faqAnswers.length > 0 ? (
-              <FaqAnswersGiven items={page.faqAnswers} viewedProfileId={page.profile._id} />
-            ) : (
-              <Surface padding="lg">
-                <Text size="sm" c="dimmed">
-                  No FAQ answers yet.
-                </Text>
-              </Surface>
-            )}
-          </Section>
-
-          <Section icon={<CircleHelp size={20} aria-hidden />} title="Questions asked">
-            {page.faqAsked.length > 0 ? (
-              <FaqQuestionsAsked items={page.faqAsked} />
-            ) : (
-              <Surface padding="lg">
-                <Text size="sm" c="dimmed">
-                  No questions asked yet.
-                </Text>
-              </Surface>
-            )}
-          </Section>
-        </Stack>
-
-        <aside className={styles.sidebar} aria-label="Profile details">
-          <Stack gap="sm">
-            <Card icon={<UsersRound size={20} aria-hidden />} title="At a glance">
-              <Stats
-                orientation="column"
-                items={[
-                  {
-                    key: 'factions',
-                    icon: <Shield size={18} aria-hidden />,
-                    value: page.factions.length,
-                    name: 'Factions',
-                    label: `${page.factions.length} factions`,
-                  },
-                  {
-                    key: 'groups',
-                    icon: <UsersRound size={18} aria-hidden />,
-                    value: page.groupSummaries.length,
-                    name: 'Groups',
-                    label: `${page.groupSummaries.length} groups`,
-                  },
-                  {
-                    key: 'answers',
-                    icon: <MessageCircleReply size={18} aria-hidden />,
-                    value: page.faqAnswers.length,
-                    name: 'Answers',
-                    label: `${page.faqAnswers.length} answers`,
-                  },
-                  {
-                    key: 'picked',
-                    icon: <CheckCircle2 size={18} aria-hidden />,
-                    value: acceptedAnswerCount,
-                    name: 'Picked answers',
-                    label: `${acceptedAnswerCount} picked answers`,
-                  },
-                  {
-                    key: 'questions',
-                    icon: <CircleHelp size={18} aria-hidden />,
-                    value: page.faqAsked.length,
-                    name: 'Questions',
-                    label: `${page.faqAsked.length} questions`,
-                  },
-                ]}
-              />
-            </Card>
-
-            <Card icon={<Link2 size={20} aria-hidden />} title="About">
-              <Stack gap="xs">
-                <ProposedContent label="Proposed profile fields">
+      </PageLayout.Header>
+      <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
+      <PageLayout.Content>
+        <div className={styles.contentColumns}>
+          <Stack gap="md" className={styles.mainColumn}>
+            <Section icon={<Shield size={20} aria-hidden />} title="Factions created">
+              {page.factions.length > 0 ? (
+                <FactionList factions={page.factions} />
+              ) : (
+                <Surface padding="lg">
                   <Text size="sm" c="dimmed">
-                    A short bio and a small set of relevant external links could live here.
+                    No factions created yet.
+                  </Text>
+                </Surface>
+              )}
+            </Section>
+
+            <Section icon={<TopicIcon topic="rulesets" size={20} />} title="Rulesets maintained">
+              <Surface padding="lg">
+                <ProposedContent label="Proposed content · page query required">
+                  <Text size="sm" c="dimmed">
+                    Rulesets owned or maintained by this contributor would appear here.
                   </Text>
                 </ProposedContent>
-                <p className={styles.memberSince}>
-                  Member since{' '}
-                  <time dateTime={page.profile.created_at}>
-                    {new Intl.DateTimeFormat('en', {
-                      month: 'short',
-                      year: 'numeric',
-                    }).format(new Date(page.profile.created_at))}
-                  </time>
-                </p>
-              </Stack>
-            </Card>
+              </Surface>
+            </Section>
 
-            <Card icon={<UsersRound size={20} aria-hidden />} title="Groups">
-              {page.groupSummaries.length === 0 ? (
-                <Text size="sm" c="dimmed">
-                  Not a member of any groups.
-                </Text>
+            <Section
+              icon={<MessageCircleReply size={20} aria-hidden />}
+              title="Answers contributed"
+            >
+              {page.faqAnswers.length > 0 ? (
+                <FaqAnswersGiven items={page.faqAnswers} viewedProfileId={page.profile._id} />
               ) : (
-                <Links>
-                  {page.groupSummaries.map((group) => (
-                    <Links.Item
-                      key={group.id}
-                      to="/groups/$groupSlug"
-                      params={{ groupSlug: group.slug }}
-                    >
-                      {group.name}
-                    </Links.Item>
-                  ))}
-                </Links>
+                <Surface padding="lg">
+                  <Text size="sm" c="dimmed">
+                    No FAQ answers yet.
+                  </Text>
+                </Surface>
               )}
-            </Card>
+            </Section>
+
+            <Section icon={<CircleHelp size={20} aria-hidden />} title="Questions asked">
+              {page.faqAsked.length > 0 ? (
+                <FaqQuestionsAsked items={page.faqAsked} />
+              ) : (
+                <Surface padding="lg">
+                  <Text size="sm" c="dimmed">
+                    No questions asked yet.
+                  </Text>
+                </Surface>
+              )}
+            </Section>
           </Stack>
-        </aside>
-      </div>
+
+          <aside className={styles.sidebar} aria-label="Profile details">
+            <Stack gap="sm">
+              <Card icon={<UsersRound size={20} aria-hidden />} title="At a glance">
+                <Stats
+                  orientation="column"
+                  items={[
+                    {
+                      key: 'factions',
+                      icon: <Shield size={18} aria-hidden />,
+                      value: page.factions.length,
+                      name: 'Factions',
+                      label: `${page.factions.length} factions`,
+                    },
+                    {
+                      key: 'groups',
+                      icon: <UsersRound size={18} aria-hidden />,
+                      value: page.groupSummaries.length,
+                      name: 'Groups',
+                      label: `${page.groupSummaries.length} groups`,
+                    },
+                    {
+                      key: 'answers',
+                      icon: <MessageCircleReply size={18} aria-hidden />,
+                      value: page.faqAnswers.length,
+                      name: 'Answers',
+                      label: `${page.faqAnswers.length} answers`,
+                    },
+                    {
+                      key: 'picked',
+                      icon: <CheckCircle2 size={18} aria-hidden />,
+                      value: acceptedAnswerCount,
+                      name: 'Picked answers',
+                      label: `${acceptedAnswerCount} picked answers`,
+                    },
+                    {
+                      key: 'questions',
+                      icon: <CircleHelp size={18} aria-hidden />,
+                      value: page.faqAsked.length,
+                      name: 'Questions',
+                      label: `${page.faqAsked.length} questions`,
+                    },
+                  ]}
+                />
+              </Card>
+
+              <Card icon={<Link2 size={20} aria-hidden />} title="About">
+                <Stack gap="xs">
+                  <ProposedContent label="Proposed profile fields">
+                    <Text size="sm" c="dimmed">
+                      A short bio and a small set of relevant external links could live here.
+                    </Text>
+                  </ProposedContent>
+                  <p className={styles.memberSince}>
+                    Member since{' '}
+                    <time dateTime={page.profile.created_at}>
+                      {new Intl.DateTimeFormat('en', {
+                        month: 'short',
+                        year: 'numeric',
+                      }).format(new Date(page.profile.created_at))}
+                    </time>
+                  </p>
+                </Stack>
+              </Card>
+
+              <Card icon={<UsersRound size={20} aria-hidden />} title="Groups">
+                {page.groupSummaries.length === 0 ? (
+                  <Text size="sm" c="dimmed">
+                    Not a member of any groups.
+                  </Text>
+                ) : (
+                  <Links>
+                    {page.groupSummaries.map((group) => (
+                      <Links.Item
+                        key={group.id}
+                        to="/groups/$groupSlug"
+                        params={{ groupSlug: group.slug }}
+                      >
+                        {group.name}
+                      </Links.Item>
+                    ))}
+                  </Links>
+                )}
+              </Card>
+            </Stack>
+          </aside>
+        </div>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/profiles/index.tsx
+++ b/src/app/routes/_app/profiles/index.tsx
@@ -27,60 +27,65 @@ function ProfilesPage() {
   const profiles = useProfilesAll({ initialData: loaderData.profiles });
 
   return (
-    <PageLayout header={<h1>Profiles</h1>}>
-      {profiles.data && profiles.data.length > 0 ? (
-        <Surface padding="lg">
-          <Stack component="ul" gap="xs" className={styles.list}>
-            {profiles.data.map((profile) => {
-              const activity = profile.activity ?? EMPTY_ACTIVITY;
-              return (
-                <li key={profile._id}>
-                  <Group justify="space-between" wrap="nowrap" gap="md">
-                    <ProfileLink
-                      slug={profile.slug}
-                      username={profile.username}
-                      avatar_url={profile.avatar_url}
-                    />
+    <PageLayout>
+      <PageLayout.Header>
+        <h1>Profiles</h1>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        {profiles.data && profiles.data.length > 0 ? (
+          <Surface padding="lg">
+            <Stack component="ul" gap="xs" className={styles.list}>
+              {profiles.data.map((profile) => {
+                const activity = profile.activity ?? EMPTY_ACTIVITY;
+                return (
+                  <li key={profile._id}>
+                    <Group justify="space-between" wrap="nowrap" gap="md">
+                      <ProfileLink
+                        slug={profile.slug}
+                        username={profile.username}
+                        avatar_url={profile.avatar_url}
+                      />
 
-                    <Stats
-                      items={[
-                        {
-                          key: 'groups',
-                          icon: <UsersRound size={16} aria-hidden />,
-                          value: activity.groupCount,
-                          label: `Groups: ${activity.groupCount}`,
-                        },
-                        {
-                          key: 'factions',
-                          icon: <Shield size={16} aria-hidden />,
-                          value: activity.factionCount,
-                          label: `Factions owned: ${activity.factionCount}`,
-                        },
-                        {
-                          key: 'questions',
-                          icon: <CircleHelp size={16} aria-hidden />,
-                          value: activity.questionCount,
-                          label: `Questions asked: ${activity.questionCount}`,
-                        },
-                        {
-                          key: 'answers',
-                          icon: <MessageCircleReply size={16} aria-hidden />,
-                          value: activity.answerCount,
-                          label: `Answers given: ${activity.answerCount}`,
-                        },
-                      ]}
-                    />
-                  </Group>
-                </li>
-              );
-            })}
-          </Stack>
-        </Surface>
-      ) : (
-        <Text size="sm" c="dimmed">
-          No profiles yet.
-        </Text>
-      )}
+                      <Stats
+                        items={[
+                          {
+                            key: 'groups',
+                            icon: <UsersRound size={16} aria-hidden />,
+                            value: activity.groupCount,
+                            label: `Groups: ${activity.groupCount}`,
+                          },
+                          {
+                            key: 'factions',
+                            icon: <Shield size={16} aria-hidden />,
+                            value: activity.factionCount,
+                            label: `Factions owned: ${activity.factionCount}`,
+                          },
+                          {
+                            key: 'questions',
+                            icon: <CircleHelp size={16} aria-hidden />,
+                            value: activity.questionCount,
+                            label: `Questions asked: ${activity.questionCount}`,
+                          },
+                          {
+                            key: 'answers',
+                            icon: <MessageCircleReply size={16} aria-hidden />,
+                            value: activity.answerCount,
+                            label: `Answers given: ${activity.answerCount}`,
+                          },
+                        ]}
+                      />
+                    </Group>
+                  </li>
+                );
+              })}
+            </Stack>
+          </Surface>
+        ) : (
+          <Text size="sm" c="dimmed">
+            No profiles yet.
+          </Text>
+        )}
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
@@ -178,20 +178,28 @@ function RulesetEditPage() {
 
   if (loaderData.notFound) {
     return (
-      <PageLayout header={header} toolbar={toolbar}>
-        <Surface padding="xl">
-          <Text>Ruleset not found.</Text>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>{header}</PageLayout.Header>
+        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
+        <PageLayout.Content>
+          <Surface padding="xl">
+            <Text>Ruleset not found.</Text>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   if (!page?.ruleset) {
     return (
-      <PageLayout header={header} toolbar={toolbar}>
-        <Surface padding="xl">
-          <Text>Ruleset not found.</Text>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>{header}</PageLayout.Header>
+        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
+        <PageLayout.Content>
+          <Surface padding="xl">
+            <Text>Ruleset not found.</Text>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
@@ -201,48 +209,64 @@ function RulesetEditPage() {
 
   if (!viewerAccess) {
     return (
-      <PageLayout header={header} toolbar={toolbar}>
-        <Surface padding="xl">
-          <Text>Loading profile…</Text>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>{header}</PageLayout.Header>
+        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
+        <PageLayout.Content>
+          <Surface padding="xl">
+            <Text>Loading profile…</Text>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   if (viewerAccess.viewer.kind === 'anonymous') {
     return (
-      <PageLayout header={header} toolbar={toolbar}>
-        <Surface padding="xl">
-          <Text>
-            <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>
-              Log in
-            </Anchor>{' '}
-            to edit this ruleset.
-          </Text>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>{header}</PageLayout.Header>
+        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
+        <PageLayout.Content>
+          <Surface padding="xl">
+            <Text>
+              <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>
+                Log in
+              </Anchor>{' '}
+              to edit this ruleset.
+            </Text>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   if (!viewerAccess.capabilities.edit) {
     return (
-      <PageLayout header={header} toolbar={toolbar}>
-        <Surface padding="xl">
-          <Text>
-            {r.group_id
-              ? 'Only the ruleset owner or an active member of its group can edit this ruleset.'
-              : 'Only the ruleset owner can edit this ruleset.'}
-          </Text>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>{header}</PageLayout.Header>
+        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
+        <PageLayout.Content>
+          <Surface padding="xl">
+            <Text>
+              {r.group_id
+                ? 'Only the ruleset owner or an active member of its group can edit this ruleset.'
+                : 'Only the ruleset owner can edit this ruleset.'}
+            </Text>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   return (
-    <PageLayout header={header} toolbar={toolbar}>
-      <Surface padding="lg">
-        <RulesetSettings key={r.slug} initial={r} canRename={viewerAccess.capabilities.rename} />
-      </Surface>
+    <PageLayout>
+      <PageLayout.Header>{header}</PageLayout.Header>
+      <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
+      <PageLayout.Content>
+        <Surface padding="lg">
+          <RulesetSettings key={r.slug} initial={r} canRename={viewerAccess.capabilities.rename} />
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
@@ -99,17 +99,25 @@ function FaqDetailPage() {
 
   if (loaderData?.notFound) {
     return (
-      <PageLayout header={header}>
-        <Surface padding="lg">
-          <h2>Question not found</h2>
-          <p>This FAQ question does not exist in this ruleset.</p>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>{header}</PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="lg">
+            <h2>Question not found</h2>
+            <p>This FAQ question does not exist in this ruleset.</p>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   if (!item) {
-    return <PageLayout header={header}>Loading question…</PageLayout>;
+    return (
+      <PageLayout>
+        <PageLayout.Header>{header}</PageLayout.Header>
+        <PageLayout.Content>Loading question…</PageLayout.Content>
+      </PageLayout>
+    );
   }
 
   const showAddAnswerForm = page.viewer.answerQuestion;
@@ -139,271 +147,274 @@ function FaqDetailPage() {
   };
 
   return (
-    <PageLayout header={header}>
-      <Surface padding="lg">
-        <Stack gap="md">
-          <Stack gap="sm">
-            {editing.editingQuestion ? (
-              <Stack gap="sm">
-                <Textarea
-                  label="Edit question"
-                  value={editing.questionValue}
-                  onChange={(e) => editingSession.setQuestionValue(e.target.value)}
-                  rows={2}
-                />
-                <Input.Wrapper label="Tags">
-                  <Stack component="fieldset" gap="xs" className={styles.tagFieldset}>
-                    <legend className={styles.visuallyHidden}>FAQ tags</legend>
-                    {FAQ_TAG_VALUES.map((tag) => (
-                      <label key={tag} className={styles.tagOption}>
-                        <input
-                          type="checkbox"
-                          checked={editing.tagValues.includes(tag)}
-                          onChange={(e) => editingSession.toggleTag(tag, e.target.checked)}
-                        />
-                        <span>{FAQ_TAG_LABELS[tag]}</span>
-                      </label>
-                    ))}
-                  </Stack>
-                </Input.Wrapper>
-                <Group gap="xs" wrap="nowrap">
-                  <IconAction
-                    label="Save question"
-                    variant="filled"
-                    color="confirm"
-                    size="lg"
-                    onClick={() => saveQuestion()}
-                    disabled={faq.editQuestion.isPending}
-                    icon={<Check size={16} aria-hidden />}
+    <PageLayout>
+      <PageLayout.Header>{header}</PageLayout.Header>
+      <PageLayout.Content>
+        <Surface padding="lg">
+          <Stack gap="md">
+            <Stack gap="sm">
+              {editing.editingQuestion ? (
+                <Stack gap="sm">
+                  <Textarea
+                    label="Edit question"
+                    value={editing.questionValue}
+                    onChange={(e) => editingSession.setQuestionValue(e.target.value)}
+                    rows={2}
                   />
-                  <IconAction
-                    label="Cancel editing question"
-                    variant="light"
-                    color="dune"
-                    size="lg"
-                    onClick={() => editingSession.cancelQuestion()}
-                    icon={<X size={16} aria-hidden />}
-                  />
-                  {faq.editQuestion.isError && (
-                    <span className={styles.error}>{faq.editQuestion.error?.message}</span>
-                  )}
-                </Group>
-              </Stack>
-            ) : (
-              <>
-                <div className={styles.questionHeader}>
-                  {item.author && (
-                    <ProfileLink
-                      slug={item.author.slug}
-                      username={item.author.username}
-                      avatar_url={item.author.avatarUrl}
-                      className={styles.questionAskerLink}
-                    />
-                  )}
-                  <div>
-                    <h2 className={styles.questionTitle}>{item.text}</h2>
-                  </div>
-                </div>
-                {item.capabilities.editQuestion && (
+                  <Input.Wrapper label="Tags">
+                    <Stack component="fieldset" gap="xs" className={styles.tagFieldset}>
+                      <legend className={styles.visuallyHidden}>FAQ tags</legend>
+                      {FAQ_TAG_VALUES.map((tag) => (
+                        <label key={tag} className={styles.tagOption}>
+                          <input
+                            type="checkbox"
+                            checked={editing.tagValues.includes(tag)}
+                            onChange={(e) => editingSession.toggleTag(tag, e.target.checked)}
+                          />
+                          <span>{FAQ_TAG_LABELS[tag]}</span>
+                        </label>
+                      ))}
+                    </Stack>
+                  </Input.Wrapper>
                   <Group gap="xs" wrap="nowrap">
                     <IconAction
-                      label="Edit question"
+                      label="Save question"
                       variant="filled"
                       color="confirm"
                       size="lg"
-                      onClick={startEditQuestion}
-                      icon={<Pencil size={16} aria-hidden />}
+                      onClick={() => saveQuestion()}
+                      disabled={faq.editQuestion.isPending}
+                      icon={<Check size={16} aria-hidden />}
                     />
                     <IconAction
-                      label="Delete question"
+                      label="Cancel editing question"
                       variant="light"
-                      color="red"
+                      color="dune"
                       size="lg"
-                      onClick={handleDeleteQuestion}
-                      disabled={faq.deleteQuestion.isPending}
-                      icon={<Trash2 size={16} aria-hidden />}
+                      onClick={() => editingSession.cancelQuestion()}
+                      icon={<X size={16} aria-hidden />}
                     />
-                    {faq.deleteQuestion.isError && (
-                      <span className={styles.error}>{faq.deleteQuestion.error?.message}</span>
+                    {faq.editQuestion.isError && (
+                      <span className={styles.error}>{faq.editQuestion.error?.message}</span>
                     )}
                   </Group>
-                )}
-              </>
-            )}
-          </Stack>
-
-          {showAddAnswerForm && (
-            <Stack
-              component="form"
-              gap="sm"
-              onSubmit={(e) => {
-                e.preventDefault();
-                const formEl = e.target as HTMLFormElement;
-                const answer = (
-                  formEl.elements.namedItem('answer') as HTMLTextAreaElement
-                ).value.trim();
-                if (!answer) {
-                  return;
-                }
-                void faq.createAnswer
-                  .run({ answer })
-                  .then(() => formEl.reset())
-                  .catch(() => undefined);
-              }}
-            >
-              <Textarea
-                description="Add your answer (1 per person-you can edit it later)"
-                error={faq.createAnswer.isError ? faq.createAnswer.error?.message : undefined}
-                name="answer"
-                rows={3}
-                required
-                minLength={1}
-                placeholder="Your answer..."
-              />
-              <Group gap="xs" wrap="nowrap">
-                <IconAction
-                  label="Add answer"
-                  variant="filled"
-                  color="confirm"
-                  size="lg"
-                  type="submit"
-                  disabled={faq.createAnswer.isPending}
-                  icon={<MessageSquarePlus size={16} aria-hidden />}
-                />
-              </Group>
+                </Stack>
+              ) : (
+                <>
+                  <div className={styles.questionHeader}>
+                    {item.author && (
+                      <ProfileLink
+                        slug={item.author.slug}
+                        username={item.author.username}
+                        avatar_url={item.author.avatarUrl}
+                        className={styles.questionAskerLink}
+                      />
+                    )}
+                    <div>
+                      <h2 className={styles.questionTitle}>{item.text}</h2>
+                    </div>
+                  </div>
+                  {item.capabilities.editQuestion && (
+                    <Group gap="xs" wrap="nowrap">
+                      <IconAction
+                        label="Edit question"
+                        variant="filled"
+                        color="confirm"
+                        size="lg"
+                        onClick={startEditQuestion}
+                        icon={<Pencil size={16} aria-hidden />}
+                      />
+                      <IconAction
+                        label="Delete question"
+                        variant="light"
+                        color="red"
+                        size="lg"
+                        onClick={handleDeleteQuestion}
+                        disabled={faq.deleteQuestion.isPending}
+                        icon={<Trash2 size={16} aria-hidden />}
+                      />
+                      {faq.deleteQuestion.isError && (
+                        <span className={styles.error}>{faq.deleteQuestion.error?.message}</span>
+                      )}
+                    </Group>
+                  )}
+                </>
+              )}
             </Stack>
-          )}
 
-          {hasUserAnswered && !showAddAnswerForm && (
-            <p className={styles.hintBlock}>
-              You&apos;ve answered. You can edit your answer below.
-            </p>
-          )}
+            {showAddAnswerForm && (
+              <Stack
+                component="form"
+                gap="sm"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  const formEl = e.target as HTMLFormElement;
+                  const answer = (
+                    formEl.elements.namedItem('answer') as HTMLTextAreaElement
+                  ).value.trim();
+                  if (!answer) {
+                    return;
+                  }
+                  void faq.createAnswer
+                    .run({ answer })
+                    .then(() => formEl.reset())
+                    .catch(() => undefined);
+                }}
+              >
+                <Textarea
+                  description="Add your answer (1 per person-you can edit it later)"
+                  error={faq.createAnswer.isError ? faq.createAnswer.error?.message : undefined}
+                  name="answer"
+                  rows={3}
+                  required
+                  minLength={1}
+                  placeholder="Your answer..."
+                />
+                <Group gap="xs" wrap="nowrap">
+                  <IconAction
+                    label="Add answer"
+                    variant="filled"
+                    color="confirm"
+                    size="lg"
+                    type="submit"
+                    disabled={faq.createAnswer.isPending}
+                    icon={<MessageSquarePlus size={16} aria-hidden />}
+                  />
+                </Group>
+              </Stack>
+            )}
 
-          {answers.length > 0 ? (
-            <ul className={styles.answerList}>
-              {answers.map((a) => {
-                const isEditing = editing.editingAnswerId === a.id;
-                const isUserAnswer = a.capabilities.editAnswer;
-                const isAccepted = a.accepted;
-                return (
-                  <li
-                    key={a.id}
-                    id={`faq-answer-${a.id}`}
-                    className={styles.answerItem}
-                    data-accepted={isAccepted ? 'true' : 'false'}
-                  >
-                    {isEditing ? (
-                      <Stack gap="sm">
-                        <Textarea
-                          label="Edit your answer"
-                          value={editing.answerValue}
-                          onChange={(e) => editingSession.setAnswerValue(e.target.value)}
-                          rows={3}
-                        />
-                        <Group gap="xs" wrap="nowrap">
-                          <IconAction
-                            label="Save answer"
-                            variant="filled"
-                            color="confirm"
-                            size="lg"
-                            onClick={() => saveAnswer(a.id)}
-                            disabled={faq.editAnswer.isPending}
-                            icon={<Check size={16} aria-hidden />}
+            {hasUserAnswered && !showAddAnswerForm && (
+              <p className={styles.hintBlock}>
+                You&apos;ve answered. You can edit your answer below.
+              </p>
+            )}
+
+            {answers.length > 0 ? (
+              <ul className={styles.answerList}>
+                {answers.map((a) => {
+                  const isEditing = editing.editingAnswerId === a.id;
+                  const isUserAnswer = a.capabilities.editAnswer;
+                  const isAccepted = a.accepted;
+                  return (
+                    <li
+                      key={a.id}
+                      id={`faq-answer-${a.id}`}
+                      className={styles.answerItem}
+                      data-accepted={isAccepted ? 'true' : 'false'}
+                    >
+                      {isEditing ? (
+                        <Stack gap="sm">
+                          <Textarea
+                            label="Edit your answer"
+                            value={editing.answerValue}
+                            onChange={(e) => editingSession.setAnswerValue(e.target.value)}
+                            rows={3}
                           />
-                          <IconAction
-                            label="Cancel editing answer"
-                            variant="light"
-                            color="dune"
-                            size="lg"
-                            onClick={() => editingSession.cancelAnswer()}
-                            icon={<X size={16} aria-hidden />}
-                          />
-                          {faq.editAnswer.isError && (
-                            <span className={styles.error}>{faq.editAnswer.error?.message}</span>
-                          )}
-                        </Group>
-                      </Stack>
-                    ) : (
-                      <Stack gap="xs">
-                        {(isAccepted || isUserAnswer || a.author) && (
-                          <div className={styles.answerMetaRow}>
-                            {isAccepted && <span>Accepted answer</span>}
-                            {isUserAnswer && <span>Your answer-you can edit or delete it</span>}
-                            {a.author && (
-                              <ProfileLink
-                                slug={a.author.slug}
-                                username={a.author.username}
-                                avatar_url={a.author.avatarUrl}
-                              />
-                            )}
-                          </div>
-                        )}
-                        <div className={styles.answerContent}>{a.text}</div>
-                        <Group gap="xs" wrap="nowrap">
-                          {a.capabilities.acceptAnswer && (
+                          <Group gap="xs" wrap="nowrap">
                             <IconAction
-                              label="Mark as accepted answer"
+                              label="Save answer"
                               variant="filled"
                               color="confirm"
                               size="lg"
-                              onClick={() =>
-                                void faq.setAcceptedAnswer
-                                  .run({ answerId: a.id })
-                                  .catch(() => undefined)
-                              }
-                              disabled={faq.setAcceptedAnswer.isPending}
+                              onClick={() => saveAnswer(a.id)}
+                              disabled={faq.editAnswer.isPending}
                               icon={<Check size={16} aria-hidden />}
                             />
-                          )}
-                          {a.capabilities.unacceptAnswer && (
                             <IconAction
-                              label="Unmark accepted answer"
+                              label="Cancel editing answer"
                               variant="light"
                               color="dune"
                               size="lg"
-                              onClick={() =>
-                                void faq.setAcceptedAnswer
-                                  .run({ answerId: null })
-                                  .catch(() => undefined)
-                              }
-                              disabled={faq.setAcceptedAnswer.isPending}
+                              onClick={() => editingSession.cancelAnswer()}
                               icon={<X size={16} aria-hidden />}
                             />
+                            {faq.editAnswer.isError && (
+                              <span className={styles.error}>{faq.editAnswer.error?.message}</span>
+                            )}
+                          </Group>
+                        </Stack>
+                      ) : (
+                        <Stack gap="xs">
+                          {(isAccepted || isUserAnswer || a.author) && (
+                            <div className={styles.answerMetaRow}>
+                              {isAccepted && <span>Accepted answer</span>}
+                              {isUserAnswer && <span>Your answer-you can edit or delete it</span>}
+                              {a.author && (
+                                <ProfileLink
+                                  slug={a.author.slug}
+                                  username={a.author.username}
+                                  avatar_url={a.author.avatarUrl}
+                                />
+                              )}
+                            </div>
                           )}
-                          {a.capabilities.editAnswer && (
-                            <IconAction
-                              label="Edit your answer"
-                              variant="filled"
-                              color="confirm"
-                              size="lg"
-                              onClick={() => startEditAnswer(a)}
-                              icon={<Pencil size={16} aria-hidden />}
-                            />
-                          )}
-                          {a.capabilities.deleteAnswer && (
-                            <IconAction
-                              label="Delete answer"
-                              variant="light"
-                              color="red"
-                              size="lg"
-                              onClick={() => handleDeleteAnswer(a.id)}
-                              disabled={faq.deleteAnswer.isPending}
-                              icon={<Trash2 size={16} aria-hidden />}
-                            />
-                          )}
-                        </Group>
-                      </Stack>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          ) : (
-            <p>No answers yet.</p>
-          )}
-        </Stack>
-      </Surface>
+                          <div className={styles.answerContent}>{a.text}</div>
+                          <Group gap="xs" wrap="nowrap">
+                            {a.capabilities.acceptAnswer && (
+                              <IconAction
+                                label="Mark as accepted answer"
+                                variant="filled"
+                                color="confirm"
+                                size="lg"
+                                onClick={() =>
+                                  void faq.setAcceptedAnswer
+                                    .run({ answerId: a.id })
+                                    .catch(() => undefined)
+                                }
+                                disabled={faq.setAcceptedAnswer.isPending}
+                                icon={<Check size={16} aria-hidden />}
+                              />
+                            )}
+                            {a.capabilities.unacceptAnswer && (
+                              <IconAction
+                                label="Unmark accepted answer"
+                                variant="light"
+                                color="dune"
+                                size="lg"
+                                onClick={() =>
+                                  void faq.setAcceptedAnswer
+                                    .run({ answerId: null })
+                                    .catch(() => undefined)
+                                }
+                                disabled={faq.setAcceptedAnswer.isPending}
+                                icon={<X size={16} aria-hidden />}
+                              />
+                            )}
+                            {a.capabilities.editAnswer && (
+                              <IconAction
+                                label="Edit your answer"
+                                variant="filled"
+                                color="confirm"
+                                size="lg"
+                                onClick={() => startEditAnswer(a)}
+                                icon={<Pencil size={16} aria-hidden />}
+                              />
+                            )}
+                            {a.capabilities.deleteAnswer && (
+                              <IconAction
+                                label="Delete answer"
+                                variant="light"
+                                color="red"
+                                size="lg"
+                                onClick={() => handleDeleteAnswer(a.id)}
+                                disabled={faq.deleteAnswer.isPending}
+                                icon={<Trash2 size={16} aria-hidden />}
+                              />
+                            )}
+                          </Group>
+                        </Stack>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p>No answers yet.</p>
+            )}
+          </Stack>
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
@@ -41,98 +41,119 @@ function FaqCreatePage() {
   );
 
   if (!rulesetRow) {
-    return <PageLayout header={header}>Loading ruleset…</PageLayout>;
+    return (
+      <PageLayout>
+        <PageLayout.Header>{header}</PageLayout.Header>
+        <PageLayout.Content>Loading ruleset…</PageLayout.Content>
+      </PageLayout>
+    );
   }
   const rulesetId = rulesetRow._id;
 
   if (!profile?.data?._id) {
     return (
-      <PageLayout header={header}>
-        <Surface padding="lg">
-          <p>
-            <Link to="/auth/login">Log in</Link> to ask a question.
-          </p>
-        </Surface>
+      <PageLayout>
+        <PageLayout.Header>{header}</PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="lg">
+            <p>
+              <Link to="/auth/login">Log in</Link> to ask a question.
+            </p>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
 
   return (
-    <PageLayout header={header}>
-      <Surface padding="lg">
-        <Stack
-          component="form"
-          gap="sm"
-          onSubmit={(e) => {
-            e.preventDefault();
-            const formEl = e.target as HTMLFormElement;
-            const question = (
-              formEl.elements.namedItem('question') as HTMLInputElement
-            ).value.trim();
-            const answer = (
-              formEl.elements.namedItem('answer') as HTMLTextAreaElement
-            ).value.trim();
-            const selectedTags = Array.from(
-              formEl.querySelectorAll<HTMLInputElement>('input[name="tags"]:checked')
-            ).map((input) => input.value as FaqTag);
-            if (!question) {
-              return;
-            }
-            if (selectedTags.length === 0) {
-              return;
-            }
-            void askQuestion
-              .run({
-                rulesetId,
-                question,
-                initialAnswer: answer || undefined,
-                tags: selectedTags,
-              })
-              .then((locator) => {
-                formEl.reset();
-                navigate({
-                  to: '/rulesets/$rulesetSlug/faq/$questionSlug',
-                  params: locator,
-                });
-              })
-              .catch(() => undefined);
-          }}
-        >
-          <TextInput
-            label="Ask a question"
-            type="text"
-            name="question"
-            required
-            minLength={1}
-            placeholder="Your question..."
-          />
-          <Textarea
-            label="Your answer (optional-you can add or edit it later)"
-            name="answer"
-            rows={3}
-            placeholder="Optional answer..."
-          />
-          <Input.Wrapper label="Tags">
-            <Stack component="fieldset" gap="xs" className={styles.tagFieldset}>
-              <legend className={styles.visuallyHidden}>FAQ tags</legend>
-              {FAQ_TAG_VALUES.map((tag) => (
-                <label key={tag} className={styles.tagOption}>
-                  <input type="checkbox" name="tags" value={tag} defaultChecked={tag === 'other'} />
-                  <span>{FAQ_TAG_LABELS[tag]}</span>
-                </label>
-              ))}
-            </Stack>
-          </Input.Wrapper>
-          <Group gap="xs" wrap="nowrap">
-            <Button variant="filled" color="confirm" type="submit" disabled={askQuestion.isPending}>
-              {askQuestion.isPending ? 'Asking…' : 'Ask'}
-            </Button>
-            {askQuestion.isError && (
-              <span className={styles.error}>{askQuestion.error?.message}</span>
-            )}
-          </Group>
-        </Stack>
-      </Surface>
+    <PageLayout>
+      <PageLayout.Header>{header}</PageLayout.Header>
+      <PageLayout.Content>
+        <Surface padding="lg">
+          <Stack
+            component="form"
+            gap="sm"
+            onSubmit={(e) => {
+              e.preventDefault();
+              const formEl = e.target as HTMLFormElement;
+              const question = (
+                formEl.elements.namedItem('question') as HTMLInputElement
+              ).value.trim();
+              const answer = (
+                formEl.elements.namedItem('answer') as HTMLTextAreaElement
+              ).value.trim();
+              const selectedTags = Array.from(
+                formEl.querySelectorAll<HTMLInputElement>('input[name="tags"]:checked')
+              ).map((input) => input.value as FaqTag);
+              if (!question) {
+                return;
+              }
+              if (selectedTags.length === 0) {
+                return;
+              }
+              void askQuestion
+                .run({
+                  rulesetId,
+                  question,
+                  initialAnswer: answer || undefined,
+                  tags: selectedTags,
+                })
+                .then((locator) => {
+                  formEl.reset();
+                  navigate({
+                    to: '/rulesets/$rulesetSlug/faq/$questionSlug',
+                    params: locator,
+                  });
+                })
+                .catch(() => undefined);
+            }}
+          >
+            <TextInput
+              label="Ask a question"
+              type="text"
+              name="question"
+              required
+              minLength={1}
+              placeholder="Your question..."
+            />
+            <Textarea
+              label="Your answer (optional-you can add or edit it later)"
+              name="answer"
+              rows={3}
+              placeholder="Optional answer..."
+            />
+            <Input.Wrapper label="Tags">
+              <Stack component="fieldset" gap="xs" className={styles.tagFieldset}>
+                <legend className={styles.visuallyHidden}>FAQ tags</legend>
+                {FAQ_TAG_VALUES.map((tag) => (
+                  <label key={tag} className={styles.tagOption}>
+                    <input
+                      type="checkbox"
+                      name="tags"
+                      value={tag}
+                      defaultChecked={tag === 'other'}
+                    />
+                    <span>{FAQ_TAG_LABELS[tag]}</span>
+                  </label>
+                ))}
+              </Stack>
+            </Input.Wrapper>
+            <Group gap="xs" wrap="nowrap">
+              <Button
+                variant="filled"
+                color="confirm"
+                type="submit"
+                disabled={askQuestion.isPending}
+              >
+                {askQuestion.isPending ? 'Asking…' : 'Ask'}
+              </Button>
+              {askQuestion.isError && (
+                <span className={styles.error}>{askQuestion.error?.message}</span>
+              )}
+            </Group>
+          </Stack>
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -88,41 +88,43 @@ export const Route = createFileRoute('/_app/rulesets/$rulesetSlug/')({
 
 function RulesetDetailPending() {
   return (
-    <PageLayout
-      header={
+    <PageLayout>
+      <PageLayout.Header>
         <Stack align="center" gap="xs">
           <Title order={1}>Ruleset</Title>
           <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>
             Back to rulesets
           </Anchor>
         </Stack>
-      }
-    >
-      <Surface padding="xl">
-        <Stack gap="xs">
-          <Title order={2}>Loading ruleset</Title>
-          <Text c="dimmed">The ruleset details are still loading.</Text>
-        </Stack>
-      </Surface>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Surface padding="xl">
+          <Stack gap="xs">
+            <Title order={2}>Loading ruleset</Title>
+            <Text c="dimmed">The ruleset details are still loading.</Text>
+          </Stack>
+        </Surface>
+      </PageLayout.Content>
     </PageLayout>
   );
 }
 
 function RulesetDetailError({ error }: ErrorComponentProps) {
   return (
-    <PageLayout
-      header={
+    <PageLayout>
+      <PageLayout.Header>
         <Stack align="center" gap="xs">
           <Title order={1}>Ruleset</Title>
           <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>
             Back to rulesets
           </Anchor>
         </Stack>
-      }
-    >
-      <Alert color="red" title="Ruleset could not be loaded" role="alert">
-        <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
-      </Alert>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Alert color="red" title="Ruleset could not be loaded" role="alert">
+          <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
+        </Alert>
+      </PageLayout.Content>
     </PageLayout>
   );
 }
@@ -143,22 +145,23 @@ function RulesetDetailPage() {
 
   if (loaderData.notFound || !page) {
     return (
-      <PageLayout
-        header={
+      <PageLayout>
+        <PageLayout.Header>
           <Stack align="center" gap="xs">
             <Title order={1}>Ruleset</Title>
             <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>
               Back to rulesets
             </Anchor>
           </Stack>
-        }
-      >
-        <Surface padding="xl">
-          <Stack gap="xs">
-            <Title order={2}>Ruleset not found</Title>
-            <Text c="dimmed">This ruleset does not exist or was deleted.</Text>
-          </Stack>
-        </Surface>
+        </PageLayout.Header>
+        <PageLayout.Content>
+          <Surface padding="xl">
+            <Stack gap="xs">
+              <Title order={2}>Ruleset not found</Title>
+              <Text c="dimmed">This ruleset does not exist or was deleted.</Text>
+            </Stack>
+          </Surface>
+        </PageLayout.Content>
       </PageLayout>
     );
   }
@@ -218,9 +221,8 @@ function RulesetDetailPage() {
   };
 
   return (
-    <PageLayout
-      headerSize="compact"
-      header={
+    <PageLayout>
+      <PageLayout.Header size="compact">
         <Group wrap="nowrap" align="center" gap="lg" className={styles.pageHead}>
           <Surface className={styles.rulesetHeadCover}>
             {r.image_cover ? (
@@ -262,8 +264,8 @@ function RulesetDetailPage() {
             </Group>
           </Stack>
         </Group>
-      }
-      toolbar={
+      </PageLayout.Header>
+      <PageLayout.Toolbar>
         <Toolbar>
           <Toolbar.Left>
             <Group gap="xs" wrap="wrap" role="group" aria-label="Navigation and editing">
@@ -375,287 +377,294 @@ function RulesetDetailPage() {
             ) : null}
           </Toolbar.Right>
         </Toolbar>
-      }
-    >
-      <Box className={styles.detailGrid}>
-        <Stack gap="xl" className={styles.primaryColumn}>
-          {mutationError ? (
-            <Alert color="red" title="The change could not be saved" role="alert">
-              {mutationError}
-            </Alert>
-          ) : null}
+      </PageLayout.Toolbar>
+      <PageLayout.Content>
+        <Box className={styles.detailGrid}>
+          <Stack gap="xl" className={styles.primaryColumn}>
+            {mutationError ? (
+              <Alert color="red" title="The change could not be saved" role="alert">
+                {mutationError}
+              </Alert>
+            ) : null}
+
+            <Section
+              id="overview"
+              icon={<BookOpen size={20} aria-hidden />}
+              title="About this ruleset"
+            >
+              <Surface padding="lg">
+                <ProposedContent label="Planned content · new fields required">
+                  <Text>
+                    A concise introduction explaining the ruleset&apos;s purpose, intended audience,
+                    and how it differs from the base game.
+                  </Text>
+                  <Text c="dimmed">
+                    Compatibility should identify the base edition or parent ruleset, required
+                    expansions, and whether this ruleset can be mixed with other variants.
+                  </Text>
+                </ProposedContent>
+              </Surface>
+            </Section>
+
+            <Section
+              id="rules"
+              icon={<TopicIcon topic="rules" size={20} />}
+              title="Rules and variants"
+              description="Proposed structured rule sections would make the ruleset useful before the FAQ has accumulated questions."
+            >
+              <Stack gap="md">
+                {[
+                  [
+                    'Setup changes',
+                    'Changes to preparation, starting resources, map state, and player count.',
+                  ],
+                  [
+                    'Core rule changes',
+                    'The rules that override or extend the base game during normal play.',
+                  ],
+                  [
+                    'Victory and end game',
+                    'Changed victory conditions, turn limits, tie breakers, or scoring.',
+                  ],
+                  [
+                    'Optional variants',
+                    'Clearly optional modules that groups may enable independently.',
+                  ],
+                ].map(([title, description]) => (
+                  <Card key={title} title={title}>
+                    <Text size="sm" c="dimmed">
+                      {description}
+                    </Text>
+                  </Card>
+                ))}
+              </Stack>
+            </Section>
+
+            <Section
+              id="factions"
+              icon={<Layers3 size={20} aria-hidden />}
+              title="Included factions"
+            >
+              {page.factions.length > 0 ? (
+                <SimpleGrid cols={{ base: 1, lg: 2 }} spacing="md">
+                  {page.factions.map((f) => (
+                    <Spotlight
+                      key={f.factionId}
+                      media={
+                        f.identity ? (
+                          <FactionToken logo={f.identity.logo} background={f.identity.background} />
+                        ) : (
+                          <TopicIcon topic="identity" size={24} />
+                        )
+                      }
+                      title={f.name}
+                      meta="Details, components, and special rules"
+                      renderRoot={(rootProps) => (
+                        <Link
+                          {...rootProps}
+                          to="/factions/$factionId"
+                          params={{ factionId: f.urlSlug }}
+                        />
+                      )}
+                    />
+                  ))}
+                </SimpleGrid>
+              ) : (
+                <Surface padding="lg">
+                  <Text size="sm" c="dimmed">
+                    No factions have been added to this ruleset yet.
+                  </Text>
+                </Surface>
+              )}
+            </Section>
+          </Stack>
 
           <Section
-            id="overview"
-            icon={<BookOpen size={20} aria-hidden />}
-            title="About this ruleset"
+            id="faq"
+            className={styles.communityColumn}
+            icon={<CircleHelp size={20} aria-hidden />}
+            title="Community FAQ"
+            description="Browse community questions and accepted answers."
           >
-            <Surface padding="lg">
-              <ProposedContent label="Planned content · new fields required">
-                <Text>
-                  A concise introduction explaining the ruleset&apos;s purpose, intended audience,
-                  and how it differs from the base game.
-                </Text>
-                <Text c="dimmed">
-                  Compatibility should identify the base edition or parent ruleset, required
-                  expansions, and whether this ruleset can be mixed with other variants.
+            <TextInput
+              value={search.q ?? ''}
+              onChange={(event) => handleFaqSearchChange(event.currentTarget.value)}
+              placeholder="Search questions…"
+              aria-label="Search FAQ questions"
+              leftSection={<Search size={16} aria-hidden />}
+              leftSectionPointerEvents="none"
+              rightSectionWidth="8rem"
+              rightSectionPointerEvents="all"
+              size="md"
+              radius="md"
+              classNames={{ wrapper: styles.faqFilterWrapper }}
+              rightSection={
+                <Select
+                  value={search.tag ?? '__all__'}
+                  onChange={handleFaqTagChange}
+                  data={[
+                    { value: '__all__', label: 'All tags' },
+                    ...FAQ_TAG_VALUES.map((tag) => ({
+                      value: tag,
+                      label: FAQ_TAG_LABELS[tag],
+                    })),
+                  ]}
+                  aria-label="Filter FAQ by tag"
+                  allowDeselect={false}
+                  variant="unstyled"
+                  size="sm"
+                  rightSectionWidth="2rem"
+                  comboboxProps={{ shadow: 'md' }}
+                  classNames={{
+                    root: styles.faqTagSelect,
+                    wrapper: styles.faqTagSelectWrapper,
+                    input: styles.faqTagSelectInput,
+                  }}
+                />
+              }
+            />
+            <FaqList
+              items={page.faqItems}
+              rulesetSlug={r.slug}
+              searchQuery={search.q ?? ''}
+              selectedTag={search.tag}
+              onOpenQuestion={(questionSlug) =>
+                navigate({
+                  to: '/rulesets/$rulesetSlug/faq/$questionSlug',
+                  params: { rulesetSlug: r.slug, questionSlug },
+                })
+              }
+            />
+          </Section>
+
+          <Stack
+            gap="md"
+            component="aside"
+            aria-label="Ruleset details"
+            miw={0}
+            className={styles.detailsColumn}
+          >
+            <Card icon={<ListTree size={20} aria-hidden />} title="At a glance">
+              <Stats
+                items={[
+                  {
+                    key: 'factions',
+                    icon: <Layers3 size={17} aria-hidden />,
+                    value: page.factions.length,
+                    label: `${page.factions.length} ${page.factions.length === 1 ? 'faction' : 'factions'}`,
+                  },
+                  {
+                    key: 'questions',
+                    icon: <CircleHelp size={17} aria-hidden />,
+                    value: page.faqItems.length,
+                    label: `${page.faqItems.length} ${page.faqItems.length === 1 ? 'question' : 'questions'}`,
+                  },
+                  {
+                    key: 'answered',
+                    icon: <CheckCircle2 size={17} aria-hidden />,
+                    value: answeredFaqCount,
+                    label: `${answeredFaqCount} answered ${answeredFaqCount === 1 ? 'question' : 'questions'}`,
+                  },
+                  {
+                    key: 'version',
+                    icon: <FileText size={17} aria-hidden />,
+                    value: '—',
+                    label: 'Version not specified',
+                  },
+                ]}
+              />
+            </Card>
+
+            <Card icon={<UsersRound size={20} aria-hidden />} title="Stewardship">
+              <Stack gap="sm">
+                <Box>
+                  <Eyebrow>Owner</Eyebrow>
+                  {page.owner ? (
+                    <ProfileLink
+                      slug={page.owner.slug}
+                      username={page.owner.username}
+                      avatar_url={page.owner.avatar_url}
+                    />
+                  ) : (
+                    <Text size="sm">Unknown</Text>
+                  )}
+                </Box>
+                <Divider />
+                {!assignedGroup ? (
+                  <Text size="sm" c="dimmed">
+                    No maintaining group.
+                  </Text>
+                ) : (
+                  <Stack gap="sm">
+                    <Box>
+                      <Eyebrow>Maintaining group</Eyebrow>
+                      {assignedGroup.slug ? (
+                        <Anchor
+                          fw={600}
+                          renderRoot={(rootProps) => (
+                            <Link
+                              {...rootProps}
+                              to="/groups/$groupSlug"
+                              params={{ groupSlug: assignedGroup.slug }}
+                            />
+                          )}
+                        >
+                          {assignedGroup.name}
+                        </Anchor>
+                      ) : (
+                        <Text fw={600}>{assignedGroup.name}</Text>
+                      )}
+                    </Box>
+                    <Group justify="space-between" gap="xs">
+                      <Text size="sm" c="dimmed">
+                        Your membership
+                      </Text>
+                      <StatusBadge
+                        tone={
+                          membershipStatus === 'active'
+                            ? 'positive'
+                            : membershipStatus === 'pending'
+                              ? 'pending'
+                              : 'neutral'
+                        }
+                      >
+                        {membershipStatus === 'active'
+                          ? 'Active'
+                          : membershipStatus === 'pending'
+                            ? 'Pending'
+                            : 'Not a member'}
+                      </StatusBadge>
+                    </Group>
+                    {canRequestMembership ? (
+                      <Button
+                        type="button"
+                        variant="light"
+                        leftSection={<UserPlus size={16} aria-hidden />}
+                        loading={membershipWorkflow.request.isPending}
+                        onClick={() =>
+                          void membershipWorkflow.request
+                            .run(assignedGroup.id)
+                            .catch(() => undefined)
+                        }
+                      >
+                        Request membership
+                      </Button>
+                    ) : null}
+                  </Stack>
+                )}
+              </Stack>
+            </Card>
+
+            <Card icon={<FileText size={20} aria-hidden />} title="Resources">
+              <ProposedContent label="Proposed content">
+                <Text size="sm" c="dimmed">
+                  Printable rules, release notes, and a version history could live here.
                 </Text>
               </ProposedContent>
-            </Surface>
-          </Section>
-
-          <Section
-            id="rules"
-            icon={<TopicIcon topic="rules" size={20} />}
-            title="Rules and variants"
-            description="Proposed structured rule sections would make the ruleset useful before the FAQ has accumulated questions."
-          >
-            <Stack gap="md">
-              {[
-                [
-                  'Setup changes',
-                  'Changes to preparation, starting resources, map state, and player count.',
-                ],
-                [
-                  'Core rule changes',
-                  'The rules that override or extend the base game during normal play.',
-                ],
-                [
-                  'Victory and end game',
-                  'Changed victory conditions, turn limits, tie breakers, or scoring.',
-                ],
-                [
-                  'Optional variants',
-                  'Clearly optional modules that groups may enable independently.',
-                ],
-              ].map(([title, description]) => (
-                <Card key={title} title={title}>
-                  <Text size="sm" c="dimmed">
-                    {description}
-                  </Text>
-                </Card>
-              ))}
-            </Stack>
-          </Section>
-
-          <Section id="factions" icon={<Layers3 size={20} aria-hidden />} title="Included factions">
-            {page.factions.length > 0 ? (
-              <SimpleGrid cols={{ base: 1, lg: 2 }} spacing="md">
-                {page.factions.map((f) => (
-                  <Spotlight
-                    key={f.factionId}
-                    media={
-                      f.identity ? (
-                        <FactionToken logo={f.identity.logo} background={f.identity.background} />
-                      ) : (
-                        <TopicIcon topic="identity" size={24} />
-                      )
-                    }
-                    title={f.name}
-                    meta="Details, components, and special rules"
-                    renderRoot={(rootProps) => (
-                      <Link
-                        {...rootProps}
-                        to="/factions/$factionId"
-                        params={{ factionId: f.urlSlug }}
-                      />
-                    )}
-                  />
-                ))}
-              </SimpleGrid>
-            ) : (
-              <Surface padding="lg">
-                <Text size="sm" c="dimmed">
-                  No factions have been added to this ruleset yet.
-                </Text>
-              </Surface>
-            )}
-          </Section>
-        </Stack>
-
-        <Section
-          id="faq"
-          className={styles.communityColumn}
-          icon={<CircleHelp size={20} aria-hidden />}
-          title="Community FAQ"
-          description="Browse community questions and accepted answers."
-        >
-          <TextInput
-            value={search.q ?? ''}
-            onChange={(event) => handleFaqSearchChange(event.currentTarget.value)}
-            placeholder="Search questions…"
-            aria-label="Search FAQ questions"
-            leftSection={<Search size={16} aria-hidden />}
-            leftSectionPointerEvents="none"
-            rightSectionWidth="8rem"
-            rightSectionPointerEvents="all"
-            size="md"
-            radius="md"
-            classNames={{ wrapper: styles.faqFilterWrapper }}
-            rightSection={
-              <Select
-                value={search.tag ?? '__all__'}
-                onChange={handleFaqTagChange}
-                data={[
-                  { value: '__all__', label: 'All tags' },
-                  ...FAQ_TAG_VALUES.map((tag) => ({
-                    value: tag,
-                    label: FAQ_TAG_LABELS[tag],
-                  })),
-                ]}
-                aria-label="Filter FAQ by tag"
-                allowDeselect={false}
-                variant="unstyled"
-                size="sm"
-                rightSectionWidth="2rem"
-                comboboxProps={{ shadow: 'md' }}
-                classNames={{
-                  root: styles.faqTagSelect,
-                  wrapper: styles.faqTagSelectWrapper,
-                  input: styles.faqTagSelectInput,
-                }}
-              />
-            }
-          />
-          <FaqList
-            items={page.faqItems}
-            rulesetSlug={r.slug}
-            searchQuery={search.q ?? ''}
-            selectedTag={search.tag}
-            onOpenQuestion={(questionSlug) =>
-              navigate({
-                to: '/rulesets/$rulesetSlug/faq/$questionSlug',
-                params: { rulesetSlug: r.slug, questionSlug },
-              })
-            }
-          />
-        </Section>
-
-        <Stack
-          gap="md"
-          component="aside"
-          aria-label="Ruleset details"
-          miw={0}
-          className={styles.detailsColumn}
-        >
-          <Card icon={<ListTree size={20} aria-hidden />} title="At a glance">
-            <Stats
-              items={[
-                {
-                  key: 'factions',
-                  icon: <Layers3 size={17} aria-hidden />,
-                  value: page.factions.length,
-                  label: `${page.factions.length} ${page.factions.length === 1 ? 'faction' : 'factions'}`,
-                },
-                {
-                  key: 'questions',
-                  icon: <CircleHelp size={17} aria-hidden />,
-                  value: page.faqItems.length,
-                  label: `${page.faqItems.length} ${page.faqItems.length === 1 ? 'question' : 'questions'}`,
-                },
-                {
-                  key: 'answered',
-                  icon: <CheckCircle2 size={17} aria-hidden />,
-                  value: answeredFaqCount,
-                  label: `${answeredFaqCount} answered ${answeredFaqCount === 1 ? 'question' : 'questions'}`,
-                },
-                {
-                  key: 'version',
-                  icon: <FileText size={17} aria-hidden />,
-                  value: '—',
-                  label: 'Version not specified',
-                },
-              ]}
-            />
-          </Card>
-
-          <Card icon={<UsersRound size={20} aria-hidden />} title="Stewardship">
-            <Stack gap="sm">
-              <Box>
-                <Eyebrow>Owner</Eyebrow>
-                {page.owner ? (
-                  <ProfileLink
-                    slug={page.owner.slug}
-                    username={page.owner.username}
-                    avatar_url={page.owner.avatar_url}
-                  />
-                ) : (
-                  <Text size="sm">Unknown</Text>
-                )}
-              </Box>
-              <Divider />
-              {!assignedGroup ? (
-                <Text size="sm" c="dimmed">
-                  No maintaining group.
-                </Text>
-              ) : (
-                <Stack gap="sm">
-                  <Box>
-                    <Eyebrow>Maintaining group</Eyebrow>
-                    {assignedGroup.slug ? (
-                      <Anchor
-                        fw={600}
-                        renderRoot={(rootProps) => (
-                          <Link
-                            {...rootProps}
-                            to="/groups/$groupSlug"
-                            params={{ groupSlug: assignedGroup.slug }}
-                          />
-                        )}
-                      >
-                        {assignedGroup.name}
-                      </Anchor>
-                    ) : (
-                      <Text fw={600}>{assignedGroup.name}</Text>
-                    )}
-                  </Box>
-                  <Group justify="space-between" gap="xs">
-                    <Text size="sm" c="dimmed">
-                      Your membership
-                    </Text>
-                    <StatusBadge
-                      tone={
-                        membershipStatus === 'active'
-                          ? 'positive'
-                          : membershipStatus === 'pending'
-                            ? 'pending'
-                            : 'neutral'
-                      }
-                    >
-                      {membershipStatus === 'active'
-                        ? 'Active'
-                        : membershipStatus === 'pending'
-                          ? 'Pending'
-                          : 'Not a member'}
-                    </StatusBadge>
-                  </Group>
-                  {canRequestMembership ? (
-                    <Button
-                      type="button"
-                      variant="light"
-                      leftSection={<UserPlus size={16} aria-hidden />}
-                      loading={membershipWorkflow.request.isPending}
-                      onClick={() =>
-                        void membershipWorkflow.request.run(assignedGroup.id).catch(() => undefined)
-                      }
-                    >
-                      Request membership
-                    </Button>
-                  ) : null}
-                </Stack>
-              )}
-            </Stack>
-          </Card>
-
-          <Card icon={<FileText size={20} aria-hidden />} title="Resources">
-            <ProposedContent label="Proposed content">
-              <Text size="sm" c="dimmed">
-                Printable rules, release notes, and a version history could live here.
-              </Text>
-            </ProposedContent>
-          </Card>
-        </Stack>
-      </Box>
+            </Card>
+          </Stack>
+        </Box>
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/rulesets/create.tsx
+++ b/src/app/routes/_app/rulesets/create.tsx
@@ -83,9 +83,11 @@ function CreateRulesetPage() {
   const profile = useCurrentProfile();
 
   return (
-    <PageLayout
-      header={<h1>Create ruleset</h1>}
-      toolbar={
+    <PageLayout>
+      <PageLayout.Header>
+        <h1>Create ruleset</h1>
+      </PageLayout.Header>
+      <PageLayout.Toolbar>
         <Toolbar>
           <Toolbar.Left>
             <IconAction
@@ -98,22 +100,23 @@ function CreateRulesetPage() {
             />
           </Toolbar.Left>
         </Toolbar>
-      }
-    >
-      {!profile.data?.user_id ? (
-        <Surface padding="lg">
-          <p>
-            <Link to="/auth/login">Log in</Link> to create a ruleset.
-          </p>
-          <p>
-            <Link to="/rulesets">Back to rulesets</Link>
-          </p>
-        </Surface>
-      ) : (
-        <Surface padding="lg">
-          <CreateRulesetForm ownerUserId={profile.data.user_id} />
-        </Surface>
-      )}
+      </PageLayout.Toolbar>
+      <PageLayout.Content>
+        {!profile.data?.user_id ? (
+          <Surface padding="lg">
+            <p>
+              <Link to="/auth/login">Log in</Link> to create a ruleset.
+            </p>
+            <p>
+              <Link to="/rulesets">Back to rulesets</Link>
+            </p>
+          </Surface>
+        ) : (
+          <Surface padding="lg">
+            <CreateRulesetForm ownerUserId={profile.data.user_id} />
+          </Surface>
+        )}
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/routes/_app/rulesets/index.tsx
+++ b/src/app/routes/_app/rulesets/index.tsx
@@ -17,8 +17,8 @@ function RulesetsPage() {
   const rulesets = useRulesetsAll({ initialData: loaderData.rulesets });
 
   return (
-    <PageLayout
-      header={
+    <PageLayout>
+      <PageLayout.Header>
         <div>
           <h1>Rulesets</h1>
           <p>
@@ -27,42 +27,43 @@ function RulesetsPage() {
             </Link>
           </p>
         </div>
-      }
-    >
-      {rulesets.data && rulesets.data.length > 0 ? (
-        <div className={styles.grid}>
-          {rulesets.data.map((r) => (
-            <Surface
-              key={r.id}
-              interactive
-              padding="sm"
-              className={styles.card}
-              renderRoot={({ className, children }) => (
-                <Link
-                  to="/rulesets/$rulesetSlug"
-                  params={{ rulesetSlug: r.slug }}
-                  className={className}
-                >
-                  {children}
-                </Link>
-              )}
-            >
-              <div className={styles.cover}>
-                {r.image_cover ? (
-                  <img src={r.image_cover} alt="" className={styles.coverImage} />
-                ) : (
-                  <span className={styles.coverPlaceholder}>No cover</span>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        {rulesets.data && rulesets.data.length > 0 ? (
+          <div className={styles.grid}>
+            {rulesets.data.map((r) => (
+              <Surface
+                key={r.id}
+                interactive
+                padding="sm"
+                className={styles.card}
+                renderRoot={({ className, children }) => (
+                  <Link
+                    to="/rulesets/$rulesetSlug"
+                    params={{ rulesetSlug: r.slug }}
+                    className={className}
+                  >
+                    {children}
+                  </Link>
                 )}
-              </div>
-              <span className={styles.name}>{r.name}</span>
-            </Surface>
-          ))}
-        </div>
-      ) : (
-        <Text size="sm" c="dimmed">
-          No rulesets yet.
-        </Text>
-      )}
+              >
+                <div className={styles.cover}>
+                  {r.image_cover ? (
+                    <img src={r.image_cover} alt="" className={styles.coverImage} />
+                  ) : (
+                    <span className={styles.coverPlaceholder}>No cover</span>
+                  )}
+                </div>
+                <span className={styles.name}>{r.name}</span>
+              </Surface>
+            ))}
+          </div>
+        ) : (
+          <Text size="sm" c="dimmed">
+            No rulesets yet.
+          </Text>
+        )}
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/shell/AppNotFound.tsx
+++ b/src/app/shell/AppNotFound.tsx
@@ -8,9 +8,14 @@ export function AppNotFound() {
 
   return (
     <ApplicationChrome pathname={pathname}>
-      <PageLayout header={<h1>404 - Page Not Found</h1>}>
-        <p>The page you're looking for doesn't exist.</p>
-        <Link to="/">Go back home</Link>
+      <PageLayout>
+        <PageLayout.Header>
+          <h1>404 - Page Not Found</h1>
+        </PageLayout.Header>
+        <PageLayout.Content>
+          <p>The page you're looking for doesn't exist.</p>
+          <Link to="/">Go back home</Link>
+        </PageLayout.Content>
       </PageLayout>
     </ApplicationChrome>
   );

--- a/src/app/shell/AppRoot.test.tsx
+++ b/src/app/shell/AppRoot.test.tsx
@@ -42,8 +42,13 @@ describe('AppRoot page header', () => {
     act(() => {
       root.render(
         <AppRoot pathname="/privacy">
-          <PageLayout header={<h1>Privacy policy</h1>}>
-            <p>Privacy content</p>
+          <PageLayout>
+            <PageLayout.Header>
+              <h1>Privacy policy</h1>
+            </PageLayout.Header>
+            <PageLayout.Content>
+              <p>Privacy content</p>
+            </PageLayout.Content>
           </PageLayout>
         </AppRoot>
       );

--- a/src/app/shell/ShellStoryPage.stories.fixture.tsx
+++ b/src/app/shell/ShellStoryPage.stories.fixture.tsx
@@ -33,11 +33,15 @@ export function ShellPageBackdrop({ children }: { children: ReactNode }) {
  */
 function ShellStoryPage({ headerSize }: { headerSize?: 'default' | 'compact' }) {
   return (
-    <PageLayout
-      header={headerSize && <LayoutSlotPlaceholder name="header slot" minHeight={0} />}
-      headerSize={headerSize}
-    >
-      <LayoutSlotPlaceholder name="children slot" minHeight={1400} />
+    <PageLayout>
+      {headerSize && (
+        <PageLayout.Header size={headerSize}>
+          <LayoutSlotPlaceholder name="header slot" minHeight={0} />
+        </PageLayout.Header>
+      )}
+      <PageLayout.Content>
+        <LayoutSlotPlaceholder name="children slot" minHeight={1400} />
+      </PageLayout.Content>
     </PageLayout>
   );
 }

--- a/src/app/ui/layout/AsymmetricSplitLayout.stories.tsx
+++ b/src/app/ui/layout/AsymmetricSplitLayout.stories.tsx
@@ -15,34 +15,50 @@ const meta = preview.meta({
       },
     },
   },
-  args: {
-    wide: <LayoutSlotPlaceholder name="wide" minHeight={360} />,
-    narrow: <LayoutSlotPlaceholder name="narrow" minHeight={360} />,
-  },
-  argTypes: { className: { control: false } },
 });
+
+const narrow = <LayoutSlotPlaceholder name="narrow" minHeight={360} />;
 
 /** Above the container breakpoint: unequal columns, wide leading. */
 export const TwoColumns = meta.story({
+  render: () => (
+    <AsymmetricSplitLayout>
+      <AsymmetricSplitLayout.Wide>
+        <LayoutSlotPlaceholder name="wide" minHeight={360} />
+      </AsymmetricSplitLayout.Wide>
+      <AsymmetricSplitLayout.Narrow>{narrow}</AsymmetricSplitLayout.Narrow>
+    </AsymmetricSplitLayout>
+  ),
   globals: { viewport: { value: 'appDesktop' } },
 });
 
 /** Below it: one reading column, wide first. Driven by the container, not the viewport. */
 export const Stacked = meta.story({
+  render: () => (
+    <AsymmetricSplitLayout>
+      <AsymmetricSplitLayout.Wide>
+        <LayoutSlotPlaceholder name="wide" minHeight={360} />
+      </AsymmetricSplitLayout.Wide>
+      <AsymmetricSplitLayout.Narrow>{narrow}</AsymmetricSplitLayout.Narrow>
+    </AsymmetricSplitLayout>
+  ),
   globals: { viewport: { value: 'appConstrained' } },
 });
 
 /** An unbreakable word and an oversized image must both respect the column they are given. */
 export const IntrinsicSizingStress = meta.story({
+  render: () => (
+    <AsymmetricSplitLayout>
+      <AsymmetricSplitLayout.Wide>
+        <Stack gap="md">
+          <Text>
+            DuneZoneLayoutStressCaseWithAnUnbrokenFactionNameThatMustRespectItsAllocatedContainer
+          </Text>
+          <Image alt="Intrinsic sizing test" mah={320} src="/web/tablet1.jpg" w={1400} />
+        </Stack>
+      </AsymmetricSplitLayout.Wide>
+      <AsymmetricSplitLayout.Narrow>{narrow}</AsymmetricSplitLayout.Narrow>
+    </AsymmetricSplitLayout>
+  ),
   globals: { viewport: { value: 'appDesktop' } },
-  args: {
-    wide: (
-      <Stack gap="md">
-        <Text>
-          DuneZoneLayoutStressCaseWithAnUnbrokenFactionNameThatMustRespectItsAllocatedContainer
-        </Text>
-        <Image alt="Intrinsic sizing test" mah={320} src="/web/tablet1.jpg" w={1400} />
-      </Stack>
-    ),
-  },
 });

--- a/src/app/ui/layout/AsymmetricSplitLayout.tsx
+++ b/src/app/ui/layout/AsymmetricSplitLayout.tsx
@@ -1,17 +1,38 @@
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import { Children, isValidElement } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 
 import styles from './AsymmetricSplitLayout.module.css';
 
-export function AsymmetricSplitLayout({
+function Wide(_: PropsWithChildren): null {
+  return null;
+}
+
+function Narrow(_: PropsWithChildren): null {
+  return null;
+}
+
+/** A wide column beside a narrow one, responsive by container query. */
+function AsymmetricSplitLayoutBase({
   className,
-  wide,
-  narrow,
-}: {
-  className?: string;
-  wide: ReactNode;
-  narrow: ReactNode;
-}) {
+  children,
+}: PropsWithChildren<{ className?: string }>) {
+  let wide: ReactNode = null;
+  let narrow: ReactNode = null;
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) {
+      return;
+    }
+    if (child.type === Wide) {
+      wide = (child.props as PropsWithChildren).children;
+      return;
+    }
+    if (child.type === Narrow) {
+      narrow = (child.props as PropsWithChildren).children;
+    }
+  });
+
   return (
     <div className={clsx(styles.root, className)}>
       <div className={styles.layout}>
@@ -21,3 +42,15 @@ export function AsymmetricSplitLayout({
     </div>
   );
 }
+
+type AsymmetricSplitLayoutComponent = ((
+  props: PropsWithChildren<{ className?: string }>
+) => ReactNode) & {
+  Wide: typeof Wide;
+  Narrow: typeof Narrow;
+};
+
+export const AsymmetricSplitLayout = Object.assign(AsymmetricSplitLayoutBase, {
+  Wide,
+  Narrow,
+}) as AsymmetricSplitLayoutComponent;

--- a/src/app/ui/layout/AtlasLayout.stories.tsx
+++ b/src/app/ui/layout/AtlasLayout.stories.tsx
@@ -14,25 +14,45 @@ const meta = preview.meta({
       },
     },
   },
-  args: {
-    sidebar: <LayoutSlotPlaceholder name="sidebar" minHeight={240} />,
-    children: <LayoutSlotPlaceholder name="children" minHeight={720} />,
-  },
-  argTypes: { className: { control: false }, sidebarClassName: { control: false } },
 });
+
+const sidebar = <LayoutSlotPlaceholder name="sidebar" minHeight={240} />;
 
 /** Above the container breakpoint: sidebar beside the content. */
 export const WithSidebar = meta.story({
+  render: () => (
+    <AtlasLayout>
+      <AtlasLayout.Sidebar>{sidebar}</AtlasLayout.Sidebar>
+      <AtlasLayout.Content>
+        <LayoutSlotPlaceholder name="children" minHeight={720} />
+      </AtlasLayout.Content>
+    </AtlasLayout>
+  ),
   globals: { viewport: { value: 'appDesktop' } },
 });
 
 /** Below it: the sidebar becomes the first block of one column. */
 export const Stacked = meta.story({
+  render: () => (
+    <AtlasLayout>
+      <AtlasLayout.Sidebar>{sidebar}</AtlasLayout.Sidebar>
+      <AtlasLayout.Content>
+        <LayoutSlotPlaceholder name="children" minHeight={720} />
+      </AtlasLayout.Content>
+    </AtlasLayout>
+  ),
   globals: { viewport: { value: 'appConstrained' } },
 });
 
 /** Long content is what the sticky sidebar exists for — scroll the canvas. */
 export const StickySidebarWhileScrolling = meta.story({
+  render: () => (
+    <AtlasLayout>
+      <AtlasLayout.Sidebar>{sidebar}</AtlasLayout.Sidebar>
+      <AtlasLayout.Content>
+        <LayoutSlotPlaceholder name="scrolling children" minHeight={1600} />
+      </AtlasLayout.Content>
+    </AtlasLayout>
+  ),
   globals: { viewport: { value: 'appDesktop' } },
-  args: { children: <LayoutSlotPlaceholder name="scrolling children" minHeight={1600} /> },
 });

--- a/src/app/ui/layout/AtlasLayout.tsx
+++ b/src/app/ui/layout/AtlasLayout.tsx
@@ -1,25 +1,54 @@
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import { Children, isValidElement } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 
 import styles from './AtlasLayout.module.css';
 
-export function AtlasLayout({
-  className,
-  sidebar,
-  sidebarClassName,
-  children,
-}: {
-  className?: string;
-  sidebar: ReactNode;
-  sidebarClassName?: string;
-  children: ReactNode;
-}) {
+function Sidebar(_: PropsWithChildren<{ className?: string }>): null {
+  return null;
+}
+
+function Content(_: PropsWithChildren): null {
+  return null;
+}
+
+/** A fixed sidebar beside flowing content, responsive by container query. */
+function AtlasLayoutBase({ className, children }: PropsWithChildren<{ className?: string }>) {
+  let sidebar: ReactNode = null;
+  let sidebarClassName: string | undefined;
+  let content: ReactNode = null;
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) {
+      return;
+    }
+    if (child.type === Sidebar) {
+      const props = child.props as PropsWithChildren<{ className?: string }>;
+      sidebar = props.children;
+      sidebarClassName = props.className;
+      return;
+    }
+    if (child.type === Content) {
+      content = (child.props as PropsWithChildren).children;
+    }
+  });
+
   return (
     <div className={clsx(styles.root, className)}>
       <div className={styles.layout}>
         <div className={clsx(styles.sidebar, sidebarClassName)}>{sidebar}</div>
-        <div>{children}</div>
+        <div>{content}</div>
       </div>
     </div>
   );
 }
+
+type AtlasLayoutComponent = ((props: PropsWithChildren<{ className?: string }>) => ReactNode) & {
+  Sidebar: typeof Sidebar;
+  Content: typeof Content;
+};
+
+export const AtlasLayout = Object.assign(AtlasLayoutBase, {
+  Sidebar,
+  Content,
+}) as AtlasLayoutComponent;

--- a/src/app/ui/layout/PageLayout.stories.tsx
+++ b/src/app/ui/layout/PageLayout.stories.tsx
@@ -48,15 +48,6 @@ const meta = preview.meta({
       },
     },
   },
-  args: {
-    header: <LayoutSlotPlaceholder name="header slot" minHeight={0} />,
-    children: <LayoutSlotPlaceholder name="children slot" minHeight={320} />,
-  },
-  argTypes: {
-    header: { control: false },
-    toolbar: { control: false },
-    children: { control: false },
-  },
   decorators: [
     (Story) => (
       <ShellFrame>
@@ -66,23 +57,41 @@ const meta = preview.meta({
   ],
 });
 
+const headerSlot = <LayoutSlotPlaceholder name="header slot" minHeight={0} />;
+const contentSlot = <LayoutSlotPlaceholder name="children slot" minHeight={320} />;
+
 /** The header sits in the band's row, aligned to its lower edge. */
 export const WithHeader = meta.story({
+  render: () => (
+    <PageLayout>
+      <PageLayout.Header>{headerSlot}</PageLayout.Header>
+      <PageLayout.Content>{contentSlot}</PageLayout.Content>
+    </PageLayout>
+  ),
   globals: { viewport: { value: 'appDesktop' } },
 });
 
-/** `headerSize="compact"` gives the header less of the row, for content-heavy detail pages. */
+/** `size="compact"` gives the header less of the row, for content-heavy detail pages. */
 export const CompactHeader = meta.story({
-  args: { headerSize: 'compact' },
+  render: () => (
+    <PageLayout>
+      <PageLayout.Header size="compact">{headerSlot}</PageLayout.Header>
+      <PageLayout.Content>{contentSlot}</PageLayout.Content>
+    </PageLayout>
+  ),
   globals: { viewport: { value: 'appDesktop' } },
 });
 
 /**
- * Omitting `header` is what marks a page intentionally compact — it sets
+ * Omitting the `Header` slot is what marks a page intentionally compact — it sets
  * `data-page-layout-compact`, which the real shell frame reads to collapse the band.
  */
 export const NoHeader = meta.story({
-  args: { header: undefined },
+  render: () => (
+    <PageLayout>
+      <PageLayout.Content>{contentSlot}</PageLayout.Content>
+    </PageLayout>
+  ),
   globals: { viewport: { value: 'appDesktop' } },
 });
 
@@ -91,18 +100,28 @@ export const NoHeader = meta.story({
  * `Toolbar` is a surface and does.
  */
 export const WithToolbar = meta.story({
-  args: {
-    toolbar: (
-      <Toolbar>
-        <Toolbar.Left>
-          <LayoutSlotPlaceholder name="toolbar controls" minHeight={0} />
-        </Toolbar.Left>
-      </Toolbar>
-    ),
-  },
+  render: () => (
+    <PageLayout>
+      <PageLayout.Header>{headerSlot}</PageLayout.Header>
+      <PageLayout.Toolbar>
+        <Toolbar>
+          <Toolbar.Left>
+            <LayoutSlotPlaceholder name="toolbar controls" minHeight={0} />
+          </Toolbar.Left>
+        </Toolbar>
+      </PageLayout.Toolbar>
+      <PageLayout.Content>{contentSlot}</PageLayout.Content>
+    </PageLayout>
+  ),
   globals: { viewport: { value: 'appDesktop' } },
 });
 
 export const Mobile = meta.story({
+  render: () => (
+    <PageLayout>
+      <PageLayout.Header>{headerSlot}</PageLayout.Header>
+      <PageLayout.Content>{contentSlot}</PageLayout.Content>
+    </PageLayout>
+  ),
   globals: { viewport: { value: 'appMobile' } },
 });

--- a/src/app/ui/layout/PageLayout.test.tsx
+++ b/src/app/ui/layout/PageLayout.test.tsx
@@ -6,8 +6,16 @@ import { PageLayout } from './PageLayout';
 describe('PageLayout', () => {
   it('renders the route-owned slots in page order', () => {
     const markup = renderToStaticMarkup(
-      <PageLayout header={<h1>Page title</h1>} toolbar={<div>Page tools</div>}>
-        <p>Page content</p>
+      <PageLayout>
+        <PageLayout.Header>
+          <h1>Page title</h1>
+        </PageLayout.Header>
+        <PageLayout.Toolbar>
+          <div>Page tools</div>
+        </PageLayout.Toolbar>
+        <PageLayout.Content>
+          <p>Page content</p>
+        </PageLayout.Content>
       </PageLayout>
     );
 
@@ -20,8 +28,13 @@ describe('PageLayout', () => {
 
   it('supports a shorter hero for content-heavy detail pages', () => {
     const markup = renderToStaticMarkup(
-      <PageLayout header={<h1>Faction</h1>} headerSize="compact">
-        <p>Faction content</p>
+      <PageLayout>
+        <PageLayout.Header size="compact">
+          <h1>Faction</h1>
+        </PageLayout.Header>
+        <PageLayout.Content>
+          <p>Faction content</p>
+        </PageLayout.Content>
       </PageLayout>
     );
 
@@ -32,7 +45,9 @@ describe('PageLayout', () => {
   it('supports an intentionally compact page without a header slot', () => {
     const markup = renderToStaticMarkup(
       <PageLayout>
-        <p>Minimal content</p>
+        <PageLayout.Content>
+          <p>Minimal content</p>
+        </PageLayout.Content>
       </PageLayout>
     );
 

--- a/src/app/ui/layout/PageLayout.tsx
+++ b/src/app/ui/layout/PageLayout.tsx
@@ -1,33 +1,82 @@
-import type { ReactNode } from 'react';
+import { Children, isValidElement } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 
 import styles from './PageLayout.module.css';
 
-export interface PageLayoutProps {
-  /** Content rendered inside the hero. Omit only for intentionally compact pages. */
-  header?: ReactNode;
-  /** Reduce the hero height for content-heavy detail pages. */
-  headerSize?: 'default' | 'compact';
-  /**
-   * A `Toolbar`, rendered before the main content. It is a surface and brings its own pane, so this
-   * slot adds nothing around it — anything passed here needs a pane of its own.
-   */
-  toolbar?: ReactNode;
-  children: ReactNode;
+function Header(_: PropsWithChildren<{ size?: 'default' | 'compact' }>): null {
+  return null;
 }
 
-/** Route-owned page composition with typed header, toolbar, and content slots. */
-export function PageLayout({ header, headerSize = 'default', toolbar, children }: PageLayoutProps) {
+function Toolbar(_: PropsWithChildren): null {
+  return null;
+}
+
+function Content(_: PropsWithChildren): null {
+  return null;
+}
+
+/**
+ * The frame every terminal route mounts: the hero band, an optional toolbar, and the content.
+ *
+ * It is the one Layout coupled to the shell — its children join `AppHeader`'s grid through
+ * `display: contents`, and it declares its state through `data-page-layout-*`, which
+ * `AppHeader.module.css` reads back with `:has()` to size the artwork band. That is why it is the
+ * documented exemption from the container-query rule: it is the page frame, sized against the
+ * viewport in concert with the shell, not a container.
+ *
+ * Slots: `Header` (omit it to mark the page intentionally compact; `size="compact"` shrinks the
+ * band), `Toolbar`, and `Content`.
+ */
+function PageLayoutBase({ children }: PropsWithChildren) {
+  let hasHeader = false;
+  let header: ReactNode = null;
+  let headerSize: 'default' | 'compact' = 'default';
+  let toolbar: ReactNode = null;
+  let content: ReactNode = null;
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) {
+      return;
+    }
+    if (child.type === Header) {
+      hasHeader = true;
+      const props = child.props as PropsWithChildren<{ size?: 'default' | 'compact' }>;
+      header = props.children;
+      headerSize = props.size ?? 'default';
+      return;
+    }
+    if (child.type === Toolbar) {
+      toolbar = (child.props as PropsWithChildren).children;
+      return;
+    }
+    if (child.type === Content) {
+      content = (child.props as PropsWithChildren).children;
+    }
+  });
+
   return (
     <div
       className={styles.layout}
-      data-page-layout-compact={header == null ? 'true' : undefined}
-      data-page-layout-header-size={header == null ? undefined : headerSize}
+      data-page-layout-compact={hasHeader ? undefined : 'true'}
+      data-page-layout-header-size={hasHeader ? headerSize : undefined}
     >
-      {header != null && <div className={styles.headerContent}>{header}</div>}
+      {hasHeader && <div className={styles.headerContent}>{header}</div>}
       <main className={styles.content}>
         {toolbar}
-        {children}
+        {content}
       </main>
     </div>
   );
 }
+
+type PageLayoutComponent = ((props: PropsWithChildren) => ReactNode) & {
+  Header: typeof Header;
+  Toolbar: typeof Toolbar;
+  Content: typeof Content;
+};
+
+export const PageLayout = Object.assign(PageLayoutBase, {
+  Header,
+  Toolbar,
+  Content,
+}) as PageLayoutComponent;

--- a/src/app/ui/layout/TriptychLayout.stories.tsx
+++ b/src/app/ui/layout/TriptychLayout.stories.tsx
@@ -14,20 +14,32 @@ const meta = preview.meta({
       },
     },
   },
-  args: {
-    left: <LayoutSlotPlaceholder name="left" minHeight={320} />,
-    center: <LayoutSlotPlaceholder name="center" minHeight={320} />,
-    right: <LayoutSlotPlaceholder name="right" minHeight={320} />,
-  },
-  argTypes: { className: { control: false }, centerClassName: { control: false } },
 });
+
+function Triptych() {
+  return (
+    <TriptychLayout>
+      <TriptychLayout.Left>
+        <LayoutSlotPlaceholder name="left" minHeight={320} />
+      </TriptychLayout.Left>
+      <TriptychLayout.Center>
+        <LayoutSlotPlaceholder name="center" minHeight={320} />
+      </TriptychLayout.Center>
+      <TriptychLayout.Right>
+        <LayoutSlotPlaceholder name="right" minHeight={320} />
+      </TriptychLayout.Right>
+    </TriptychLayout>
+  );
+}
 
 /** Above the container breakpoint: three columns, centre filled. */
 export const ThreeColumns = meta.story({
+  render: () => <Triptych />,
   globals: { viewport: { value: 'appDesktop' } },
 });
 
 /** Below it: one column, in source order. */
 export const Stacked = meta.story({
+  render: () => <Triptych />,
   globals: { viewport: { value: 'appConstrained' } },
 });

--- a/src/app/ui/layout/TriptychLayout.tsx
+++ b/src/app/ui/layout/TriptychLayout.tsx
@@ -1,21 +1,47 @@
 import clsx from 'clsx';
-import type { ReactNode } from 'react';
+import { Children, isValidElement } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 
 import styles from './TriptychLayout.module.css';
 
-export function TriptychLayout({
-  className,
-  left,
-  center,
-  centerClassName,
-  right,
-}: {
-  className?: string;
-  left: ReactNode;
-  center: ReactNode;
-  centerClassName?: string;
-  right: ReactNode;
-}) {
+function Left(_: PropsWithChildren): null {
+  return null;
+}
+
+function Center(_: PropsWithChildren<{ className?: string }>): null {
+  return null;
+}
+
+function Right(_: PropsWithChildren): null {
+  return null;
+}
+
+/** Three columns — the outer two fixed, the centre flowing — responsive by container query. */
+function TriptychLayoutBase({ className, children }: PropsWithChildren<{ className?: string }>) {
+  let left: ReactNode = null;
+  let center: ReactNode = null;
+  let centerClassName: string | undefined;
+  let right: ReactNode = null;
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) {
+      return;
+    }
+    if (child.type === Left) {
+      left = (child.props as PropsWithChildren).children;
+      return;
+    }
+    if (child.type === Center) {
+      const props = child.props as PropsWithChildren<{ className?: string }>;
+      center = props.children;
+      centerClassName = props.className;
+      return;
+    }
+    if (child.type === Right) {
+      right = (child.props as PropsWithChildren).children;
+    }
+  });
+
   return (
     <div className={clsx(styles.root, className)}>
       <div className={styles.layout}>
@@ -28,3 +54,15 @@ export function TriptychLayout({
     </div>
   );
 }
+
+type TriptychLayoutComponent = ((props: PropsWithChildren<{ className?: string }>) => ReactNode) & {
+  Left: typeof Left;
+  Center: typeof Center;
+  Right: typeof Right;
+};
+
+export const TriptychLayout = Object.assign(TriptychLayoutBase, {
+  Left,
+  Center,
+  Right,
+}) as TriptychLayoutComponent;

--- a/src/app/ui/layout/containerQueries.test.ts
+++ b/src/app/ui/layout/containerQueries.test.ts
@@ -1,0 +1,24 @@
+import { readdirSync, readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const layoutDir = new URL('.', import.meta.url);
+
+/*
+ * A Layout is responsive by container query, so it lays out by the room it is given, not the size
+ * of the window (DD-003). `PageLayout` is the one exemption: it is the shell's page frame, sized
+ * against the viewport in concert with `AppHeader` through the `data-page-layout-*` bridge
+ * (DD-018), so it is genuinely viewport-scoped and uses `@media`.
+ */
+const VIEWPORT_EXEMPT = new Set(['PageLayout.module.css']);
+
+describe('layout responsiveness', () => {
+  it('lays out by container query, not media query (PageLayout is the shell-frame exemption)', () => {
+    const offenders = readdirSync(layoutDir)
+      .map(String)
+      .filter((name) => name.endsWith('.module.css') && !VIEWPORT_EXEMPT.has(name))
+      .filter((name) => /@media\s*\(/.test(readFileSync(new URL(name, layoutDir), 'utf8')));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/app/ui/layout/containerQueries.test.ts
+++ b/src/app/ui/layout/containerQueries.test.ts
@@ -15,9 +15,9 @@ const VIEWPORT_EXEMPT = new Set(['PageLayout.module.css']);
 describe('layout responsiveness', () => {
   it('lays out by container query, not media query (PageLayout is the shell-frame exemption)', () => {
     const offenders = readdirSync(layoutDir)
-      .map(String)
       .filter((name) => name.endsWith('.module.css') && !VIEWPORT_EXEMPT.has(name))
-      .filter((name) => /@media\s*\(/.test(readFileSync(new URL(name, layoutDir), 'utf8')));
+      // Any `@media` at-rule — `@media (…)`, `@media screen and (…)`, `@media only screen …`.
+      .filter((name) => /@media\b/.test(readFileSync(new URL(name, layoutDir), 'utf8')));
 
     expect(offenders).toEqual([]);
   });


### PR DESCRIPTION
Encapsulates a design decision in code so it isn't lost: **DD-003 reinstated and strengthened.** DD-015 only half-retired it — it swapped the legacy `generic/layout` wrappers for Mantine but kept "parent-owned spacing" — and the kit had since grown custom layouts (`PageLayout`, `Triptych`, `Atlas`, `AsymmetricSplit`) with no rule written down for them.

## The rules (now written, partly guarded)

1. Spacing is owned by the **Layout**, not scattered as margin/padding in leaves.
2. Layouts are **custom, built on Mantine primitives** — a recurring layout becomes a named component so pages don't re-nest flex/grid at every call site.
3. Responsive by **container query, not media query** — a layout lays out by the room it's given. Guarded by `containerQueries.test.ts`.
4. Every Layout uses **named compound slots**.
5. **No single-slot Layout** — one slot is a passthrough, not a layout.

## What changed

All four layouts move from prop-slots to compound slots (matching the house `Toolbar.Left/Right` pattern):

```
PageLayout             .Header / .Toolbar / .Content
TriptychLayout         .Left / .Center / .Right
AtlasLayout            .Sidebar / .Content
AsymmetricSplitLayout  .Wide / .Narrow
```

**60 PageLayout call sites across 27 routes**, plus the shell (`AppRoot` test, `AppNotFound`, the shell story fixture) and every layout story (args → `render`). Content moved **verbatim**; only the wrapping changed.

`PageLayout` is the documented **exemption from the container-query rule** — it's the shell's page frame, viewport-scoped in concert with `AppHeader` through the `data-page-layout-*` bridge (DD-018).

## The header animation is preserved

The seamless header transition lives in the **shell** — `AppHeader`'s persistent band, CSS-transitioned by `:has()` on the `data-page-layout-*` attributes — **not** in PageLayout, which is untouched structurally. The refactor changes how PageLayout *receives* its header (slot vs prop), not what it renders or what the shell reads:

- The PageLayout **contract test** proves the rendered markup is byte-identical (`data-page-layout-compact`, `header-size`, slot order).
- The **`page-header-transition` e2e** — which samples the persistent hero's height across a navigation to a headerless route — **stays green**.
- The **`AppHeader` `Resizing` story** (band interpolates on a single mounted element) stays green.

## Verification

typecheck, lint, format, knip, check:app-layout, check:css-orphans, **448 unit** (incl. the PageLayout contract and the new container-query guard, proven to bite), **279 story** (incl. the animation story), **6/6 e2e** (incl. `page-header-transition`). AGENTS.md gains the Layout discipline; DD-003 is rewritten as a live, guarded decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized page layouts with dedicated header, toolbar, content, sidebar, and column regions.
  * Improved layout composition and responsive behavior across pages.
  * Existing page content, controls, forms, and navigation remain unchanged.
  * Updated layout components to use named content regions for clearer composition.

* **Documentation**
  * Added guidance and examples for consistent, responsive layouts.

* **Tests**
  * Added safeguards to verify responsive layout conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->