### PR TITLE
docs: a technical Language glossary; membrane becomes a bi-directional contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,60 @@ Convex agent skills for common tasks can be installed by running
 - The checked-in `Fresh default branch` Codex local environment runs this preflight automatically
   when a new worktree is created, then installs the frozen dependency graph.
 
+## Language
+
+The technical vocabulary for this codebase's structure — the words for *how the code is built*.
+Product vocabulary (Groups, factions, the catalogue) lives in [`CONTEXT.md`](CONTEXT.md). A term
+earns an entry here when it carries an obligation you can check; say the words in prose and
+reviews, because a term nobody uses stops retrieving its concept.
+
+**Kit**:
+The six-category component vocabulary under `src/app/ui`, reached through `@ui/*`. Domain-free,
+story-covered, and never extracted into a package.
+_Avoid_: design system, component library — they promise an independence the kit does not have.
+
+**Membrane**:
+The surface where a component meets its caller — a bi-directional contract, selectively permeable
+both ways: data, slots and values flow in; chosen values and intents flow out through callbacks
+(`onChange`, `onPick`). In either direction what crosses is data, never effects — a component may
+report "the user picked X," not go and do X. Two rules follow. What passes decides the component's
+category: kind is judged at the membrane, and the insides are composition. And there is no traffic
+*around* it: a fetch brings data in that the caller never handed over, a navigation sends an effect
+out that the caller never receives — both route around the membrane, which is why both are banned.
+The Picker is the one
+documented fetch exception, and that is why a Picker is domain, never kit, whatever its membrane
+resembles.
+_Avoid_: interface, API — one-way words that say how to call the thing, but not what flows back
+out, or what may never cross at all.
+
+**Organ**:
+A file whose only importers are its own feature's or category's machinery. Two obligations, no
+exceptions: nothing outside may import it, and it carries no story. A file that gains an outside
+importer or a story is no longer an organ — it is vocabulary that needs a proper home.
+_Avoid_: internal, private, helper — visibility without the obligations.
+
+**Doorway**:
+The one sanctioned import path to something otherwise off-limits. `src/app/db` is the Convex
+doorway; `ApplicationChrome` and `AppNotFound` are the shell's. Reach the thing through its doorway
+or not at all.
+_Avoid_: wrapper, gateway.
+
+**Seam**:
+A joint where one implementation can be swapped for another, and therefore where tests attach —
+[`src/app/db/core/live.ts`](src/app/db/core/live.ts) is the app–Convex seam, and
+[ADR-0002](docs/adr/0002-confidence-stack.md)'s suites are seam suites. Not a synonym for membrane:
+a membrane classifies a component by what crosses it; a seam exists to be swapped.
+
+**Chrome**:
+The persistent frame `_app` pages sit in (`src/app/shell`); bare renderer and auth routes go
+without. Classified by *position* rather than at the membrane — so it is not a kit category — and
+its stories and doorway audience are what keep it from being a set of organs.
+
 ## Component taxonomy
 
 Every component is exactly one of these. The category is the folder; the folder is the Storybook
-root. Both stay flat — one level, no nesting. What a caller hands a component decides its category.
+root. Both stay flat — one level, no nesting. What crosses a component's membrane — what a caller
+hands it — decides its category.
 
 | Category | Folder | Caller hands it | It owns |
 |---|---|---|---|
@@ -94,11 +144,15 @@ Outside the kit:
     was really vocabulary, the route when it was page composition, `src/app/print/` for the
     document-rendering glue, and `src/app/shell/` for the chrome.
 - **The application shell** (`src/app/shell`) — the chrome every page sits in: `AppRoot`
