### PR TITLE
Rewrite the UI design decisions as a from-scratch rulebook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,9 @@ Outside the kit:
   classification — nothing outside the folder imports them — but unlike other organs they **do carry
   stories**, filed under a `Shell` root, because the chrome's states are worth looking at and cannot
   be reached from any page's story. It is not a category and never will be: the six are decided by
-  what a caller hands a component, and the shell is decided by position. See DD-018 in
-  `docs/technical/ui-design-decisions.md` for why the header is neither a Surface nor a Layout.
+  what a caller hands a component, and the shell is decided by position. See *The shell is chrome* in
+  [`docs/technical/ui-design-decisions.md`](docs/technical/ui-design-decisions.md#the-shell-is-chrome-decided-by-position)
+  for why the header is neither a Surface nor a Layout.
 - **Widgets** (`src/app/widgets/<name>`) — an assembly too domain-specific to be kit and too
   shared to be one page's JSX. Prefab: built outside the page only because two or more routes
   install the identical thing.
@@ -118,8 +119,9 @@ Outside the kit:
   A Picker is a domain control whose whole job is to let the user choose from a list it loads
   itself — the factions you can load, the users you can assign — and it loads them **lazily and
   read-only**, so a page that renders a "pick a user" control never queries every user up front
-  just in case the control is opened. That laziness is the entire justification (DD-013 subscription
-  discipline: hold no subscription you are not using); a Picker that fetched eagerly, or fetched page
+  just in case the control is opened. That laziness is the entire justification (the *one Convex query
+  per route* subscription discipline: hold no subscription you are not using); a Picker that fetched
+  eagerly, or fetched page
   data, or *mutated*, would just be a widget breaking the rule.
   - **The contract.** A Picker fetches only what presenting its own options needs, through reads that
     are torn down when it leaves the screen; it never mutates and never reads the page's data; the
@@ -185,8 +187,8 @@ Rules between categories:
   takes **named compound slots** (`<TriptychLayout><TriptychLayout.Left>…</TriptychLayout.Left>…`),
   never fewer than two, and is responsive **by container query, not media query** — so it lays out by
   the room it is given. `PageLayout` is the one exemption from the container-query rule: it is the
-  shell's page frame, viewport-scoped in concert with `AppHeader` (see DD-003 and DD-018).
-  `containerQueries.test.ts` guards it.
+  shell's page frame, viewport-scoped in concert with `AppHeader` (see *Layouts own spacing* and *The
+  shell is chrome* in `docs/technical/ui-design-decisions.md`). `containerQueries.test.ts` guards it.
 - **Knowledge points one way.** Content knows the theme. Blocks know Content. Lists know their
   item shape. Layouts and Surfaces know nothing about their contents. No component fetches, and none
   navigates on its own behalf.
@@ -208,6 +210,8 @@ The tells:
 - A string prop becoming a heading → Block, or a Surface naming itself.
 - Two components answering the same question → one dies.
 - The JSDoc cannot say "callers own X; this owns Y" in one sentence → not a component.
+- A wrapper that only renames or lightly forwards a Mantine component → not a component. Use Mantine
+  directly, and extract only when there is a concern to own.
 
 Glyphs (`icon`) and controls (`action`) stay `ReactNode` everywhere — "data" means *the words are
 data*. Every component in `src/app/ui` has stories; Mantine components used by

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -30,8 +30,8 @@ document-rendering target).
 [`@ui/layout/PageLayout`](../src/app/ui/layout/PageLayout.tsx), supplying its
 `header`, optional `toolbar`, and content together. Nested parent routes stay outlet-only. This is
 enforced — [`PageLayout.architecture.test.ts`](../src/app/ui/layout/PageLayout.architecture.test.ts)
