### PR TITLE
fix(storybook): stop the router Link mock leaking activeProps into the DOM

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -132,6 +132,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@storybook/tanstack-react@10.5.6": "patches/@storybook%2Ftanstack-react@10.5.6.patch",
+  },
   "overrides": {
     "@babel/core": "7.29.7",
     "immutable": "5.1.9",

--- a/package.json
+++ b/package.json
@@ -147,5 +147,8 @@
     "shell-quote": "1.10.0",
     "ws": "8.21.2"
   },
-  "packageManager": "bun@1.3.14"
+  "packageManager": "bun@1.3.14",
+  "patchedDependencies": {
+    "@storybook/tanstack-react@10.5.6": "patches/@storybook%2Ftanstack-react@10.5.6.patch"
+  }
 }

--- a/patches/@storybook%2Ftanstack-react@10.5.6.patch
+++ b/patches/@storybook%2Ftanstack-react@10.5.6.patch
@@ -1,8 +1,11 @@
+diff --git a/node_modules/@storybook/tanstack-react/.bun-tag-901b2ec1dde78d81 b/.bun-tag-901b2ec1dde78d81
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/export-mocks/react-router.js b/dist/export-mocks/react-router.js
-index 2e732a878fb0ff61096f14527ca4b6ad8dae89e4..2a799cc7950f9037e48b3d2f67fde96639ba5ef9 100644
+index 2e732a878fb0ff61096f14527ca4b6ad8dae89e4..0a3cd3f1188ef2afec6608071838d788d58c3bce 100644
 --- a/dist/export-mocks/react-router.js
 +++ b/dist/export-mocks/react-router.js
-@@ -36,17 +36,51 @@ var useNavigate = fn(_useNavigate).mockName("@tanstack/react-router::useNavigate
+@@ -36,19 +36,56 @@ var useNavigate = fn(_useNavigate).mockName("@tanstack/react-router::useNavigate
  }, [to, href]), null), Link = ({
    to,
    children,
@@ -49,12 +52,17 @@ index 2e732a878fb0ff61096f14527ca4b6ad8dae89e4..2a799cc7950f9037e48b3d2f67fde966
 +      style,
 +      "data-status": isActive ? "active" : void 0,
 +      "aria-current": isActive ? "page" : props["aria-current"],
++      // Mirrors the real Link: the caller's handler runs first and can cancel
++      // navigation via preventDefault; otherwise the mock swallows the click.
        onClick: (e) => {
--        e.preventDefault(), onNavigate({ to, from: location.href });
++        if (onClick?.(e), e.defaultPrevented) return;
+         e.preventDefault(), onNavigate({ to, from: location.href });
 -      },
 -      ...props
-+        e.preventDefault(), onNavigate({ to, from: location.href }), onClick?.(e);
 +      }
      },
-     children
+-    children
++    typeof children == "function" ? children({ isActive, isTransitioning: false }) : children
    );
+ };
+ function createFileRoute(path) {

--- a/patches/@storybook%2Ftanstack-react@10.5.6.patch
+++ b/patches/@storybook%2Ftanstack-react@10.5.6.patch
@@ -1,0 +1,60 @@
+diff --git a/dist/export-mocks/react-router.js b/dist/export-mocks/react-router.js
+index 2e732a878fb0ff61096f14527ca4b6ad8dae89e4..2a799cc7950f9037e48b3d2f67fde96639ba5ef9 100644
+--- a/dist/export-mocks/react-router.js
++++ b/dist/export-mocks/react-router.js
+@@ -36,17 +36,51 @@ var useNavigate = fn(_useNavigate).mockName("@tanstack/react-router::useNavigate
+ }, [to, href]), null), Link = ({
+   to,
+   children,
++  onClick,
++  // Router-only props: consumed here so they never reach the DOM element.
++  params,
++  search,
++  hash,
++  state,
++  from,
++  mask,
++  activeProps,
++  inactiveProps,
++  activeOptions,
++  preload,
++  preloadDelay,
++  replace,
++  resetScroll,
++  startTransition,
++  viewTransition,
++  reloadDocument,
++  ignoreBlocker,
++  hashScrollIntoView,
+   ...props
+ }) => {
+   let location = useLocation();
++  let href = String(to ?? "");
++  if (params)
++    href = href.replace(/\$([A-Za-z0-9_]+)/g, (match, key) => params[key] != null ? String(params[key]) : match);
++  let pathname = location.pathname ?? "";
++  let isActive = activeOptions?.exact ? pathname === href : pathname === href || pathname.startsWith(href.endsWith("/") ? href : href + "/");
++  let stateProps = isActive ? activeProps : inactiveProps;
++  let { className: stateClassName, style: stateStyle, ...restStateProps } = (typeof stateProps == "function" ? stateProps() : stateProps) ?? {};
++  let className = [props.className, stateClassName].filter(Boolean).join(" ") || void 0;
++  let style = props.style || stateStyle ? { ...props.style, ...stateStyle } : void 0;
+   return React.createElement(
+     "a",
+     {
+-      href: to,
++      ...props,
++      ...restStateProps,
++      href,
++      className,
++      style,
++      "data-status": isActive ? "active" : void 0,
++      "aria-current": isActive ? "page" : props["aria-current"],
+       onClick: (e) => {
+-        e.preventDefault(), onNavigate({ to, from: location.href });
+-      },
+-      ...props
++        e.preventDefault(), onNavigate({ to, from: location.href }), onClick?.(e);
++      }
+     },
+     children
+   );

