### PR TITLE
Priority-plus navigation with portaled panels and the scrim treatment

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -15,6 +15,7 @@ import * as sizes from '../src/game/data/sizes';
    deterministic, per-story return values from these network-incapable mocks. */
 sb.mock(import('convex/react'));
 sb.mock(import('convex/browser'));
+sb.mock(import('@convex-dev/auth/react'));
 
 export default definePreview({
   addons: [addonDocs()],

--- a/__mocks__/@convex-dev/auth/react.js
+++ b/__mocks__/@convex-dev/auth/react.js
@@ -1,0 +1,12 @@
+import { fn } from 'storybook/test';
+
+const unconfigured = (operation) =>
+  fn(async () => {
+    throw new Error(`Unconfigured Storybook Convex auth ${operation}`);
+  });
+
+/** The Convex auth surface currently reachable from Storybook. */
+export const useAuthActions = fn(() => ({
+  signIn: unconfigured('signIn'),
+  signOut: unconfigured('signOut'),
+}));

--- a/src/app/shell/AppRoot.test.tsx
+++ b/src/app/shell/AppRoot.test.tsx
@@ -16,8 +16,8 @@ vi.mock('@db/profiles', () => ({
   useCurrentProfile: () => ({ data: null }),
 }));
 
-vi.mock('@ui/content/ProfileLink', () => ({
-  ProfileLink: () => null,
+vi.mock('@convex-dev/auth/react', () => ({
+  useAuthActions: () => ({ signIn: async () => {}, signOut: async () => {} }),
 }));
 
 class ResizeObserverStub {

--- a/src/app/shell/SiteNavigation.module.css
+++ b/src/app/shell/SiteNavigation.module.css
@@ -53,7 +53,7 @@
 .root a.activeLink {
   opacity: 1;
   font-weight: 600;
-  border-bottom-color: currentColor;
+  border-bottom-color: currentcolor;
 }
 
 .logo {
@@ -145,7 +145,10 @@
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.3);
+  /* Opaque so the white initials keep a deterministic contrast over any video frame. */
+  background: rgb(38, 32, 22);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  box-sizing: border-box;
   color: #fff;
   display: flex;
   align-items: center;

--- a/src/app/shell/SiteNavigation.module.css
+++ b/src/app/shell/SiteNavigation.module.css
@@ -3,52 +3,63 @@
   top: 0;
   left: 0;
   width: 100%;
-  aspect-ratio: 3064 / 180;
+  min-height: 51px;
   display: flex;
   flex-direction: row;
-  justify-content: space-between;
   align-items: center;
   box-sizing: border-box;
-  gap: 20px;
+  gap: 1rem;
+  padding: 0.5rem 1.5rem;
   color: #fff;
   z-index: 2;
 }
 
-.links {
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  padding: 1rem 1.5rem;
-  box-sizing: border-box;
-  gap: 1rem;
-}
-
-.account {
-  display: flex;
-  justify-content: flex-end;
-  align-items: flex-end;
-  padding: 0 18px;
-  box-sizing: border-box;
-  gap: 1rem;
+/* The gradient scrim: darkness belongs to the band's top edge, not to the text or a bar. */
+.root::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 220%;
+  background: linear-gradient(
+    to bottom,
+    rgba(10, 8, 4, 0.75),
+    rgba(10, 8, 4, 0.35) 45%,
+    transparent
+  );
+  pointer-events: none;
+  z-index: -1;
 }
 
 .root a {
   color: inherit;
   text-decoration: none;
+  white-space: nowrap;
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+  padding: 0.35rem 0.15rem;
+  border-bottom: 2px solid transparent;
+  opacity: 0.85;
+  transition:
+    opacity 0.15s ease-out,
+    border-color 0.15s ease-out;
 }
 
 .root a:hover {
-  text-decoration: underline;
+  opacity: 1;
 }
 
-.activeLink {
+.root a.activeLink {
+  opacity: 1;
   font-weight: 600;
-  text-decoration: underline;
+  border-bottom-color: currentColor;
 }
 
 .logo {
   display: flex;
   align-items: center;
+  flex: none;
 }
 
 .logoImage {
@@ -57,13 +68,71 @@
   width: auto;
 }
 
-.avatarLink {
+.linkGroup {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.linkRow {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+/* The full list, invisibly, in the row's own text styles — what the fit measurement reads. */
+.measureRow {
+  position: absolute;
+  visibility: hidden;
+  pointer-events: none;
+  display: flex;
+  gap: 1rem;
+}
+
+.measureRow span {
+  white-space: nowrap;
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+  padding: 0.35rem 0.15rem;
+}
+
+.ghostButton {
+  flex: none;
+  background: rgba(0, 0, 0, 0.35);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 4px;
+  padding: 0.25rem 0.6rem;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.9rem;
+  white-space: nowrap;
+}
+
+.account {
+  display: flex;
+  align-items: center;
+  flex: none;
+  margin-left: auto;
+}
+
+.avatarButton {
   display: flex;
   align-items: center;
   justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
 }
 
-.avatarLink img {
+.avatarImage {
   width: 32px;
   height: 32px;
   border-radius: 50%;
@@ -72,11 +141,12 @@
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.7);
 }
 
-.avatarLink > span {
+.avatarInitials {
   width: 32px;
   height: 32px;
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.3);
+  color: #fff;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -84,8 +154,54 @@
   font-weight: 600;
 }
 
+/* Portaled under its anchor (see NavPopover): fixed so the band's overflow cannot clip it. */
+.popover {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 220px;
+  max-width: min(360px, calc(100vw - 16px));
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
+  padding: 0.75rem 1rem;
+  background: rgba(10, 10, 10, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+  color: #fff;
+  z-index: 20;
+}
+
+.popover a,
+.popover button {
+  color: inherit;
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.35rem 0.15rem;
+  font-family: inherit;
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  opacity: 0.85;
+}
+
+.popover a:hover,
+.popover button:hover {
+  opacity: 1;
+}
+
+.popover a.activeLink {
+  opacity: 1;
+  font-weight: 600;
+}
+
 @media (max-width: 900px) {
   .root {
-    height: 51px;
+    padding: 0.5rem 1rem;
   }
 }

--- a/src/app/shell/SiteNavigation.stories.tsx
+++ b/src/app/shell/SiteNavigation.stories.tsx
@@ -38,8 +38,11 @@ export const AllLinksFit = meta.story({
   globals: { viewport: { value: 'appDesktop' } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    // Positive first: once the measured row shows its last link, the absence check is meaningful.
+    await waitFor(async () => {
+      await expect(canvas.getByRole('link', { name: 'Assets' })).toBeVisible();
+    });
     await expect(canvas.queryByRole('button', { name: /More/ })).toBeNull();
-    await expect(canvas.getByRole('link', { name: 'Assets' })).toBeVisible();
   },
 });
 

--- a/src/app/shell/SiteNavigation.stories.tsx
+++ b/src/app/shell/SiteNavigation.stories.tsx
@@ -1,0 +1,85 @@
+import preview from '@sb/preview';
+import { expect, waitFor, within } from 'storybook/test';
+
+import { SiteNavigation } from './SiteNavigation';
+import type { NavLinkItem } from './SiteNavigation';
+
+/* A deliberately oversized set: the system's contract is any count, any length, so the overflow
+   stories feed it more than any width can hold. Labels are fake — only their widths matter. */
+const manyLinks: readonly NavLinkItem[] = [
+  { label: 'Factions', to: '/factions' },
+  { label: 'Rulesets', to: '/rulesets' },
+  { label: 'Profiles', to: '/profiles' },
+  { label: 'Assets', to: '/assets' },
+  { label: 'Battle Reports', to: '/factions' },
+  { label: 'Events Calendar', to: '/rulesets' },
+  { label: 'Community', to: '/profiles' },
+  { label: 'Tournament Organizer Resources', to: '/assets' },
+  { label: 'Errata & Clarifications', to: '/factions' },
+  { label: 'Getting Started Guide', to: '/rulesets' },
+  { label: 'Marketplace', to: '/profiles' },
+];
+
+const meta = preview.meta({
+  component: SiteNavigation,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The priority-plus navigation row: links that fit stay visible, the rest collapse behind a More control, re-measured on resize — correct for any link count at any width. The gradient scrim behind it belongs to the row, so it travels into these stories. The account slot shows Login here because stories run signed out; the signed-in avatar menu has no story for the same reason.',
+      },
+    },
+  },
+});
+
+/** The product's own link set at desktop width: everything fits, so no More control renders. */
+export const AllLinksFit = meta.story({
+  globals: { viewport: { value: 'appDesktop' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('button', { name: /More/ })).toBeNull();
+    await expect(canvas.getByRole('link', { name: 'Assets' })).toBeVisible();
+  },
+});
+
+/** More links than the width holds: the tail collapses behind More, the head stays visible. */
+export const PartialOverflow = meta.story({
+  globals: { viewport: { value: 'appDesktop' } },
+  args: { links: manyLinks },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(async () => {
+      await expect(canvas.getByRole('button', { name: /More/ })).toBeVisible();
+    });
+    await expect(canvas.getByRole('link', { name: 'Factions' })).toBeVisible();
+  },
+});
+
+/**
+ * The More panel, opened. It renders through a portal outside the canvas — the band hosting the nav
+ * is `overflow: hidden`, so an in-place panel would clip at compact band heights.
+ */
+export const OverflowPanelOpen = meta.story({
+  globals: { viewport: { value: 'appDesktop' } },
+  args: { links: manyLinks },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const more = await waitFor(() => canvas.getByRole('button', { name: /More/ }));
+    more.click();
+    await waitFor(async () => {
+      await expect(within(document.body).getByRole('link', { name: 'Marketplace' })).toBeVisible();
+    });
+  },
+});
+
+/** At phone width even the product's own set folds away — priority-plus degrades to a menu. */
+export const CollapsedMobile = meta.story({
+  globals: { viewport: { value: 'appMobile' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(async () => {
+      await expect(canvas.getByRole('button', { name: /More/ })).toBeVisible();
+    });
+  },
+});

--- a/src/app/shell/SiteNavigation.tsx
+++ b/src/app/shell/SiteNavigation.tsx
@@ -23,11 +23,14 @@ const PRIMARY_LINKS: readonly NavLinkItem[] = [
   { label: 'Assets', to: '/assets' },
 ];
 
-/* Must match the CSS: `gap` on `.linkRow` (1rem) and the widest the More control gets. The
-   reserve doubles as slack for the one width the measure row cannot know — the active link's
-   600 weight. */
-const ROW_GAP_PX = 16;
+/* Room reserved for the More control before deciding which links fit. It cannot be measured —
+   the control only exists once something overflows — so this over-reserves slightly, which also
+   covers the one width the measure row cannot know: the active link's 600 weight. */
 const MORE_RESERVE_PX = 90;
+
+/* Mirrors `.popover`'s max-width; the clamp keeps that widest panel inside the viewport. */
+const PANEL_MAX_WIDTH_PX = 360;
+const VIEWPORT_MARGIN_PX = 8;
 
 export interface SiteNavigationProps {
   /** The destinations to offer. Defaults to the product's primary set. */
@@ -114,7 +117,7 @@ export function SiteNavigation({ links = PRIMARY_LINKS }: SiteNavigationProps) {
                 <img src={profile.data.avatar_url} alt="" className={styles.avatarImage} />
               ) : (
                 <span className={styles.avatarInitials}>
-                  {profile.data.username?.slice(0, 2).toUpperCase()}
+                  {profile.data.username?.slice(0, 2).toUpperCase() ?? '??'}
                 </span>
               )}
             </button>
@@ -176,12 +179,14 @@ function useVisibleLinkCount(
     }
 
     const compute = () => {
+      // Read the gap the row actually renders with, so the math can never drift from the CSS.
+      const gap = Number.parseFloat(getComputedStyle(measure).gap) || 0;
       const widths = Array.from(measure.children).map(
-        (child) => (child as HTMLElement).offsetWidth + ROW_GAP_PX
+        (child) => (child as HTMLElement).offsetWidth + gap
       );
       const total = widths.reduce((sum, width) => sum + width, 0);
       // A fitting row renders one fewer gap than the per-item sum counts.
-      if (total - ROW_GAP_PX <= group.clientWidth) {
+      if (total - gap <= group.clientWidth) {
         setVisibleCount(widths.length);
         return;
       }
@@ -231,7 +236,10 @@ function NavPopover({
     const rect = anchor.getBoundingClientRect();
     return {
       top: rect.bottom + 8,
-      left: Math.max(8, Math.min(rect.left, window.innerWidth - 368)),
+      left: Math.max(
+        VIEWPORT_MARGIN_PX,
+        Math.min(rect.left, window.innerWidth - PANEL_MAX_WIDTH_PX - VIEWPORT_MARGIN_PX)
+      ),
     };
   });
 

--- a/src/app/shell/SiteNavigation.tsx
+++ b/src/app/shell/SiteNavigation.tsx
@@ -1,46 +1,151 @@
+import { useAuthActions } from '@convex-dev/auth/react';
 import { Link } from '@tanstack/react-router';
-import { ProfileLink } from '@ui/content/ProfileLink';
+import type { LinkProps } from '@tanstack/react-router';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type { ReactNode, RefObject } from 'react';
+import { createPortal } from 'react-dom';
 
 import { useCurrentProfile } from '@db/profiles';
 
 import styles from './SiteNavigation.module.css';
 
-/** Product navigation, including its profile-aware account destination. */
-export function SiteNavigation() {
+export interface NavLinkItem {
+  label: string;
+  to: LinkProps['to'];
+}
+
+/* The link set is content, not structure: the system renders whatever list it is given, at any
+   count and any label length, so editing this array is the whole job of changing the navigation. */
+const PRIMARY_LINKS: readonly NavLinkItem[] = [
+  { label: 'Factions', to: '/factions' },
+  { label: 'Rulesets', to: '/rulesets' },
+  { label: 'Profiles', to: '/profiles' },
+  { label: 'Assets', to: '/assets' },
+];
+
+/* Must match the CSS: `gap` on `.linkRow` (1rem) and the widest the More control gets. The
+   reserve doubles as slack for the one width the measure row cannot know — the active link's
+   600 weight. */
+const ROW_GAP_PX = 16;
+const MORE_RESERVE_PX = 90;
+
+export interface SiteNavigationProps {
+  /** The destinations to offer. Defaults to the product's primary set. */
+  links?: readonly NavLinkItem[];
+}
+
+/**
+ * Product navigation, including its profile-aware account slot.
+ *
+ * The row is priority-plus: links that fit stay visible, the rest collapse behind a More control,
+ * re-measured through a `ResizeObserver` against a hidden copy of the full list — so the row is
+ * correct for any link count, any label length, at any width, without a breakpoint. At phone widths
+ * it collapses down to the More control.
+ *
+ * Both popovers (More, and the signed-in account menu) render through a portal: the band that hosts
+ * this nav is `overflow: hidden` for its rounded corners, so anything positioned inside it clips at
+ * the band's lower edge — at compact band heights that swallows the panel entirely.
+ */
+export function SiteNavigation({ links = PRIMARY_LINKS }: SiteNavigationProps) {
   const profile = useCurrentProfile();
+  const { signOut } = useAuthActions();
+  const groupRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const visibleCount = useVisibleLinkCount(groupRef, measureRef, links);
+  const [moreAnchor, setMoreAnchor] = useState<HTMLElement | null>(null);
+  const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
+
+  const overflow = links.slice(visibleCount);
 
   return (
     <nav className={styles.root} aria-label="Primary navigation">
-      <div className={styles.links}>
-        <Link to="/" className={styles.logo} aria-label="Dune home">
-          <img className={styles.logoImage} src="/web/logo.svg" alt="" />
-        </Link>
-        <Link to="/" activeProps={{ className: styles.activeLink }} activeOptions={{ exact: true }}>
-          Home
-        </Link>
-        <Link to="/factions" activeProps={{ className: styles.activeLink }}>
-          Factions
-        </Link>
-        <Link to="/rulesets" activeProps={{ className: styles.activeLink }}>
-          Rulesets
-        </Link>
-        <Link to="/profiles" activeProps={{ className: styles.activeLink }}>
-          Profiles
-        </Link>
-        <Link to="/assets" activeProps={{ className: styles.activeLink }}>
-          Assets
-        </Link>
+      <Link to="/" className={styles.logo} aria-label="Dune home">
+        <img className={styles.logoImage} src="/web/logo.svg" alt="" />
+      </Link>
+      <div className={styles.linkGroup} ref={groupRef}>
+        <div className={styles.linkRow}>
+          <div className={styles.measureRow} ref={measureRef} aria-hidden>
+            {links.map((item) => (
+              <span key={item.label}>{item.label}</span>
+            ))}
+          </div>
+          {links.slice(0, visibleCount).map((item) => (
+            <Link key={item.label} to={item.to} activeProps={{ className: styles.activeLink }}>
+              {item.label}
+            </Link>
+          ))}
+        </div>
+        {overflow.length > 0 && (
+          <button
+            type="button"
+            className={styles.ghostButton}
+            aria-expanded={moreAnchor !== null}
+            onClick={(e) => setMoreAnchor(moreAnchor ? null : e.currentTarget)}
+          >
+            More <span aria-hidden>▾</span>
+          </button>
+        )}
+        {moreAnchor && (
+          <NavPopover anchor={moreAnchor} onClose={() => setMoreAnchor(null)}>
+            {overflow.map((item) => (
+              <Link
+                key={item.label}
+                to={item.to}
+                activeProps={{ className: styles.activeLink }}
+                onClick={() => setMoreAnchor(null)}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </NavPopover>
+        )}
       </div>
       <div className={styles.account}>
         {profile.data ? (
-          <ProfileLink
-            slug={profile.data.slug}
-            username={profile.data.username}
-            avatar_url={profile.data.avatar_url}
-            className={styles.avatarLink}
-            title={profile.data.username ?? 'Profile'}
-            showUsername={false}
-          />
+          <>
+            <button
+              type="button"
+              className={styles.avatarButton}
+              aria-label={profile.data.username ?? 'Account'}
+              aria-expanded={menuAnchor !== null}
+              onClick={(e) => setMenuAnchor(menuAnchor ? null : e.currentTarget)}
+            >
+              {profile.data.avatar_url ? (
+                <img src={profile.data.avatar_url} alt="" className={styles.avatarImage} />
+              ) : (
+                <span className={styles.avatarInitials}>
+                  {profile.data.username?.slice(0, 2).toUpperCase()}
+                </span>
+              )}
+            </button>
+            {menuAnchor && (
+              <NavPopover anchor={menuAnchor} onClose={() => setMenuAnchor(null)}>
+                <Link
+                  to="/profiles/$profileSlug"
+                  params={{ profileSlug: profile.data.slug }}
+                  onClick={() => setMenuAnchor(null)}
+                >
+                  Your profile
+                </Link>
+                <Link
+                  to="/profiles/$profileSlug/edit"
+                  params={{ profileSlug: profile.data.slug }}
+                  onClick={() => setMenuAnchor(null)}
+                >
+                  Edit profile
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMenuAnchor(null);
+                    void signOut();
+                  }}
+                >
+                  Sign out
+                </button>
+              </NavPopover>
+            )}
+          </>
         ) : (
           <Link to="/auth/login" activeProps={{ className: styles.activeLink }}>
             Login
@@ -48,5 +153,138 @@ export function SiteNavigation() {
         )}
       </div>
     </nav>
+  );
+}
+
+/**
+ * How many leading links fit the group's width. The hidden measure row renders every label with the
+ * row's own text styles, so each label's true width is read rather than estimated; when the full
+ * list fits nothing is reserved, otherwise the More control's reserve is subtracted first.
+ */
+function useVisibleLinkCount(
+  groupRef: RefObject<HTMLDivElement | null>,
+  measureRef: RefObject<HTMLDivElement | null>,
+  links: readonly NavLinkItem[]
+) {
+  const [visibleCount, setVisibleCount] = useState(links.length);
+
+  useLayoutEffect(() => {
+    const group = groupRef.current;
+    const measure = measureRef.current;
+    if (!group || !measure) {
+      return;
+    }
+
+    const compute = () => {
+      const widths = Array.from(measure.children).map(
+        (child) => (child as HTMLElement).offsetWidth + ROW_GAP_PX
+      );
+      const total = widths.reduce((sum, width) => sum + width, 0);
+      // A fitting row renders one fewer gap than the per-item sum counts.
+      if (total - ROW_GAP_PX <= group.clientWidth) {
+        setVisibleCount(widths.length);
+        return;
+      }
+      const available = group.clientWidth - MORE_RESERVE_PX;
+      let used = 0;
+      let fit = 0;
+      for (const width of widths) {
+        used += width;
+        if (used > available) {
+          break;
+        }
+        fit++;
+      }
+      setVisibleCount(fit);
+    };
+
+    compute();
+    const observer = new ResizeObserver(compute);
+    observer.observe(group);
+    /* The measure row shrink-wraps its labels, so it also resizes when the webfont swaps in —
+       the one width change the group (viewport-sized) never reports. */
+    observer.observe(measure);
+    return () => observer.disconnect();
+  }, [groupRef, measureRef, links]);
+
+  return Math.min(visibleCount, links.length);
+}
+
+/**
+ * A small panel under its anchor, portaled to `document.body` to escape the band's `overflow:
+ * hidden`. Position is taken once on open; any reflow (scroll, resize) closes it rather than
+ * tracking the anchor.
+ */
+function NavPopover({
+  anchor,
+  onClose,
+  children,
+}: {
+  anchor: HTMLElement;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const [position] = useState(() => {
+    const rect = anchor.getBoundingClientRect();
+    return {
+      top: rect.bottom + 8,
+      left: Math.max(8, Math.min(rect.left, window.innerWidth - 368)),
+    };
+  });
+
+  // Focus moves into the panel on open (Tab then walks its items); Escape hands it back.
+  useEffect(() => {
+    panelRef.current?.querySelector<HTMLElement>('a, button')?.focus();
+  }, []);
+
+  useEffect(() => {
+    const close = () => onCloseRef.current();
+    const isInside = (target: EventTarget | null) =>
+      target instanceof Node &&
+      (anchor.contains(target) || panelRef.current?.contains(target) === true);
+    const onPointerDown = (event: PointerEvent) => {
+      if (!isInside(event.target)) {
+        close();
+      }
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        close();
+        anchor.focus();
+      }
+    };
+    const onScroll = (event: Event) => {
+      // The panel scrolls its own overflow; only the page scrolling away should close it.
+      if (!(event.target instanceof Node && panelRef.current?.contains(event.target))) {
+        close();
+      }
+    };
+    const onFocusIn = (event: FocusEvent) => {
+      if (!isInside(event.target)) {
+        close();
+      }
+    };
+    window.addEventListener('pointerdown', onPointerDown);
+    window.addEventListener('keydown', onKeyDown);
+    window.addEventListener('resize', close);
+    window.addEventListener('scroll', onScroll, true);
+    window.addEventListener('focusin', onFocusIn);
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown);
+      window.removeEventListener('keydown', onKeyDown);
+      window.removeEventListener('resize', close);
+      window.removeEventListener('scroll', onScroll, true);
+      window.removeEventListener('focusin', onFocusIn);
+    };
+  }, [anchor]);
+
+  return createPortal(
+    <div ref={panelRef} className={styles.popover} style={position}>
+      {children}
+    </div>,
+    document.body
   );
 }


### PR DESCRIPTION
Implements the navigation system charted on [Navigation system: any-N links, any screen, legible over the band](https://github.com/ndelangen/dunezone/issues/382) — resolves the build for [Implement the navigation system](https://github.com/ndelangen/dunezone/issues/386).

## What

- **Priority-plus row** (#383): a hidden measure row + `ResizeObserver` decide how many links fit; the rest fold behind a More control. No breakpoints — correct for any link count/length at any width. The observer also watches the measure row so the webfont swap re-measures.
- **Gradient scrim + row design pass** (#384): darkness belongs to the band's top edge; links rest at 85% opacity, active gets weight + underline, More is a ghost button.
- **Link set + avatar menu** (#385): Factions · Rulesets · Profiles · Assets (no Home — the logo carries it). Signed-in avatar opens Your profile / Edit profile / Sign out; Login unchanged.
- **Portaled panels**: the band is `overflow: hidden`, so both popovers render via `createPortal` — panels stay whole at every band height. Focus moves into the panel on open; Escape returns it; outside pointer/focus/page-scroll close it.
- **Stories** under the Shell root pin the four system states (fit / partial overflow / panel open / mobile collapsed); Storybook gains a `@convex-dev/auth/react` mock beside the existing convex ones.

## Build-time decisions (recorded on the ticket)

- One PR — the change is one cohesive system.
- The profile page keeps its own sign-out button; the menu adds a path, doesn't move it.
- The signed-in avatar menu has no story (preview mocks are signed-out by design); it rides on prod verification (#387).

## Verified

- 448 unit tests, 287 story tests green (the one red story in full-suite runs — AppRoot's Scrolling Background — is a pre-existing exact-equality flake on main, fails on a clean checkout too; flagged separately).
- Browser-checked signed-out states over the video band: desktop fit, compact band, mobile collapse, portaled panel unclipped, active states in row and panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive navigation that moves extra links into a “More” menu.
  * Added mobile navigation collapse and improved overflow handling.
  * Added account controls with avatar, profile, edit, sign-out, and login actions.
  * Added configurable navigation links for different site contexts.

* **Testing**
  * Added Storybook scenarios for full, partial, overflow, and mobile navigation layouts.
  * Added authentication mocks for authentication-dependent previews and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->