-scans the route files and fails on a terminal route that omits it. The reasoning is DD-014 in
-[`technical/ui-design-decisions.md`](technical/ui-design-decisions.md).
+scans the route files and fails on a terminal route that omits it. The reasoning is
+[*Terminal routes mount PageLayout*](technical/ui-design-decisions.md#terminal-routes-mount-pagelayout).
 
 ## File-Based Routing
 
@@ -68,7 +68,7 @@ function Component() {
 ```
 
 The loader-then-subscribe handoff is covered in [State Management](./state-management.md); the
-one-query-per-route rule is DD-013.
+one-query-per-route rule is [*One Convex query per route*](technical/ui-design-decisions.md#one-convex-query-per-route).
 
 **Example**: [`src/app/routes/_app/index.tsx`](../src/app/routes/_app/index.tsx)
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -27,8 +27,9 @@ chrome: `auth/oauth.tsx` (a non-visual hand-off) and `preview/sheet/$factionSlug
 document-rendering target).
 
 **Every terminal visual route must render `PageLayout`** from
-[`@ui/layout/PageLayout`](../src/app/ui/layout/PageLayout.tsx), supplying its
-`header`, optional `toolbar`, and content together. Nested parent routes stay outlet-only. This is
+[`@ui/layout/PageLayout`](../src/app/ui/layout/PageLayout.tsx), supplying the slots that page needs —
+`content`, usually a `header` (omit it for a compact page), and an optional `toolbar`. Nested parent
+routes stay outlet-only. This is
 enforced — [`PageLayout.architecture.test.ts`](../src/app/ui/layout/PageLayout.architecture.test.ts)
 scans the route files and fails on a terminal route that omits it. The reasoning is
 [*Terminal routes mount PageLayout*](technical/ui-design-decisions.md#terminal-routes-mount-pagelayout).

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -61,9 +61,9 @@ either no-ops or a second read of data that is already arriving.
 
 ## Rules
 
-- One Convex page query per route, plus `useCurrentProfile` when the UI is auth-aware — see DD-013
-  in [`technical/ui-design-decisions.md`](technical/ui-design-decisions.md). Derive what the screen
-  needs inside that query rather than adding child subscriptions.
+- One Convex page query per route, plus `useCurrentProfile` when the UI is auth-aware — see
+  [*One Convex query per route*](technical/ui-design-decisions.md#one-convex-query-per-route). Derive
+  what the screen needs inside that query rather than adding child subscriptions.
 - Pass loader data down as `initialData`; do not re-query in a child for data the page already has.
 - Client-side parsing is for UX feedback only. The authoritative parse happens in the Convex
   handler — see [`data-layer.md`](data-layer.md).

--- a/docs/technical/ui-component-hierarchy.md
+++ b/docs/technical/ui-component-hierarchy.md
@@ -22,8 +22,9 @@ does not: ownership rules that sit around it.
 
 ## Route and data ownership
 
-- Every terminal visual `_app` route renders `PageLayout` and supplies `header`, optional
-  `toolbar`, and content together. Nested parent routes remain outlet-only.
+- Every terminal visual `_app` route renders `PageLayout` and supplies the slots it needs —
+  `content`, usually a `header` (omit it for a compact page), and an optional `toolbar`. Nested
+  parent routes remain outlet-only.
 - Each route subscribes to at most one Convex query for page data, plus `useCurrentProfile` when
   needed. Pass query-derived data down; do not create nested subscriptions for the same screen.
 - Pages compose — heavy JSX at the page level is the intended shape. Widgets receive data and

--- a/docs/technical/ui-component-hierarchy.md
+++ b/docs/technical/ui-component-hierarchy.md
@@ -16,8 +16,8 @@ does not: ownership rules that sit around it.
 | Page composition | the route file itself | One page's own JSX, split into local functions when the route grows. Never exported as a feature component: one page → route, two or more pages → Widget. |
 | Document-rendering glue | `src/app/print/` | `print/sheet/` bridges a `Faction` row to the sheet renderer; `print/capture/` is the page the publisher screenshots. Not published, not storied. |
 | Widgets | `src/app/widgets/<name>` | Shared assemblies; see the widget rules in `AGENTS.md`. |
-| Application shell | `src/app/shell/**` | `AppRoot` owns the persistent frame and document effects, `AppHeader` the artwork band, `AppFooter` the closing waypoints. Organs, not kit — filed under the `Shell` Storybook root. See DD-018. |
-| Page frame | `src/app/ui/layout/PageLayout.tsx` | Terminal routes compose its slots directly; import from `@ui/layout/PageLayout`. Domain-free, but its `data-page-layout-*` contract is read by the shell (DD-018). |
+| Application shell | `src/app/shell/**` | `AppRoot` owns the persistent frame and document effects, `AppHeader` the artwork band, `AppFooter` the closing waypoints. Organs, not kit — filed under the `Shell` Storybook root. See [*The shell is chrome*](ui-design-decisions.md#the-shell-is-chrome-decided-by-position). |
+| Page frame | `src/app/ui/layout/PageLayout.tsx` | Terminal routes compose its slots directly; import from `@ui/layout/PageLayout`. Domain-free, but its `data-page-layout-*` contract is read by the shell (see [*The shell is chrome*](ui-design-decisions.md#the-shell-is-chrome-decided-by-position)). |
 | Game and document renderers | `src/game/**`, sheet/print/capture/publishing entry points | Independent of Mantine and the kit; exact rendering output preserved. |
 
 ## Route and data ownership

--- a/docs/technical/ui-design-decisions.md
+++ b/docs/technical/ui-design-decisions.md
@@ -105,9 +105,10 @@ by name); the rest convention. Canonical in [`AGENTS.md`](../../AGENTS.md). Layo
 
 A parent-owned `staticData.PageHead` bridge once split one screen into detached header and body
 sub-views, duplicated the page query, and hid the whole composition across router metadata and the
-shell. So every terminal `_app` route renders `PageLayout` directly, filling its
-`Header`/`Toolbar`/`Content` slots alongside its content; route parents are outlet-only, and
-`AppRoot` owns only persistent chrome and document effects.
+shell. So every terminal `_app` route renders `PageLayout` directly and fills only the slots that
+page needs — often all of `Header`/`Toolbar`/`Content`, but a page may omit the header and render
+`Content` alone, which marks it compact. Route parents are outlet-only, and `AppRoot` owns only
+persistent chrome and document effects.
 
 *Enforced by
 [`PageLayout.architecture.test.ts`](../../src/app/ui/layout/PageLayout.architecture.test.ts) (every
@@ -120,9 +121,12 @@ terminal route mounts it). Canonical in [`AGENTS.md`](../../AGENTS.md).*
 Mounting several `useQuery` hooks on a route multiplies live subscriptions, complicates loading
 states, and scatters a screen's authoritative shape across Convex functions. Each route subscribes to
 **at most one Convex query for page data**, plus `useCurrentProfile` when the UI is auth-aware;
-derive UI-ready fields inside that query and pass server-derived collections (such as a Picker's
-options) into controls rather than adding child subscriptions. This subscription discipline is the
-real reason widgets don't fetch and Pickers fetch only lazily. Mutations don't count.
+derive UI-ready fields inside that query, and pass small server-derived collections into controls
+through it rather than adding child subscriptions. The one documented exception is a lazily-mounted
+[Picker](#pickers-are-the-one-place-a-component-may-fetch), which may hold its own read-only options
+subscription — so a control choosing from a large set never forces those rows into the page query.
+This subscription discipline is the real reason widgets don't fetch and Pickers fetch only lazily.
+Mutations don't count.
 
 *Convention — no automated guard. (`check:convex-skip` bans `useQuery("skip")` inside `src/app/db`, a
 separate, adjacent rule.) Stated here; [`AGENTS.md`](../../AGENTS.md) and

--- a/docs/technical/ui-design-decisions.md
+++ b/docs/technical/ui-design-decisions.md
@@ -1,56 +1,50 @@
 # UI design decisions
 
-This document records durable UI decisions for consistency across features.
+This log records durable UI decisions and, more importantly, **why they exist**. The rules
+themselves are canonical in [`AGENTS.md`](../../AGENTS.md) and enforced by guards; this log is the
+reasoning behind them — the incidents that earned each rule.
 
 ## How to use this log
 
-- Treat entries with `Status: accepted` as defaults.
-- If a change needs to violate an accepted decision, get explicit user approval first.
-- Add new entries instead of silently changing old ones.
-- **`Status: superseded` entries are history, not instructions.** They are kept to explain why the
-  current rules exist, and they deliberately still name paths and components that have since been
-  deleted — `generic/ui`, `form/**`, `UIButton`, `Block`. Do not follow their rules and do not
-  restore the structures they describe; read the entry that superseded them instead.
-- Renames are applied throughout the log so a symbol stays searchable; substance is never rewritten.
-  `AppShell` was renamed `AppRoot`, and the header it owns is now `AppHeader` (see DD-018).
+- **One rule, one home.** A live rule is stated once — in `AGENTS.md` (or a guard). An entry here
+  does not restate a rule that lives there; it records the *why*. Two entries must never enforce the
+  same thing.
+- **The war story survives.** When entries merge, or a rule moves to `AGENTS.md`, the incident that
+  motivated it is kept. A rule without its story loses its strength — a reader who cannot see what
+  went wrong cannot tell whether the rule still applies.
+- **`Status: superseded` entries are history, not instructions.** They are kept to explain how the
+  current rules came to be, and they still name paths and components since deleted (`generic/ui`,
+  `form/**`, `UIButton`, `Block`, `*.domain.tsx`). Do not follow them; read the entry that replaced
+  them. History lives at the bottom.
+- **Numbers are permanent anchors.** Entries are cross-referenced by number; a merged or superseded
+  entry keeps a stub so its number still resolves.
+- Renames are applied throughout so a symbol stays searchable; substance is never quietly rewritten.
+  `AppShell` → `AppRoot`; the header it owns is `AppHeader` (DD-018).
 
-## Entry template
+## What applies now
 
-```md
-## DD-XXX: Decision title
-- Status: accepted | proposed | superseded
-- Context: Why this decision exists.
-- Rule: The default behavior to follow.
-- Examples: Concrete examples and mappings.
-- Exceptions: Allowed exceptions and approval requirements.
-- Changed on: YYYY-MM-DD
-```
+The live rules at a glance, each pointing at its canonical home and its guard. Nothing here restates
+a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]` code contract.
 
-## DD-001: Reuse existing shared components first
-- Status: superseded
-- Context: UI drift and duplication increase when new components are created before surveying existing primitives.
-- Rule (historical — these paths no longer exist): Always check `src/app/components/generic/ui`, `src/app/components/form`, `src/app/components/generic/layout`, and `src/app/components/generic/surfaces` before creating new UI components.
-- Examples:
-  - Extend with `props`, `className`, or composition before introducing a new shared component.
-  - Keep feature-local code local unless the pattern clearly repeats.
-- Exceptions:
-  - New component is allowed when no existing component can satisfy requirements without awkward API growth.
-  - Confirm with user before creating a new shared API if reuse options are not exhausted.
-- Changed on: 2026-03-25
-- Superseded on: 2026-07-19 by DD-015. The listed legacy presentation paths are now migration-only; discovery starts with Mantine for standard UI.
+| Live rule | Canonical home | Guard | Why (DD) |
+|-----------|----------------|-------|----------|
+| A component renders what it is given — no Convex, no `@db` value, no router-nav, no shell·widgets·routes | `AGENTS.md` component taxonomy | `[M]` `.oxlintrc.json` `src/app/ui/**` | DD-020 |
+| A widget never fetches | `AGENTS.md` (Widgets) | `[M]` `.oxlintrc.json` `src/app/widgets/**` | DD-020, DD-021 |
+| Pickers — the one place a component may fetch: its own options, lazy, read-only | `AGENTS.md` (Pickers) | `[C]` structural (`check:app-layout` slot; absence from the ui/widget bans) | DD-021, DD-013 |
+| Six-category taxonomy; folder = category = Storybook root | `AGENTS.md` component taxonomy | `[M]` `check:app-layout` (top slot only); rest `[D]` | DD-017 |
+| The shell is chrome, not a category | `AGENTS.md` (application shell) | `[M]` `check:app-layout` + the `data-page-layout-*` contract | DD-018 |
+| Layouts own spacing; named compound slots; container queries not media; ≥2 slots | `AGENTS.md` (Rules between categories) | `[M]` `containerQueries.test.ts` (the container-query half) | DD-003 |
+| Every terminal `_app` route mounts `PageLayout`; the leaf owns composition | `AGENTS.md` (routes) | `[M]` `PageLayout.architecture.test.ts` (mount check) | DD-014 |
+| One Convex page query per route, plus `useCurrentProfile` | this log (`AGENTS.md` cites it by name) | `[D]` (`check:convex-skip` is an *adjacent* rule, not this one) | DD-013 |
+| Action semantics — icon-only buttons, one styled toolbar primary, colour by intent | this log | `[D]` (the kit carries it: `IconAction`, `CallToAction`, the theme tuples) | DD-005 |
+| Recurring topics use one canonical icon mapping | this log (`TopicIcon.tsx` is the code home) | `[D]` | DD-016 |
+| Extract a component only at a real concern boundary | `AGENTS.md` (the membrane tells) | `[D]` | DD-009 |
+| No CSS `composes`; one TSX owner per stylesheet | `docs/technical/ui-component-hierarchy.md` (Styling) | `[M]` `check:css-orphans` (orphans/unimported only) | DD-004 |
+| Renderers stay isolated (no Mantine/Radix/app reach) | `AGENTS.md` (game assets) | `[M]` `rendererIsolation.test.ts` | DD-015 |
 
-## DD-002: Component layering and dependency direction
-- Status: superseded
-- Context: Layer violations (`generic` importing domain code) create tight coupling and brittle reuse.
-- Rule: Preserve direction `generic/ui` -> `form` -> `generic/layout|generic/surfaces` -> `features/routes`. Never import upward.
-- Examples:
-  - `generic/ui/**` imports only `generic/ui` and shared tokens.
-  - `form/**` can import `generic/ui` and shared tokens.
-  - Features/routes can import `generic/**` and `form/**`.
-- Exceptions:
-  - None by default; treat violations as architecture exceptions requiring explicit approval.
-- Changed on: 2026-03-25
-- Superseded on: 2026-07-19 by DD-015. The legacy generic/form/layout hierarchy is replaced by the Mantine, shared-content, domain, shell, and renderer ownership model.
+---
+
+# Active decisions
 
 ## DD-003: Layout components own spacing, and lay out through named slots
 - Status: accepted
@@ -86,313 +80,230 @@ This document records durable UI decisions for consistency across features.
     (DD-018). It is genuinely viewport-scoped, not a container. The guard excepts it by name.
 - Changed on: 2026-08-13
 
-## DD-004: Avoid custom CSS and prohibit CSS composes
-- Status: superseded
-- Context: Excess custom CSS and cross-module style composition hide ownership and reduce maintainability.
-- Rule: Prefer composing existing components and classes in TSX. Avoid custom CSS when existing primitives/wrappers solve the need. Do not use CSS `composes`.
+## DD-005: Action semantics — icon-only buttons, one toolbar primary, colour by intent
+- Status: accepted (absorbs DD-006 and DD-007)
+- Context: Actions become unpredictable when their meaning is carried by hue rather than intent, when
+  a toolbar has several competing "primary" buttons, or when an icon-only control has no explicit
+  semantics. Three earlier entries (DD-005/006/007) each stated part of this and overlapped on
+  "confirm-colour for the positive primary"; they are one concern and are combined here so the rule
+  is stated once.
+- Rule:
+  - **Colour by intent, then style.** Positive primary actions take the `confirm` colour; destructive
+    actions take `red` (the Dune danger tuple); neutral/auxiliary actions stay the default colour and
+    vary by Mantine `variant`, never by hue. The map is the code, in
+    [`theme.ts`](../../src/app/ui/theme.ts) — do not re-type it here.
+  - **One primary per toolbar.** A multi-action toolbar keeps exactly one clear positive primary,
+    styled `confirm`; secondary and utility actions drop to `default`/`subtle`.
+  - **Icon-only for established actions only.** Use an icon-only button for a common, recognizable
+    action with explicit intent and an accessible label (`aria-label`); if the icon would be
+    ambiguous, use a text-labelled control.
 - Examples:
-  - Apply multiple classes with `clsx` in component code rather than style inheritance.
-  - Keep CSS module ownership local to the component that owns it.
-- Exceptions:
-  - Custom CSS can be added when composition cannot satisfy requirements and the exception is explicitly approved.
-- Changed on: 2026-03-25
-- Superseded on: 2026-07-19 by DD-015. Mantine APIs are the standard-UI default; CSS Modules remain valid for domain, shell, and justified page-specific ownership, while `composes` remains prohibited.
-
-## DD-005: Icon-only buttons are for established actions with explicit semantics
-- Status: accepted
-- Context: Icon-only actions are harder to parse and can become ambiguous without consistent semantics.
-- Rule: Use icon-only buttons for common, recognizable actions and pair them with clear intent/variant selection.
-- Examples:
-  - Primary positive toolbar action should use confirm semantics where applicable.
-  - Destructive icon-only actions should use danger/critical semantics.
-  - Use accessible labeling (for example `aria-label`) so meaning is explicit.
-- Exceptions:
-  - If icon meaning is ambiguous for the context, prefer text-labeled button or composite control.
-- Changed on: 2026-03-25
-
-## DD-006: Toolbar primary-action hierarchy
-- Status: accepted
-- Context: Toolbars become noisy when multiple actions compete as primary.
-- Rule: In a multi-action toolbar, keep one clear primary positive action; style it with confirm semantics unless product direction says otherwise.
-- Examples:
-  - `Create`, `Start`, `Add`, `Save`, `Confirm` default to the `confirm` colour.
-  - Secondary and utility actions stay on the default colour, dropping to Mantine's `default` or
-    `subtle` variant.
-- Exceptions:
-  - Non-confirm primary action is allowed only with explicit product/user direction.
-- Changed on: 2026-03-25
-
-## DD-007: Button color intent mapping
-- Status: accepted
-- Context: Inconsistent color semantics make actions unpredictable and increase user error risk.
-- Rule: Choose the colour by semantic intent first, then the visual style.
-- Examples:
-  - Positive primary actions: the `confirm` colour from [`src/app/ui/theme.ts`](../../src/app/ui/theme.ts).
-  - Neutral/auxiliary actions: the default colour, varied by Mantine `variant` rather than by hue.
-  - Destructive/irreversible actions: `red`, which the theme maps to the Dune danger tuple.
   - The kit carries this at the call site: `IconAction` for icon-only actions, `CallToAction` for the
-    forward-moving primary. `StatusBadge` has its own tone scale (including `critical`) for state,
-    which is not an action vocabulary.
+    forward-moving primary. `StatusBadge` has its own tone scale (including `critical`) for *state* —
+    that is not an action vocabulary.
 - Exceptions:
-  - Product-directed visual overrides are allowed with explicit instruction.
-- Changed on: 2026-03-25
+  - A non-`confirm` primary, or a product-directed visual override, is allowed only with explicit
+    product/user direction.
+- Changed on: 2026-08-13 (combined from DD-005/006/007, originally 2026-03-25)
 
-## DD-008: Generic components require Storybook stories
-- Status: superseded
-- Context: Stories document usage, prevent regressions, and improve AI discoverability of intended APIs.
-- Rule: Every new generic component must include `*.stories.tsx` in the same area.
+## DD-009: Extract a component only at a real concern boundary
+- Status: accepted (absorbs DD-012)
+- Context: Splitting JSX into "helper" components without a clear responsibility boundary produces
+  prop bloat, indirection, and harder reasoning for no reuse. **The war story:**
+  `RulesetGroupToolbarControl` was extracted from the ruleset detail page's toolbar row — but it was
+  a slice of one page's layout, not a component. To render anything it needed ~11 props, every one a
+  mirror of the route's own state (`rulesetId`, `rulesetName`, `groupId`, `groupSlug`, `groupName`,
+  `isOwner`, `membershipStatus`, `canRequestMembership`, `onRequestMembership`, `canEditGroup`,
+  `onChangeGroup`). The route computed all of it and threaded it down; the "component" handed it
+  straight back. No encapsulation, one caller, and to understand one toolbar you now read two files.
+  It was inlined. (DD-012's rule and this incident; DD-009's earlier "prefer small components" folds
+  in here — one is the generic form of the other.)
+- Rule: Extract a component only when it is a real **concern boundary** — a behaviour or domain
+  concept with a small, meaningful API — not merely a sub-section of one page's layout. A view-only
+  sub-view stays inline in the route, or becomes a **local helper function** in the same file, never
+  an exported feature component. This is the same test the taxonomy states at the membrane in
+  `AGENTS.md`: *the JSDoc must be able to say "callers own X; this owns Y" in one sentence.*
 - Examples:
-  - Include default state, key variants, relevant interaction states, and a composition example in a reusable layout wrapper.
-- Exceptions:
-  - No default exceptions; missing stories should block completion for new generic components.
-- Changed on: 2026-03-25
-- Superseded on: 2026-07-19 by DD-015. Installed Mantine components and route-local compositions are exempt from local duplication; locally owned shared and domain components still require representative coverage.
+  - Good: a picker that owns pick-and-search over `assignableGroups` behind a small API
+    (`disabled`, `options`, `onAssign`) — it owns a concern.
+  - Bad: a `*ToolbarControl` that renders one page's toolbar row and needs a dozen props mirroring
+    route state; or a long JSX block moved to a file without reducing responsibility or API surface.
+- Changed on: 2026-08-13 (combined DD-009 + DD-012, originally 2026-04-01)
 
-## DD-009: Prefer small composable components over large monoliths
+## DD-013: One Convex page query per route, plus optional profile
 - Status: accepted
-- Context: Very large components are harder to reuse, test, and reason about.
-- Rule: Split UI into small, focused components when responsibilities or API surface grows.
+- Context: Mounting several `useQuery` hooks on one route multiplies live subscriptions, complicates
+  loading states, and scatters the authoritative shape of a screen across Convex functions. This
+  session reaffirmed it as the *real* reason a widget does not fetch and a Picker fetches only its
+  own options lazily (DD-020, DD-021): the principle protected is **subscription discipline** — hold
+  no subscription you are not using, keep one authoritative shape per screen.
+- Rule: Each route subscribes to **at most one Convex query for page data**, plus **`useCurrentProfile`
+  when the UI is auth-aware**. Derive UI-ready fields inside that query rather than adding child
+  subscriptions. `AGENTS.md` and the state-management doc point at this entry by name for the *why*.
 - Examples:
-  - Extract repeated sub-structures into composable subcomponents.
-  - Keep each component focused on a single concern.
+  - Bundle what a page needs into one query (a ruleset `detailPageBySlug` carrying FAQ, viewer
+    access, owner, and assignable-group summaries).
+  - Pass server-derived collections into controls (e.g. a Picker's options) instead of a child
+    subscription.
 - Exceptions:
-  - Short-lived feature-local components may stay combined temporarily if extraction adds noise; revisit if reuse emerges.
-- Changed on: 2026-03-25
-
-## DD-010: Component placement is generic-first but domain-honest
-- Status: superseded
-- Context: Shared components were difficult to discover and domain-specific code was occasionally exposed as generic API.
-- Rule (historical — these paths no longer exist): Place reusable controls under `src/app/components/form/**`, reusable primitives/layout/surfaces under `src/app/components/generic/**`, and domain-coupled components under domain folders (`factions`, `faq`, `profile`, `auth`, etc).
-- Examples:
-  - Reusable controls belong to `form`; primitives/layout/surfaces belong to `generic/ui`, `generic/layout`, `generic/surfaces`.
-  - Faction editor widgets stay under `factions/editor` and are imported directly from that domain.
-- Exceptions:
-  - None by default. Duplicate wrappers and parallel import paths for the same shared component are not allowed.
-- Changed on: 2026-03-25
-- Superseded on: 2026-07-19 by DD-015. Standard presentation is Mantine-owned, while domain behavior and identity-rich visuals remain locally owned.
-
-## DD-011: One shared component, one canonical path
-- Status: superseded
-- Context: Parallel paths (`components/ui` plus `components/generic/ui`) made shared components hard to discover and caused duplicate usage patterns.
-- Rule (historical — these paths no longer exist): Shared components must use one canonical path: controls via `@app/components/form/...`, other shared primitives via `@app/components/generic/...`.
-- Examples:
-  - `UIButton` and `IconButton` live in `generic/ui`.
-  - `TextField` lives in `form`.
-  - `Card` and `Block` live in `generic/surfaces`.
-  - Product-specific `AppRoot` and `PageLayout` live in `components/shell`.
-- Exceptions:
-  - None by default.
-- Changed on: 2026-03-25
-- Superseded on: 2026-07-19 by DD-015. One canonical owner remains required, but the standard-UI owner is Mantine and the named legacy paths are migration-only.
-
-## DD-012: Components are concern boundaries, not sub-views
-- Status: accepted
-- Context: Extracting chunks of JSX into \"helper\" components without a clear responsibility boundary leads to prop bloat, indirection, and harder reasoning, while providing little reuse. We observed this with `RulesetGroupToolbarControl`, which was just a fragment of the ruleset detail toolbar and required many props mirroring route-local state.
-- Rule: Only extract a component when it represents a real concern boundary (behavior or domain concept), not merely a sub-section of a single page's layout. Keep view-only sub-views inline in the route or feature component.
-- Examples:
-  - Good: `GroupAssignPopover` owns assignment picking and search UX over server-derived `assignableGroups`, with a small semantic API (`disabled`, `assignableGroups`, `onAssignGroup`, and optional text props). Faction and ruleset routes wrap it with thin adapters.
-  - Good: A reusable search box component that manages debounced navigation and accessible labeling.
-  - Bad: A `*ToolbarControl` component that only renders one page's toolbar row and needs many props like `rulesetId`, `rulesetName`, `groupId`, `groupSlug`, `groupName`, `isOwner`, `membershipStatus`, `canRequestMembership`, `onRequestMembership`, `canEditGroup`, `onChangeGroup`.
-  - Bad: Moving a long JSX block out of a route into a separate file without reducing responsibility or API surface, just to \"make it shorter\".
-- Exceptions:
-  - Very large routes can still be split for readability, but the extracted pieces should either:
-    - Form real concern-boundary components (as above), or
-    - Be kept as local helper functions in the same file, not exported feature components.
-  - If in doubt, prefer inlining and only extract when a clear responsibility and small prop surface emerge.
-- Changed on: 2026-04-01
-
-## DD-013: One Convex page query plus optional profile
-- Status: accepted
-- Context: Mounting several `useQuery` hooks on the same route (page data plus nested component queries) multiplies subscriptions, complicates loading states, and scatters the authoritative shape of a screen across Convex functions.
-- Rule: Each route should subscribe to **at most one Convex query for page data**, plus **`useCurrentProfile` when needed** for auth-aware UI. Derive UI-ready fields in that page query; avoid child hooks that issue additional Convex queries for the same screen unless an explicit exception is approved.
-- Examples:
-  - Bundle data the page needs into one query (e.g. ruleset `detailPageBySlug` including FAQ, viewer access, owner, and assignable Group summaries).
-  - Pass server-derived collections into controls such as `GroupAssignPopover` via `assignableGroups` instead of exposing raw membership transport or adding a child subscription.
-- Exceptions:
-  - Mutations are not counted against this limit.
-  - Intentional lazy loading or rare technical constraints require explicit call-out in review.
+  - Mutations do not count. Intentional lazy loading — a Picker's own options — requires the explicit
+    call-out its docstring provides. See DD-021.
+- Provenance note: **`check:convex-skip` does not enforce this rule.** That guard bans `useQuery("skip")`
+  inside `src/app/db` — an adjacent, narrower concern whose own header states a *preference* and names
+  no incident. The one-query rule is documented-only; its guard is pre-emptive.
 - Changed on: 2026-04-04
 
 ## DD-014: Leaf routes own page composition
-- Status: accepted
-- Context: A parent-owned `staticData.PageHead` bridge split one screen into detached header and body sub-views, duplicated page subscriptions, and hid the complete page composition across router metadata and the app shell.
-- Rule: Every terminal `_app` route renders `PageLayout` directly and supplies its `header` and optional `toolbar` slots alongside its content. Nested route parents are outlet-only. `AppRoot` owns only persistent application chrome and document effects.
-- Examples:
-  - A detail route reads its page query once, then passes query-backed identity to `header`, actions to `toolbar`, and feature components as children.
-  - Loading, error, empty, and authorization states still render through `PageLayout` so page chrome stays consistent.
-  - The faction-sheet preview intentionally omits `AppRoot` and `PageLayout` because it is a document-rendering surface.
-- Exceptions:
-  - Auth hand-off/redirect routes and document-only render targets may use a purpose-built layout.
-  - Do not reintroduce router metadata, context registration, or portals solely to move page header content into a parent shell.
+- Status: accepted — rule now in `AGENTS.md` (routes); this entry keeps the why
+- Context: A parent-owned `staticData.PageHead` bridge split one screen into detached header and
+  body sub-views, duplicated the page subscription, and hid the whole composition across router
+  metadata and the app shell. **That incident is why the rule exists.**
+- Rule (stated in `AGENTS.md`): every terminal `_app` route renders `PageLayout` directly, supplying
+  its `Header`/`Toolbar`/`Content` slots (DD-003) alongside its content; nested route parents are
+  outlet-only; `AppRoot` owns only persistent chrome and document effects. Do not reintroduce router
+  metadata or a parent shell to move header content upward.
+- Provenance: **earned** — by the `PageHead` bridge above. Enforced by
+  [`PageLayout.architecture.test.ts`](../../src/app/ui/layout/PageLayout.architecture.test.ts), whose
+  surviving assertion (every terminal route mounts `PageLayout`) is a structural check in the ADR-0001
+  style: it forecloses the earned incident but names no incident of its own.
 - Changed on: 2026-07-18
-
-## DD-015: Mantine owns standard application-content UI
-- Status: superseded
-- Context: The home-grown generic primitive, form-presentation, layout, and surface layers duplicated maintained library concerns and encouraged new work to deepen a parallel component system. The application still needs clear ownership for product-specific composition, distinctive Dune Zone visuals, and precision-rendered game and document output.
-- Rule:
-  - Use Mantine directly for standard application controls, surfaces, layout, feedback, overlays, and typography.
-  - Use the free Mantine UI catalogue as the preferred page-composition reference. Adapt patterns route-locally first; extract locally owned shared content only after repeated product semantics or repeated composition are demonstrated.
-  - Do not create local wrappers that merely rename or lightly forward Mantine components.
-  - Keep Dune Zone behavior and identity-rich visuals in domain components. `FactionListItem`, leader/troop/planet showcases, and similar visuals may remain custom while composing Mantine around their domain-specific core.
-  - Keep game, sheet, print, capture, and publishing renderers isolated. No Mantine dependency, provider, theme, stylesheet, styling assumption, or internal restyling may enter those renderers.
-  - (Historical — the migration finished and these paths are deleted.) Treat `src/app/components/generic/ui/**`, `generic/layout/**`, `generic/surfaces/**`, and current `form/**` presentation primitives as migration-only. Do not add consumers or expand their presentation APIs; migrate and remove them as consumers move. This does not deprecate domain behavior, TanStack Form state, or validation contracts.
-  - Preserve route-owned `PageLayout` composition and the one-page-query rule from DD-013 and DD-014.
-  - Preserve semantic action hierarchy from DD-005 through DD-007 and focused concern boundaries from DD-009 and DD-012.
-  - Installed Mantine components and route-local Mantine compositions do not require duplicate local Storybook stories. New or materially changed locally owned shared content and domain components require representative stories for meaningful variants and interactions.
-  - Prefer Mantine APIs and theme facilities for standard styling. CSS Modules remain valid for domain visuals, shell ownership, and page-specific composition Mantine cannot express clearly; CSS `composes` and cross-owned CSS module imports remain prohibited.
-- Examples:
-  - Compose Mantine `Button`, `ActionIcon`, `Group`, `Stack`, `Paper`, `Text`, and `Title` directly in a terminal route instead of adding another application button, card, or stack wrapper.
-  - Keep a faction tile's identity-rich art and game renderer intact while using Mantine for its surrounding page section, heading, actions, and responsive layout.
-  - Use Mantine's root-rendering integration with TanStack Router's typed `Link` at call sites; extract a routing adapter only if repeated usage proves it preserves typed `to`, `params`, and `search` without recreating the legacy broad button API.
-- Exceptions:
-  - `AppRoot` and `PageLayout` remain application-owned; Mantine adoption does not authorize redesigning persistent shell appearance.
-  - A locally owned shared composition is allowed when it expresses stable product semantics or demonstrated repeated composition, not merely repeated JSX.
-  - A domain-specific component may use custom CSS and visuals when standard Mantine UI would erase product meaning or renderer fidelity.
-  - Before the Mantine foundation dependency lands, do not add Mantine imports prematurely and do not deepen the legacy primitive system; coordinate the work with the foundation or migration scope.
-- Changed on: 2026-07-19
-- Superseded on: 2026-08-12 by DD-017. Mantine remains the base library, but a domain-free
-  interface kit (`src/ui`) now owns the concerns the app repeats; renderer isolation and the
-  no-thin-wrappers rule carry forward.
 
 ## DD-016: Recurring topics use one canonical icon mapping
 - Status: accepted
-- Context: The same topic appeared with different icons between the faction editor and application detail pages, weakening visual recognition.
-- Rule: Render recurring topic icons through `TopicIcon`; the faction editor's established mapping is authoritative.
-- Examples:
-  - Identity: eye; background: image; hero: Caesar; leaders: traitor.
-  - Alliance and alliance decals: alliance; troops: Atreides troop.
-  - Rules: balance; advantages: Kwisatz Haderach.
+- Context: The same topic appeared with different icons between the faction editor and the detail
+  pages, weakening recognition.
+- Rule: Render recurring topic icons through `TopicIcon`; the faction editor's mapping is
+  authoritative and lives in the code, [`TopicIcon.tsx`](../../src/app/ui/content/TopicIcon.tsx) —
+  read it there rather than trusting a copy here.
 - Exceptions:
-  - One-off topics without a canonical mapping may keep a locally selected icon until they recur or receive product direction.
-  - Renderer-owned game visuals remain isolated and do not consume the application component.
+  - A one-off topic without a canonical mapping may keep a local icon until it recurs or gets product
+    direction. Renderer-owned game visuals stay isolated and do not consume `TopicIcon`.
 - Changed on: 2026-07-20
 
 ## DD-017: The component taxonomy governs all interface components
-- Status: accepted
+- Status: accepted — rule now in `AGENTS.md`; this entry keeps the why
 - Context: DD-015 made Mantine the only sanctioned shared layer, so recurring concerns (the pane
-  treatment, titled regions, heading levels) were re-spelled at every call site and drifted. A
-  domain-free kit was rebuilt deliberately, category by category, with a rule for what may live
-  in each.
-- Rule: The taxonomy in [`AGENTS.md`](../../AGENTS.md#component-taxonomy) is canonical. Six
-  categories under `src/app/ui` — Content, Controls, Lists, Layout, Surfaces, Blocks — each defined
-  by what a caller hands the component, and each holding every published component of that kind.
-  Feature folders keep only organs. Widgets (`src/app/widgets`) are the last-resort shared assemblies
-  with their own rules. The category is the folder; the folder is the Storybook root. (Originally this
-  entry also split the categories across two trees; DD-019 collapsed that.)
-- Examples:
-  - `Surface` owns the pane; surfaces never nest.
-  - `Section` (a Block) takes words and owns the heading; loudness derives from depth.
-  - `FactionEditor` is a Widget: two routes install it whole; pages own its data.
-  - Mantine components the app uses get stories under our theme, filed by kind.
-- Exceptions:
-  - Thin wrappers that merely rename a Mantine component remain prohibited (carried from DD-015).
-  - Game, sheet, print, capture, and publishing renderers stay outside the kit and Mantine.
+  treatment, titled regions, heading levels) were re-spelled at every call site and drifted. **That
+  drift is why** a domain-free kit was rebuilt deliberately, category by category, with a rule for
+  what may live in each.
+- Rule (canonical in [`AGENTS.md`](../../AGENTS.md#component-taxonomy)): six categories under
+  `src/app/ui` — Content, Controls, Lists, Layout, Surfaces, Blocks — each decided by what a caller
+  hands the component; the category is the folder and the Storybook root; feature folders keep only
+  organs; Widgets are the last-resort shared assemblies; Pickers (DD-021) are the one fetching peer.
 - Changed on: 2026-08-12
 
 ## DD-018: The application shell is chrome, not a category
-- Status: accepted
+- Status: accepted — rule now in `AGENTS.md`; this entry keeps the derivation
 - Context: The header had no component and no story — four lines of JSX inside `AppShell` whose height
-  was negotiated in CSS with whatever page the router mounted. Asking which category it belonged to
-  exposed that it belongs to none: `Surface` is one specific treatment, a pane content sits *on*
-  (border, translucent infill, blur), while the header is full-bleed artwork that content sits
-  *beside* in a shared grid row, overlapping only by `z-index`. It is not a Layout either, because
-  Layouts are transparent and it paints.
-- Rule: The shell's chrome lives in `src/app/shell/**` as named organs, not in the kit and
-  not in a category. `AppRoot` owns the persistent frame and the document-level effects, `AppHeader`
-  owns the artwork band and the two-row frame it shares with route content, `AppFooter` owns the
-  closing waypoints. They may carry stories, filed under the `Shell` Storybook root alongside the
-  other taxonomy carve-outs (`Widgets`, `Game Assets`).
-- Examples:
-  - The band's height is not a prop. `AppRoot` renders whatever the router hands it, so it cannot
-    pass a height down, and `PageLayout` cannot report upward; they meet in CSS instead — the page
-    joins the grid through `display: contents`, claims the `hero` row, and declares what it wants
-    through `data-page-layout-*`, which `AppHeader.module.css` reads back with `:has()`.
-  - Keeping the band and that frame in one file is deliberate: split across a published Layout and an
-    organ, the negotiation becomes unobservable, because CSS Modules can only target a class from the
-    module that owns it and a kit Layout may not import a shell organ.
-  - `data-app-root` on the container is the hook the Mantine compatibility stylesheet matches.
-- Exceptions:
-  - Nothing outside `src/app/shell` may import these; a route reaches the shell only by being
-    mounted inside the `_app` layout route.
-  - Product-specific chrome does not migrate to `src/ui` even when it would pass the import boundary.
-    A component with exactly one possible caller is not kit vocabulary.
+  was negotiated in CSS with whatever page mounted. Asking which category it belonged to exposed that
+  it belongs to none.
+- Why (the derivation worth keeping): `Surface` is one specific treatment, a pane content sits *on*
+  (border, translucent infill, blur); the header is full-bleed artwork content sits *beside* in a
+  shared grid row, overlapping only by `z-index`. It is not a Layout either — Layouts are transparent
+  and it paints. So the shell is decided by *position*, not by what a caller hands it, and lives in
+  `src/app/shell/**` as named organs.
+  - The band's height is not a prop: `AppRoot` renders whatever the router hands it and cannot pass a
+    height down; `PageLayout` cannot report upward. They meet in CSS — the page joins the grid through
+    `display: contents`, claims the `hero` row, and declares its state through `data-page-layout-*`,
+    which `AppHeader.module.css` reads back with `:has()`. Keeping the band and that frame in one file
+    is deliberate: split across a published Layout and an organ, the negotiation becomes unobservable,
+    because a CSS Module can only target a class from the module that owns it and a kit Layout may not
+    import a shell organ. This is also why `PageLayout` is DD-003's container-query exemption.
+- Rule (in `AGENTS.md`): `AppRoot`/`AppHeader`/`AppFooter` live in `src/app/shell/**`; nothing outside
+  imports them; they carry stories under the `Shell` root. A component with exactly one possible caller
+  is not kit vocabulary.
 - Changed on: 2026-08-12
-
-## DD-019: One components tree, with the domain boundary in the filename
-- Status: superseded
-- Context: DD-017 filed components into two trees — `src/ui` for domain-free, `src/app/components` for
-  domain-aware — because a lint glob is the only machine-checkable way to keep the kit clean, and a
-  glob wants a directory. That was a reaction to real history: `generic/**` had twice decayed by
-  absorbing domain knowledge (DD-002, DD-010, DD-011). But the split was carrying two jobs at once,
-  guaranteeing cleanliness *and* deciding where a component goes, and the taxonomy now does the second
-  job far better. Left as a second sorting axis it disagreed with the first: `PageLayout` was filed
-  app-side while importing nothing but `ReactNode`, `src/app/components/layout` held that one file and
-  nothing else, `surface` had no counterpart at all, and `main.ts` ran two entries per category
-  pointed at one `titlePrefix` — the sidebar working to hide a distinction the file system insisted
-  on. There is one product and no second consumer of the kit, so the directory bought nothing else.
-- Rule: Every published component lives in `src/ui/<category>`. A component that needs `@app`, `@db`,
-  `@game`, `@data`, or `convex/` is named `*.domain.tsx`; everything else is domain-free and oxlint
-  enforces it via `excludeFiles` rather than via location. Domain-free files may not import domain
-  modules **or** a `.domain` sibling, which is what keeps the guarantee transitive now that both live
-  in one directory.
-- Examples:
-  - `FactionCard.domain.tsx`, `FactionList.domain.tsx`, `FaqList.domain.tsx`,
-    `ProfileLink.domain.tsx`, `AnimatedLeaderToken.domain.tsx`,
-    `FactionCatalogueSpotlight.domain.tsx`, `GroupAssignPopover.domain.tsx`.
-  - The suffix grants import permission and nothing else. `TopicIcon` and `ProposedContent` speak the
-    product's vocabulary but import none of it, so they carry no suffix and need none — do not read
-    the suffix as a second taxonomy.
-  - `GroupAssignPopover` was found only by the typechecker: it reached convex types through
-    `../../../../convex/lib/collaborativeAccess`, a relative path the old boundary never matched. The
-    pattern list now covers `convex/` too.
-  - Stories, story fixtures, and tests are support modules and sit outside the restriction: a test
-    must be able to import the component it exercises.
-- Exceptions:
-  - The shell stays in `src/app/shell` (DD-018) and the document-rendering glue in `src/app/sheet`.
-    Neither is published, so neither belongs in a category. `src/app/components` is gone: a folder
-    named "components" made everything inside it look like one.
-  - If a second application or a published package ever becomes real, revisit: a directory is
-    extractable in a way a filename suffix is not. That was the one argument for two trees, and it was
-    explicitly ruled out when this was decided.
-- Changed on: 2026-08-12
-- Superseded on: 2026-08-12 by DD-020. Collapsing to one tree was right; the deny-list of aliases that
-  came with it was not, and the `*.domain.tsx` suffix existed only to paper over it.
 
 ## DD-020: A component renders what it is given
-- Status: accepted
-- Context: DD-019 kept the kit clean with a deny-list — no `@app`, `@db`, `@game`, `@data` or `convex`
-  imports — and a `*.domain.tsx` suffix for the seven components that tripped it. Reading what those
-  seven actually imported settled the question: **every single `@db` import was `import type`**, erased
-  at compile time, and the rest were game renderers, a date formatter, and a tag-label map. Not one
-  component fetched anything. Meanwhile the one real violation went unnoticed — `FaqList` called
-  `useNavigate` and decided where the reader went next — because the router was not on the list. The
-  rule was policing the alias in the import specifier, which is a proxy for the property that matters,
+- Status: accepted — rule now in `AGENTS.md` + oxlint; this entry keeps the why (absorbs DD-019)
+- Context: An earlier version of the kit boundary (DD-019) banned every `@app`/`@db`/`@game` import
+  and carved out the seven components that tripped it with a `*.domain.tsx` suffix. **The war story:**
+  reading what those seven actually imported settled it — *every single `@db` import was `import type`*,
+  erased at compile time, and the rest were game renderers, a date formatter, and a tag-label map. Not
+  one component fetched anything. Meanwhile the one real violation went unnoticed: `FaqList` called
+  `useNavigate` and decided where the reader went next, because the router was not on the ban list. The
+  rule had been policing the *alias in the import specifier* — a proxy for the property that matters —
   and the proxy was both too strict and too loose.
-- Rule: Inside `src/app/ui/**`, a component renders what it is given; it does not go and get things.
-  Concretely, [`.oxlintrc.json`](../../.oxlintrc.json) forbids the Convex client in any form; **value**
-  imports from a data module by every spelling it has (`@db/**`, `@app/db/**`, `@app/*/db`, and the
-  relative forms with or without a `.ts` extension), with `allowTypeImports` keeping `import type`
-  legal; the router's data and navigation surface, `useRouter` included, while leaving `Link`,
-  `createLink` and `renderRoot` allowed; and imports of `@app/shell`, `@app/widgets` or `@app/routes`,
-  which are built out of the kit rather than the other way round. Nothing is exempt and no filename
-  marks an escape — the `*.domain.tsx` suffix is deleted.
-- Note on the spellings: the first version of this rule named `@db/**` and four router hooks, which
-  looked complete and was not. `@app/db/core` reaches the same live client through the other alias;
-  `../../factions/db.ts` dodges a pattern that expects the specifier to end in `db`; and `useRouter`
-  returns an object with `.navigate()` on it, which made naming the four hooks decorative. Each hole
-  was found by probing the rule with throwaway files rather than by reading the config, and each
-  closed pattern is verified to leave the real kit at zero diagnostics.
-- Examples:
-  - `import type { FactionCatalogueEntry } from '@db/factions'` is welcome: a type is a statement
-    about what you render, not a dependency on how it was fetched.
-  - `@game` renderers and pure helpers stay allowed. They compute and draw; they do not reach. The
-    helpers that turn data into words now live in the kit itself — `@ui/content/dates`,
-    `@ui/content/assetPublishingStatus` — since that is Content's job description.
-  - Pointing at a place is presentation, so a component may render a `Link`. Deciding to go there is a
-    page's call, so `FaqList` now takes `onOpenQuestion` and the ruleset route navigates.
-  - The kit moved to `src/app/ui` at the same time, reached through the unchanged `@ui/*` alias. There
-    is one application; a top-level `src/ui` promised an independence that will never exist.
-- Exceptions:
-  - Stories, story fixtures, and tests sit outside the restriction: a test must import what it
-    exercises, and a story must be able to hand a component realistic data.
+- Why the suffix (DD-019) is gone: the two-tree split it enforced bought a machine-checkable boundary,
+  but the property that matters is behaviour, not location. There is one product and no second consumer
+  of the kit, so a directory (extractable in a way a filename suffix is not) bought nothing — the one
+  argument for two trees was ruled out when this was decided.
+- Rule (canonical in `AGENTS.md`, enforced by `.oxlintrc.json` `src/app/ui/**`): a component renders
+  what it is given; it does not go and get things. Banned — the Convex client in any form; **value**
+  imports from a data module by every spelling (`import type` stays legal); the router's data and
+  navigation surface (`useRouter`, `useNavigate`, … — `Link`/`createLink`/`renderRoot` stay allowed);
+  and `@app/shell`/`@app/widgets`/`@app/routes`. Nothing is exempt and no filename marks an escape.
+- Provenance: **earned** — the `FaqList`/`useNavigate` miss above. The rule was hardened by probing it
+  with throwaway files rather than reading the config, closing each hole (`@app/db/core` via the other
+  alias; the relative `db.ts` spelling; `useRouter` returning an object with `.navigate()` on it).
 - Changed on: 2026-08-12
+
+## DD-021: Pickers — the one place a component may fetch
+- Status: accepted
+- Context: The rule "a widget never fetches" looked like it made the faction load popover a violation.
+  It is not: that popover is a control that fetches *its own options* lazily, so a page rendering a
+  "pick a user" control never queries every user up front. The two stated reasons for the fetch ban
+  (can't be storied, destroys reuse) did not survive scrutiny — Storybook already mocks Convex, and the
+  fetching control was reused on *more* routes than the props-only one. The real reason is DD-013
+  subscription discipline. That gave the missing classification a home.
+- Rule (canonical in `AGENTS.md`, Pickers): a Picker is a domain control whose whole job is to let the
+  user choose from a list it loads itself. It fetches only what presenting its own options needs, read
+  only, through a subscription torn down when it leaves the screen; it never mutates and never reads the
+  page's data; the chosen value leaves through an `onPick`-style callback and the route decides what
+  happens next. It is domain-specific (so it lives outside the kit) and renders *through* the kit — a
+  peer of Widgets, not a seventh category.
+- Examples: `FactionPicker` (`src/app/pickers/`), mounted only while the load popover is open, so it
+  subscribes on mount because the container already gated it.
+- Provenance: **structural** — the `pickers` slot in `check:app-layout` and the deliberate *absence*
+  of Pickers from the `ui/**` and `widgets/**` fetch bans. The lazy/read-only/never-mutate contract is
+  documented-only.
+- Cross-links: DD-013 (the subscription discipline it applies), DD-020 (the fetch ban it is the
+  deliberate exemption to).
+- Changed on: 2026-08-13
+
+---
+
+# Provenance of the guards
+
+Verified against each entry's text and the guard, not assumed — two claims came back different from
+how the log read.
+
+| Rule (DD) | Guard | Earned / pre-emptive | Incident |
+|-----------|-------|----------------------|----------|
+| Renders what it is given (DD-020) | `.oxlintrc.json` `src/app/ui/**` | **earned** | `FaqList` called `useNavigate`, slipped the alias ban |
+| Closed `src/app` top level (DD-017) | `check:app-layout` | **earned** | folders "empty-but-alive for months" after the domain scheme was dismantled |
+| The Convex doorway | `.oxlintrc.json` `src/**` | **earned** | `viewerActions.ts`/`assetPublishingStatus.ts` reached `convex/lib` for a wide union |
+| `shared` ↛ app/convex/game | `.oxlintrc.json` `src/shared/**` | **earned** | 7 convex modules reached `src/app/*/validation`; the faction schema lived under a renderer folder |
+| `convex`/`workers` ↛ app/game | `.oxlintrc.json` overrides | **earned** | publisher Worker reached the app's capture folder |
+| Renderer isolation (DD-015) | `rendererIsolation.test.ts` | **earned** | `/app/components/content/` stopped existing, so the test "passed for the wrong reason" |
+| No orphan CSS classes | `check:css-orphans` | **earned** | `.rulesetHeadCover` etc. shipped three times in one refactor |
+| Layout container queries (DD-003) | `containerQueries.test.ts` | **pre-emptive** | design-derived; no violation preceded it |
+| Leaf routes mount `PageLayout` (DD-014) | `PageLayout.architecture.test.ts` | **earned rule, structural guard** | the `staticData.PageHead` bridge earned the rule; the surviving assertion names no incident of its own |
+| Shell is chrome (DD-018) | `check:app-layout` slot + `data-page-layout-*` | **borrowed** | the slot is earned by the empty-folders incident, not by any shell violation |
+| One query per route (DD-013) | — | **documented-only** | `check:convex-skip` is a *different*, adjacent rule; it does not enforce this |
+
+---
+
+# History
+
+The generic component system, its retirement, and the taxonomy that replaced it. These entries are
+kept only so their numbers resolve and their reasoning is not lost; do not follow their rules.
+
+**The arc (2026-03 → superseded 2026-07-19 by DD-015 → DD-017):** DuneZone began with a home-grown
+generic primitive / form / layout / surface system (`src/app/components/generic/**`, `form/**`).
+DD-001–004, 008, 010, 011 codified how to work inside it: reuse first, layer direction, parent-owned
+spacing, avoid custom CSS, stories for generics, generic-first placement, one canonical path. DD-015
+retired that whole system in favour of Mantine for standard UI, keeping only distinctive visuals and
+the isolated renderers. DD-017 then rebuilt a domain-free *kit* on top of Mantine; DD-020 replaced
+DD-019's two-tree/`*.domain.tsx` boundary with the behavioural import rule.
+
+- **DD-001** Reuse existing shared components first — *superseded by DD-015.* Discovery now starts with Mantine, then the kit.
+- **DD-002** Component layering / dependency direction — *superseded by DD-015.* Its lasting lesson, cited by DD-019/020: `generic/**` twice decayed by absorbing domain knowledge, which is why the kit boundary is behavioural.
+- **DD-004** Avoid custom CSS, prohibit `composes` — *superseded by DD-015 in part.* "Avoid CSS" is dead (Mantine is the default), but **the no-`composes` / one-owner-per-stylesheet half is live** — see the Styling section of `docs/technical/ui-component-hierarchy.md`.
+- **DD-006, DD-007** Toolbar primary / colour intent — *folded into DD-005 (Action semantics).*
+- **DD-008** Generic components require stories — *superseded by DD-015.* Live story expectation is in `AGENTS.md`; installed Mantine and route-local composition are exempt.
+- **DD-010** Placement generic-first but domain-honest — *superseded by DD-015 → DD-017.* Placement is the taxonomy's job; domain-honesty is the DD-020 boundary.
+- **DD-011** One shared component, one canonical path — *superseded by DD-015 → DD-017.* "One canonical path" became "one tree, inside the app".
+- **DD-012** Concern boundaries, not sub-views — *folded into DD-009,* which carries its `RulesetGroupToolbarControl` war story.
+- **DD-015** Mantine owns standard application-content UI — *superseded by DD-017.* The pivot that retired the generic system; the renderer-isolation and no-thin-wrappers rules carried forward. The migration finished and the named legacy paths are deleted.
+- **DD-019** One components tree, domain boundary in the filename — *superseded by DD-020.* Collapsing to one tree was right; the alias deny-list and the `*.domain.tsx` suffix were not — its one-tree rationale is folded into DD-020.

--- a/docs/technical/ui-design-decisions.md
+++ b/docs/technical/ui-design-decisions.md
@@ -1,14 +1,17 @@
 # UI design decisions
 
 This log records durable UI decisions and, more importantly, **why they exist**. The rules
-themselves are canonical in [`AGENTS.md`](../../AGENTS.md) and enforced by guards; this log is the
-reasoning behind them — the incidents that earned each rule.
+are canonical in [`AGENTS.md`](../../AGENTS.md), in a guard, or in the code that carries them; this
+log is the reasoning behind them — the incidents that earned each rule.
 
 ## How to use this log
 
-- **One rule, one home.** A live rule is stated once — in `AGENTS.md` (or a guard). An entry here
-  does not restate a rule that lives there; it records the *why*. Two entries must never enforce the
-  same thing.
+- **One rule, one home.** Every live rule has exactly one *normative* home — usually `AGENTS.md` or a
+  guard, sometimes the code that carries it (`theme.ts`, `TopicIcon.tsx`), and for the few not yet
+  lifted into `AGENTS.md` (action semantics, the one-query rule) this log *is* that home. An entry
+  here records the *why*; where it names the rule, it is a one-line pointer tagged with the canonical
+  home (`Rule (stated in AGENTS.md): …`), never a second authority you could edit in isolation. Two
+  editable copies of one rule is the thing this forbids.
 - **The war story survives.** When entries merge, or a rule moves to `AGENTS.md`, the incident that
   motivated it is kept. A rule without its story loses its strength — a reader who cannot see what
   went wrong cannot tell whether the rule still applies.
@@ -35,7 +38,7 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
 | The shell is chrome, not a category | `AGENTS.md` (application shell) | `[M]` `check:app-layout` + the `data-page-layout-*` contract | DD-018 |
 | Layouts own spacing; named compound slots; container queries not media; ≥2 slots | `AGENTS.md` (Rules between categories) | `[M]` `containerQueries.test.ts` (the container-query half) | DD-003 |
 | Every terminal `_app` route mounts `PageLayout`; the leaf owns composition | `AGENTS.md` (routes) | `[M]` `PageLayout.architecture.test.ts` (mount check) | DD-014 |
-| One Convex page query per route, plus `useCurrentProfile` | this log (`AGENTS.md` cites it by name) | `[D]` (`check:convex-skip` is an *adjacent* rule, not this one) | DD-013 |
+| At most one Convex page query per route, plus `useCurrentProfile` when auth-aware | this log (`AGENTS.md` cites it by name) | `[D]` (`check:convex-skip` is an *adjacent* rule, not this one) | DD-013 |
 | Action semantics — icon-only buttons, one styled toolbar primary, colour by intent | this log | `[D]` (the kit carries it: `IconAction`, `CallToAction`, the theme tuples) | DD-005 |
 | Recurring topics use one canonical icon mapping | this log (`TopicIcon.tsx` is the code home) | `[D]` | DD-016 |
 | Extract a component only at a real concern boundary | `AGENTS.md` (the membrane tells) | `[D]` | DD-009 |
@@ -44,9 +47,9 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
 
 ---
 
-# Active decisions
+## Active decisions
 
-## DD-003: Layout components own spacing, and lay out through named slots
+### DD-003: Layout components own spacing, and lay out through named slots
 - Status: accepted
 - Context: Margin-led spacing scattered through leaf components produces inconsistent layout and
   buries every page in nested `<Stack><Group><Grid>…`. The original rule — parent-owned spacing,
@@ -80,7 +83,25 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
     (DD-018). It is genuinely viewport-scoped, not a container. The guard excepts it by name.
 - Changed on: 2026-08-13
 
-## DD-005: Action semantics — icon-only buttons, one toolbar primary, colour by intent
+### DD-004: One owner per stylesheet — no CSS `composes`
+- Status: accepted in part — DD-004's first half ("avoid custom CSS") is superseded by DD-015; this
+  live remnant keeps its why. The rule lives in the Styling section of
+  [`ui-component-hierarchy.md`](./ui-component-hierarchy.md).
+- Context: `composes` pulls declarations across module boundaries, so the stylesheet a rule actually
+  comes from stops being greppable and two files quietly co-own one class. The original "avoid custom
+  CSS, prohibit `composes`" rule lost its first half when Mantine became the default (DD-015); the
+  second half survived on its own merit.
+- Rule (stated in `ui-component-hierarchy.md`): no CSS `composes`; exactly one TSX component owns each
+  `.module.css`. Share through the component, not the stylesheet.
+- Why (the derivation worth keeping): ownership you cannot grep is ownership that drifts — the same
+  failure the kit boundary (DD-020) and the taxonomy (DD-017) guard against, applied to styles. A
+  reader must be able to open one TSX file and see every rule that styles it.
+- Provenance: **pre-emptive** — a discipline, no incident. `check:css-orphans`
+  ([`assert-no-orphan-css-classes.mjs`](../../scripts/assert-no-orphan-css-classes.mjs)) catches
+  orphaned/unimported stylesheets only; the one-owner rule itself is documented.
+- Changed on: 2026-08-13
+
+### DD-005: Action semantics — icon-only buttons, one toolbar primary, colour by intent
 - Status: accepted (absorbs DD-006 and DD-007)
 - Context: Actions become unpredictable when their meaning is carried by hue rather than intent, when
   a toolbar has several competing "primary" buttons, or when an icon-only control has no explicit
@@ -106,7 +127,7 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
     product/user direction.
 - Changed on: 2026-08-13 (combined from DD-005/006/007, originally 2026-03-25)
 
-## DD-009: Extract a component only at a real concern boundary
+### DD-009: Extract a component only at a real concern boundary
 - Status: accepted (absorbs DD-012)
 - Context: Splitting JSX into "helper" components without a clear responsibility boundary produces
   prop bloat, indirection, and harder reasoning for no reuse. **The war story:**
@@ -130,7 +151,7 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
     route state; or a long JSX block moved to a file without reducing responsibility or API surface.
 - Changed on: 2026-08-13 (combined DD-009 + DD-012, originally 2026-04-01)
 
-## DD-013: One Convex page query per route, plus optional profile
+### DD-013: One Convex page query per route, plus optional profile
 - Status: accepted
 - Context: Mounting several `useQuery` hooks on one route multiplies live subscriptions, complicates
   loading states, and scatters the authoritative shape of a screen across Convex functions. This
@@ -150,10 +171,10 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
     call-out its docstring provides. See DD-021.
 - Provenance note: **`check:convex-skip` does not enforce this rule.** That guard bans `useQuery("skip")`
   inside `src/app/db` — an adjacent, narrower concern whose own header states a *preference* and names
-  no incident. The one-query rule is documented-only; its guard is pre-emptive.
+  no incident. The one-query rule has no guard — it is documented-only. (`check:convex-skip` is pre-emptive as its own, separate rule.)
 - Changed on: 2026-04-04
 
-## DD-014: Leaf routes own page composition
+### DD-014: Leaf routes own page composition
 - Status: accepted — rule now in `AGENTS.md` (routes); this entry keeps the why
 - Context: A parent-owned `staticData.PageHead` bridge split one screen into detached header and
   body sub-views, duplicated the page subscription, and hid the whole composition across router
@@ -168,7 +189,23 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
   style: it forecloses the earned incident but names no incident of its own.
 - Changed on: 2026-07-18
 
-## DD-016: Recurring topics use one canonical icon mapping
+### DD-015: Renderers stay isolated
+- Status: accepted in part — DD-015's pivot (Mantine owns standard content) is itself superseded by
+  DD-017; the renderer-isolation remnant is live and keeps its why. The rule lives in
+  [`AGENTS.md`](../../AGENTS.md) (game assets).
+- Context: When the generic UI system was retired, game-asset renderers were deliberately walled off
+  from it. A renderer that reaches into Mantine, Radix, or app code stops being portable — the same
+  asset must paint identically in a worker, in print, and in the browser, and none of those load the
+  app shell.
+- Rule (stated in `AGENTS.md`): renderers import no Mantine, no Radix, no `src/app`; they are pure
+  over their inputs, with no thin wrappers around app UI leaking in.
+- Why (the derivation worth keeping): isolation is what lets one renderer serve three deploy targets;
+  a single app import would couple print and worker output to the browser bundle.
+- Provenance: **earned** — by the coupling the generic system caused. Enforced by
+  [`rendererIsolation.test.ts`](../../src/game/rendererIsolation.test.ts).
+- Changed on: 2026-08-13
+
+### DD-016: Recurring topics use one canonical icon mapping
 - Status: accepted
 - Context: The same topic appeared with different icons between the faction editor and the detail
   pages, weakening recognition.
@@ -180,7 +217,7 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
     direction. Renderer-owned game visuals stay isolated and do not consume `TopicIcon`.
 - Changed on: 2026-07-20
 
-## DD-017: The component taxonomy governs all interface components
+### DD-017: The component taxonomy governs all interface components
 - Status: accepted — rule now in `AGENTS.md`; this entry keeps the why
 - Context: DD-015 made Mantine the only sanctioned shared layer, so recurring concerns (the pane
   treatment, titled regions, heading levels) were re-spelled at every call site and drifted. **That
@@ -192,13 +229,13 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
   organs; Widgets are the last-resort shared assemblies; Pickers (DD-021) are the one fetching peer.
 - Changed on: 2026-08-12
 
-## DD-018: The application shell is chrome, not a category
+### DD-018: The application shell is chrome, not a category
 - Status: accepted — rule now in `AGENTS.md`; this entry keeps the derivation
 - Context: The header had no component and no story — four lines of JSX inside `AppShell` whose height
   was negotiated in CSS with whatever page mounted. Asking which category it belonged to exposed that
   it belongs to none.
 - Why (the derivation worth keeping): `Surface` is one specific treatment, a pane content sits *on*
-  (border, translucent infill, blur); the header is full-bleed artwork content sits *beside* in a
+  (border, translucent infill, blur); the header is full-bleed artwork that content sits *beside* in a
   shared grid row, overlapping only by `z-index`. It is not a Layout either — Layouts are transparent
   and it paints. So the shell is decided by *position*, not by what a caller hands it, and lives in
   `src/app/shell/**` as named organs.
@@ -214,7 +251,7 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
   is not kit vocabulary.
 - Changed on: 2026-08-12
 
-## DD-020: A component renders what it is given
+### DD-020: A component renders what it is given
 - Status: accepted — rule now in `AGENTS.md` + oxlint; this entry keeps the why (absorbs DD-019)
 - Context: An earlier version of the kit boundary (DD-019) banned every `@app`/`@db`/`@game` import
   and carved out the seven components that tripped it with a `*.domain.tsx` suffix. **The war story:**
@@ -238,7 +275,7 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
   alias; the relative `db.ts` spelling; `useRouter` returning an object with `.navigate()` on it).
 - Changed on: 2026-08-12
 
-## DD-021: Pickers — the one place a component may fetch
+### DD-021: Pickers — the one place a component may fetch
 - Status: accepted
 - Context: The rule "a widget never fetches" looked like it made the faction load popover a violation.
   It is not: that popover is a control that fetches *its own options* lazily, so a page rendering a
@@ -263,12 +300,12 @@ a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]
 
 ---
 
-# Provenance of the guards
+## Provenance of the guards
 
 Verified against each entry's text and the guard, not assumed — two claims came back different from
 how the log read.
 
-| Rule (DD) | Guard | Earned / pre-emptive | Incident |
+| Rule (DD) | Guard | Provenance | Incident |
 |-----------|-------|----------------------|----------|
 | Renders what it is given (DD-020) | `.oxlintrc.json` `src/app/ui/**` | **earned** | `FaqList` called `useNavigate`, slipped the alias ban |
 | Closed `src/app` top level (DD-017) | `check:app-layout` | **earned** | folders "empty-but-alive for months" after the domain scheme was dismantled |
@@ -284,7 +321,7 @@ how the log read.
 
 ---
 
-# History
+## History
 
 The generic component system, its retirement, and the taxonomy that replaced it. These entries are
 kept only so their numbers resolve and their reasoning is not lost; do not follow their rules.
@@ -299,11 +336,11 @@ DD-019's two-tree/`*.domain.tsx` boundary with the behavioural import rule.
 
 - **DD-001** Reuse existing shared components first — *superseded by DD-015.* Discovery now starts with Mantine, then the kit.
 - **DD-002** Component layering / dependency direction — *superseded by DD-015.* Its lasting lesson, cited by DD-019/020: `generic/**` twice decayed by absorbing domain knowledge, which is why the kit boundary is behavioural.
-- **DD-004** Avoid custom CSS, prohibit `composes` — *superseded by DD-015 in part.* "Avoid CSS" is dead (Mantine is the default), but **the no-`composes` / one-owner-per-stylesheet half is live** — see the Styling section of `docs/technical/ui-component-hierarchy.md`.
+- **DD-004** Avoid custom CSS, prohibit `composes` — *"avoid CSS" superseded by DD-015.* The no-`composes` / one-owner-per-stylesheet half is live and now carries its own why at **DD-004 above**.
 - **DD-006, DD-007** Toolbar primary / colour intent — *folded into DD-005 (Action semantics).*
 - **DD-008** Generic components require stories — *superseded by DD-015.* Live story expectation is in `AGENTS.md`; installed Mantine and route-local composition are exempt.
 - **DD-010** Placement generic-first but domain-honest — *superseded by DD-015 → DD-017.* Placement is the taxonomy's job; domain-honesty is the DD-020 boundary.
 - **DD-011** One shared component, one canonical path — *superseded by DD-015 → DD-017.* "One canonical path" became "one tree, inside the app".
 - **DD-012** Concern boundaries, not sub-views — *folded into DD-009,* which carries its `RulesetGroupToolbarControl` war story.
-- **DD-015** Mantine owns standard application-content UI — *superseded by DD-017.* The pivot that retired the generic system; the renderer-isolation and no-thin-wrappers rules carried forward. The migration finished and the named legacy paths are deleted.
+- **DD-015** Mantine owns standard application-content UI — *superseded by DD-017.* The pivot that retired the generic system; the migration finished and the named legacy paths are deleted. Its live renderer-isolation remnant carries its own why at **DD-015 above**.
 - **DD-019** One components tree, domain boundary in the filename — *superseded by DD-020.* Collapsing to one tree was right; the alias deny-list and the `*.domain.tsx` suffix were not — its one-tree rationale is folded into DD-020.

--- a/docs/technical/ui-design-decisions.md
+++ b/docs/technical/ui-design-decisions.md
@@ -1,346 +1,177 @@
 # UI design decisions
 
-This log records durable UI decisions and, more importantly, **why they exist**. The rules
-are canonical in [`AGENTS.md`](../../AGENTS.md), in a guard, or in the code that carries them; this
-log is the reasoning behind them — the incidents that earned each rule.
+The rules that govern UI code in this app, each with the one reason it exists. This is the current
+rulebook, not a changelog — every rule here applies. Most are also stated in
+[`AGENTS.md`](../../AGENTS.md) or caught by a guard; the italic line under each rule says where it is
+enforced and where its canonical statement lives.
 
-## How to use this log
+## The component boundary
 
-- **One rule, one home.** Every live rule has exactly one *normative* home — usually `AGENTS.md` or a
-  guard, sometimes the code that carries it (`theme.ts`, `TopicIcon.tsx`), and for the few not yet
-  lifted into `AGENTS.md` (action semantics, the one-query rule) this log *is* that home. An entry
-  here records the *why*; where it names the rule, it is a one-line pointer tagged with the canonical
-  home (`Rule (stated in AGENTS.md): …`), never a second authority you could edit in isolation. Two
-  editable copies of one rule is the thing this forbids.
-- **The war story survives.** When entries merge, or a rule moves to `AGENTS.md`, the incident that
-  motivated it is kept. A rule without its story loses its strength — a reader who cannot see what
-  went wrong cannot tell whether the rule still applies.
-- **`Status: superseded` entries are history, not instructions.** They are kept to explain how the
-  current rules came to be, and they still name paths and components since deleted (`generic/ui`,
-  `form/**`, `UIButton`, `Block`, `*.domain.tsx`). Do not follow them; read the entry that replaced
-  them. History lives at the bottom.
-- **Numbers are permanent anchors.** Entries are cross-referenced by number; a merged or superseded
-  entry keeps a stub so its number still resolves.
-- Renames are applied throughout so a symbol stays searchable; substance is never quietly rewritten.
-  `AppShell` → `AppRoot`; the header it owns is `AppHeader` (DD-018).
+### A component renders what it is given
 
-## What applies now
+It renders its inputs; it does not go and get things. The moment a component fetches, navigates, or
+reaches into the shell, it stops being reusable and a screen's behaviour scatters across the tree.
+What matters is the capability, not where the file sits: a ban keyed on import *aliases* once waved
+through `FaqList` calling `useNavigate` while flagging harmless compile-time `import type`s — so the
+rule bans the behaviour, not the location.
 
-The live rules at a glance, each pointing at its canonical home and its guard. Nothing here restates
-a rule; it indexes them. `[M]` machine-enforced · `[D]` documented-only · `[C]` code contract.
+*Enforced by [`.oxlintrc.json`](../../.oxlintrc.json) for `src/app/ui/**` — no Convex client, no
+value import from a data module (`import type` stays legal), no router navigation
+(`useNavigate`/`useRouter`; `Link` stays), no reach into `shell`/`widgets`/`routes`. Canonical in
+[`AGENTS.md`](../../AGENTS.md#component-taxonomy).*
 
-| Live rule | Canonical home | Guard | Why (DD) |
-|-----------|----------------|-------|----------|
-| A component renders what it is given — no Convex, no `@db` value, no router-nav, no shell·widgets·routes | `AGENTS.md` component taxonomy | `[M]` `.oxlintrc.json` `src/app/ui/**` | DD-020 |
-| A widget never fetches | `AGENTS.md` (Widgets) | `[M]` `.oxlintrc.json` `src/app/widgets/**` | DD-020, DD-021 |
-| Pickers — the one place a component may fetch: its own options, lazy, read-only | `AGENTS.md` (Pickers) | `[C]` structural (`check:app-layout` slot; absence from the ui/widget bans) | DD-021, DD-013 |
-| Six-category taxonomy; folder = category = Storybook root | `AGENTS.md` component taxonomy | `[M]` `check:app-layout` (top slot only); rest `[D]` | DD-017 |
-| The shell is chrome, not a category | `AGENTS.md` (application shell) | `[M]` `check:app-layout` + the `data-page-layout-*` contract | DD-018 |
-| Layouts own spacing; named compound slots; container queries not media; ≥2 slots | `AGENTS.md` (Rules between categories) | `[M]` `containerQueries.test.ts` (the container-query half) | DD-003 |
-| Every terminal `_app` route mounts `PageLayout`; the leaf owns composition | `AGENTS.md` (routes) | `[M]` `PageLayout.architecture.test.ts` (mount check) | DD-014 |
-| At most one Convex page query per route, plus `useCurrentProfile` when auth-aware | this log (`AGENTS.md` cites it by name) | `[D]` (`check:convex-skip` is an *adjacent* rule, not this one) | DD-013 |
-| Action semantics — icon-only buttons, one styled toolbar primary, colour by intent | this log | `[D]` (the kit carries it: `IconAction`, `CallToAction`, the theme tuples) | DD-005 |
-| Recurring topics use one canonical icon mapping | this log (`TopicIcon.tsx` is the code home) | `[D]` | DD-016 |
-| Extract a component only at a real concern boundary | `AGENTS.md` (the membrane tells) | `[D]` | DD-009 |
-| No CSS `composes`; one TSX owner per stylesheet | `docs/technical/ui-component-hierarchy.md` (Styling) | `[M]` `check:css-orphans` (orphans/unimported only) | DD-004 |
-| Renderers stay isolated (no Mantine/Radix/app reach) | `AGENTS.md` (game assets) | `[M]` `rendererIsolation.test.ts` | DD-015 |
+### Widgets are the last resort
 
----
+A widget is a shared assembly for the rare case that none of the six kit categories fit. Like any
+component it renders what it is handed and never fetches — fetching would multiply a route's live
+subscriptions and scatter its authoritative shape.
 
-## Active decisions
+*Enforced by [`.oxlintrc.json`](../../.oxlintrc.json) for `src/app/widgets/**`. Canonical in
+[`AGENTS.md`](../../AGENTS.md).*
 
-### DD-003: Layout components own spacing, and lay out through named slots
-- Status: accepted
-- Context: Margin-led spacing scattered through leaf components produces inconsistent layout and
-  buries every page in nested `<Stack><Group><Grid>…`. The original rule — parent-owned spacing,
-  flex+`gap`/grid — was only half-retired by DD-015: DD-015 replaced the specific legacy
-  `generic/layout` *wrappers* with Mantine's `Stack`/`Group`/`Grid`, but stated in the same breath
-  that "parent-owned spacing remains useful". This entry reinstates that surviving principle and
-  strengthens it into a Layout-component discipline, because the kit had already grown custom
-  layouts (`PageLayout`, `TriptychLayout`, `AtlasLayout`, `AsymmetricSplitLayout`) with no rule
-  written down for them.
-- Rule:
-  - **Spacing is owned by the Layout, not the leaf.** A leaf control never carries page
-    margin/padding; a Layout arranges its slots. Margin only for unavoidable third-party constraints.
-  - **Layout components are custom, built on Mantine primitives.** A recurring layout situation
-    becomes a named component so a page composes `<TriptychLayout>` instead of re-nesting flex/grid
-    at the call site.
-  - **Responsive by container query, not media query.** A Layout lays out by the room it is given,
-    so it stays context-independent. Guarded by
-    [`containerQueries.test.ts`](../../src/app/ui/layout/containerQueries.test.ts).
-  - **Every Layout lays out through named slots**, as compound children —
-    `<TriptychLayout><TriptychLayout.Left>…</TriptychLayout.Left>…</TriptychLayout>` — so the
-    composition reads top-down and large content never rides inside a prop value.
-  - **No single-slot Layout.** One slot is a passthrough, not a layout; a Layout earns its existence
-    by arranging two or more.
-- Examples:
-  - `PageLayout` (`.Header`/`.Toolbar`/`.Content`), `TriptychLayout` (`.Left`/`.Center`/`.Right`),
-    `AtlasLayout` (`.Sidebar`/`.Content`), `AsymmetricSplitLayout` (`.Wide`/`.Narrow`).
-- Exceptions:
-  - **`PageLayout` uses `@media`, not a container query, and it is the one exemption.** It is the
-    shell's page frame — its children join `AppHeader`'s grid through `display: contents`, and it is
-    sized against the viewport in concert with the shell through the `data-page-layout-*` bridge
-    (DD-018). It is genuinely viewport-scoped, not a container. The guard excepts it by name.
-- Changed on: 2026-08-13
+### Pickers are the one place a component may fetch
 
-### DD-004: One owner per stylesheet — no CSS `composes`
-- Status: accepted in part — DD-004's first half ("avoid custom CSS") is superseded by DD-015; this
-  live remnant keeps its why. The rule lives in the Styling section of
-  [`ui-component-hierarchy.md`](./ui-component-hierarchy.md).
-- Context: `composes` pulls declarations across module boundaries, so the stylesheet a rule actually
-  comes from stops being greppable and two files quietly co-own one class. The original "avoid custom
-  CSS, prohibit `composes`" rule lost its first half when Mantine became the default (DD-015); the
-  second half survived on its own merit.
-- Rule (stated in `ui-component-hierarchy.md`): no CSS `composes`; exactly one TSX component owns each
-  `.module.css`. Share through the component, not the stylesheet.
-- Why (the derivation worth keeping): ownership you cannot grep is ownership that drifts — the same
-  failure the kit boundary (DD-020) and the taxonomy (DD-017) guard against, applied to styles. A
-  reader must be able to open one TSX file and see every rule that styles it.
-- Provenance: **pre-emptive** — a discipline, no incident. `check:css-orphans`
-  ([`assert-no-orphan-css-classes.mjs`](../../scripts/assert-no-orphan-css-classes.mjs)) catches
-  orphaned/unimported stylesheets only; the one-owner rule itself is documented.
-- Changed on: 2026-08-13
+A Picker is a domain control whose whole job is to let the user choose from a list it loads itself —
+so a "pick a user" control never queries every user up front. It fetches only what showing its own
+options needs, read-only, through a subscription torn down when it leaves the screen; it never
+mutates, never reads the page's data, and returns the chosen value through an `onPick`-style
+callback. It is the deliberate exception to the fetch ban — justified by the one-query subscription
+discipline below, not by being a new category — and renders *through* the kit as a peer of Widgets.
 
-### DD-005: Action semantics — icon-only buttons, one toolbar primary, colour by intent
-- Status: accepted (absorbs DD-006 and DD-007)
-- Context: Actions become unpredictable when their meaning is carried by hue rather than intent, when
-  a toolbar has several competing "primary" buttons, or when an icon-only control has no explicit
-  semantics. Three earlier entries (DD-005/006/007) each stated part of this and overlapped on
-  "confirm-colour for the positive primary"; they are one concern and are combined here so the rule
-  is stated once.
-- Rule:
-  - **Colour by intent, then style.** Positive primary actions take the `confirm` colour; destructive
-    actions take `red` (the Dune danger tuple); neutral/auxiliary actions stay the default colour and
-    vary by Mantine `variant`, never by hue. The map is the code, in
-    [`theme.ts`](../../src/app/ui/theme.ts) — do not re-type it here.
-  - **One primary per toolbar.** A multi-action toolbar keeps exactly one clear positive primary,
-    styled `confirm`; secondary and utility actions drop to `default`/`subtle`.
-  - **Icon-only for established actions only.** Use an icon-only button for a common, recognizable
-    action with explicit intent and an accessible label (`aria-label`); if the icon would be
-    ambiguous, use a text-labelled control.
-- Examples:
-  - The kit carries this at the call site: `IconAction` for icon-only actions, `CallToAction` for the
-    forward-moving primary. `StatusBadge` has its own tone scale (including `critical`) for *state* —
-    that is not an action vocabulary.
-- Exceptions:
-  - A non-`confirm` primary, or a product-directed visual override, is allowed only with explicit
-    product/user direction.
-- Changed on: 2026-08-13 (combined from DD-005/006/007, originally 2026-03-25)
+*Structural: the `pickers` slot in `check:app-layout` and its deliberate absence from the fetch bans;
+the lazy/read-only/never-mutate contract is convention. Canonical in [`AGENTS.md`](../../AGENTS.md).
+Example: `FactionPicker` in `src/app/pickers/`.*
 
-### DD-009: Extract a component only at a real concern boundary
-- Status: accepted (absorbs DD-012)
-- Context: Splitting JSX into "helper" components without a clear responsibility boundary produces
-  prop bloat, indirection, and harder reasoning for no reuse. **The war story:**
-  `RulesetGroupToolbarControl` was extracted from the ruleset detail page's toolbar row — but it was
-  a slice of one page's layout, not a component. To render anything it needed ~11 props, every one a
-  mirror of the route's own state (`rulesetId`, `rulesetName`, `groupId`, `groupSlug`, `groupName`,
-  `isOwner`, `membershipStatus`, `canRequestMembership`, `onRequestMembership`, `canEditGroup`,
-  `onChangeGroup`). The route computed all of it and threaded it down; the "component" handed it
-  straight back. No encapsulation, one caller, and to understand one toolbar you now read two files.
-  It was inlined. (DD-012's rule and this incident; DD-009's earlier "prefer small components" folds
-  in here — one is the generic form of the other.)
-- Rule: Extract a component only when it is a real **concern boundary** — a behaviour or domain
-  concept with a small, meaningful API — not merely a sub-section of one page's layout. A view-only
-  sub-view stays inline in the route, or becomes a **local helper function** in the same file, never
-  an exported feature component. This is the same test the taxonomy states at the membrane in
-  `AGENTS.md`: *the JSDoc must be able to say "callers own X; this owns Y" in one sentence.*
-- Examples:
-  - Good: a picker that owns pick-and-search over `assignableGroups` behind a small API
-    (`disabled`, `options`, `onAssign`) — it owns a concern.
-  - Bad: a `*ToolbarControl` that renders one page's toolbar row and needs a dozen props mirroring
-    route state; or a long JSX block moved to a file without reducing responsibility or API surface.
-- Changed on: 2026-08-13 (combined DD-009 + DD-012, originally 2026-04-01)
+### Extract a component only at a real concern boundary
 
-### DD-013: One Convex page query per route, plus optional profile
-- Status: accepted
-- Context: Mounting several `useQuery` hooks on one route multiplies live subscriptions, complicates
-  loading states, and scatters the authoritative shape of a screen across Convex functions. This
-  session reaffirmed it as the *real* reason a widget does not fetch and a Picker fetches only its
-  own options lazily (DD-020, DD-021): the principle protected is **subscription discipline** — hold
-  no subscription you are not using, keep one authoritative shape per screen.
-- Rule: Each route subscribes to **at most one Convex query for page data**, plus **`useCurrentProfile`
-  when the UI is auth-aware**. Derive UI-ready fields inside that query rather than adding child
-  subscriptions. `AGENTS.md` and the state-management doc point at this entry by name for the *why*.
-- Examples:
-  - Bundle what a page needs into one query (a ruleset `detailPageBySlug` carrying FAQ, viewer
-    access, owner, and assignable-group summaries).
-  - Pass server-derived collections into controls (e.g. a Picker's options) instead of a child
-    subscription.
-- Exceptions:
-  - Mutations do not count. Intentional lazy loading — a Picker's own options — requires the explicit
-    call-out its docstring provides. See DD-021.
-- Provenance note: **`check:convex-skip` does not enforce this rule.** That guard bans `useQuery("skip")`
-  inside `src/app/db` — an adjacent, narrower concern whose own header states a *preference* and names
-  no incident. The one-query rule has no guard — it is documented-only. (`check:convex-skip` is pre-emptive as its own, separate rule.)
-- Changed on: 2026-04-04
+A component must own a behaviour or domain concept behind a small, meaningful API — not a slice of
+one page's layout, and not a thin wrapper that merely renames or forwards a Mantine component.
+`RulesetGroupToolbarControl` was neither: it took ~11 props, every one a mirror of the route's own
+state, was used once, and handed that state straight back — so you read two files to understand one
+toolbar. It was inlined. A view-only sub-view stays inline in the route, or becomes a local helper
+function in the same file.
 
-### DD-014: Leaf routes own page composition
-- Status: accepted — rule now in `AGENTS.md` (routes); this entry keeps the why
-- Context: A parent-owned `staticData.PageHead` bridge split one screen into detached header and
-  body sub-views, duplicated the page subscription, and hid the whole composition across router
-  metadata and the app shell. **That incident is why the rule exists.**
-- Rule (stated in `AGENTS.md`): every terminal `_app` route renders `PageLayout` directly, supplying
-  its `Header`/`Toolbar`/`Content` slots (DD-003) alongside its content; nested route parents are
-  outlet-only; `AppRoot` owns only persistent chrome and document effects. Do not reintroduce router
-  metadata or a parent shell to move header content upward.
-- Provenance: **earned** — by the `PageHead` bridge above. Enforced by
-  [`PageLayout.architecture.test.ts`](../../src/app/ui/layout/PageLayout.architecture.test.ts), whose
-  surviving assertion (every terminal route mounts `PageLayout`) is a structural check in the ADR-0001
-  style: it forecloses the earned incident but names no incident of its own.
-- Changed on: 2026-07-18
+*Convention — the taxonomy's membrane test in [`AGENTS.md`](../../AGENTS.md#component-taxonomy): the
+JSDoc must be able to say "callers own X; this owns Y" in one sentence.*
 
-### DD-015: Renderers stay isolated
-- Status: accepted in part — DD-015's pivot (Mantine owns standard content) is itself superseded by
-  DD-017; the renderer-isolation remnant is live and keeps its why. The rule lives in
-  [`AGENTS.md`](../../AGENTS.md) (game assets).
-- Context: When the generic UI system was retired, game-asset renderers were deliberately walled off
-  from it. A renderer that reaches into Mantine, Radix, or app code stops being portable — the same
-  asset must paint identically in a worker, in print, and in the browser, and none of those load the
-  app shell.
-- Rule (stated in `AGENTS.md`): renderers import no Mantine, no Radix, no `src/app`; they are pure
-  over their inputs, with no thin wrappers around app UI leaking in.
-- Why (the derivation worth keeping): isolation is what lets one renderer serve three deploy targets;
-  a single app import would couple print and worker output to the browser bundle.
-- Provenance: **earned** — by the coupling the generic system caused. Enforced by
-  [`rendererIsolation.test.ts`](../../src/game/rendererIsolation.test.ts).
-- Changed on: 2026-08-13
+## Where components live
 
-### DD-016: Recurring topics use one canonical icon mapping
-- Status: accepted
-- Context: The same topic appeared with different icons between the faction editor and the detail
-  pages, weakening recognition.
-- Rule: Render recurring topic icons through `TopicIcon`; the faction editor's mapping is
-  authoritative and lives in the code, [`TopicIcon.tsx`](../../src/app/ui/content/TopicIcon.tsx) —
-  read it there rather than trusting a copy here.
-- Exceptions:
-  - A one-off topic without a canonical mapping may keep a local icon until it recurs or gets product
-    direction. Renderer-owned game visuals stay isolated and do not consume `TopicIcon`.
-- Changed on: 2026-07-20
+### Six categories, one home each
 
-### DD-017: The component taxonomy governs all interface components
-- Status: accepted — rule now in `AGENTS.md`; this entry keeps the why
-- Context: DD-015 made Mantine the only sanctioned shared layer, so recurring concerns (the pane
-  treatment, titled regions, heading levels) were re-spelled at every call site and drifted. **That
-  drift is why** a domain-free kit was rebuilt deliberately, category by category, with a rule for
-  what may live in each.
-- Rule (canonical in [`AGENTS.md`](../../AGENTS.md#component-taxonomy)): six categories under
-  `src/app/ui` — Content, Controls, Lists, Layout, Surfaces, Blocks — each decided by what a caller
-  hands the component; the category is the folder and the Storybook root; feature folders keep only
-  organs; Widgets are the last-resort shared assemblies; Pickers (DD-021) are the one fetching peer.
-- Changed on: 2026-08-12
+Once Mantine became the shared layer, recurring concerns — the pane treatment, titled regions,
+heading levels — were re-spelled at every call site and drifted. The kit fixes that: six domain-free
+categories under `src/app/ui` — Content, Controls, Lists, Layout, Surfaces, Blocks — each decided by
+what a caller hands the component. The category is the folder and the Storybook root; feature folders
+keep only organs.
 
-### DD-018: The application shell is chrome, not a category
-- Status: accepted — rule now in `AGENTS.md`; this entry keeps the derivation
-- Context: The header had no component and no story — four lines of JSX inside `AppShell` whose height
-  was negotiated in CSS with whatever page mounted. Asking which category it belonged to exposed that
-  it belongs to none.
-- Why (the derivation worth keeping): `Surface` is one specific treatment, a pane content sits *on*
-  (border, translucent infill, blur); the header is full-bleed artwork that content sits *beside* in a
-  shared grid row, overlapping only by `z-index`. It is not a Layout either — Layouts are transparent
-  and it paints. So the shell is decided by *position*, not by what a caller hands it, and lives in
-  `src/app/shell/**` as named organs.
-  - The band's height is not a prop: `AppRoot` renders whatever the router hands it and cannot pass a
-    height down; `PageLayout` cannot report upward. They meet in CSS — the page joins the grid through
-    `display: contents`, claims the `hero` row, and declares its state through `data-page-layout-*`,
-    which `AppHeader.module.css` reads back with `:has()`. Keeping the band and that frame in one file
-    is deliberate: split across a published Layout and an organ, the negotiation becomes unobservable,
-    because a CSS Module can only target a class from the module that owns it and a kit Layout may not
-    import a shell organ. This is also why `PageLayout` is DD-003's container-query exemption.
-- Rule (in `AGENTS.md`): `AppRoot`/`AppHeader`/`AppFooter` live in `src/app/shell/**`; nothing outside
-  imports them; they carry stories under the `Shell` root. A component with exactly one possible caller
-  is not kit vocabulary.
-- Changed on: 2026-08-12
+*Top-level slots enforced by `check:app-layout`; category placement is convention. Canonical in
+[`AGENTS.md`](../../AGENTS.md#component-taxonomy).*
 
-### DD-020: A component renders what it is given
-- Status: accepted — rule now in `AGENTS.md` + oxlint; this entry keeps the why (absorbs DD-019)
-- Context: An earlier version of the kit boundary (DD-019) banned every `@app`/`@db`/`@game` import
-  and carved out the seven components that tripped it with a `*.domain.tsx` suffix. **The war story:**
-  reading what those seven actually imported settled it — *every single `@db` import was `import type`*,
-  erased at compile time, and the rest were game renderers, a date formatter, and a tag-label map. Not
-  one component fetched anything. Meanwhile the one real violation went unnoticed: `FaqList` called
-  `useNavigate` and decided where the reader went next, because the router was not on the ban list. The
-  rule had been policing the *alias in the import specifier* — a proxy for the property that matters —
-  and the proxy was both too strict and too loose.
-- Why the suffix (DD-019) is gone: the two-tree split it enforced bought a machine-checkable boundary,
-  but the property that matters is behaviour, not location. There is one product and no second consumer
-  of the kit, so a directory (extractable in a way a filename suffix is not) bought nothing — the one
-  argument for two trees was ruled out when this was decided.
-- Rule (canonical in `AGENTS.md`, enforced by `.oxlintrc.json` `src/app/ui/**`): a component renders
-  what it is given; it does not go and get things. Banned — the Convex client in any form; **value**
-  imports from a data module by every spelling (`import type` stays legal); the router's data and
-  navigation surface (`useRouter`, `useNavigate`, … — `Link`/`createLink`/`renderRoot` stay allowed);
-  and `@app/shell`/`@app/widgets`/`@app/routes`. Nothing is exempt and no filename marks an escape.
-- Provenance: **earned** — the `FaqList`/`useNavigate` miss above. The rule was hardened by probing it
-  with throwaway files rather than reading the config, closing each hole (`@app/db/core` via the other
-  alias; the relative `db.ts` spelling; `useRouter` returning an object with `.navigate()` on it).
-- Changed on: 2026-08-12
+### The shell is chrome, decided by position
 
-### DD-021: Pickers — the one place a component may fetch
-- Status: accepted
-- Context: The rule "a widget never fetches" looked like it made the faction load popover a violation.
-  It is not: that popover is a control that fetches *its own options* lazily, so a page rendering a
-  "pick a user" control never queries every user up front. The two stated reasons for the fetch ban
-  (can't be storied, destroys reuse) did not survive scrutiny — Storybook already mocks Convex, and the
-  fetching control was reused on *more* routes than the props-only one. The real reason is DD-013
-  subscription discipline. That gave the missing classification a home.
-- Rule (canonical in `AGENTS.md`, Pickers): a Picker is a domain control whose whole job is to let the
-  user choose from a list it loads itself. It fetches only what presenting its own options needs, read
-  only, through a subscription torn down when it leaves the screen; it never mutates and never reads the
-  page's data; the chosen value leaves through an `onPick`-style callback and the route decides what
-  happens next. It is domain-specific (so it lives outside the kit) and renders *through* the kit — a
-  peer of Widgets, not a seventh category.
-- Examples: `FactionPicker` (`src/app/pickers/`), mounted only while the load popover is open, so it
-  subscribes on mount because the container already gated it.
-- Provenance: **structural** — the `pickers` slot in `check:app-layout` and the deliberate *absence*
-  of Pickers from the `ui/**` and `widgets/**` fetch bans. The lazy/read-only/never-mutate contract is
-  documented-only.
-- Cross-links: DD-013 (the subscription discipline it applies), DD-020 (the fetch ban it is the
-  deliberate exemption to).
-- Changed on: 2026-08-13
+`AppRoot`, `AppHeader`, and `AppFooter` belong to no kit category. The header is full-bleed artwork
+that content sits *beside* in a shared grid row — where a Surface is something content sits *on*, and
+a Layout is transparent while the header paints. So the shell is decided by *position*, not by what a
+caller hands it: it lives in `src/app/shell/**`, nothing outside imports it, and it carries stories
+under the `Shell` root. Its band height is negotiated with the page in CSS — the page joins the grid
+through `display: contents` and declares its state via `data-page-layout-*`, which
+`AppHeader.module.css` reads back with `:has()` — which is why the band and the page frame stay in
+one place, and why `PageLayout` is the container-query exemption below.
 
----
+*Enforced by `check:app-layout` and the `data-page-layout-*` contract. Canonical in
+[`AGENTS.md`](../../AGENTS.md).*
 
-## Provenance of the guards
+## Layout and spacing
 
-Verified against each entry's text and the guard, not assumed — two claims came back different from
-how the log read.
+### Layouts own spacing and lay out through named slots
 
-| Rule (DD) | Guard | Provenance | Incident |
-|-----------|-------|----------------------|----------|
-| Renders what it is given (DD-020) | `.oxlintrc.json` `src/app/ui/**` | **earned** | `FaqList` called `useNavigate`, slipped the alias ban |
-| Closed `src/app` top level (DD-017) | `check:app-layout` | **earned** | folders "empty-but-alive for months" after the domain scheme was dismantled |
-| The Convex doorway | `.oxlintrc.json` `src/**` | **earned** | `viewerActions.ts`/`assetPublishingStatus.ts` reached `convex/lib` for a wide union |
-| `shared` ↛ app/convex/game | `.oxlintrc.json` `src/shared/**` | **earned** | 7 convex modules reached `src/app/*/validation`; the faction schema lived under a renderer folder |
-| `convex`/`workers` ↛ app/game | `.oxlintrc.json` overrides | **earned** | publisher Worker reached the app's capture folder |
-| Renderer isolation (DD-015) | `rendererIsolation.test.ts` | **earned** | `/app/components/content/` stopped existing, so the test "passed for the wrong reason" |
-| No orphan CSS classes | `check:css-orphans` | **earned** | `.rulesetHeadCover` etc. shipped three times in one refactor |
-| Layout container queries (DD-003) | `containerQueries.test.ts` | **pre-emptive** | design-derived; no violation preceded it |
-| Leaf routes mount `PageLayout` (DD-014) | `PageLayout.architecture.test.ts` | **earned rule, structural guard** | the `staticData.PageHead` bridge earned the rule; the surviving assertion names no incident of its own |
-| Shell is chrome (DD-018) | `check:app-layout` slot + `data-page-layout-*` | **borrowed** | the slot is earned by the empty-folders incident, not by any shell violation |
-| One query per route (DD-013) | — | **documented-only** | `check:convex-skip` is a *different*, adjacent rule; it does not enforce this |
+Margin scattered through leaf components makes layout inconsistent and buries pages in nested
+`<Stack><Group><Grid>`. Spacing belongs to a Layout: a custom component built on Mantine primitives
+that arranges two or more **named compound slots** —
+`<TriptychLayout><TriptychLayout.Left>…</TriptychLayout.Left>…</TriptychLayout>` — so composition
+reads top-down and large content never rides inside a prop. A leaf never carries page margin (only
+for unavoidable third-party constraints), one slot is a passthrough rather than a Layout, and Layouts
+respond by **container query, not media query**, so they lay out by the room they are given.
 
----
+*Exemption:* `PageLayout` uses `@media` — it is the shell's page frame, sized against the viewport in
+concert with `AppHeader`, genuinely viewport-scoped rather than a container.
 
-## History
+*Container-query half enforced by
+[`containerQueries.test.ts`](../../src/app/ui/layout/containerQueries.test.ts) (`PageLayout` excepted
+by name); the rest convention. Canonical in [`AGENTS.md`](../../AGENTS.md). Layouts today:
+`PageLayout`, `TriptychLayout`, `AtlasLayout`, `AsymmetricSplitLayout`.*
 
-The generic component system, its retirement, and the taxonomy that replaced it. These entries are
-kept only so their numbers resolve and their reasoning is not lost; do not follow their rules.
+### Terminal routes mount PageLayout
 
-**The arc (2026-03 → superseded 2026-07-19 by DD-015 → DD-017):** DuneZone began with a home-grown
-generic primitive / form / layout / surface system (`src/app/components/generic/**`, `form/**`).
-DD-001–004, 008, 010, 011 codified how to work inside it: reuse first, layer direction, parent-owned
-spacing, avoid custom CSS, stories for generics, generic-first placement, one canonical path. DD-015
-retired that whole system in favour of Mantine for standard UI, keeping only distinctive visuals and
-the isolated renderers. DD-017 then rebuilt a domain-free *kit* on top of Mantine; DD-020 replaced
-DD-019's two-tree/`*.domain.tsx` boundary with the behavioural import rule.
+A parent-owned `staticData.PageHead` bridge once split one screen into detached header and body
+sub-views, duplicated the page query, and hid the whole composition across router metadata and the
+shell. So every terminal `_app` route renders `PageLayout` directly, filling its
+`Header`/`Toolbar`/`Content` slots alongside its content; route parents are outlet-only, and
+`AppRoot` owns only persistent chrome and document effects.
 
-- **DD-001** Reuse existing shared components first — *superseded by DD-015.* Discovery now starts with Mantine, then the kit.
-- **DD-002** Component layering / dependency direction — *superseded by DD-015.* Its lasting lesson, cited by DD-019/020: `generic/**` twice decayed by absorbing domain knowledge, which is why the kit boundary is behavioural.
-- **DD-004** Avoid custom CSS, prohibit `composes` — *"avoid CSS" superseded by DD-015.* The no-`composes` / one-owner-per-stylesheet half is live and now carries its own why at **DD-004 above**.
-- **DD-006, DD-007** Toolbar primary / colour intent — *folded into DD-005 (Action semantics).*
-- **DD-008** Generic components require stories — *superseded by DD-015.* Live story expectation is in `AGENTS.md`; installed Mantine and route-local composition are exempt.
-- **DD-010** Placement generic-first but domain-honest — *superseded by DD-015 → DD-017.* Placement is the taxonomy's job; domain-honesty is the DD-020 boundary.
-- **DD-011** One shared component, one canonical path — *superseded by DD-015 → DD-017.* "One canonical path" became "one tree, inside the app".
-- **DD-012** Concern boundaries, not sub-views — *folded into DD-009,* which carries its `RulesetGroupToolbarControl` war story.
-- **DD-015** Mantine owns standard application-content UI — *superseded by DD-017.* The pivot that retired the generic system; the migration finished and the named legacy paths are deleted. Its live renderer-isolation remnant carries its own why at **DD-015 above**.
-- **DD-019** One components tree, domain boundary in the filename — *superseded by DD-020.* Collapsing to one tree was right; the alias deny-list and the `*.domain.tsx` suffix were not — its one-tree rationale is folded into DD-020.
+*Enforced by
+[`PageLayout.architecture.test.ts`](../../src/app/ui/layout/PageLayout.architecture.test.ts) (every
+terminal route mounts it). Canonical in [`AGENTS.md`](../../AGENTS.md).*
+
+## Data
+
+### One Convex query per route
+
+Mounting several `useQuery` hooks on a route multiplies live subscriptions, complicates loading
+states, and scatters a screen's authoritative shape across Convex functions. Each route subscribes to
+**at most one Convex query for page data**, plus `useCurrentProfile` when the UI is auth-aware;
+derive UI-ready fields inside that query and pass server-derived collections (such as a Picker's
+options) into controls rather than adding child subscriptions. This subscription discipline is the
+real reason widgets don't fetch and Pickers fetch only lazily. Mutations don't count.
+
+*Convention — no automated guard. (`check:convex-skip` bans `useQuery("skip")` inside `src/app/db`, a
+separate, adjacent rule.) Stated here; [`AGENTS.md`](../../AGENTS.md) and
+[`state-management.md`](../state-management.md) cite it.*
+
+## Visual semantics
+
+### Action semantics: colour by intent, one primary
+
+Actions get unpredictable when meaning rides on hue, when a toolbar has several competing "primary"
+buttons, or when an icon-only control has no explicit semantics. So colour by intent, then style: a
+positive primary takes the `confirm` colour, a destructive action takes `red` (the Dune danger
+tuple), and neutral or auxiliary actions keep the default colour and vary by Mantine `variant`, never
+by hue. Keep exactly one clear primary per toolbar. Use an icon-only button only for a common,
+recognizable action with an `aria-label`; if the icon would be ambiguous, label it.
+
+*Convention — the kit carries it: `IconAction` for icon-only actions, `CallToAction` for the
+forward-moving primary, and the colour tuples in [`theme.ts`](../../src/app/ui/theme.ts).
+(`StatusBadge`'s tone scale is for state, not actions.)*
+
+### One canonical icon per recurring topic
+
+The same topic once appeared with different icons between the faction editor and the detail pages,
+weakening recognition. Render recurring topic icons through `TopicIcon`; the faction editor's mapping
+is authoritative.
+
+*Convention — the mapping is the code in
+[`TopicIcon.tsx`](../../src/app/ui/content/TopicIcon.tsx). A one-off topic may keep a local icon
+until it recurs; renderer-owned game visuals stay isolated and don't consume `TopicIcon`.*
+
+## Styling and renderers
+
+### One owner per stylesheet, no `composes`
+
+CSS `composes` pulls declarations across module boundaries, so the stylesheet a rule actually comes
+from stops being greppable and two files quietly co-own one class. Ownership you cannot grep drifts.
+Exactly one TSX component imports each `.module.css`; share through the component, not the stylesheet.
+
+*`check:css-orphans`
+([`assert-no-orphan-css-classes.mjs`](../../scripts/assert-no-orphan-css-classes.mjs)) catches
+orphaned or unimported stylesheets, not `composes` itself; the one-owner rule is convention.
+Canonical in [`ui-component-hierarchy.md`](./ui-component-hierarchy.md) (Styling).*
+
+### Renderers stay isolated
+
+Game-asset renderers must paint identically in a Worker, in print, and in the browser — and none of
+those load the app shell. So a renderer imports no Mantine, no Radix, and nothing from `src/app`; it
+is pure over its inputs. A single app import would couple print and Worker output to the browser
+bundle; isolation is what lets one renderer serve three deploy targets.
+
+*Enforced by [`rendererIsolation.test.ts`](../../src/game/rendererIsolation.test.ts). Canonical in
+[`AGENTS.md`](../../AGENTS.md) (game assets).*

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -404,7 +404,7 @@ function OwnedAssetPicker({
 /**
  * Only mounted for active members (see call sites): the owned-factions query requires
  * authentication, so it must not be called for anonymous, pending, or non-member viewers.
- * Subscribing to a second query beyond the page query deviates from DD-013's default; that was
+ * Subscribing to a second query beyond the page query deviates from the one-query-per-route default; that was
  * decided explicitly for this picker (issues #348/#182: keep `detailBySlug` unchanged, expose the
  * viewer-scoped owned lists as their own queries).
  */

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -404,9 +404,9 @@ function OwnedAssetPicker({
 /**
  * Only mounted for active members (see call sites): the owned-factions query requires
  * authentication, so it must not be called for anonymous, pending, or non-member viewers.
- * Subscribing to a second query beyond the page query deviates from the one-query-per-route default; that was
- * decided explicitly for this picker (issues #348/#182: keep `detailBySlug` unchanged, expose the
- * viewer-scoped owned lists as their own queries).
+ * Subscribing to a second query beyond the page query deviates from the one-query-per-route
+ * default; that was decided explicitly for this picker (issues #348/#182: keep `detailBySlug`
+ * unchanged, expose the viewer-scoped owned lists as their own queries).
  */
 function FactionAssignPicker(props: AssignPickerProps) {
   const ownedFactionsQuery = useFactionsOwnedForGroupAssign();

--- a/src/app/ui/control/SubmitAction.tsx
+++ b/src/app/ui/control/SubmitAction.tsx
@@ -17,8 +17,9 @@ export interface SubmitActionProps {
  * Commits a form.
  *
  * Callers own when it may fire and what it says; this owns the fact that a commit looks the same
- * everywhere — the confirm colour that marks a positive action (the action-semantics rule), and the swap to a progress
- * label that also latches the button so an impatient second click cannot submit twice.
+ * everywhere — the confirm colour that marks a positive action (the action-semantics rule), and the
+ * swap to a progress label that also latches the button so an impatient second click cannot submit
+ * twice.
  *
  * Distinct from `CallToAction`, which starts a journey by navigating and therefore needs a
  * `renderRoot`; this one submits the form it sits in and needs no route at all.

--- a/src/app/ui/control/SubmitAction.tsx
+++ b/src/app/ui/control/SubmitAction.tsx
@@ -17,7 +17,7 @@ export interface SubmitActionProps {
  * Commits a form.
  *
  * Callers own when it may fire and what it says; this owns the fact that a commit looks the same
- * everywhere — the confirm colour that marks a positive action (DD-007), and the swap to a progress
+ * everywhere — the confirm colour that marks a positive action (the action-semantics rule), and the swap to a progress
  * label that also latches the button so an impatient second click cannot submit twice.
  *
  * Distinct from `CallToAction`, which starts a journey by navigating and therefore needs a

--- a/src/app/ui/layout/containerQueries.test.ts
+++ b/src/app/ui/layout/containerQueries.test.ts
@@ -6,9 +6,10 @@ const layoutDir = new URL('.', import.meta.url);
 
 /*
  * A Layout is responsive by container query, so it lays out by the room it is given, not the size
- * of the window (DD-003). `PageLayout` is the one exemption: it is the shell's page frame, sized
- * against the viewport in concert with `AppHeader` through the `data-page-layout-*` bridge
- * (DD-018), so it is genuinely viewport-scoped and uses `@media`.
+ * of the window (the "Layouts own spacing" rule in docs/technical/ui-design-decisions.md).
+ * `PageLayout` is the one exemption: it is the shell's page frame, sized against the viewport in
+ * concert with `AppHeader` through the `data-page-layout-*` bridge (the "shell is chrome" rule), so
+ * it is genuinely viewport-scoped and uses `@media`.
  */
 const VIEWPORT_EXEMPT = new Set(['PageLayout.module.css']);
 


### PR DESCRIPTION
Documentation only.

## The pivot

This PR began as a *dedup* of the design-decision log — merge overlapping entries, keep the DD numbers and a History section, add a provenance table. On review that approach was judged to make the file **worse for its actual reader (an agent asking "what do I follow?")**: it had to route past nine superseded entries, a "how to use this log" preamble, and a table about each rule's *pedigree* — none of which is a rule — and risked following a superseded one.

So the log is now **rewritten from scratch as the current rulebook**: only the rules that apply today, grouped by concern, each with a one-line *why* and a compact "enforced / canonical" footer. **347 → ~150 lines.**

## What the doc is now

- Thirteen live rules, grouped: the component boundary, where components live, layout & spacing, data, visual semantics, styling & renderers.
- Each rule = a descriptive heading (the rule as a sentence), a tight rationale (the lesson, not the archaeology), and an italic footer naming its guard and its canonical home.
- **Gone:** the History section, superseded stubs, `DD-NNN` numbers, the provenance/earned-vs-pre-emptive table, the "how to use this log" preamble, `Changed on` dates. Git carries the history.
- **Kept:** every live rule and its war story, compressed to the lesson — `RulesetGroupToolbarControl`'s 11 route-mirroring props, the `FaqList`/`useNavigate` alias-ban miss, the `staticData.PageHead` bridge, shell-decided-by-position.

## Beyond the doc

- **Restores a rule the earlier overhaul dropped:** "no thin wrapper that merely renames/forwards a Mantine component" — folded into the concern-boundary rule here, and added to `AGENTS.md`'s taxonomy tells (its canonical home).
- **Migrates the cross-references:** `DD-NNN` citations become descriptive rule names/anchors across `AGENTS.md`, `docs/routing.md`, `docs/state-management.md`, `ui-component-hierarchy.md`, `containerQueries.test.ts`, `SubmitAction.tsx`, and the groups route. No `DD-NNN` reference remains anywhere.

## Verification

Two independent audits (preservation + accuracy): all live rules present with their whys; every footer claim checked against the actual guards/homes; all links and anchors resolve; no `DD-NNN` left in the tree. The earlier commits (the dedup overhaul + its review fixes) remain in history; this commit supersedes their output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the UI design decision log with a concise, current rulebook covering component boundaries, taxonomy, layout, data access, visual semantics, styling, and rendering.
  * Clarified enforcement sources and canonical references for key interface and routing conventions.
  * Updated related technical documentation and guidance to use descriptive section links instead of legacy decision identifiers.
  * Added guidance discouraging unnecessary wrappers around lightly forwarded interface components.
  * Updated in-code documentation and test comments without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->