### PR TITLE
Brand icon links for the community band and footer

### DIFF
--- a/src/app/routes/_app/index.module.css
+++ b/src/app/routes/_app/index.module.css
@@ -70,6 +70,13 @@
 
 .communityIconLink {
   display: inline-flex;
+  padding: 0.25rem;
+  border-radius: 50%;
+}
+
+.communityIconLink:focus-visible {
+  outline: 3px solid var(--mantine-color-dune-6);
+  outline-offset: 2px;
 }
 
 .avatarLink {

--- a/src/app/routes/_app/index.module.css
+++ b/src/app/routes/_app/index.module.css
@@ -68,6 +68,10 @@
   white-space: nowrap;
 }
 
+.communityIconLink {
+  display: inline-flex;
+}
+
 .avatarLink {
   border-radius: 50%;
 }

--- a/src/app/routes/_app/index.tsx
+++ b/src/app/routes/_app/index.tsx
@@ -28,7 +28,8 @@ import { TriptychLayout } from '@ui/layout/TriptychLayout';
 import { Bullets } from '@ui/list/Bullets';
 import { Surface } from '@ui/surface';
 import { ArrowRight, BookOpen, ExternalLink, MessageCircle, Printer, Trophy } from 'lucide-react';
-import { SiBoardgamegeek, SiDiscord, SiReddit } from 'react-icons/si';
+import { FaRedditAlien } from 'react-icons/fa6';
+import { SiBoardgamegeek, SiDiscord } from 'react-icons/si';
 
 import { loadHomepage, useHomepage } from '@db/homepage';
 
