### PR TITLE
Add ruleset description field (widen phase)

### DIFF
--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -11,6 +11,11 @@
       "requires": []
     },
     {
+      "id": "rulesets_description_v1",
+      "phase": "widen",
+      "requires": []
+    },
+    {
       "id": "faq_item_slug_v1",
       "phase": "widen",
       "requires": []

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -32,6 +32,7 @@ type MigrationRef = FunctionReference<'mutation', 'internal'>;
 const MIGRATION_IDS: Record<string, MigrationRef> = {
   groups_slug_v1: internal.migrations.groups_slug_v1,
   rulesets_slug_v1: internal.migrations.rulesets_slug_v1,
+  rulesets_description_v1: internal.migrations.rulesets_description_v1,
   faq_item_slug_v1: internal.migrations.faq_item_slug_v1,
   faq_item_tags_v1: internal.migrations.faq_item_tags_v1,
   profiles_from_users_v1: internal.migrations.profiles_from_users_v1,
@@ -163,6 +164,22 @@ export const rulesets_slug_v1 = migrations.define({
     }
     const slug = await resolveUniqueRulesetSlug(ctx, row.name, row._id);
     return { slug };
+  },
+});
+
+/**
+ * Backfills `description` so the field can narrow to a required `v.string()`.
+ * Empty is the deliberate value: a generated placeholder would be indistinguishable from prose someone wrote, and the
+ * 50-character floor in `rulesetDescriptionSchema` applies to what is written, never to what is inherited.
+ */
+export const rulesets_description_v1 = migrations.define({
+  table: 'rulesets',
+  batchSize: 50,
+  migrateOne: async (_ctx, row) => {
+    if (typeof (row as { description?: unknown }).description === 'string') {
+      return;
+    }
+    return { description: '' };
   },
 });
 

--- a/convex/rulesets.description.test.ts
+++ b/convex/rulesets.description.test.ts
@@ -1,0 +1,65 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import aggregateTest from '@convex-dev/aggregate/test';
+import { convexTest } from 'convex-test';
+import { describe, expect, test } from 'vitest';
+
+import { api } from './_generated/api';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+
+const VALID_DESCRIPTION = 'A house ruleset that rebalances spice income and shortens the endgame considerably.';
+
+function rulesetTest() {
+  const t = convexTest(schema, modules);
+  aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileActivity');
+  aggregateTest.register(t, 'profileDiscovery');
+  return t;
+}
+
+async function ownedRuleset(description?: string) {
+  const t = rulesetTest();
+  const ownerId = await t.run(async (ctx) => await ctx.db.insert('users', { name: 'Ruleset owner' }));
+  const owner = t.withIdentity({ subject: ownerId });
+  const ruleset = await owner.mutation(api.rulesets.create, {
+    name: 'DescriptionRuleset',
+    ...(description === undefined ? {} : { description }),
+    group_id: null,
+    image_cover: null,
+  });
+  return { owner, ruleset };
+}
+
+describe('ruleset descriptions', () => {
+  test('a ruleset created without one carries the backfill value', async () => {
+    const { ruleset } = await ownedRuleset();
+
+    expect(ruleset.description).toBe('');
+  });
+
+  test('an update that omits the description leaves the stored one intact', async () => {
+    const { owner, ruleset } = await ownedRuleset(VALID_DESCRIPTION);
+
+    const renamed = await owner.mutation(api.rulesets.update, {
+      id: ruleset._id,
+      name: 'RenamedRuleset',
+    });
+
+    expect(renamed.description).toBe(VALID_DESCRIPTION);
+  });
+
+  test('a description below the floor is rejected', async () => {
+    const { owner, ruleset } = await ownedRuleset(VALID_DESCRIPTION);
+
+    await expect(
+      owner.mutation(api.rulesets.update, {
+        id: ruleset._id,
+        name: 'DescriptionRuleset',
+        description: 'Too short.',
+      })
+    ).rejects.toThrow(/at least 50 characters/);
+  });
+});

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -25,6 +25,14 @@ async function getRulesetById(ctx: QueryCtx | MutationCtx, id: Id<'rulesets'>) {
   return await ctx.db.get(id);
 }
 
