### PR TITLE
Preserve historical assets during complexity backfill

### DIFF
--- a/convex/migrations.factionComplexity.test.ts
+++ b/convex/migrations.factionComplexity.test.ts
@@ -57,11 +57,7 @@ async function migrationTest() {
         ...withoutComplexity(),
         complexity: { calculated: 0.01, manual: 0.4 },
       }),
-      historicalAsset: await insert(
-        'complexity-historical-asset',
-        historicalAssetData,
-        true
-      ),
+      historicalAsset: await insert('complexity-historical-asset', historicalAssetData, true),
     };
   });
   return { t, ids, historicalAssetData };

--- a/convex/migrations.factionComplexity.test.ts
+++ b/convex/migrations.factionComplexity.test.ts
@@ -25,6 +25,11 @@ async function migrationTest() {
   aggregateTest.register(t, 'profileActivity');
   aggregateTest.register(t, 'profileDiscovery');
   migrationsTest.register(t);
+  const historicalAssetBase = withoutComplexity();
+  const historicalAssetData = {
+    ...historicalAssetBase,
+    background: { ...historicalAssetBase.background, image: '' },
+  };
   const ids = await t.run(async (ctx) => {
     const ownerId = await ctx.db.insert('users', { name: 'Complexity migration owner' });
     await ctx.db.insert('profiles', {
@@ -54,20 +59,17 @@ async function migrationTest() {
       }),
       historicalAsset: await insert(
         'complexity-historical-asset',
-        {
-          ...withoutComplexity(),
-          background: { ...withoutComplexity().background, image: '' },
-        },
+        historicalAssetData,
         true
       ),
     };
   });
-  return { t, ids };
+  return { t, ids, historicalAssetData };
 }
 
 describe('faction grouped complexity migration', () => {
   test('backfills accurate calculated values and preserves legacy manual ratings', async () => {
-    const { t, ids } = await migrationTest();
+    const { t, ids, historicalAssetData } = await migrationTest();
     const calculated = calculateComplexity(assetPublishingFaction.rules);
 
     const legacyDetail = await t.query(api.factions.getBySlug, { slug: 'complexity-scalar' });
@@ -90,7 +92,9 @@ describe('faction grouped complexity migration', () => {
     expect(rows.scalar?.data.complexity).toEqual({ calculated, manual: 0.7 });
     expect(rows.staleGrouped?.data.complexity).toEqual({ calculated, manual: 0.4 });
     expect(rows.historicalAsset?.data.complexity).toEqual({ calculated });
-    expect(rows.historicalAsset?.data.background.image).toBe('');
+    const { complexity: _complexity, ...preservedHistoricalAssetData } =
+      rows.historicalAsset?.data ?? {};
+    expect(preservedHistoricalAssetData).toEqual(historicalAssetData);
   });
 
   test('verification rejects inaccurate grouped values', async () => {

--- a/convex/migrations.factionComplexity.test.ts
+++ b/convex/migrations.factionComplexity.test.ts
@@ -35,14 +35,14 @@ async function migrationTest() {
       created_at: now,
       updated_at: now,
     });
-    const insert = async (slug: string, data: unknown) =>
+    const insert = async (slug: string, data: unknown, isDeleted = false) =>
       await ctx.db.insert('factions', {
         owner_id: ownerId,
         data,
         slug,
         created_at: now,
         updated_at: now,
-        is_deleted: false,
+        is_deleted: isDeleted,
         group_id: null,
       });
     return {
@@ -52,6 +52,14 @@ async function migrationTest() {
         ...withoutComplexity(),
         complexity: { calculated: 0.01, manual: 0.4 },
       }),
+      historicalAsset: await insert(
+        'complexity-historical-asset',
+        {
+          ...withoutComplexity(),
+          background: { ...withoutComplexity().background, image: '' },
+        },
+        true
+      ),
     };
   });
   return { t, ids };
@@ -76,10 +84,13 @@ describe('faction grouped complexity migration', () => {
       absent: await ctx.db.get('factions', ids.absent),
       scalar: await ctx.db.get('factions', ids.scalar),
       staleGrouped: await ctx.db.get('factions', ids.staleGrouped),
+      historicalAsset: await ctx.db.get('factions', ids.historicalAsset),
     }));
     expect(rows.absent?.data.complexity).toEqual({ calculated });
     expect(rows.scalar?.data.complexity).toEqual({ calculated, manual: 0.7 });
     expect(rows.staleGrouped?.data.complexity).toEqual({ calculated, manual: 0.4 });
+    expect(rows.historicalAsset?.data.complexity).toEqual({ calculated });
+    expect(rows.historicalAsset?.data.background.image).toBe('');
   });
 
   test('verification rejects inaccurate grouped values', async () => {

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -68,6 +68,16 @@ const migrations = new Migrations(components.migrations, {
   schema,
 });
 
+/**
+ * Complexity backfills only depend on rules and the transitional complexity value. Historical
+ * factions may contain unrelated asset ids that current authoring no longer accepts, so validating
+ * the entire document here would couple this migration to fields it must preserve untouched.
+ */
+const factionComplexityMigrationDataSchema = CanonicalFactionStoredSchema.pick({
+  rules: true,
+  complexity: true,
+}).passthrough();
+
 async function resolveUniqueGroupSlug(
   ctx: QueryCtx | MutationCtx,
   name: string,
@@ -433,16 +443,16 @@ export const faction_complexity_grouped_v1 = migrations.define({
   table: 'factions',
   batchSize: 50,
   migrateOne: async (_ctx, row) => {
-    const data = CanonicalFactionStoredSchema.parse(row.data);
-    const next = recalculateFactionComplexity(data);
+    const { rules, complexity } = factionComplexityMigrationDataSchema.parse(row.data);
+    const next = recalculateFactionComplexity({ rules, complexity });
     if (
-      typeof data.complexity === 'object' &&
-      data.complexity.calculated === next.complexity.calculated &&
-      data.complexity.manual === next.complexity.manual
+      typeof complexity === 'object' &&
+      complexity.calculated === next.complexity.calculated &&
+      complexity.manual === next.complexity.manual
     ) {
       return;
     }
-    return { data: next };
+    return { data: { ...row.data, complexity: next.complexity } };
   },
 });
 
@@ -451,14 +461,14 @@ export const faction_complexity_grouped_verify_v1 = migrations.define({
   table: 'factions',
   batchSize: 50,
   migrateOne: async (_ctx, row) => {
-    const data = CanonicalFactionStoredSchema.parse(row.data);
-    if (typeof data.complexity !== 'object') {
+    const { rules, complexity } = factionComplexityMigrationDataSchema.parse(row.data);
+    if (typeof complexity !== 'object') {
       throw new Error(`Faction ${row._id} still has legacy complexity storage`);
     }
-    const expected = calculateComplexity(data.rules);
-    if (data.complexity.calculated !== expected) {
+    const expected = calculateComplexity(rules);
+    if (complexity.calculated !== expected) {
       throw new Error(
-        `Faction ${row._id} has calculated complexity ${data.complexity.calculated}; expected ${expected}`
+        `Faction ${row._id} has calculated complexity ${complexity.calculated}; expected ${expected}`
       );
     }
   },

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -446,6 +446,7 @@ export const faction_complexity_grouped_v1 = migrations.define({
     const { rules, complexity } = factionComplexityMigrationDataSchema.parse(row.data);
     const next = recalculateFactionComplexity({ rules, complexity });
     if (
+      complexity !== null &&
       typeof complexity === 'object' &&
       complexity.calculated === next.complexity.calculated &&
       complexity.manual === next.complexity.manual
@@ -462,7 +463,7 @@ export const faction_complexity_grouped_verify_v1 = migrations.define({
   batchSize: 50,
   migrateOne: async (_ctx, row) => {
     const { rules, complexity } = factionComplexityMigrationDataSchema.parse(row.data);
-    if (typeof complexity !== 'object') {
+    if (complexity === null || typeof complexity !== 'object') {
       throw new Error(`Faction ${row._id} still has legacy complexity storage`);
     }
     const expected = calculateComplexity(rules);


### PR DESCRIPTION
## Summary

- validate only the rules and transitional complexity fields needed by the backfill
- preserve unrelated historical faction fields byte-for-byte
- cover the production-discovered empty historical background asset id in migration tests

## Production dry-run finding

The initial rollback-only dry run processed zero rows and made no changes because soft-deleted faction `k17764w63h8q6896v3b3v8wcdx85gjqm` contains a historical empty background asset id. Full current-authoring validation was unnecessarily coupling the complexity migration to that unrelated field.

## Verification

- `bunx vitest run convex/migrations.factionComplexity.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run test` (75 files, 470 tests)
- `bun run migrations:static-check`
- `bun run publisher:release:verify`

Refs #414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved historical data migrations to calculate missing faction complexity without overwriting unrelated information.
  * Preserved empty background images and other existing historical asset details during migration.
  * Added validation to confirm migrated records retain their original data while receiving updated complexity values.
  * Ensured deleted historical assets remain available with their original details after migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->