### PR TITLE
Persist grouped faction complexity

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,15 @@ _Avoid_: Featured faction
 **Faction card**:
 A reusable, identity-first summary of a faction shown in discovery grids, including the Faction catalogue and profile detail pages. It communicates faction identity and ruleset membership; stewardship and complete game content belong on the faction detail page.
 
+**Calculated complexity rating**:
+The required estimate of how hard a faction is to play, derived from its rules. It remains distinct from an author's judgment so the estimate can be inspected and retuned without erasing that judgment.
+
+**Manual complexity rating**:
+An optional author-chosen assessment of how hard a faction is to play. When present, it overrides the Calculated complexity rating on reader-facing surfaces without replacing it.
+
+**Effective complexity rating**:
+The rating presented to readers: the Manual complexity rating when one exists, otherwise the Calculated complexity rating. It is a selection between the two ratings, not an independently maintained rating.
+
 **Profile summary**:
 The public identity chip for a person referenced by content they are shown on — profile identity, URL slug, display name, and avatar. It is one shape everywhere a contributor appears on content (FAQ askers and answerers, Group owners and rosters, ruleset owners), distinct from the full profile.
 

--- a/convex/factions.authoringRoundTrip.test.ts
+++ b/convex/factions.authoringRoundTrip.test.ts
@@ -6,6 +6,7 @@ import { convexTest } from 'convex-test';
 import { describe, expect, test } from 'vitest';
 
 import { PLANET, TROOP_MODIFIER } from '../src/shared/assetIds';
+import { recalculateFactionComplexity } from '../src/shared/factions/complexity';
 import { assetPublishingFaction } from '../src/shared/factions/fixtures/assetPublishingFaction';
 import { CanonicalFactionStoredSchema, FactionInputSchema } from '../src/shared/factions/schema';
 import type { FactionInput } from '../src/shared/factions/schema';
