### PR TITLE
docs: AppHeader is chrome, not an organ

### DIFF
--- a/src/app/shell/AppHeader.tsx
+++ b/src/app/shell/AppHeader.tsx
@@ -11,13 +11,13 @@ export interface AppHeaderProps {
 /**
  * The artwork band above every page, and the two-row frame it shares with the route's content.
  *
- * Chrome rather than a kit component, and the frame is the reason: `AppRoot` renders
- * whatever the router hands it, so it cannot pass the band's height down, and `PageLayout` cannot
- * report upward. The two meet in CSS instead — the page joins this grid through `display:
- * contents`, takes the `hero` row to overlay the band's lower edge, and declares which height it
- * wants through `data-page-layout-*`, which the rules here read back. Keeping the band and the
- * frame in one file keeps both halves of that contract in one place; the band element then stays
- * mounted across navigations, so a height change animates instead of cutting.
+ * Chrome rather than a kit component, and the frame is the reason: `AppRoot` renders whatever the
+ * router hands it, so it cannot pass the band's height down, and `PageLayout` cannot report upward.
+ * The two meet in CSS instead — the page joins this grid through `display: contents`, takes the
+ * `hero` row to overlay the band's lower edge, and declares which height it wants through
+ * `data-page-layout-*`, which the rules here read back. Keeping the band and the frame in one file
+ * keeps both halves of that contract in one place; the band element then stays mounted across
+ * navigations, so a height change animates instead of cutting.
  */
 export function AppHeader({ children }: AppHeaderProps) {
   return (

--- a/src/app/shell/AppHeader.tsx
+++ b/src/app/shell/AppHeader.tsx
@@ -11,7 +11,7 @@ export interface AppHeaderProps {
 /**
  * The artwork band above every page, and the two-row frame it shares with the route's content.
  *
- * An organ of the shell rather than a kit component, and the frame is the reason: `AppRoot` renders
+ * Chrome rather than a kit component, and the frame is the reason: `AppRoot` renders
  * whatever the router hands it, so it cannot pass the band's height down, and `PageLayout` cannot
  * report upward. The two meet in CSS instead — the page joins this grid through `display:
  * contents`, takes the `hero` row to overlay the band's lower edge, and declares which height it


### PR DESCRIPTION
One-word JSDoc fix, the last survivor of the #377 code review: `AppHeader`'s comment still opened "An organ of the shell rather than a kit component," but AppHeader carries a story and an organ carries none (AGENTS.md, *Language* → *Organ*) — it is **chrome**, classified by position. The rest of the comment (the CSS band-height contract) is untouched.

A sweep of `src/app/shell` and `src/app/ui` confirms this was the only stale `organ` claim in source.

`publisher:release:verify`: comment-only edit to a shell file; renderer identity intentionally excludes application shell files and comments are stripped at build, so the digest cannot move. The verify run remains blocked in this worktree on the missing `.env.local` (env, not a diff); CI is the backstop, as with #377.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `AppHeader` documentation to clarify that it provides shell-level navigation and interface chrome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->