### PR TITLE
style: the More control is a link, visually

### DIFF
--- a/src/app/shell/SiteNavigation.module.css
+++ b/src/app/shell/SiteNavigation.module.css
@@ -68,9 +68,11 @@
   width: auto;
 }
 
+/* Baseline, not center: the row's items are text, and baseline alignment keeps their labels
+   level automatically — whatever borders, padding, or glyph metrics their boxes pick up. */
 .linkGroup {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 1rem;
   flex: 1;
   min-width: 0;
@@ -79,7 +81,7 @@
 .linkRow {
   position: relative;
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 1rem;
   flex: 0 1 auto;
   min-width: 0;

--- a/src/app/shell/SiteNavigation.module.css
+++ b/src/app/shell/SiteNavigation.module.css
@@ -102,17 +102,24 @@
   padding: 0.35rem 0.15rem;
 }
 
-.ghostButton {
+/* Deliberately a link, visually: the control continues the row it belongs to. */
+.moreButton {
   flex: none;
-  background: rgba(0, 0, 0, 0.35);
+  background: none;
+  border: none;
   color: inherit;
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  border-radius: 4px;
-  padding: 0.25rem 0.6rem;
+  padding: 0.35rem 0.15rem;
   cursor: pointer;
   font: inherit;
   font-size: 0.9rem;
+  letter-spacing: 0.02em;
   white-space: nowrap;
+  opacity: 0.85;
+  transition: opacity 0.15s ease-out;
+}
+
+.moreButton:hover {
+  opacity: 1;
 }
 
 .account {

--- a/src/app/shell/SiteNavigation.module.css
+++ b/src/app/shell/SiteNavigation.module.css
@@ -104,13 +104,16 @@
   padding: 0.35rem 0.15rem;
 }
 
-/* Deliberately a link, visually: the control continues the row it belongs to. */
+/* Deliberately a link, visually: the control continues the row it belongs to. The extra
+   horizontal padding widens the tap target; the matching negative margin hands that space
+   back to the layout, so the row's visual spacing doesn't change. */
 .moreButton {
   flex: none;
   background: none;
   border: none;
   color: inherit;
-  padding: 0.35rem 0.15rem;
+  padding: 0.35rem 0.5rem;
+  margin: 0 -0.35rem;
   cursor: pointer;
   font: inherit;
   font-size: 0.9rem;
@@ -120,7 +123,8 @@
   transition: opacity 0.15s ease-out;
 }
 
-.moreButton:hover {
+.moreButton:hover,
+.moreButton:focus-visible {
   opacity: 1;
 }
 

--- a/src/app/shell/SiteNavigation.tsx
+++ b/src/app/shell/SiteNavigation.tsx
@@ -81,7 +81,7 @@ export function SiteNavigation({ links = PRIMARY_LINKS }: SiteNavigationProps) {
         {overflow.length > 0 && (
           <button
             type="button"
-            className={styles.ghostButton}
+            className={styles.moreButton}
             aria-expanded={moreAnchor !== null}
             onClick={(e) => setMoreAnchor(moreAnchor ? null : e.currentTarget)}
           >


### PR DESCRIPTION
The More control loses its ghost box and takes the row's own link styling — same size, opacity, and hover as the links beside it.

Correction to the [contrast-treatment resolution](https://github.com/ndelangen/dunezone/issues/384): the ghost-button look rode in from prototype scaffolding without an explicit reaction, and it was rejected on sight. Three candidates (link-look, bare ⋯, soft pill) were staged over the live band; link-look won.

Verified locally over the band at overflow widths; shell story suite green (the stories locate More by accessible name, which is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the “More” navigation control with a lighter, link-like appearance.
  * Improved navigation alignment and visual consistency with transparent styling, inherited typography, and hover feedback.
  * Expanded the control’s tap target for easier interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->