@@ -15,7 +16,7 @@ import schema from './schema';
 const modules = import.meta.glob('./**/*.ts');
 
 function representativeFullFieldFaction(): FactionInput {
-  return FactionInputSchema.parse({
+  const input = {
     ...structuredClone(assetPublishingFaction),
     name: 'Complete Authoring Proof',
     colors: [
@@ -162,10 +163,50 @@ function representativeFullFieldFaction(): FactionInput {
         ],
       },
     ],
-  });
+  };
+  return FactionInputSchema.parse(recalculateFactionComplexity(input));
 }
 
 describe('faction authoring full-field round trip', () => {
+  test('normalizes stale scalar writes while trusting grouped client calculations', async () => {
+    const t = convexTest(schema, modules);
+    aggregateTest.register(t, 'statistics');
+    aggregateTest.register(t, 'profileActivity');
+    aggregateTest.register(t, 'profileDiscovery');
+    const userId = await t.run(
+      async (ctx) => await ctx.db.insert('users', { name: 'Faction transition proof user' })
+    );
+    const asUser = t.withIdentity({ subject: userId });
+    const { complexity: _complexity, ...legacyData } = structuredClone(assetPublishingFaction);
+
+    const legacyCreated = await asUser.mutation(api.factions.create, {
+      data: { ...legacyData, name: 'Legacy Scalar Proof', complexity: 0.6 },
+      group_id: null,
+    });
+    expect(legacyCreated.data.complexity).toEqual({
+      calculated: assetPublishingFaction.complexity.calculated,
+      manual: 0.6,
+    });
+    const legacyUpdated = await asUser.mutation(api.factions.update, {
+      id: legacyCreated._id,
+      data: { ...legacyData, name: 'Legacy Scalar Proof Updated', complexity: 0.7 },
+    });
+    expect(legacyUpdated.data.complexity).toEqual({
+      calculated: assetPublishingFaction.complexity.calculated,
+      manual: 0.7,
+    });
+
+    const groupedCreated = await asUser.mutation(api.factions.create, {
+      data: {
+        ...legacyData,
+        name: 'Grouped Trust Proof',
+        complexity: { calculated: 0.123, manual: 0.4 },
+      },
+      group_id: null,
+    });
+    expect(groupedCreated.data.complexity).toEqual({ calculated: 0.123, manual: 0.4 });
+  });
+
   test('creates, schedules, reloads, edits, and shares every admitted field without loss', async () => {
     const t = convexTest(schema, modules);
     aggregateTest.register(t, 'statistics');
@@ -274,7 +315,7 @@ describe('faction authoring full-field round trip', () => {
       ],
     });
 
-    const editedInput: FactionInput = {
+    const editedInput: FactionInput = recalculateFactionComplexity({
       ...structuredClone(createdInput),
       name: 'Complete Authoring Proof Revised',
       colors: [...createdInput.colors].reverse(),
@@ -286,7 +327,7 @@ describe('faction authoring full-field round trip', () => {
         ...structuredClone(createdInput.rules),
         advantages: [...createdInput.rules.advantages].reverse(),
       },
-    };
+    });
     const updatedRow = await asUser.mutation(api.factions.update, {
       id: createdRow._id,
       data: editedInput,

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -1,6 +1,5 @@
 import { v } from 'convex/values';
 
-import { CanonicalFactionStoredSchema } from '../src/shared/factions/schema';
 import type { Doc, Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 import { factionSheetPublishingStatus } from './assetPublishingStatus';
@@ -20,7 +19,7 @@ import {
 } from './lib/collaborativeAccessValidators';
 import { loadFactionCatalogue, selectFactionCatalogueSpotlights } from './lib/factionCatalogue';
 import { factionDataValidator } from './lib/factionData';
-import { parseFactionInput } from './lib/factionInput';
+import { parseFactionInput, parseStoredFactionForRead } from './lib/factionInput';
 import {
   buildOwnedForGroupAssignRows,
   OWNED_FOR_GROUP_ASSIGN_LIMIT,
@@ -46,7 +45,7 @@ async function assertFactionSlugAvailable(
 }
 
 function factionDataForClient(data: unknown) {
-  return CanonicalFactionStoredSchema.parse(data);
+  return parseStoredFactionForRead(data);
 }
 
 function factionRowForClient(row: Doc<'factions'>) {

--- a/convex/lib/factionCatalogue.ts
+++ b/convex/lib/factionCatalogue.ts
@@ -1,7 +1,7 @@
-import { CanonicalFactionStoredSchema } from '../../src/shared/factions/schema';
 import type { FactionInput } from '../../src/shared/factions/schema';
 import type { Doc, Id } from '../_generated/dataModel';
 import type { QueryCtx } from '../types';
+import { parseStoredFactionForRead } from './factionInput';
 
 export type FactionRulesetSummary = {
   id: Id<'rulesets'>;
@@ -56,7 +56,7 @@ export async function loadFactionCatalogue(
 
   const factions = rows.map((row) => ({
     ...row,
-    data: CanonicalFactionStoredSchema.parse(row.data),
+    data: parseStoredFactionForRead(row.data),
     rulesets: (linksByFaction.get(row._id) ?? [])
       .map((rulesetId) => activeRulesetById.get(rulesetId))
       .filter((ruleset): ruleset is FactionRulesetSummary => ruleset != null)
@@ -108,7 +108,7 @@ export async function loadFactionCatalogueSpotlightPreviews(ctx: QueryCtx) {
     if (!row) {
       return null;
     }
-    const faction = CanonicalFactionStoredSchema.parse(row.data);
+    const faction = parseStoredFactionForRead(row.data);
     return {
       slug: row.slug,
       created_at: row.created_at,

--- a/convex/lib/factionInput.ts
+++ b/convex/lib/factionInput.ts
@@ -1,11 +1,19 @@
-import { CanonicalFactionStoredSchema, FactionInputSchema } from '../../src/shared/factions/schema';
+import { normalizeStoredFactionComplexity } from '../../src/shared/factions/complexity';
+import {
+  CanonicalFactionStoredSchema,
+  TransitionalFactionInputSchema,
+} from '../../src/shared/factions/schema';
+
+export function parseStoredFactionForRead(input: unknown) {
+  return normalizeStoredFactionComplexity(CanonicalFactionStoredSchema.parse(input));
+}
 
 export function parseFactionInput(
   input: unknown,
   { requireAuthoringSemantics = false }: { requireAuthoringSemantics?: boolean } = {}
 ) {
   const parsed = (
-    requireAuthoringSemantics ? FactionInputSchema : CanonicalFactionStoredSchema
+    requireAuthoringSemantics ? TransitionalFactionInputSchema : CanonicalFactionStoredSchema
   ).safeParse(input);
   if (!parsed.success) {
     const firstIssue = parsed.error.issues[0];

--- a/convex/migrations.factionComplexity.test.ts
+++ b/convex/migrations.factionComplexity.test.ts
@@ -1,0 +1,103 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import aggregateTest from '@convex-dev/aggregate/test';
+import migrationsTest from '@convex-dev/migrations/test';
+import { convexTest } from 'convex-test';
+import { describe, expect, test } from 'vitest';
+
+import { calculateComplexity } from '../src/shared/factions/complexity';
+import { assetPublishingFaction } from '../src/shared/factions/fixtures/assetPublishingFaction';
+import { api, internal } from './_generated/api';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+const now = '2026-08-16T00:00:00.000Z';
+
+function withoutComplexity() {
+  const { complexity: _complexity, ...data } = structuredClone(assetPublishingFaction);
+  return data;
+}
+
+async function migrationTest() {
+  const t = convexTest(schema, modules);
+  aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileActivity');
+  aggregateTest.register(t, 'profileDiscovery');
+  migrationsTest.register(t);
+  const ids = await t.run(async (ctx) => {
+    const ownerId = await ctx.db.insert('users', { name: 'Complexity migration owner' });
+    await ctx.db.insert('profiles', {
+      user_id: ownerId,
+      username: 'Complexity migration owner',
+      avatar_url: null,
+      slug: 'complexity-migration-owner',
+      created_at: now,
+      updated_at: now,
+    });
+    const insert = async (slug: string, data: unknown) =>
+      await ctx.db.insert('factions', {
+        owner_id: ownerId,
+        data,
+        slug,
+        created_at: now,
+        updated_at: now,
+        is_deleted: false,
+        group_id: null,
+      });
+    return {
+      absent: await insert('complexity-absent', withoutComplexity()),
+      scalar: await insert('complexity-scalar', { ...withoutComplexity(), complexity: 0.7 }),
+      staleGrouped: await insert('complexity-stale-grouped', {
+        ...withoutComplexity(),
+        complexity: { calculated: 0.01, manual: 0.4 },
+      }),
+    };
+  });
+  return { t, ids };
+}
+
+describe('faction grouped complexity migration', () => {
+  test('backfills accurate calculated values and preserves legacy manual ratings', async () => {
+    const { t, ids } = await migrationTest();
+    const calculated = calculateComplexity(assetPublishingFaction.rules);
+
+    const legacyDetail = await t.query(api.factions.getBySlug, { slug: 'complexity-scalar' });
+    const legacyCatalogue = await t.query(api.factions.cataloguePage, {});
+    expect(legacyDetail.faction.data.complexity).toEqual({ calculated, manual: 0.7 });
+    expect(
+      legacyCatalogue.factions.find((faction) => faction._id === ids.absent)?.data.complexity
+    ).toEqual({ calculated });
+
+    await t.mutation(internal.migrations.faction_complexity_grouped_v1, {});
+    await t.mutation(internal.migrations.faction_complexity_grouped_verify_v1, {});
+
+    const rows = await t.run(async (ctx) => ({
+      absent: await ctx.db.get('factions', ids.absent),
+      scalar: await ctx.db.get('factions', ids.scalar),
+      staleGrouped: await ctx.db.get('factions', ids.staleGrouped),
+    }));
+    expect(rows.absent?.data.complexity).toEqual({ calculated });
+    expect(rows.scalar?.data.complexity).toEqual({ calculated, manual: 0.7 });
+    expect(rows.staleGrouped?.data.complexity).toEqual({ calculated, manual: 0.4 });
+  });
+
+  test('verification rejects inaccurate grouped values', async () => {
+    const { t, ids } = await migrationTest();
+
+    await t.mutation(internal.migrations.faction_complexity_grouped_v1, {});
+    await t.run(async (ctx) => {
+      const row = await ctx.db.get('factions', ids.absent);
+      if (!row) {
+        throw new Error('Missing migrated faction');
+      }
+      await ctx.db.patch(row._id, {
+        data: { ...row.data, complexity: { calculated: 0.01 } },
+      });
+    });
+
+    const result = await t.mutation(internal.migrations.faction_complexity_grouped_verify_v1, {});
+
+    expect(result.Status).toMatch(/Migration failed: .*expected/);
+  });
+});

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -2,6 +2,11 @@ import { Migrations } from '@convex-dev/migrations';
 import type { FunctionReference } from 'convex/server';
 import { v } from 'convex/values';
 
+import {
+  calculateComplexity,
+  recalculateFactionComplexity,
+} from '../src/shared/factions/complexity';
+import { CanonicalFactionStoredSchema } from '../src/shared/factions/schema';
 import { DEFAULT_FAQ_TAG } from '../src/shared/faq/tags';
 import { components, internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
@@ -51,6 +56,8 @@ const MIGRATION_IDS: Record<string, MigrationRef> = {
   faction_decal_retune_v1: internal.migrations.faction_decal_retune_v1,
   groups_soft_delete_backfill_v1: internal.migrations.groups_soft_delete_backfill_v1,
   groups_soft_delete_verify_v1: internal.migrations.groups_soft_delete_verify_v1,
+  faction_complexity_grouped_v1: internal.migrations.faction_complexity_grouped_v1,
+  faction_complexity_grouped_verify_v1: internal.migrations.faction_complexity_grouped_verify_v1,
 };
 
 type MigrationId = keyof typeof MIGRATION_IDS;
@@ -418,6 +425,42 @@ export const faction_decal_retune_v1 = migrations.define({
       return;
     }
     return { data: { ...data, decals } };
+  },
+});
+
+/** Backfills the grouped record with the current shared calculation and any legacy manual value. */
+export const faction_complexity_grouped_v1 = migrations.define({
+  table: 'factions',
+  batchSize: 50,
+  migrateOne: async (_ctx, row) => {
+    const data = CanonicalFactionStoredSchema.parse(row.data);
+    const next = recalculateFactionComplexity(data);
+    if (
+      typeof data.complexity === 'object' &&
+      data.complexity.calculated === next.complexity.calculated &&
+      data.complexity.manual === next.complexity.manual
+    ) {
+      return;
+    }
+    return { data: next };
+  },
+});
+
+/** Successful completion proves every faction has an accurate grouped calculated value. */
+export const faction_complexity_grouped_verify_v1 = migrations.define({
+  table: 'factions',
+  batchSize: 50,
+  migrateOne: async (_ctx, row) => {
+    const data = CanonicalFactionStoredSchema.parse(row.data);
+    if (typeof data.complexity !== 'object') {
+      throw new Error(`Faction ${row._id} still has legacy complexity storage`);
+    }
+    const expected = calculateComplexity(data.rules);
+    if (data.complexity.calculated !== expected) {
+      throw new Error(
+        `Faction ${row._id} has calculated complexity ${data.complexity.calculated}; expected ${expected}`
+      );
+    }
   },
 });
 

--- a/src/app/db/factions.ts
+++ b/src/app/db/factions.ts
@@ -1,3 +1,4 @@
+import { recalculateFactionComplexity } from '@shared/factions/complexity';
 import { CanonicalFactionClientSchema, FactionInputSchema } from '@shared/factions/schema';
 import type { FactionInput } from '@shared/factions/schema';
 import { useQuery } from 'convex/react';
@@ -210,7 +211,7 @@ export function useCreateFaction() {
     ) =>
       mutation.mutate(
         {
-          data: FactionInputSchema.parse(variables.input),
+          data: FactionInputSchema.parse(recalculateFactionComplexity(variables.input)),
           group_id: variables.groupId ?? null,
         },
         {
@@ -219,7 +220,7 @@ export function useCreateFaction() {
         }
       ),
     mutateAsync: async ({ input, groupId }: { input: Faction; groupId?: string | null }) => {
-      const validatedData = FactionInputSchema.parse(input);
+      const validatedData = FactionInputSchema.parse(recalculateFactionComplexity(input));
       const entry = await mutation.mutateAsync({
         data: validatedData,
         group_id: groupId ?? null,
@@ -241,7 +242,7 @@ export function useUpdateFaction() {
       mutation.mutate(
         {
           id: variables.id,
-          data: FactionInputSchema.parse(variables.input),
+          data: FactionInputSchema.parse(recalculateFactionComplexity(variables.input)),
         },
         {
           onSuccess: (entry) => options?.onSuccess?.(toFactionEntry(entry)),
@@ -256,7 +257,7 @@ export function useUpdateFaction() {
       id: string;
       previousUrlSlug?: string;
     }) => {
-      const validatedData = FactionInputSchema.parse(input);
+      const validatedData = FactionInputSchema.parse(recalculateFactionComplexity(input));
       const entry = await mutation.mutateAsync({
         id,
         data: validatedData,

--- a/src/app/pickers/FactionPicker.tsx
+++ b/src/app/pickers/FactionPicker.tsx
@@ -10,7 +10,7 @@ import {
   Text,
   Title,
 } from '@mantine/core';
-import { CanonicalFactionStoredSchema } from '@shared/factions/schema';
+import { FactionInputSchema } from '@shared/factions/schema';
 import { Link } from '@tanstack/react-router';
 import { Surface } from '@ui/surface';
 import { useMemo, useState } from 'react';
@@ -93,7 +93,7 @@ export function FactionPicker({ currentPublicSlug, onLoaded, onCancel }: Faction
     if (!selectedRow) {
       return;
     }
-    const parsed = CanonicalFactionStoredSchema.safeParse(selectedRow.data);
+    const parsed = FactionInputSchema.safeParse(selectedRow.data);
     if (!parsed.success) {
       setError(formatZodIssues(parsed.error));
       return;

--- a/src/app/routes/_app/factions/-catalogue.test.ts
+++ b/src/app/routes/_app/factions/-catalogue.test.ts
@@ -35,7 +35,7 @@ function faction(
     data: {
       ...assetPublishingFaction,
       name,
-      ...(options.complexity == null ? {} : { complexity: options.complexity }),
+      ...(options.complexity == null ? {} : { complexity: { calculated: options.complexity } }),
       hero: { ...assetPublishingFaction.hero, name: options.hero ?? 'Lady Jessica' },
       leaders: (options.leaders ?? ['Duncan Idaho']).map((leader, index) => ({
         ...assetPublishingFaction.leaders[index],

--- a/src/app/ui/content/complexity.test.ts
+++ b/src/app/ui/content/complexity.test.ts
@@ -1,3 +1,7 @@
+import {
+  normalizeStoredFactionComplexity,
+  recalculateFactionComplexity,
+} from '@shared/factions/complexity';
 import type { FactionInput } from '@shared/factions/schema';
 import { describe, expect, it } from 'vitest';
 
@@ -82,8 +86,36 @@ describe('calculateComplexity', () => {
 describe('effectiveComplexity', () => {
   it('prefers the manual rating and falls back to the calculation', () => {
     const rules = rulesWith({ startText: wordsOf(COMPLEXITY_CAPACITY_WORDS) });
+    expect(effectiveComplexity({ rules, complexity: { calculated: 0.8, manual: 0.2 } })).toBe(0.2);
+    expect(effectiveComplexity({ rules, complexity: { calculated: 0.8 } })).toBe(0.8);
     expect(effectiveComplexity({ rules, complexity: 0.2 })).toBe(0.2);
     expect(effectiveComplexity({ rules })).toBe(1);
+  });
+});
+
+describe('stored complexity records', () => {
+  it('uses stored grouped calculations on reads and only calculates legacy states', () => {
+    const rules = rulesWith({ startText: wordsOf(COMPLEXITY_CAPACITY_WORDS) });
+
+    expect(
+      normalizeStoredFactionComplexity({ rules, complexity: { calculated: 0.123 } }).complexity
+    ).toEqual({ calculated: 0.123 });
+    expect(normalizeStoredFactionComplexity({ rules, complexity: 0.4 }).complexity).toEqual({
+      calculated: 1,
+      manual: 0.4,
+    });
+    expect(normalizeStoredFactionComplexity({ rules }).complexity).toEqual({ calculated: 1 });
+  });
+
+  it('recalculates before writes while preserving only the manual rating', () => {
+    const rules = rulesWith({ startText: wordsOf(COMPLEXITY_CAPACITY_WORDS) });
+
+    expect(
+      recalculateFactionComplexity({
+        rules,
+        complexity: { calculated: 0.123, manual: 0.4 },
+      }).complexity
+    ).toEqual({ calculated: 1, manual: 0.4 });
   });
 });
 

--- a/src/app/ui/content/complexity.ts
+++ b/src/app/ui/content/complexity.ts
@@ -1,4 +1,11 @@
+import { calculateComplexity } from '@shared/factions/complexity';
 import type { FactionInput } from '@shared/factions/schema';
+
+export {
+  COMPLEXITY_CAPACITY_WORDS,
+  calculateComplexity,
+  effectiveComplexity,
+} from '@shared/factions/complexity';
 
 type FactionRules = FactionInput['rules'];
 
@@ -6,98 +13,15 @@ type FactionRules = FactionInput['rules'];
  * How hard a faction is to play, as a 0..1 score derived from the amount of rules text the printed
  * sheet must carry. Calibrated against the live corpus (see wayfinder #405): the grace floor keeps
  * near-empty drafts at 0, the capacity anchor marks the word count at which text stops fitting the
- * sheet, and adjustments capture complexity that word count alone misses. The author's manual
- * `complexity` field, when present, always wins over the calculation.
+ * sheet, and adjustments capture complexity that word count alone misses. The optional stored
+ * manual rating wins over the stored calculated rating on reader-facing surfaces.
  */
-
-/** Below this many words the score stays 0 — every faction needs some baseline text. */
-const COMPLEXITY_GRACE_FLOOR_WORDS = 80;
-
-/** At this many words the base score reaches 1.0 — roughly the printed sheet's capacity. */
-export const COMPLEXITY_CAPACITY_WORDS = 700;
-
-/** Advantages beyond this count each add {@link COMPLEXITY_MANY_ADVANTAGES_STEP} to the score. */
-const COMPLEXITY_MANY_ADVANTAGES_THRESHOLD = 8;
-const COMPLEXITY_MANY_ADVANTAGES_STEP = 0.03;
 
 /** A manual rating this far from the calculation earns the editor's deviation advisory. */
 const COMPLEXITY_DEVIATION_THRESHOLD_POINTS = 3;
 
 /** A calculated score at or above this earns the editor's near-capacity advisory. */
 const COMPLEXITY_NEAR_CAPACITY = 0.9;
-
-/**
- * A tuning rule applied after the base curve; the sum is clamped to 0..1. Adding one is a single
- * entry here plus a test.
- */
-type ComplexityAdjustment = {
-  id: string;
-  apply: (rules: FactionRules) => number;
-};
-
-const COMPLEXITY_ADJUSTMENTS: ComplexityAdjustment[] = [
-  {
-    /* Many separate rules cost table overhead and sheet headers beyond their words. */
-    id: 'many-advantages',
-    apply: (rules) =>
-      Math.max(0, rules.advantages.length - COMPLEXITY_MANY_ADVANTAGES_THRESHOLD) *
-      COMPLEXITY_MANY_ADVANTAGES_STEP,
-  },
-];
-
-function words(text: string | undefined): number {
-  if (!text) {
-    return 0;
-  }
-  return (
-    text
-      /* A markdown link renders only its text — the URL never reaches the sheet. */
-      .replace(/\]\([^)]*\)/g, '] ')
-      /* Fenced-code markers and their optional language metadata render no text. */
-      .replace(/^[ \t]*(?:`{3,}|~{3,})[^\r\n]*$/gm, ' ')
-      /* Block markers and thematic breaks occupy source bytes but render no words. */
-      .replace(/^[ \t]*(?:[-+*]|\d+[.)])[ \t]+/gm, '')
-      .replace(/^[ \t]*(?:[-*_][ \t]*){3,}$/gm, ' ')
-      .replace(/[*_~`#>[\]()]/g, ' ')
-      .split(/\s+/)
-      .filter(Boolean).length
-  );
-}
-
-/** Word count over exactly the text the faction sheet renders, markdown syntax stripped. */
-function sheetWordCount(rules: FactionRules): number {
-  return (
-    words(rules.startText) +
-    words(rules.revivalText) +
-    words(rules.alliance.text) +
-    words(rules.fate.title) +
-    words(rules.fate.text) +
-    rules.advantages.reduce(
-      (sum, rule) => sum + words(rule.title) + words(rule.text) + words(rule.karama),
-      0
-    )
-  );
-}
-
-/** The calculated 0..1 complexity of a rules block — never reads the manual field. */
-export function calculateComplexity(rules: FactionRules): number {
-  const total = sheetWordCount(rules);
-  const base =
-    total <= COMPLEXITY_GRACE_FLOOR_WORDS
-      ? 0
-      : Math.min(
-          1,
-          (total - COMPLEXITY_GRACE_FLOOR_WORDS) /
-            (COMPLEXITY_CAPACITY_WORDS - COMPLEXITY_GRACE_FLOOR_WORDS)
-        );
-  const adjusted = COMPLEXITY_ADJUSTMENTS.reduce((sum, rule) => sum + rule.apply(rules), base);
-  return Math.min(1, Math.max(0, adjusted));
-}
-
-/** The rating surfaces actually show: the author's manual rating when set, else the calculation. */
-export function effectiveComplexity(data: Pick<FactionInput, 'rules' | 'complexity'>): number {
-  return data.complexity ?? calculateComplexity(data.rules);
-}
 
 export type ComplexityTier = 'novice' | 'intermediate' | 'expert' | 'master';
 

--- a/src/app/widgets/faction-editor/FactionComplexityIndicator.tsx
+++ b/src/app/widgets/faction-editor/FactionComplexityIndicator.tsx
@@ -17,7 +17,7 @@ export function FactionComplexityIndicator({ form }: { form: FactionFormApi }) {
     <form.Subscribe
       selector={(state: { values: FactionInput }) => ({
         rules: state.values.rules,
-        manual: state.values.complexity,
+        manual: state.values.complexity.manual,
       })}
     >
       {({ rules, manual }) => {

--- a/src/app/widgets/faction-editor/FactionFormFields.tsx
+++ b/src/app/widgets/faction-editor/FactionFormFields.tsx
@@ -9,6 +9,7 @@ import {
   Stack,
   Text,
 } from '@mantine/core';
+import { recalculateFactionComplexity } from '@shared/factions/complexity';
 import { FactionCard } from '@ui/block/FactionCard';
 import { effectiveComplexity } from '@ui/content/complexity';
 import { ComplexityGlyph } from '@ui/content/ComplexityGlyph';
@@ -85,7 +86,12 @@ function ChapterIcon({
     return (
       <form.Subscribe
         selector={(state) =>
-          effectiveComplexity({ rules: state.values.rules, complexity: state.values.complexity })
+          effectiveComplexity(
+            recalculateFactionComplexity({
+              rules: state.values.rules,
+              complexity: state.values.complexity,
+            })
+          )
         }
       >
         {(score) => <ComplexityGlyph score={score} size={21} decorative />}
@@ -284,7 +290,7 @@ function ArtifactProof({
                     _id: 'complexity-proof',
                     slug: 'complexity-proof',
                     rulesets: [],
-                    data: faction,
+                    data: recalculateFactionComplexity(faction),
                   } as unknown as FactionCatalogueEntry
                 }
               />

--- a/src/app/widgets/faction-editor/FactionFormSectionComplexity.tsx
+++ b/src/app/widgets/faction-editor/FactionFormSectionComplexity.tsx
@@ -26,18 +26,18 @@ function complexityModeDescription({
 }) {
   const calculated10 = complexityOutOfTen(calculated);
   if (active) {
-    return `Rules-text estimate: ${calculated10}/10. Your rating is saved with the faction.`;
+    return `Rules-text estimate: ${calculated10}/10. Both it and your rating are saved with the faction.`;
   }
   if (retainedManual == null) {
-    return `Automatic estimate: ${calculated10}/10. Nothing is stored; the rating tracks your edits.`;
+    return `Automatic estimate: ${calculated10}/10. It is saved with the faction and tracks your edits.`;
   }
   return `Automatic estimate: ${calculated10}/10. The disabled slider keeps your last manual ${complexityOutOfTen(retainedManual)}/10 rating for when you switch back.`;
 }
 
 /**
- * The Complexity chapter: an override-switch over the `complexity` field. The slider is always
- * visible — disabled while the rating is automatic — and keeps its last manual value when the
- * switch turns off, though only an active manual rating is stored (absent field = automatic).
+ * The Complexity chapter: an override-switch over `complexity.manual`. The slider is always visible
+ * — disabled while the rating is automatic — and keeps its last manual value when the switch turns
+ * off, though only an active manual rating is stored (absent field = automatic).
  */
 export function FactionFormSectionComplexity({
   form,
@@ -53,7 +53,7 @@ export function FactionFormSectionComplexity({
     <form.Subscribe selector={(state: { values: FactionInput }) => state.values.rules}>
       {(rules) => {
         return (
-          <form.Field name="complexity">
+          <form.Field name="complexity.manual">
             {(field) => {
               const manual = field.state.value;
               const {

--- a/src/app/widgets/faction-editor/defaultFaction.ts
+++ b/src/app/widgets/faction-editor/defaultFaction.ts
@@ -1,4 +1,5 @@
 import { LEADERS, LOGO, TROOP } from '@shared/assetIds';
+import { recalculateFactionComplexity } from '@shared/factions/complexity';
 import { FactionInputSchema } from '@shared/factions/schema';
 
 import type { Faction } from '@db/factions';
@@ -49,7 +50,9 @@ const defaultFactionInput = {
       text: 'Fate rules text.',
     },
   },
-} satisfies Faction;
+} satisfies Omit<Faction, 'complexity'>;
 
 /** Valid starter document for the faction editor (create + reset). */
-export const defaultFaction: Faction = FactionInputSchema.parse(defaultFactionInput);
+export const defaultFaction: Faction = FactionInputSchema.parse(
+  recalculateFactionComplexity(defaultFactionInput)
+);

--- a/src/app/widgets/faction-editor/factionAuthoringContract.ts
+++ b/src/app/widgets/faction-editor/factionAuthoringContract.ts
@@ -165,7 +165,7 @@ export function preserveFactionExtras(values: Faction, baseline: Faction): Facti
   return next;
 }
 
-type FactionAuthoringCoverageState = 'control' | 'preserved';
+type FactionAuthoringCoverageState = 'control' | 'derived' | 'preserved';
 
 type CoverageEntry = {
   state: FactionAuthoringCoverageState;
@@ -180,9 +180,8 @@ function coverage(paths: readonly string[], entry: CoverageEntry): Record<string
 /**
  * Leaf-path coverage for FactionInputSchema.
  *
- * `preserved` is the sole product-approved no-control exception. There is no temporary/planned
- * state: every newly admitted schema leaf must ship with a domain control or fail this contract
- * until an explicit exception is approved.
+ * A non-control leaf must identify its owner: `derived` values are generated at the save boundary;
+ * `preserved` values round-trip unchanged. There is no temporary/planned state.
  */
 export const factionAuthoringCoverage: Readonly<Record<string, CoverageEntry>> = {
   ...coverage(['name', 'logo', 'themeColor', 'colors[]'], {
@@ -271,7 +270,11 @@ export const factionAuthoringCoverage: Readonly<Record<string, CoverageEntry>> =
     ['rules.advantages[].title', 'rules.advantages[].text', 'rules.advantages[].karama'],
     { state: 'control', chapter: 'advantages' }
   ),
-  ...coverage(['complexity'], { state: 'control', chapter: 'complexity' }),
+  ...coverage(['complexity.manual'], { state: 'control', chapter: 'complexity' }),
+  ...coverage(['complexity.calculated'], {
+    state: 'derived',
+    owner: 'Shared faction-complexity calculation at the create and update boundary',
+  }),
   ...coverage(
     [
       'extras[].name',

--- a/src/game/fixtures/sceneAtreides.ts
+++ b/src/game/fixtures/sceneAtreides.ts
@@ -67,4 +67,5 @@ export default {
       text: 'Fate',
     },
   },
+  complexity: { calculated: 0 },
 } satisfies FactionInput;

--- a/src/shared/factions/complexity.ts
+++ b/src/shared/factions/complexity.ts
@@ -1,0 +1,133 @@
+import type { FactionInput } from './schema';
+
+type FactionRules = FactionInput['rules'];
+export type FactionComplexity = FactionInput['complexity'];
+export type TransitionalFactionComplexity = FactionComplexity | number | undefined;
+
+/** Below this many words the score stays 0 — every faction needs some baseline text. */
+const COMPLEXITY_GRACE_FLOOR_WORDS = 80;
+
+/** At this many words the base score reaches 1.0 — roughly the printed sheet's capacity. */
+export const COMPLEXITY_CAPACITY_WORDS = 700;
+
+/** Advantages beyond this count each add {@link COMPLEXITY_MANY_ADVANTAGES_STEP} to the score. */
+const COMPLEXITY_MANY_ADVANTAGES_THRESHOLD = 8;
+const COMPLEXITY_MANY_ADVANTAGES_STEP = 0.03;
+
+type ComplexityAdjustment = {
+  id: string;
+  apply: (rules: FactionRules) => number;
+};
+
+const COMPLEXITY_ADJUSTMENTS: ComplexityAdjustment[] = [
+  {
+    id: 'many-advantages',
+    apply: (rules) =>
+      Math.max(0, rules.advantages.length - COMPLEXITY_MANY_ADVANTAGES_THRESHOLD) *
+      COMPLEXITY_MANY_ADVANTAGES_STEP,
+  },
+];
+
+function words(text: string | undefined): number {
+  if (!text) {
+    return 0;
+  }
+  return text
+    .replace(/\]\([^)]*\)/g, '] ')
+    .replace(/^[ \t]*(?:`{3,}|~{3,})[^\r\n]*$/gm, ' ')
+    .replace(/^[ \t]*(?:[-+*]|\d+[.)])[ \t]+/gm, '')
+    .replace(/^[ \t]*(?:[-*_][ \t]*){3,}$/gm, ' ')
+    .replace(/[*_~`#>[\]()]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean).length;
+}
+
+function sheetWordCount(rules: FactionRules): number {
+  return (
+    words(rules.startText) +
+    words(rules.revivalText) +
+    words(rules.alliance.text) +
+    words(rules.fate.title) +
+    words(rules.fate.text) +
+    rules.advantages.reduce(
+      (sum, rule) => sum + words(rule.title) + words(rule.text) + words(rule.karama),
+      0
+    )
+  );
+}
+
+/** The calculated 0..1 complexity of a rules block — never reads the manual rating. */
+export function calculateComplexity(rules: FactionRules): number {
+  const total = sheetWordCount(rules);
+  const base =
+    total <= COMPLEXITY_GRACE_FLOOR_WORDS
+      ? 0
+      : Math.min(
+          1,
+          (total - COMPLEXITY_GRACE_FLOOR_WORDS) /
+            (COMPLEXITY_CAPACITY_WORDS - COMPLEXITY_GRACE_FLOOR_WORDS)
+        );
+  const adjusted = COMPLEXITY_ADJUSTMENTS.reduce((sum, rule) => sum + rule.apply(rules), base);
+  return Math.min(1, Math.max(0, adjusted));
+}
+
+function complexityRecord(calculated: number, manual: number | undefined): FactionComplexity {
+  return manual === undefined ? { calculated } : { calculated, manual };
+}
+
+function isGroupedComplexity(
+  complexity: TransitionalFactionComplexity
+): complexity is FactionComplexity {
+  return complexity !== null && typeof complexity === 'object';
+}
+
+function manualComplexity(complexity: TransitionalFactionComplexity): number | undefined {
+  return typeof complexity === 'number'
+    ? complexity
+    : isGroupedComplexity(complexity)
+      ? complexity.manual
+      : undefined;
+}
+
+function withRecalculatedComplexity<
+  T extends { rules: FactionRules; complexity?: TransitionalFactionComplexity },
+>(data: T): T & { complexity: FactionComplexity } {
+  return {
+    ...data,
+    complexity: complexityRecord(
+      calculateComplexity(data.rules),
+      manualComplexity(data.complexity)
+    ),
+  };
+}
+
+/**
+ * Normalizes either side of the migration for readers. A stored grouped calculation is
+ * authoritative; only absent and legacy-scalar records calculate on read.
+ */
+export function normalizeStoredFactionComplexity<
+  T extends { rules: FactionRules; complexity?: TransitionalFactionComplexity },
+>(data: T): T & { complexity: FactionComplexity } {
+  if (isGroupedComplexity(data.complexity)) {
+    return { ...data, complexity: data.complexity };
+  }
+  return withRecalculatedComplexity(data);
+}
+
+/** Recalculates the stored value at an authoring or migration boundary while retaining manual. */
+export function recalculateFactionComplexity<
+  T extends { rules: FactionRules; complexity?: TransitionalFactionComplexity },
+>(data: T): T & { complexity: FactionComplexity } {
+  return withRecalculatedComplexity(data);
+}
+
+/** Manual when present, otherwise stored calculated; legacy rows calculate only as a fallback. */
+export function effectiveComplexity(data: {
+  rules: FactionRules;
+  complexity?: TransitionalFactionComplexity;
+}): number {
+  if (isGroupedComplexity(data.complexity)) {
+    return data.complexity.manual ?? data.complexity.calculated;
+  }
+  return data.complexity ?? calculateComplexity(data.rules);
+}

--- a/src/shared/factions/fixtures/assetPublishingFaction.ts
+++ b/src/shared/factions/fixtures/assetPublishingFaction.ts
@@ -1,3 +1,4 @@
+import { recalculateFactionComplexity } from '../complexity';
 import { FactionInputSchema } from '../schema';
 import type { FactionInput } from '../schema';
 
@@ -72,9 +73,9 @@ const assetPublishingFactionInput = {
       text: 'Play your fate card before Ship and Move to obtain the Carryall Tech Token.',
     },
   },
-} satisfies FactionInput;
+} satisfies Omit<FactionInput, 'complexity'>;
 
 /** Stable, representative payload for asset-publishing integration and regression coverage. */
 export const assetPublishingFaction: FactionInput = FactionInputSchema.parse(
-  assetPublishingFactionInput
+  recalculateFactionComplexity(assetPublishingFactionInput)
 );

--- a/src/shared/factions/schema.test.ts
+++ b/src/shared/factions/schema.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { assetPublishingFaction } from './fixtures/assetPublishingFaction';
-import { Background, CanonicalFactionStoredSchema, FactionInputSchema } from './schema';
+import {
+  Background,
+  CanonicalFactionClientSchema,
+  CanonicalFactionStoredSchema,
+  FactionInputSchema,
+  TransitionalFactionInputSchema,
+} from './schema';
 
 describe('faction schema', () => {
   it('rejects the retired legacy background shape', () => {
@@ -25,6 +31,44 @@ describe('faction schema', () => {
 
     expect(FactionInputSchema.safeParse(historical).success).toBe(false);
     expect(CanonicalFactionStoredSchema.parse(historical).name).toBe('');
+  });
+
+  it('requires grouped complexity for authored writes while accepting both legacy stored states', () => {
+    const { complexity: _complexity, ...withoutComplexity } =
+      structuredClone(assetPublishingFaction);
+
+    expect(FactionInputSchema.safeParse(withoutComplexity).success).toBe(false);
+    expect(FactionInputSchema.safeParse({ ...withoutComplexity, complexity: 0.4 }).success).toBe(
+      false
+    );
+    expect(CanonicalFactionStoredSchema.safeParse(withoutComplexity).success).toBe(true);
+    expect(
+      CanonicalFactionStoredSchema.safeParse({ ...withoutComplexity, complexity: 0.4 }).success
+    ).toBe(true);
+    expect(
+      TransitionalFactionInputSchema.parse({ ...withoutComplexity, complexity: 0.4 }).complexity
+    ).toEqual({
+      calculated: assetPublishingFaction.complexity.calculated,
+      manual: 0.4,
+    });
+    expect(FactionInputSchema.safeParse(assetPublishingFaction).success).toBe(true);
+  });
+
+  it('normalizes legacy client reads but preserves an already stored calculated value', () => {
+    const { complexity: _complexity, ...withoutComplexity } =
+      structuredClone(assetPublishingFaction);
+    const scalar = CanonicalFactionClientSchema.parse({
+      ...withoutComplexity,
+      complexity: 0.4,
+    });
+    const grouped = CanonicalFactionClientSchema.parse({
+      ...withoutComplexity,
+      complexity: { calculated: 0.123 },
+    });
+
+    expect(scalar.complexity.manual).toBe(0.4);
+    expect(scalar.complexity.calculated).toBe(assetPublishingFaction.complexity.calculated);
+    expect(grouped.complexity).toEqual({ calculated: 0.123 });
   });
 
   it.each([

--- a/src/shared/factions/schema.ts
+++ b/src/shared/factions/schema.ts
@@ -11,6 +11,7 @@ import {
   TROOP,
   TROOP_MODIFIER,
 } from '../assetIds';
+import { normalizeStoredFactionComplexity } from './complexity';
 
 const STRENGTH = z.union([z.number().int(), z.string().length(1)]);
 const OFFSET = z.tuple([z.number(), z.number()]);
@@ -97,7 +98,12 @@ export const TTSColor = z.enum([
   'Pink',
 ]);
 
-const factionShape = {
+const FactionComplexitySchema = z.strictObject({
+  calculated: SCALE,
+  manual: SCALE.optional(),
+});
+
+const factionBaseShape = {
   name: z.string().refine((name) => name.trim().length > 0, {
     message: 'Faction name is required because it determines the faction URL',
   }),
@@ -134,12 +140,6 @@ const factionShape = {
     alliance: RULE.omit({ karama: true, title: true }).required(),
   }),
 
-  /**
-   * The author's manual complexity rating (0 = trivial, 1 = as hard as the sheet allows). Absent
-   * means automatic: surfaces derive the rating live from the rules text (see `complexity.ts`).
-   */
-  complexity: z.number().min(0).max(1).optional(),
-
   /** Extra game assets, used by TTS */
   extras: z
     .array(
@@ -152,15 +152,32 @@ const factionShape = {
     .optional(),
 };
 
+const factionShape = {
+  ...factionBaseShape,
+  /** Stored calculated rating plus the optional author-chosen override. */
+  complexity: FactionComplexitySchema,
+};
+
+const transitionalFactionShape = {
+  ...factionBaseShape,
+  /** Widened during the grouped-complexity migration: absent and scalar are legacy states. */
+  complexity: FactionComplexitySchema.or(SCALE).optional(),
+};
+
 /** Rejects unknown keys (e.g. `slug` must live on the Convex row, not in `data`). */
 export const FactionInputSchema = z.strictObject(factionShape);
+
+/** Widened authoring boundary for stale clients during the grouped-complexity rollout. */
+export const TransitionalFactionInputSchema = z
+  .strictObject(transitionalFactionShape)
+  .transform(normalizeStoredFactionComplexity);
 
 /**
  * Canonical storage is intentionally wider than current authoring semantics: historical rows with a
  * blank name must remain readable while the UI requires a name for all new canonical writes.
  */
 export const CanonicalFactionStoredSchema = z.strictObject({
-  ...factionShape,
+  ...transitionalFactionShape,
   name: z.string(),
 });
 
@@ -169,7 +186,9 @@ export const CanonicalFactionStoredSchema = z.strictObject({
  * break stale tabs; genuine breaks (missing or mistyped fields) still fail the client boundary (see
  * db/core/clientBoundary).
  */
-export const CanonicalFactionClientSchema = z.looseObject({ ...factionShape, name: z.string() });
+export const CanonicalFactionClientSchema = z
+  .looseObject({ ...transitionalFactionShape, name: z.string() })
+  .transform(normalizeStoredFactionComplexity);
 export const BackgroundClientSchema = z.looseObject(Background.shape);
 
 /** URL slug on the `factions` row — not a field on `FactionInput` / `factions.data`. */

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -5,12 +5,12 @@
 export const rendererManifest = {
   schemaVersion: 2,
   rendererIdentity:
-    'faction-sheet/sha256:cb41b388cf83e53f6a3ff6ca2dcfc5d82b8f0685535147d663f66264012b6d57',
-  digest: 'cb41b388cf83e53f6a3ff6ca2dcfc5d82b8f0685535147d663f66264012b6d57',
+    'faction-sheet/sha256:f514957b86068202cc7f06bb7ecce4f99743150d626162f5d854fba74da4fd52',
+  digest: 'f514957b86068202cc7f06bb7ecce4f99743150d626162f5d854fba74da4fd52',
   components: {
     sources: '5289b6254320530ee857ff2912681e9d6a30135dbb3a92239296365f53397813',
     toolchain: 'a9d66c69040fffeadd0766d2a37756f785d33b1b7240d1bda5d6eeb081dd51ab',
-    code: '4f0ba34361253bd1f095bb7c8bf566f054f31eb74c33e60bd130725acf61f7c3',
+    code: '12e7eab7c97eeed39bea07b30a6f5424b4fef505a211ee64685574c79bc4ec14',
     contract: '2920714c87493d104342355dda2b956202259513c78ce6195670034f31a656a6',
   },
   contract: {


### PR DESCRIPTION
## Summary

- persist calculated and optional manual faction complexity as one grouped record
- recalculate at the authoring boundary while preserving transitional stale-client writes
- normalize legacy reads without storing an effective complexity value
- add resumable grouped-complexity backfill and verification migrations, but do not run them in production yet

## Migration sequence

This is the widened release for the first stage of the migration. Existing absent/scalar rows remain readable. New and updated factions are stored in the grouped shape. The production backfill remains deferred to the follow-up ticket.

## Verification

- bun run check
- bun run typecheck
- bun run test
- bun run storybook:test
- bun run app:build
- bun run migrations:static-check
- bun run publisher:release:verify

Refs #413