-  (the frame and the document-level effects), `AppHeader` (the artwork band), `AppFooter`. Organs by
-  classification — nothing outside the folder imports them — but unlike other organs they **do carry
-  stories**, filed under a `Shell` root, because the chrome's states are worth looking at and cannot
-  be reached from any page's story. It is not a category and never will be: the six are decided by
-  what a caller hands a component, and the shell is decided by position. See *The shell is chrome* in
+  (the frame and the document-level effects), `AppHeader` (the artwork band), `AppFooter`, and the
+  organs behind them (`SiteNavigation`). The shell is chrome, not a set of organs: it has a
+  doorway — `routes/_app.tsx` mounts `ApplicationChrome` and `AppNotFound`, and nothing else
+  outside the folder imports from it — and its chrome (`AppRoot`, `AppHeader`, `AppFooter`)
+  **carries stories**, filed under a `Shell` root, because those states are worth looking at and
+  cannot be reached from any page's story. An outside importer or a story alone ends organ-hood,
+  which is why only `SiteNavigation` qualifies as one here. The shell is not a category and never
+  will be: the six are decided at the membrane, and the shell is decided by position. See *The
+  shell is chrome* in
   [`docs/technical/ui-design-decisions.md`](docs/technical/ui-design-decisions.md#the-shell-is-chrome-decided-by-position)
   for why the header is neither a Surface nor a Layout.
 - **Widgets** (`src/app/widgets/<name>`) — an assembly too domain-specific to be kit and too
@@ -169,7 +223,8 @@ without it the router scans the file and warns.
 Not everything in a component folder is a component. Types, the theme, and story fixtures are
 support modules. **Organs exist at every level, not only inside widgets**: a file whose only
 importers are its own feature's or category's machinery is an organ — "organ" *is* its
-classification, it needs no story, and nothing outside may import it. The kit has organs of its
+classification, it carries no story, and nothing outside may import it; gaining either an outside
+importer or a story ends the classification. The kit has organs of its
 own (`BlockHeading`, the depth context); a feature may keep a one-route form as an organ of its
 page.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ reviews, because a term nobody uses stops retrieving its concept.
 
 **Kit**:
 The six-category component vocabulary under `src/app/ui`, reached through `@ui/*`. Domain-free,
-story-covered, and never extracted into a package.
+story-covered apart from its organs, and never extracted into a package.
 _Avoid_: design system, component library — they promise an independence the kit does not have.
 
 **Membrane**:
@@ -71,18 +71,19 @@ _Avoid_: wrapper, gateway.
 
 **Seam**:
 A joint where one implementation can be swapped for another, and therefore where tests attach —
-[`src/app/db/core/live.ts`](src/app/db/core/live.ts) is the app–Convex seam, and
-[ADR-0002](docs/adr/0002-confidence-stack.md)'s suites are seam suites. Not a synonym for membrane:
-a membrane classifies a component by what crosses it; a seam exists to be swapped.
+[`src/app/db/core/live.ts`](src/app/db/core/live.ts) is the app–Convex seam, and the suites in
+[ADR-0002](docs/adr/0002-confidence-stack.md), an Architecture Decision Record, are seam suites.
+Not a synonym for membrane: a membrane classifies a component by what crosses it; a seam exists to
+be swapped.
 
 **Chrome**:
-The persistent frame `_app` pages sit in (`src/app/shell`); bare renderer and auth routes go
-without. Classified by *position* rather than at the membrane — so it is not a kit category — and
-its stories and doorway audience are what keep it from being a set of organs.
+The persistent frame `_app` pages sit in (`src/app/shell`); bare renderer routes and the OAuth
+callback go without. Classified by *position* rather than at the membrane — so it is not a kit
+category — and its stories and doorway audience are what keep it from being a set of organs.
 
 ## Component taxonomy
 
-Every component is exactly one of these. The category is the folder; the folder is the Storybook
+Every kit component is exactly one of these. The category is the folder; the folder is the Storybook
 root. Both stay flat — one level, no nesting. What crosses a component's membrane — what a caller
 hands it — decides its category.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,7 +315,7 @@ the ban possible, with zero exceptions. The shared side of the ban is written `*
 `../../game` spelling a file inside `src` uses), not `**/src/game/**` (the outside spelling) — the
 same vacuous-pattern trap as the app ban.
 
-`src/game` also has its own inward fence, `src/game/rendererIsolation.test.ts`, which forbids
+`src/game` also has its own inward guard, `src/game/rendererIsolation.test.ts`, which forbids
 Mantine, Radix, and any reach into the app — by alias or by relative climb. It is a test rather than
 a lint override because it also bans framework packages a `no-restricted-imports` group would not
 naturally express.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,6 +4,9 @@ Dune Zone is a community catalogue for Dune board-game factions, rulesets, and t
 
 ## Language
 
+The product vocabulary. The technical vocabulary — kit, membrane, organ, doorway, seam, chrome —
+lives in [`AGENTS.md`](AGENTS.md#language).
+
 **Group**:
 A collaboration boundary shared by factions, rulesets, and future community assets. Active members may maintain associated content and manage membership intake, while the Group owner alone may rename the Group or remove active members.
 

--- a/docs/technical/ui-component-hierarchy.md
+++ b/docs/technical/ui-component-hierarchy.md
@@ -16,7 +16,7 @@ does not: ownership rules that sit around it.
 | Page composition | the route file itself | One page's own JSX, split into local functions when the route grows. Never exported as a feature component: one page → route, two or more pages → Widget. |
 | Document-rendering glue | `src/app/print/` | `print/sheet/` bridges a `Faction` row to the sheet renderer; `print/capture/` is the page the publisher screenshots. Not published, not storied. |
 | Widgets | `src/app/widgets/<name>` | Shared assemblies; see the widget rules in `AGENTS.md`. |
-| Application shell | `src/app/shell/**` | `AppRoot` owns the persistent frame and document effects, `AppHeader` the artwork band, `AppFooter` the closing waypoints. Chrome, not kit — storied under the `Shell` Storybook root, mounted through the `ApplicationChrome` doorway. See [*The shell is chrome*](ui-design-decisions.md#the-shell-is-chrome-decided-by-position). |
+| Application shell | `src/app/shell/**` | `AppRoot` owns the persistent frame and document effects, `AppHeader` the artwork band, `AppFooter` the closing waypoints. Chrome, not kit — storied under the `Shell` Storybook root, mounted through its doorway (`ApplicationChrome`, `AppNotFound`). See [*The shell is chrome*](ui-design-decisions.md#the-shell-is-chrome-decided-by-position). |
 | Page frame | `src/app/ui/layout/PageLayout.tsx` | Terminal routes compose its slots directly; import from `@ui/layout/PageLayout`. Domain-free, but its `data-page-layout-*` contract is read by the shell (see [*The shell is chrome*](ui-design-decisions.md#the-shell-is-chrome-decided-by-position)). |
 | Game and document renderers | `src/game/**`, sheet/print/capture/publishing entry points | Independent of Mantine and the kit; exact rendering output preserved. |
 

--- a/docs/technical/ui-component-hierarchy.md
+++ b/docs/technical/ui-component-hierarchy.md
@@ -16,7 +16,7 @@ does not: ownership rules that sit around it.
 | Page composition | the route file itself | One page's own JSX, split into local functions when the route grows. Never exported as a feature component: one page → route, two or more pages → Widget. |
 | Document-rendering glue | `src/app/print/` | `print/sheet/` bridges a `Faction` row to the sheet renderer; `print/capture/` is the page the publisher screenshots. Not published, not storied. |
 | Widgets | `src/app/widgets/<name>` | Shared assemblies; see the widget rules in `AGENTS.md`. |
-| Application shell | `src/app/shell/**` | `AppRoot` owns the persistent frame and document effects, `AppHeader` the artwork band, `AppFooter` the closing waypoints. Organs, not kit — filed under the `Shell` Storybook root. See [*The shell is chrome*](ui-design-decisions.md#the-shell-is-chrome-decided-by-position). |
+| Application shell | `src/app/shell/**` | `AppRoot` owns the persistent frame and document effects, `AppHeader` the artwork band, `AppFooter` the closing waypoints. Chrome, not kit — storied under the `Shell` Storybook root, mounted through the `ApplicationChrome` doorway. See [*The shell is chrome*](ui-design-decisions.md#the-shell-is-chrome-decided-by-position). |
 | Page frame | `src/app/ui/layout/PageLayout.tsx` | Terminal routes compose its slots directly; import from `@ui/layout/PageLayout`. Domain-free, but its `data-page-layout-*` contract is read by the shell (see [*The shell is chrome*](ui-design-decisions.md#the-shell-is-chrome-decided-by-position)). |
 | Game and document renderers | `src/game/**`, sheet/print/capture/publishing entry points | Independent of Mantine and the kit; exact rendering output preserved. |
 

--- a/docs/technical/ui-design-decisions.md
+++ b/docs/technical/ui-design-decisions.md
@@ -9,11 +9,13 @@ enforced and where its canonical statement lives.
 
 ### A component renders what it is given
 
-It renders its inputs; it does not go and get things. The moment a component fetches, navigates, or
-reaches into the shell, it stops being reusable and a screen's behaviour scatters across the tree.
-What matters is the capability, not where the file sits: a ban keyed on import *aliases* once waved
-through `FaqList` calling `useNavigate` while flagging harmless compile-time `import type`s — so the
-rule bans the behaviour, not the location.
+It renders its inputs; it does not go and get things. All of a component's traffic crosses its
+membrane, in both directions: a fetch brings data in that the caller never handed over, and a
+navigation sends an effect out that the caller never receives — both route around the membrane,
+and either way the component stops being reusable and a screen's behaviour scatters across the
+tree. What matters is the capability, not where the file sits: a ban keyed on import *aliases* once
+waved through `FaqList` calling `useNavigate` while flagging harmless compile-time `import type`s —
+so the rule bans the behaviour, not the location.
 
 *Enforced by [`.oxlintrc.json`](../../.oxlintrc.json) for `src/app/ui/**` — no Convex client, no
 value import from a data module (`import type` stays legal), no router navigation
@@ -60,9 +62,9 @@ JSDoc must be able to say "callers own X; this owns Y" in one sentence.*
 
 Once Mantine became the shared layer, recurring concerns — the pane treatment, titled regions,
 heading levels — were re-spelled at every call site and drifted. The kit fixes that: six domain-free
-categories under `src/app/ui` — Content, Controls, Lists, Layout, Surfaces, Blocks — each decided by
-what a caller hands the component. The category is the folder and the Storybook root; feature folders
-keep only organs.
+categories under `src/app/ui` — Content, Controls, Lists, Layout, Surfaces, Blocks — each decided
+at the membrane, by what a caller hands the component. The category is the folder and the Storybook
+root; feature folders keep only organs.
 
 *Top-level slots enforced by `check:app-layout`; category placement is convention. Canonical in
 [`AGENTS.md`](../../AGENTS.md#component-taxonomy).*
@@ -71,10 +73,11 @@ keep only organs.
 
 `AppRoot`, `AppHeader`, and `AppFooter` belong to no kit category. The header is full-bleed artwork
 that content sits *beside* in a shared grid row — where a Surface is something content sits *on*, and
-a Layout is transparent while the header paints. So the shell is decided by *position*, not by what a
-caller hands it: it lives in `src/app/shell/**`, nothing outside imports it, and it carries stories
-under the `Shell` root. Its band height is negotiated with the page in CSS — the page joins the grid
-through `display: contents` and declares its state via `data-page-layout-*`, which
+a Layout is transparent while the header paints. So the shell is decided by *position*, not at the
+membrane: it lives in `src/app/shell/**`, reached only through its doorway (`routes/_app.tsx` mounts
+`ApplicationChrome` and `AppNotFound`), and it carries stories under the `Shell` root. Its band
+height is negotiated with the page in CSS — the page joins the grid through `display: contents` and
+declares its state via `data-page-layout-*`, which
 `AppHeader.module.css` reads back with `:has()` — which is why the band and the page frame stay in
 one place, and why `PageLayout` is the container-query exemption below.
 

--- a/src/game/rendererIsolation.test.ts
+++ b/src/game/rendererIsolation.test.ts
@@ -11,7 +11,7 @@ const rendererDirectory = new URL('.', import.meta.url);
  * Two ways to reach the app: the aliases (`@ui`/`@app`/`@db`), and a relative climb `../app/…`
  * (`@ui` and `@db` both resolve under `src/app`, so a relative reach into either also passes
  * through an `app/` segment). Catching only the aliases would leave the relative spelling as a
- * silent hole — no oxlint override guards `src/game`, so this test is the only fence.
+ * silent hole — no oxlint override covers `src/game`, so this test is the only guard.
  *
  * The alias or the climb is followed by either a `/` (a deeper path) or the closing quote (a bare
  * `import x from '@db'` at a package/index entry). Requiring the slash alone would miss the bare


### PR DESCRIPTION
## What

Docs and vocabulary only. Gives the codebase's technical vocabulary the same treatment the product vocabulary already has in `CONTEXT.md`, and tightens the terms so each one carries a checkable obligation.

- **`AGENTS.md` gains a `## Language` section** mirroring `CONTEXT.md`'s glossary format: **kit**, **membrane**, **organ**, **doorway**, **seam**, **chrome** — definition, obligation, and an `_Avoid_` list per term. `CONTEXT.md` cross-points to it.
- **Membrane is promoted** to consistent use wherever the caller contract decides a component's kind, and defined as a *bi-directional* contract — data, slots and values flow in; chosen values and intents flow out through callbacks; in both directions data crosses, never effects. The fetch and navigation bans become one statement: no traffic *around* the membrane — a fetch brings data in the caller never handed over, a navigation sends an effect out the caller never receives. The Picker stays the one documented fetch exception.
- **Organ is now airtight**: no outside importer *and* no story, zero exceptions. The shell is accordingly reclassified as **chrome**, not "organs that carry stories": mounted through its two-file doorway (`ApplicationChrome` + `AppNotFound`, imported only by `routes/_app.tsx`), chrome trio storied under the `Shell` root, `SiteNavigation` as its one true organ. This also fixes the previously false claim that nothing outside `src/app/shell` imports it.
- **"Fence" is retired** — one prose use and one test comment, both now "guard"; the glossary's admission test cuts both ways. This touches only a JSDoc comment in `src/game/rendererIsolation.test.ts`.
- `ui-component-hierarchy.md`'s shell row updated to match ("Chrome, not kit").

## Why

The bespoke vocabulary (organs, membranes, doorways) was smeared through prose with no home — and "membrane" appeared exactly twice, which is jargon, not vocabulary. A term earns coinage when it carries an obligation and is used enough to retrieve its concept; the glossary is where that's now enforced. "Membrane" over "API" is deliberate: API is a one-way word (how you call the thing); the membrane governs what flows back out and what may never cross at all.

## Notes

- An independent review pass ran before commit; it caught and fixed two internal contradictions (the membrane entry vs the Picker exception; the old permissive "needs no story" organ wording) and two factual over-claims (shell story coverage, "every page" having chrome).
- The known `FaqActivity` misfiling in `src/app/ui/list` is deliberately out of scope, tracked separately.
- `publisher:release:verify`: attempted; the app built cleanly and the run stopped only at prerender for want of a Convex address in the fresh worktree (env, not a manifest diff). The one non-doc file touched, `rendererIsolation.test.ts`, is not in `RENDERER_RUNTIME_CLOSURE_PATHS` and tests are never bundled, so renderer identity is provably unaffected; CI will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a shared glossary for key product and UI architecture terms.
  * Clarified how components are classified by their inputs, boundaries, and runtime behavior.
  * Updated shell and navigation guidance, including application entry points and routing.
  * Documented the distinction between shell chrome, organs, and kit components.
  * Clarified the renderer isolation guidance and terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->