### PR TITLE
style: pin the compact band to a static 51px at every width

### DIFF
--- a/src/app/shell/AppHeader.module.css
+++ b/src/app/shell/AppHeader.module.css
@@ -1,5 +1,6 @@
 .frame {
   position: relative;
+  container-type: inline-size;
   display: grid;
   grid-template-areas:
     "hero"
@@ -8,17 +9,20 @@
   gap: 40px;
 }
 
+/*
+ * The band's heights are lengths (artwork crop rows scaled to the frame's width via cqw) rather
+ * than aspect-ratios: the compact strip is a fixed 51px at every width, and a transition can only
+ * interpolate between two lengths, so every mode must state its height in the same currency.
+ */
 .band {
   grid-area: hero;
   position: relative;
   width: 100%;
-  aspect-ratio: 3064 / 1125;
+  height: calc(100cqw * (1125 / 3064));
   overflow: hidden;
   border-radius: 6px;
   box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.5);
-  transition:
-    aspect-ratio 0.2s ease-out,
-    height 0.2s ease-out;
+  transition: height 0.2s ease-out;
 }
 
 /* The band artwork, bottom to top: inlined blurred frame, poster photograph, looping video.
@@ -51,16 +55,15 @@
 }
 
 .frame:has([data-page-layout-compact="true"]) .band {
-  aspect-ratio: 3064 / 178;
+  height: 51px;
 }
 
 .frame:has([data-page-layout-header-size="compact"]) .band {
-  aspect-ratio: 3064 / 760;
+  height: calc(100cqw * (760 / 3064));
 }
 
 @media (max-width: 900px) {
   .band {
-    aspect-ratio: unset;
     height: 319px;
   }
 
@@ -68,10 +71,6 @@
   .bandPoster,
   .bandVideo {
     object-position: left center;
-  }
-
-  .frame:has([data-page-layout-compact="true"]) .band {
-    height: 51px;
   }
 
   .frame:has([data-page-layout-header-size="compact"]) .band {

--- a/src/app/shell/AppHeader.stories.tsx
+++ b/src/app/shell/AppHeader.stories.tsx
@@ -98,7 +98,7 @@ export const HeaderlessPageResponsive = meta.story({
     for (const width of [1160, 1000, 860, 390]) {
       canvasElement.style.width = `${width}px`;
       await expect(Math.round(band.getBoundingClientRect().width)).toBe(width);
-      await expect(Math.round(band.getBoundingClientRect().height)).toBe(51);
+      await expect(band.getBoundingClientRect().height).toBe(51);
     }
     canvasElement.style.removeProperty('width');
   },

--- a/src/app/shell/AppHeader.stories.tsx
+++ b/src/app/shell/AppHeader.stories.tsx
@@ -35,7 +35,7 @@ export const DefaultHeader = meta.story({
   globals: { viewport: { value: 'appDesktop' } },
 });
 
-/** Below 900px the band swaps aspect ratio for a fixed height and the artwork anchors left. */
+/** Below 900px the band drops to a fixed height and the artwork anchors left. */
 export const DefaultHeaderMobile = meta.story({
   globals: { viewport: { value: 'appMobile' } },
 });
@@ -72,9 +72,42 @@ export const HeaderlessPageMobile = meta.story({
 });
 
 /**
+ * Left responsive on purpose — drag the preview to any width: the compact strip must hold its fixed
+ * 51px while the artwork modes track the frame's width. The play function proves the static half of
+ * that contract by walking the canvas through the widths the shell can hand the frame and measuring
+ * the band at each one.
+ */
+export const HeaderlessPageResponsive = meta.story({
+  args: { children: shellPageOptionLabels[2] },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'No pinned viewport: resize the preview and the compact strip stays 51px tall at every width. Flip the `children` control to watch the artwork modes scale with width instead.',
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const band = canvasElement.querySelector('header');
+    if (band == null) {
+      throw new Error('The masthead band never rendered, so its height cannot be measured.');
+    }
+
+    /* The band sizes against its container, so pinching the canvas stands in for every viewport
+       the shell can meet — no window resize needed. */
+    for (const width of [1160, 1000, 860, 390]) {
+      canvasElement.style.width = `${width}px`;
+      await expect(Math.round(band.getBoundingClientRect().width)).toBe(width);
+      await expect(Math.round(band.getBoundingClientRect().height)).toBe(51);
+    }
+    canvasElement.style.removeProperty('width');
+  },
+});
+
+/**
  * Plays the resize on open by stepping the `children` arg through every route state, then proves it
- * animated rather than jumped: the aspect ratio the page asks for is a CSS transition on an element
- * that survives the swap, so a static frame can never show it.
+ * animated rather than jumped: the height the page asks for is a CSS transition on an element that
+ * survives the swap, so a static frame can never show it.
  */
 export const Resizing = meta.story({
   globals: { viewport: { value: 'appDesktop' } },


### PR DESCRIPTION
## What

The `AppHeader` band's smallest mode (headerless pages, `data-page-layout-compact`) previously scaled with viewport width — `aspect-ratio: 3064 / 178`, ~50–67px on desktop — and only became 51px under 900px. It now holds a **static 51px at every width**, which lines up exactly with the nav strip's `min-height: 51px` from the priority-plus navigation rework.

## How

A CSS transition can only interpolate between two values of the same property, so mixing `aspect-ratio` modes with a fixed-`height` mode would make the switch snap instead of animate. Every mode now states its height as a length:

- the frame is a `container-type: inline-size` container, and the two artwork modes use `calc(100cqw * (crop / 3064))` — pixel-identical to their old aspect-ratios at every width (verified to the hundredth of a pixel)
- the compact strip is `height: 51px`, now one rule for all widths (the mobile duplicate is gone)
- the transition collapses to `height 0.2s ease-out` alone; same duration and easing as before

The mobile (≤900px) overrides for the artwork modes (319px / 220px) are unchanged.

## Testing

- New `HeaderlessPageResponsive` story: no pinned viewport for hand-testing by drag-resize, plus a play function that walks the canvas through shell widths (1160/1000/860/390) and asserts the strip is exactly 51px at each — the band sizes off its container, so this is a real multi-width test in CI.
- The existing `Resizing`/`ResizingMobile` stories still guard that mode switches animate through intermediate heights on the same mounted element; drove the transition by hand in both directions (~45 intermediate frames, exact endpoints).
- `storybook:test` (10/10 AppHeader stories), vitest (448), oxlint, oxfmt, css-orphans all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive header behavior using container-aware sizing.
  * Maintains a consistent 51px height for compact page layouts across varying widths.
  * Improved responsive artwork handling across header layouts.

* **Documentation**
  * Updated header guidance to reflect fixed-height mobile behavior.
  * Clarified that header sizing transitions by height rather than aspect ratio.
  * Added responsive coverage for headerless pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->