--- a/patches/@storybook%2Ftanstack-react@10.5.6.patch
+++ b/patches/@storybook%2Ftanstack-react@10.5.6.patch
@@ -1,11 +1,14 @@
 diff --git a/node_modules/@storybook/tanstack-react/.bun-tag-901b2ec1dde78d81 b/.bun-tag-901b2ec1dde78d81
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@storybook/tanstack-react/.bun-tag-dd01d4d4cd88254e b/.bun-tag-dd01d4d4cd88254e
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/export-mocks/react-router.js b/dist/export-mocks/react-router.js
-index 2e732a878fb0ff61096f14527ca4b6ad8dae89e4..0a3cd3f1188ef2afec6608071838d788d58c3bce 100644
+index 2e732a878fb0ff61096f14527ca4b6ad8dae89e4..9a800a9c6c519fdd98a124c8bf43924cc9111e85 100644
 --- a/dist/export-mocks/react-router.js
 +++ b/dist/export-mocks/react-router.js
-@@ -36,19 +36,56 @@ var useNavigate = fn(_useNavigate).mockName("@tanstack/react-router::useNavigate
+@@ -36,19 +36,60 @@ var useNavigate = fn(_useNavigate).mockName("@tanstack/react-router::useNavigate
  }, [to, href]), null), Link = ({
    to,
    children,
@@ -29,6 +32,10 @@ index 2e732a878fb0ff61096f14527ca4b6ad8dae89e4..0a3cd3f1188ef2afec6608071838d788
 +  reloadDocument,
 +  ignoreBlocker,
 +  hashScrollIntoView,
++  disabled,
++  unsafeRelative,
++  preloadIntentProximity,
++  _fromLocation,
    ...props
  }) => {
    let location = useLocation();

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,26 @@
+# Dependency patches
+
+Applied by bun via `patchedDependencies` in `package.json`. The key pins an exact
+version, so a version bump silently stops applying the patch — re-evaluate the
+patch whenever the dependency it names is upgraded.
+
+## @storybook/tanstack-react
+
+The framework replaces every `@tanstack/react-router` import inside Storybook
+with its own mock, and the mock's `Link` stub spreads all router-only props
+(`activeProps`, `params`, `search`, …) onto a plain `<a>`. That leaks unknown
+props into the DOM (React logs `React does not recognize the 'activeProps'
+prop…` on every render of components like `SiteNavigation`) and never applies
+active-link styling in stories. Still broken upstream as of 10.5.8.
+
+The patch rewrites the stub to consume the router-only prop set, apply
+`activeProps`/`inactiveProps` when the link matches the current location,
+support function-form `children`, and let a caller's `onClick` cancel the mock
+navigation — mirroring the real `Link`'s semantics.
+
+On upgrade: check whether upstream's `dist/export-mocks/react-router.js` still
+spreads `...props` onto the anchor. If fixed, drop the patch; if not, regenerate
+it (`bun patch @storybook/tanstack-react`, re-apply, `bun patch --commit`).
+Verify either way by loading the `shell-appheader--default-header` story — the
+console must be free of unknown-prop warnings and `bun run storybook:test` must
+pass.

--- a/patches/README.md
+++ b/patches/README.md
@@ -18,9 +18,11 @@ The patch rewrites the stub to consume the router-only prop set, apply
 support function-form `children`, and let a caller's `onClick` cancel the mock
 navigation — mirroring the real `Link`'s semantics.
 
-On upgrade: check whether upstream's `dist/export-mocks/react-router.js` still
-spreads `...props` onto the anchor. If fixed, drop the patch; if not, regenerate
-it (`bun patch @storybook/tanstack-react`, re-apply, `bun patch --commit`).
+Fixed upstream by <https://github.com/storybookjs/storybook/pull/35505>
+(merged to `next` 2026-08-12, ships with the 10.6 line — not cherry-picked to
+10.5.x). Drop this patch when upgrading to a release that contains it; until
+then, regenerate on any 10.5.x bump (`bun patch @storybook/tanstack-react`,
+re-apply, `bun patch --commit`).
 Verify either way by loading the `shell-appheader--default-header` story — the
 console must be free of unknown-prop warnings and `bun run storybook:test` must
 pass.


### PR DESCRIPTION
## What

Every render of `SiteNavigation` in Storybook logged React's unknown-prop warning:

> React does not recognize the `activeProps` prop on a DOM element.

The component is fine — `activeProps` is the correct TanStack Router `Link` API. The leak is in `@storybook/tanstack-react`: its Vite plugin redirects every `@tanstack/react-router` import to a mock whose `Link` stub destructures only `to`/`children` and spreads **all remaining props** onto a plain `<a>`. Upstream's latest stable (10.5.8) still has the same stub, so a version bump doesn't help.

## How

A `bun patch` on `@storybook/tanstack-react@10.5.6` fixing the `Link` stub:

- Router-only props (`activeProps`, `inactiveProps`, `activeOptions`, `params`, `search`, `preload`, …) are consumed and never reach the DOM.
- `activeProps`/`inactiveProps` are now actually applied (merging `className`/`style`) when the link matches the current location, honoring `activeOptions.exact` and interpolating `$params` into the href — active styling works in stories instead of silently doing nothing.
- Sets `data-status="active"`/`aria-current="page"` like the real `Link`, and composes a caller's `onClick` with the mock's `preventDefault` + `onNavigate` instead of letting it clobber them (previously an overflow-panel link click could navigate the story iframe away).

The real app is untouched — the mock only loads inside Storybook and its vitest runner.

## Verification

- `shell-appheader--default-header` loads with a clean console; DOM inspection shows no `activeprops` attribute on any nav anchor.
- `bun run storybook:test`: 287 tests across 71 files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Storybook’s React Router link mock to support route parameters and active-link states.
  * Added appropriate active and inactive styling, accessibility attributes, and status indicators.
  * Preserved custom link properties and ensured click callbacks are invoked while preventing navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->