### PR TITLE
test: cover the signed-in avatar menu end-to-end

### DIFF
--- a/e2e/avatar-menu.spec.ts
+++ b/e2e/avatar-menu.spec.ts
@@ -9,15 +9,21 @@ test.use({ storageState: '.playwright/user-a-avatar-menu.json' });
  * reach — its Convex mocks are signed-out by design — so the contract lives here.
  */
 test('the avatar menu offers the profile routes and signs out', async ({ page }) => {
+  /* The seed derives username and slug from the email's local part (convex/e2e.ts). */
+  const username = (process.env.PLAYWRIGHT_USER_A_EMAIL ?? 'e2e-user-a@example.com').split('@')[0];
+
   await page.goto('/');
   const nav = page.getByRole('navigation', { name: 'Primary navigation' });
-  const avatar = nav.getByRole('button');
+  const avatar = nav.getByRole('button', { name: username });
   await expect(avatar).toBeVisible();
 
   await avatar.click();
-  await expect(page.getByRole('link', { name: 'Edit profile' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Edit profile' })).toHaveAttribute(
+    'href',
+    new RegExp(`/profiles/${username}/edit/?$`)
+  );
   await page.getByRole('link', { name: 'Your profile' }).click();
-  await expect(page).toHaveURL(/\/profiles\/[^/]+\/?$/);
+  await expect(page).toHaveURL(new RegExp(`/profiles/${username}/?$`));
   await expect(page.getByRole('link', { name: 'Your profile' })).not.toBeVisible();
 
   await avatar.click();

--- a/e2e/avatar-menu.spec.ts
+++ b/e2e/avatar-menu.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from './coverage';
+
+/* Own storage state because the last step signs out, which would invalidate a shared session. */
+test.use({ storageState: '.playwright/user-a-avatar-menu.json' });
+
+/**
+ * The signed-in account slot: the avatar opens a menu whose items lead to the user's own profile
+ * routes, and Sign out returns the slot to Login. This is the one navigation state Storybook cannot
+ * reach — its Convex mocks are signed-out by design — so the contract lives here.
+ */
+test('the avatar menu offers the profile routes and signs out', async ({ page }) => {
+  await page.goto('/');
+  const nav = page.getByRole('navigation', { name: 'Primary navigation' });
+  const avatar = nav.getByRole('button');
+  await expect(avatar).toBeVisible();
+
+  await avatar.click();
+  await expect(page.getByRole('link', { name: 'Edit profile' })).toBeVisible();
+  await page.getByRole('link', { name: 'Your profile' }).click();
+  await expect(page).toHaveURL(/\/profiles\/[^/]+\/?$/);
+  await expect(page.getByRole('link', { name: 'Your profile' })).not.toBeVisible();
+
+  await avatar.click();
+  await page.getByRole('button', { name: 'Sign out' }).click();
+  await expect(nav.getByRole('link', { name: 'Login' })).toBeVisible();
+});

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -102,6 +102,11 @@ export default async function globalSetup(config: FullConfig) {
       password: userPassword,
       storageStatePath: '.playwright/user-a-asset-assign.json',
     },
+    {
+      email: userAEmail,
+      password: userPassword,
+      storageStatePath: '.playwright/user-a-avatar-menu.json',
+    },
     { email: userBEmail, password: userPassword, storageStatePath: '.playwright/user-b.json' },
     { email: userBEmail, password: userPassword, storageStatePath: '.playwright/user-b-faq.json' },
     {


### PR DESCRIPTION
Covers the signed-in avatar menu — the one navigation state Storybook can't reach (its Convex mocks are signed-out by design). Closes the verification gap left on [Verify the navigation rework in prod](https://github.com/ndelangen/dunezone/issues/387).

One happy-path spec, per the testing pyramid: avatar opens the menu, Your profile / Edit profile lead to the user's own routes, Sign out returns the slot to Login. It gets its own storage state in global-setup because the last step destroys its session.

Full local e2e run: 7/7 passed, the new spec in 1.9s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