+/**
+ * The authoring shape `rulesetInputSchema` parses, built from mutation args.
+ * An omitted `description` stays omitted rather than becoming `undefined`, because the schema is strict and the difference carries meaning: absent means "not part of this write", not "blank it".
+ */
+function rulesetInputFrom(args: { name: string; description?: string }) {
+  return args.description === undefined ? { name: args.name } : { name: args.name, description: args.description };
+}
+
 async function resolveUniqueRulesetSlug(ctx: QueryCtx | MutationCtx, name: string, excludeId?: Id<'rulesets'>) {
   const baseSlug = slugify(name) || 'ruleset';
   let slug = baseSlug;
@@ -106,12 +114,13 @@ export const listByFaction = query({
 export const create = mutation({
   args: {
     name: v.string(),
+    description: v.optional(v.string()),
     group_id: v.union(v.id('groups'), v.null()),
     image_cover: v.union(v.string(), v.null()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuthUserId(ctx);
-    const parsed = rulesetInputSchema.safeParse({ name: args.name });
+    const parsed = rulesetInputSchema.safeParse(rulesetInputFrom(args));
     if (!parsed.success) {
       const msg = parsed.error.issues.map((i) => i.message).join(' ');
       throw new Error(msg || 'Invalid ruleset input');
@@ -134,6 +143,8 @@ export const create = mutation({
     const slug = await resolveUniqueRulesetSlug(ctx, normalizedName);
     const _id = await ctx.db.insert('rulesets', {
       name: normalizedName,
+      /** Empty until the create form collects one; the backfilled value for every row that predates the field. */
+      description: parsed.data.description ?? '',
       slug,
       owner_id: userId,
       group_id: args.group_id,
@@ -154,11 +165,12 @@ export const update = mutation({
   args: {
     id: v.id('rulesets'),
     name: v.string(),
+    description: v.optional(v.string()),
     group_id: v.optional(v.union(v.id('groups'), v.null())),
     image_cover: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
-    const parsed = rulesetInputSchema.safeParse({ name: args.name });
+    const parsed = rulesetInputSchema.safeParse(rulesetInputFrom(args));
     if (!parsed.success) {
       const msg = parsed.error.issues.map((i) => i.message).join(' ');
       throw new Error(msg || 'Invalid ruleset input');
@@ -182,6 +194,7 @@ export const update = mutation({
       name: string;
       slug: string;
       updated_at: string;
+      description?: string;
       group_id?: Id<'groups'> | null;
       image_cover?: string | null;
     } = {
@@ -189,6 +202,10 @@ export const update = mutation({
       slug: await resolveUniqueRulesetSlug(ctx, normalizedName, args.id),
       updated_at: nowIso(),
     };
+    /** Absent means "leave it alone", so a caller that only moves the group cannot blank a description. */
+    if (parsed.data.description !== undefined) {
+      patch.description = parsed.data.description;
+    }
     if (args.group_id !== undefined) {
       patch.group_id = args.group_id;
     }

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -33,6 +33,28 @@ function rulesetInputFrom(args: { name: string; description?: string }) {
   return args.description === undefined ? { name: args.name } : { name: args.name, description: args.description };
 }
 
+/**
+ * The patch an update writes, with one rule for every optional field: absent from the caller means absent from the patch.
+ * That is what lets `update` serve as a partial patcher without a caller that only moves the group blanking a description.
+ * The shape is inferred rather than restated, so adding a field here cannot drift from the type that describes it.
+ */
+function rulesetUpdatePatch(fields: {
+  name: string;
+  slug: string;
+  description?: string;
+  group_id?: Id<'groups'> | null;
+  image_cover?: string | null;
+}) {
+  return {
+    name: fields.name,
+    slug: fields.slug,
+    updated_at: nowIso(),
+    ...(fields.description === undefined ? {} : { description: fields.description }),
+    ...(fields.group_id === undefined ? {} : { group_id: fields.group_id }),
+    ...(fields.image_cover === undefined ? {} : { image_cover: fields.image_cover }),
+  };
+}
+
 async function resolveUniqueRulesetSlug(ctx: QueryCtx | MutationCtx, name: string, excludeId?: Id<'rulesets'>) {
   const baseSlug = slugify(name) || 'ruleset';
   let slug = baseSlug;
@@ -190,30 +212,16 @@ export const update = mutation({
       throw new Error('Ruleset name already exists');
     }
 
-    const patch: {
-      name: string;
-      slug: string;
-      updated_at: string;
-      description?: string;
-      group_id?: Id<'groups'> | null;
-      image_cover?: string | null;
-    } = {
-      name: normalizedName,
-      slug: await resolveUniqueRulesetSlug(ctx, normalizedName, args.id),
-      updated_at: nowIso(),
-    };
-    /** Absent means "leave it alone", so a caller that only moves the group cannot blank a description. */
-    if (parsed.data.description !== undefined) {
-      patch.description = parsed.data.description;
-    }
-    if (args.group_id !== undefined) {
-      patch.group_id = args.group_id;
-    }
-    if (args.image_cover !== undefined) {
-      patch.image_cover = args.image_cover;
-    }
-
-    await ctx.db.patch(ruleset._id, patch);
+    await ctx.db.patch(
+      ruleset._id,
+      rulesetUpdatePatch({
+        name: normalizedName,
+        slug: await resolveUniqueRulesetSlug(ctx, normalizedName, args.id),
+        description: parsed.data.description,
+        group_id: args.group_id,
+        image_cover: args.image_cover,
+      })
+    );
     const updated = await ctx.db.get(ruleset._id);
     if (!updated) {
       throw new Error('Failed to update ruleset');

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -100,6 +100,12 @@ export default defineSchema({
   rulesets: defineTable({
     name: v.string(),
     slug: v.string(),
+    /**
+     * Widen phase of `rulesets_description_v1`: optional only until every row is backfilled, then narrowed to a required `v.string()`.
+     * Empty is the backfilled value for rows that predate the field and is tolerated on read;
+     * anything written goes through `rulesetDescriptionSchema`, which demands 50 characters.
+     */
+    description: v.optional(v.string()),
     created_at: v.string(),
     updated_at: v.string(),
     owner_id: v.id('users'),

--- a/src/app/db/rulesets.ts
+++ b/src/app/db/rulesets.ts
@@ -14,7 +14,12 @@ import type { Doc } from '../../../convex/_generated/dataModel';
 import type { AssignedGroupSummary, CollaborativeAccess } from '../../../convex/lib/collaborativeAccess';
 import type { ProfileSummary } from '../../../convex/lib/collaborativeAccessValidators';
 
-export type Ruleset = { name: string };
+/**
+ * What a caller authors.
+ * `description` is optional for the widen phase only — omitting it leaves an existing description untouched, and the
+ * 50-character floor applies to anything supplied.
+ */
+export type Ruleset = { name: string; description?: string };
 export type RulesetRow = Doc<'rulesets'>;
 export type RulesetEntry = Omit<RulesetRow, 'name'> & {
   name: Ruleset['name'];
@@ -143,9 +148,10 @@ export function useRulesetDetailPage(slug: string, options?: { initialData?: Rul
 }
 
 export function useCreateRuleset() {
-  const mutation = useLiveMutation<{ name: string; group_id: string | null; image_cover: string | null }, RulesetRow>(
-    api.rulesets.create
-  );
+  const mutation = useLiveMutation<
+    { name: string; description?: string; group_id: string | null; image_cover: string | null },
+    RulesetRow
+  >(api.rulesets.create);
   return {
     ...mutation,
     mutate: (
@@ -157,7 +163,7 @@ export function useCreateRuleset() {
     ) =>
       mutation.mutate(
         {
-          name: rulesetInputSchema.parse({ name: variables.input.name }).name,
+          ...rulesetInputSchema.parse(variables.input),
           group_id: variables.groupId ?? null,
           image_cover: variables.imageCover ?? null,
         },
@@ -180,20 +186,20 @@ export function useCreateRuleset() {
       groupId?: string | null;
       imageCover?: string | null;
     }) => {
-      const validatedName = rulesetInputSchema.parse({ name: input.name }).name;
+      const validated = rulesetInputSchema.parse(input);
       const entry = await mutation.mutateAsync({
-        name: validatedName,
+        ...validated,
         group_id: groupId ?? null,
         image_cover: imageCover ?? null,
       });
-      return { ...entry, id: entry._id, name: validatedName };
+      return { ...entry, id: entry._id, name: validated.name };
     },
   };
 }
 
 export function useUpdateRuleset() {
   const mutation = useLiveMutation<
-    { id: string; name: string; group_id?: string | null; image_cover?: string | null },
+    { id: string; name: string; description?: string; group_id?: string | null; image_cover?: string | null },
     RulesetRow
   >(api.rulesets.update);
   return {
@@ -213,7 +219,7 @@ export function useUpdateRuleset() {
       mutation.mutate(
         {
           id: variables.id,
-          name: rulesetInputSchema.parse({ name: variables.input.name }).name,
+          ...rulesetInputSchema.parse(variables.input),
           group_id: variables.groupId,
           image_cover: variables.imageCover,
         },
@@ -238,14 +244,14 @@ export function useUpdateRuleset() {
       groupId?: string | null;
       imageCover?: string | null;
     }) => {
-      const validatedName = rulesetInputSchema.parse({ name: input.name }).name;
+      const validated = rulesetInputSchema.parse(input);
       const entry = await mutation.mutateAsync({
         id,
-        name: validatedName,
+        ...validated,
         group_id: groupId,
         image_cover: imageCover,
       });
-      return { ...entry, id: entry._id, name: validatedName };
+      return { ...entry, id: entry._id, name: validated.name };
     },
   };
 }

--- a/src/shared/rulesets/validation.ts
+++ b/src/shared/rulesets/validation.ts
@@ -3,6 +3,17 @@ import { z } from 'zod';
 
 const rulesetNameSchema = alphanumericNameSchema('Ruleset name');
 
+/**
+ * Free prose, so no upper bound — the FAQ's question and answer schemas set that precedent.
+ * The floor is deliberate: a description shorter than this says nothing a reader could not get from the name.
+ */
+const rulesetDescriptionSchema = z.string().trim().min(50, 'Ruleset description must be at least 50 characters');
+
+/**
+ * `description` is optional here only for the widen phase of `rulesets_description_v1`: rows that predate the field carry an empty string, and no caller may be forced to invent 50 characters to change a ruleset's name.
+ * It narrows to required once the backfill has run in production.
+ */
 export const rulesetInputSchema = z.strictObject({
   name: rulesetNameSchema,
+  description: rulesetDescriptionSchema.optional(),
 });


### PR DESCRIPTION
Adds `description` to rulesets as the **widen half** of `rulesets_description_v1`. The field is optional here on purpose; it narrows to a required `v.string()` in a second release.

Resolves the widen scope of #427. Part of the map in #426.

## Why two releases

`.github/workflows/deploy-main.yml` runs `migrations:narrow-check` *before* `convex:deploy`, and that check asserts against production that every migration id required by a `narrow` guard entry has already completed. A PR carrying both the widen and the narrow entry therefore fails the check on the very merge that was supposed to run the migration, and the deploy deadlocks. So this PR ships only the widen entry, and the narrow follows in #438 once `rulesets_description_v1` has completed in production.

## What changed

- **`convex/schema.ts`** — `description: v.optional(v.string())`, commented with the phase it belongs to.
- **`convex/migrations.ts`** — `rulesets_description_v1`, idempotent: patches `''` only where `description` is not already a string.
- **`convex/migration-guards.json`** — the widen entry, and only the widen entry.
- **`src/shared/rulesets/validation.ts`** — `rulesetDescriptionSchema`: `.trim().min(50)`, with no upper bound. `faqQuestionSchema` and `faqAnswerSchema` set the precedent that free prose carries no invented maximum. `description` joins `rulesetInputSchema` as optional for this phase only.
- **`convex/rulesets.ts`** — `create` and `update` accept `description` as an optional argument. An absent value means *not part of this write*, never *blank it*, so the ruleset toolbar's group assign and clear calls — which reuse `update` as a general patcher — cannot wipe a description. `create` writes `''` when none is supplied, matching what the backfill gives older rows.
- **`src/app/db/rulesets.ts`** — `Ruleset` gains `description?`, and both hooks parse the whole input instead of picking `name` out of it.
- **`convex/rulesets.description.test.ts`** — three contract assertions, each covering something types cannot express: a ruleset created without a description carries `''`; an update that omits it leaves the stored one intact; a description under the floor is rejected.

## Deliberately not in this PR

- **Wire validators are untouched.** `rulesetValidator` is `docValidator('rulesets')`, derived from the schema, so the field reaches the wire contracts without a hand edit.
- **`rulesetDescriptionSchema` is not exported.** It has no consumer outside its module yet and `knip` fails on unused exports; #429 exports it when the form needs it for UX feedback.
- **Enforcement is not live.** Both mutations still accept an absent description, so a ruleset can still be created without one. #429 owns both authoring surfaces — the create form as well as settings — because demanding 50 characters at creation is what breaks creation if there is nowhere to type them.

## Verification

`typecheck`, `lint`, `format:check`, `knip`, `migrations:static-check`, `check:app-layout`, `check:css-orphans`, `check:convex-skip`, `publisher:release:verify`, and the full suite at 469 tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional descriptions to rulesets.
  * Descriptions are trimmed and must contain at least 50 characters when provided.
  * Ruleset updates preserve existing descriptions when no new description is supplied.

* **Data Updates**
  * Existing rulesets are automatically backfilled with empty descriptions where needed.

* **Bug Fixes**
  * Improved validation consistency for ruleset creation and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->