@@ -43,7 +44,7 @@ const communityLinks = [
   {
     href: 'https://www.reddit.com/r/DuneBoardGame/',
     label: 'r/DuneBoardGame on Reddit',
-    Icon: SiReddit,
+    Icon: FaRedditAlien,
   },
   {
     href: 'https://boardgamegeek.com/boardgame/283355/dune/forums/69',

--- a/src/app/routes/_app/index.tsx
+++ b/src/app/routes/_app/index.tsx
@@ -11,6 +11,7 @@ import {
   Stack,
   Text,
   Title,
+  Tooltip,
 } from '@mantine/core';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
@@ -27,10 +28,29 @@ import { TriptychLayout } from '@ui/layout/TriptychLayout';
 import { Bullets } from '@ui/list/Bullets';
 import { Surface } from '@ui/surface';
 import { ArrowRight, BookOpen, ExternalLink, MessageCircle, Printer, Trophy } from 'lucide-react';
+import { SiBoardgamegeek, SiDiscord, SiReddit } from 'react-icons/si';
 
 import { loadHomepage, useHomepage } from '@db/homepage';
 
 import styles from './index.module.css';
+
+const communityLinks = [
+  {
+    href: 'https://discord.com/invite/dune-tabletop-624609341886169117',
+    label: 'Dune Discord server',
+    Icon: SiDiscord,
+  },
+  {
+    href: 'https://www.reddit.com/r/DuneBoardGame/',
+    label: 'r/DuneBoardGame on Reddit',
+    Icon: SiReddit,
+  },
+  {
+    href: 'https://boardgamegeek.com/boardgame/283355/dune/forums/69',
+    label: 'Dune forums on BoardGameGeek',
+    Icon: SiBoardgamegeek,
+  },
+] as const;
 
 export const Route = createFileRoute('/_app/')({
   codeSplitGroupings: [['component', 'pendingComponent', 'errorComponent']],
@@ -200,30 +220,21 @@ function IndexPage() {
                     Meet the community
                   </Button>
                 </Group>
-                <Group gap="xs">
-                  <Anchor
-                    href="https://discord.com/invite/dune-tabletop-624609341886169117"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Discord
-                  </Anchor>
-                  <Text c="dimmed">·</Text>
-                  <Anchor
-                    href="https://www.reddit.com/r/DuneBoardGame/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Reddit
-                  </Anchor>
-                  <Text c="dimmed">·</Text>
-                  <Anchor
-                    href="https://boardgamegeek.com/boardgame/283355/dune/forums/69"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    BoardGameGeek
-                  </Anchor>
+                <Group gap="md">
+                  {communityLinks.map(({ href, label, Icon }) => (
+                    <Tooltip key={href} label={label}>
+                      <Anchor
+                        href={href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label={label}
+                        underline="never"
+                        className={styles.communityIconLink}
+                      >
+                        <Icon size={22} aria-hidden />
+                      </Anchor>
+                    </Tooltip>
+                  ))}
                 </Group>
               </Stack>
             </SimpleGrid>

--- a/src/app/shell/AppFooter.module.css
+++ b/src/app/shell/AppFooter.module.css
@@ -78,6 +78,11 @@
   content: "";
 }
 
+/* The connector joins neighbours within a row; a row's last entry has none to draw. */
+.waypointLink:nth-child(3n)::after {
+  display: none;
+}
+
 .waypointLink:hover .icon {
   background: var(--color-link);
   color: #fff9ef;

--- a/src/app/shell/AppFooter.module.css
+++ b/src/app/shell/AppFooter.module.css
@@ -73,33 +73,6 @@
   outline-offset: 3px;
 }
 
-/* Hand-rolled tooltip: the chrome sits outside the Mantine provider (see AppFooter.tsx). */
-.waypointLink::after {
-  position: absolute;
-  bottom: calc(100% + 0.55rem);
-  left: 50%;
-  padding: 0.25rem 0.6rem;
-  border: 1px solid rgba(248, 175, 64, 0.42);
-  border-radius: 999px;
-  background: rgba(17, 11, 8, 0.92);
-  color: #fff9ef;
-  font-size: 0.68rem;
-  white-space: nowrap;
-  content: attr(data-tooltip);
-  opacity: 0;
-  pointer-events: none;
-  transform: translate(-50%, 3px);
-  transition:
-    opacity var(--transition-fast),
-    transform var(--transition-fast);
-}
-
-.waypointLink:hover::after,
-.waypointLink:focus-visible::after {
-  opacity: 1;
-  transform: translate(-50%, 0);
-}
-
 .motionToggle {
   display: inline-flex;
   align-items: center;

--- a/src/app/shell/AppFooter.module.css
+++ b/src/app/shell/AppFooter.module.css
@@ -7,21 +7,6 @@
   text-transform: uppercase;
 }
 
-.icon {
-  display: grid;
-  flex: 0 0 auto;
-  width: 2.5rem;
-  height: 2.5rem;
-  border: 1px solid rgba(248, 175, 64, 0.42);
-  border-radius: 50%;
-  color: var(--color-accent);
-  place-items: center;
-  transition:
-    color var(--transition-fast),
-    background var(--transition-fast),
-    transform var(--transition-fast);
-}
-
 .linkCopy {
   display: grid;
   gap: 0.15rem;
@@ -53,46 +38,66 @@
 }
 
 .waypoints nav {
-  display: grid;
-  max-width: 42rem;
-  margin: 1rem auto 0;
-  grid-template-columns: repeat(3, 1fr);
+  display: flex;
+  margin-top: 1rem;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .waypointLink {
   display: grid;
   position: relative;
-  gap: 0.7rem;
-  padding: 0.4rem 1rem;
-  color: inherit;
+  flex: 0 0 auto;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid rgba(248, 175, 64, 0.42);
+  border-radius: 50%;
+  color: var(--color-accent);
   text-decoration: none;
-  justify-items: center;
+  place-items: center;
+  transition:
+    color var(--transition-fast),
+    background var(--transition-fast),
+    transform var(--transition-fast);
 }
 
-.waypointLink:not(:last-child)::after {
-  position: absolute;
-  top: 1.55rem;
-  right: -25%;
-  width: 50%;
-  border-top: 1px dashed rgba(115, 92, 71, 0.28);
-  content: "";
-}
-
-/* The connector joins neighbours within a row; a row's last entry has none to draw. */
-.waypointLink:nth-child(3n)::after {
-  display: none;
-}
-
-.waypointLink:hover .icon {
+.waypointLink:hover {
   background: var(--color-link);
   color: #fff9ef;
   transform: translateY(-3px);
 }
 
 .waypointLink:focus-visible {
-  border-radius: 6px;
   outline: 2px solid var(--color-accent);
-  outline-offset: 4px;
+  outline-offset: 3px;
+}
+
+/* Hand-rolled tooltip: the chrome sits outside the Mantine provider (see AppFooter.tsx). */
+.waypointLink::after {
+  position: absolute;
+  bottom: calc(100% + 0.55rem);
+  left: 50%;
+  padding: 0.25rem 0.6rem;
+  border: 1px solid rgba(248, 175, 64, 0.42);
+  border-radius: 999px;
+  background: rgba(17, 11, 8, 0.92);
+  color: #fff9ef;
+  font-size: 0.68rem;
+  white-space: nowrap;
+  content: attr(data-tooltip);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 3px);
+  transition:
+    opacity var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.waypointLink:hover::after,
+.waypointLink:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, 0);
 }
 
 .motionToggle {
@@ -150,21 +155,4 @@
 .motionInput:focus-visible + .motionTrack {
   outline: 2px solid var(--color-accent);
   outline-offset: 3px;
-}
-
-@media (max-width: 700px) {
-  .waypoints nav {
-    grid-template-columns: 1fr;
-  }
-
-  .waypointLink {
-    grid-template-columns: auto 1fr;
-    text-align: left;
-    align-items: center;
-    justify-items: start;
-  }
-
-  .waypointLink::after {
-    display: none;
-  }
 }

--- a/src/app/shell/AppFooter.tsx
+++ b/src/app/shell/AppFooter.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@mantine/core';
 import { ShieldCheck } from 'lucide-react';
 import { FaRedditAlien } from 'react-icons/fa6';
 import { SiBoardgamegeek, SiDiscord, SiGithub, SiStorybook } from 'react-icons/si';
@@ -26,8 +27,8 @@ const footerLinks = [
  * Public waypoints to the project's component catalogue, source, policies, and community homes —
  * and the switch that overrides the OS's reduced-motion hint for this site (see `motion.ts`). The
  * waypoints are icon-only circles; one `label` per entry fans out to the accessible name and the
- * CSS tooltip, so the two cannot come apart. The tooltip and the switch are hand-rolled because the
- * chrome sits outside `ApplicationChrome`'s Mantine provider.
+ * `Tooltip`, so the two cannot come apart. The switch stays a bare checkbox: it is bespoke footer
+ * chrome, styled with the band rather than the content theme.
  */
 export function AppFooter() {
   const motion = useMotionAllowed();
@@ -37,18 +38,18 @@ export function AppFooter() {
       <p className={styles.eyebrow}>Continue exploring</p>
       <nav aria-label="Footer">
         {footerLinks.map(({ href, icon: Icon, label }) => (
-          <a
-            aria-label={label}
-            className={styles.waypointLink}
-            data-tooltip={label}
-            href={href}
-            key={href}
-            {...(href.startsWith('https://')
-              ? { target: '_blank', rel: 'noopener noreferrer' }
-              : undefined)}
-          >
-            <Icon aria-hidden size={20} strokeWidth={1.8} />
-          </a>
+          <Tooltip key={href} label={label}>
+            <a
+              aria-label={label}
+              className={styles.waypointLink}
+              href={href}
+              {...(href.startsWith('https://')
+                ? { target: '_blank', rel: 'noopener noreferrer' }
+                : undefined)}
+            >
+              <Icon aria-hidden size={20} strokeWidth={1.8} />
+            </a>
+          </Tooltip>
         ))}
       </nav>
       <label aria-label="Ambient motion" className={styles.motionToggle}>

--- a/src/app/shell/AppFooter.tsx
+++ b/src/app/shell/AppFooter.tsx
@@ -1,53 +1,33 @@
 import { ShieldCheck } from 'lucide-react';
-import { SiBoardgamegeek, SiDiscord, SiGithub, SiReddit, SiStorybook } from 'react-icons/si';
+import { FaRedditAlien } from 'react-icons/fa6';
+import { SiBoardgamegeek, SiDiscord, SiGithub, SiStorybook } from 'react-icons/si';
 
 import styles from './AppFooter.module.css';
 import { setMotionOverride, useMotionAllowed } from './motion';
 
 const footerLinks = [
-  {
-    href: '/__storybook/',
-    icon: SiStorybook,
-    label: 'Component library',
-    note: 'Explore the interface',
-  },
-  {
-    href: 'https://github.com/ndelangen/dunezone',
-    icon: SiGithub,
-    label: 'Source code',
-    note: 'Built in the open',
-  },
-  {
-    href: '/privacy',
-    icon: ShieldCheck,
-    label: 'Privacy policy',
-    note: 'How data is handled',
-  },
+  { href: '/__storybook/', icon: SiStorybook, label: 'Component library' },
+  { href: 'https://github.com/ndelangen/dunezone', icon: SiGithub, label: 'Source code' },
+  { href: '/privacy', icon: ShieldCheck, label: 'Privacy policy' },
   {
     href: 'https://discord.com/invite/dune-tabletop-624609341886169117',
     icon: SiDiscord,
     label: 'Discord',
-    note: 'Join the conversation',
   },
-  {
-    href: 'https://www.reddit.com/r/DuneBoardGame/',
-    icon: SiReddit,
-    label: 'Reddit',
-    note: 'r/DuneBoardGame',
-  },
+  { href: 'https://www.reddit.com/r/DuneBoardGame/', icon: FaRedditAlien, label: 'Reddit' },
   {
     href: 'https://boardgamegeek.com/boardgame/283355/dune/forums/69',
     icon: SiBoardgamegeek,
     label: 'BoardGameGeek',
-    note: 'The Dune forums',
   },
 ] as const;
 
 /**
  * Public waypoints to the project's component catalogue, source, policies, and community homes —
  * and the switch that overrides the OS's reduced-motion hint for this site (see `motion.ts`). The
- * switch is a bare checkbox because the chrome sits outside `ApplicationChrome`'s Mantine
- * provider.
+ * waypoints are icon-only circles; one `label` per entry fans out to the accessible name and the
+ * CSS tooltip, so the two cannot come apart. The tooltip and the switch are hand-rolled because the
+ * chrome sits outside `ApplicationChrome`'s Mantine provider.
  */
 export function AppFooter() {
   const motion = useMotionAllowed();
@@ -56,22 +36,18 @@ export function AppFooter() {
     <div className={styles.waypoints}>
       <p className={styles.eyebrow}>Continue exploring</p>
       <nav aria-label="Footer">
-        {footerLinks.map(({ href, icon: Icon, label, note }) => (
+        {footerLinks.map(({ href, icon: Icon, label }) => (
           <a
+            aria-label={label}
             className={styles.waypointLink}
+            data-tooltip={label}
             href={href}
             key={href}
             {...(href.startsWith('https://')
               ? { target: '_blank', rel: 'noopener noreferrer' }
               : undefined)}
           >
-            <span className={styles.icon}>
-              <Icon aria-hidden size={20} strokeWidth={1.8} />
-            </span>
-            <span className={styles.linkCopy}>
-              <strong>{label}</strong>
-              <small>{note}</small>
-            </span>
+            <Icon aria-hidden size={20} strokeWidth={1.8} />
           </a>
         ))}
       </nav>

--- a/src/app/shell/AppFooter.tsx
+++ b/src/app/shell/AppFooter.tsx
@@ -1,4 +1,5 @@
-import { BookOpen, GitFork, ShieldCheck } from 'lucide-react';
+import { ShieldCheck } from 'lucide-react';
+import { SiBoardgamegeek, SiDiscord, SiGithub, SiReddit, SiStorybook } from 'react-icons/si';
 
 import styles from './AppFooter.module.css';
 import { setMotionOverride, useMotionAllowed } from './motion';
@@ -6,13 +7,13 @@ import { setMotionOverride, useMotionAllowed } from './motion';
 const footerLinks = [
   {
     href: '/__storybook/',
-    icon: BookOpen,
+    icon: SiStorybook,
     label: 'Component library',
     note: 'Explore the interface',
   },
   {
     href: 'https://github.com/ndelangen/dunezone',
-    icon: GitFork,
+    icon: SiGithub,
     label: 'Source code',
     note: 'Built in the open',
   },
@@ -22,12 +23,31 @@ const footerLinks = [
     label: 'Privacy policy',
     note: 'How data is handled',
   },
+  {
+    href: 'https://discord.com/invite/dune-tabletop-624609341886169117',
+    icon: SiDiscord,
+    label: 'Discord',
+    note: 'Join the conversation',
+  },
+  {
+    href: 'https://www.reddit.com/r/DuneBoardGame/',
+    icon: SiReddit,
+    label: 'Reddit',
+    note: 'r/DuneBoardGame',
+  },
+  {
+    href: 'https://boardgamegeek.com/boardgame/283355/dune/forums/69',
+    icon: SiBoardgamegeek,
+    label: 'BoardGameGeek',
+    note: 'The Dune forums',
+  },
 ] as const;
 
 /**
- * Public waypoints to the project's component catalogue, source, and policies — and the switch that
- * overrides the OS's reduced-motion hint for this site (see `motion.ts`). The switch is a bare
- * checkbox because the chrome sits outside `ApplicationChrome`'s Mantine provider.
+ * Public waypoints to the project's component catalogue, source, policies, and community homes —
+ * and the switch that overrides the OS's reduced-motion hint for this site (see `motion.ts`). The
+ * switch is a bare checkbox because the chrome sits outside `ApplicationChrome`'s Mantine
+ * provider.
  */
 export function AppFooter() {
   const motion = useMotionAllowed();
@@ -37,7 +57,14 @@ export function AppFooter() {
       <p className={styles.eyebrow}>Continue exploring</p>
       <nav aria-label="Footer">
         {footerLinks.map(({ href, icon: Icon, label, note }) => (
-          <a className={styles.waypointLink} href={href} key={href}>
+          <a
+            className={styles.waypointLink}
+            href={href}
+            key={href}
+            {...(href.startsWith('https://')
+              ? { target: '_blank', rel: 'noopener noreferrer' }
+              : undefined)}
+          >
             <span className={styles.icon}>
               <Icon aria-hidden size={20} strokeWidth={1.8} />
             </span>

--- a/src/app/shell/AppFooter.tsx
+++ b/src/app/shell/AppFooter.tsx
@@ -1,4 +1,5 @@
 import { Tooltip } from '@mantine/core';
+import { Link } from '@tanstack/react-router';
 import { ShieldCheck } from 'lucide-react';
 import { FaRedditAlien } from 'react-icons/fa6';
 import { SiBoardgamegeek, SiDiscord, SiGithub, SiStorybook } from 'react-icons/si';
@@ -6,20 +7,26 @@ import { SiBoardgamegeek, SiDiscord, SiGithub, SiStorybook } from 'react-icons/s
 import styles from './AppFooter.module.css';
 import { setMotionOverride, useMotionAllowed } from './motion';
 
+/* `to` marks a routed page; `href` is a destination outside the router — the static Storybook
+   build, or an external site (opened in a new tab). */
 const footerLinks = [
   { href: '/__storybook/', icon: SiStorybook, label: 'Component library' },
   { href: 'https://github.com/ndelangen/dunezone', icon: SiGithub, label: 'Source code' },
-  { href: '/privacy', icon: ShieldCheck, label: 'Privacy policy' },
+  { to: '/privacy', icon: ShieldCheck, label: 'Privacy policy' },
   {
     href: 'https://discord.com/invite/dune-tabletop-624609341886169117',
     icon: SiDiscord,
-    label: 'Discord',
+    label: 'Dune Discord server',
   },
-  { href: 'https://www.reddit.com/r/DuneBoardGame/', icon: FaRedditAlien, label: 'Reddit' },
+  {
+    href: 'https://www.reddit.com/r/DuneBoardGame/',
+    icon: FaRedditAlien,
+    label: 'r/DuneBoardGame on Reddit',
+  },
   {
     href: 'https://boardgamegeek.com/boardgame/283355/dune/forums/69',
     icon: SiBoardgamegeek,
-    label: 'BoardGameGeek',
+    label: 'Dune forums on BoardGameGeek',
   },
 ] as const;
 
@@ -37,20 +44,31 @@ export function AppFooter() {
     <div className={styles.waypoints}>
       <p className={styles.eyebrow}>Continue exploring</p>
       <nav aria-label="Footer">
-        {footerLinks.map(({ href, icon: Icon, label }) => (
-          <Tooltip key={href} label={label}>
-            <a
-              aria-label={label}
-              className={styles.waypointLink}
-              href={href}
-              {...(href.startsWith('https://')
-                ? { target: '_blank', rel: 'noopener noreferrer' }
-                : undefined)}
-            >
-              <Icon aria-hidden size={20} strokeWidth={1.8} />
-            </a>
-          </Tooltip>
-        ))}
+        {footerLinks.map((entry) => {
+          const { icon: Icon, label } = entry;
+          const glyph = <Icon aria-hidden size={20} strokeWidth={1.8} />;
+
+          return (
+            <Tooltip key={label} label={label}>
+              {'to' in entry ? (
+                <Link aria-label={label} className={styles.waypointLink} to={entry.to}>
+                  {glyph}
+                </Link>
+              ) : (
+                <a
+                  aria-label={label}
+                  className={styles.waypointLink}
+                  href={entry.href}
+                  {...(entry.href.startsWith('https://')
+                    ? { target: '_blank', rel: 'noopener noreferrer' }
+                    : undefined)}
+                >
+                  {glyph}
+                </a>
+              )}
+            </Tooltip>
+          );
+        })}
       </nav>
       <label aria-label="Ambient motion" className={styles.motionToggle}>
         <input

--- a/src/app/shell/AppRoot.test.tsx
+++ b/src/app/shell/AppRoot.test.tsx
@@ -16,7 +16,11 @@ function chrome(children: ReactNode) {
 }
 
 vi.mock('@tanstack/react-router', () => ({
-  Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
+  Link: ({ children, to, ...rest }: { children: ReactNode; to: string }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
 }));
 
 vi.mock('@db/profiles', () => ({
@@ -147,12 +151,12 @@ describe('AppRoot page header', () => {
       { href: '/privacy', label: 'Privacy policy' },
       {
         href: 'https://discord.com/invite/dune-tabletop-624609341886169117',
-        label: 'Discord',
+        label: 'Dune Discord server',
       },
-      { href: 'https://www.reddit.com/r/DuneBoardGame/', label: 'Reddit' },
+      { href: 'https://www.reddit.com/r/DuneBoardGame/', label: 'r/DuneBoardGame on Reddit' },
       {
         href: 'https://boardgamegeek.com/boardgame/283355/dune/forums/69',
-        label: 'BoardGameGeek',
+        label: 'Dune forums on BoardGameGeek',
       },
     ]);
 

--- a/src/app/shell/AppRoot.test.tsx
+++ b/src/app/shell/AppRoot.test.tsx
@@ -1,12 +1,19 @@
 /** @vitest-environment jsdom */
 
+import { MantineProvider } from '@mantine/core';
 import { PageLayout } from '@ui/layout/PageLayout';
+import { appContentTheme } from '@ui/theme';
 import { act } from 'react';
 import type { ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppRoot } from './AppRoot';
+
+/* The chrome renders inside `ApplicationChrome`'s Mantine provider; mirror that here. */
+function chrome(children: ReactNode) {
+  return <MantineProvider theme={appContentTheme}>{children}</MantineProvider>;
+}
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
@@ -18,6 +25,17 @@ vi.mock('@db/profiles', () => ({
 
 vi.mock('@convex-dev/auth/react', () => ({
   useAuthActions: () => ({ signIn: async () => {}, signOut: async () => {} }),
+}));
+
+window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
 }));
 
 class ResizeObserverStub {
@@ -41,16 +59,18 @@ describe('AppRoot page header', () => {
 
     act(() => {
       root.render(
-        <AppRoot pathname="/privacy">
-          <PageLayout>
-            <PageLayout.Header>
-              <h1>Privacy policy</h1>
-            </PageLayout.Header>
-            <PageLayout.Content>
-              <p>Privacy content</p>
-            </PageLayout.Content>
-          </PageLayout>
-        </AppRoot>
+        chrome(
+          <AppRoot pathname="/privacy">
+            <PageLayout>
+              <PageLayout.Header>
+                <h1>Privacy policy</h1>
+              </PageLayout.Header>
+              <PageLayout.Content>
+                <p>Privacy content</p>
+              </PageLayout.Content>
+            </PageLayout>
+          </AppRoot>
+        )
       );
     });
     const expandedHeader = container.querySelector('header');
@@ -60,12 +80,14 @@ describe('AppRoot page header', () => {
 
     act(() => {
       root.render(
-        <AppRoot pathname="/assets">
-          <PageLayout>
-            <h2>Assets</h2>
-            <p>Asset content</p>
-          </PageLayout>
-        </AppRoot>
+        chrome(
+          <AppRoot pathname="/assets">
+            <PageLayout>
+              <h2>Assets</h2>
+              <p>Asset content</p>
+            </PageLayout>
+          </AppRoot>
+        )
       );
     });
 
@@ -81,9 +103,11 @@ describe('AppRoot page header', () => {
 
     act(() => {
       root.render(
-        <AppRoot pathname="/privacy">
-          <p>Privacy content</p>
-        </AppRoot>
+        chrome(
+          <AppRoot pathname="/privacy">
+            <p>Privacy content</p>
+          </AppRoot>
+        )
       );
     });
 
@@ -104,21 +128,32 @@ describe('AppRoot page header', () => {
 
     act(() => {
       root.render(
-        <AppRoot pathname="/privacy">
-          <p>Privacy content</p>
-        </AppRoot>
+        chrome(
+          <AppRoot pathname="/privacy">
+            <p>Privacy content</p>
+          </AppRoot>
+        )
       );
     });
 
     expect(
       [...container.querySelectorAll('footer nav a')].map((link) => ({
         href: link.getAttribute('href'),
-        label: link.querySelector('strong')?.textContent,
+        label: link.getAttribute('aria-label'),
       }))
     ).toEqual([
       { href: '/__storybook/', label: 'Component library' },
       { href: 'https://github.com/ndelangen/dunezone', label: 'Source code' },
       { href: '/privacy', label: 'Privacy policy' },
+      {
+        href: 'https://discord.com/invite/dune-tabletop-624609341886169117',
+        label: 'Discord',
+      },
+      { href: 'https://www.reddit.com/r/DuneBoardGame/', label: 'Reddit' },
+      {
+        href: 'https://boardgamegeek.com/boardgame/283355/dune/forums/69',
+        label: 'BoardGameGeek',
+      },
     ]);
 
     act(() => root.unmount());

--- a/src/app/shell/ApplicationChrome.tsx
+++ b/src/app/shell/ApplicationChrome.tsx
@@ -12,7 +12,11 @@ export interface ApplicationChromeProps {
   pathname: string;
 }
 
-/** Application-only shell and Mantine provider, kept outside bare renderer routes. */
+/**
+ * Application-only shell and Mantine provider, kept outside bare renderer routes. The provider
+ * wraps the chrome too — the shell's markup stays plain CSS-module styling, but its components (the
+ * footer's tooltips) reuse the same Mantine primitives as page content.
+ */
 export function ApplicationChrome({ children, pathname }: ApplicationChromeProps) {
   useEffect(
     () => () => {
@@ -22,10 +26,8 @@ export function ApplicationChrome({ children, pathname }: ApplicationChromeProps
   );
 
   return (
-    <AppRoot pathname={pathname}>
-      <MantineProvider theme={appContentTheme} forceColorScheme="light">
-        {children}
-      </MantineProvider>
-    </AppRoot>
+    <MantineProvider theme={appContentTheme} forceColorScheme="light">
+      <AppRoot pathname={pathname}>{children}</AppRoot>
+    </MantineProvider>
   );
 }


### PR DESCRIPTION
## What

Two related changes to how the site's external community/project links render:

1. **Homepage community band** ("A living game needs a living community"): Discord · Reddit · BoardGameGeek text links are now brand icon links.
2. **Footer**: the community links join "Continue exploring", and the whole footer nav is now a single compact row of six icon-only circles with the app's standard tooltips — Storybook, GitHub, Privacy, Discord, Reddit, BoardGameGeek. Storybook and GitHub trade their generic lucide glyphs for their brand marks, and the privacy waypoint now routes through the typed router `Link` (it was a full-reload `<a>`).

## How

- Glyphs come from **Simple Icons via `react-icons/si`** — the repo's existing brand-glyph precedent (the login page's `SiDiscord`) — except Reddit, which uses **`FaRedditAlien` (react-icons/fa6)**: Simple Icons' snoo-in-a-filled-circle turned to mush inside the footer's circular waypoint, so the bare alien mark is used in both surfaces. `public/` and `src/game/assets` hold only first-party game art, so no SVG files were added there.
- **Band:** the three links stay Mantine `Anchor`s driven by one `communityLinks` array, each wrapped in a `Tooltip` with a matching `aria-label` (SVG `aria-hidden`). Nothing is hardcoded color-wise — glyphs inherit `currentColor` from `Anchor`'s `--mantine-color-anchor` (dune-8 `#84220c` = `--color-link` in light; dune-4 amber in dark). Kit `IconAction` was deliberately not used: Mantine's subtle/transparent ActionIcon variants clamp explicit shades to ≤6, so they can't reach the shade-8 link amber without hardcoding a hex, which would also break the dark-scheme anchor swap.
- **Footer:** `ApplicationChrome`'s `MantineProvider` now wraps the chrome too — the provider renders no DOM, so the shell's markup and CSS-module styling are untouched, but the footer reuses the standard Mantine `Tooltip` instead of a hand-rolled CSS one. One `label` per waypoint fans out to both the `aria-label` and the `Tooltip`; entries carry `to` (routed page) or `href` (outside the router), and `https://` destinations open with `target="_blank" rel="noopener noreferrer"`. Community labels use the same descriptive vocabulary as the band ("Dune Discord server", "r/DuneBoardGame on Reddit", "Dune forums on BoardGameGeek").
- **Test:** `AppRoot.test.tsx` renders inside the provider (mirroring the production doorway), stubs `matchMedia` per the repo's existing pattern, passes props through its router-`Link` mock, and asserts the six-waypoint contract via `aria-label`s.

## Verification

- `typecheck`, `oxlint --deny-warnings`, `oxfmt --check`, the CSS-orphan check, and the full unit suite (448 tests / 72 files) all pass.
- Verified live (dev app + Storybook `Shell/AppFooter`): six circles with standard Mantine tooltips; band links compute to `rgb(132, 34, 12)` = `--color-link`; external links carry `target`/`rel`; clicking the privacy waypoint navigates client-side (no full reload — verified by a window mark surviving the navigation).
- Two `/code-review` passes (standards + spec axes) — the final pass's findings (privacy `Link`, label vocabulary) are fixed in `50ea6bed2ec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added icon-based community links for Discord, Reddit, and BoardGameGeek.
  * Added tooltips and accessible labels to footer and community navigation links.
  * External links now open safely in new browser tabs.

* **Style**
  * Improved circular link controls, hover states, keyboard focus indicators, and responsive footer layout.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->