### PR TITLE
Give rulesets their own setGroup mutation

### DIFF
--- a/convex/collaborationPermissions.test.ts
+++ b/convex/collaborationPermissions.test.ts
@@ -63,7 +63,6 @@ describe('group collaboration permissions', () => {
       member.mutation(api.rulesets.update, {
         id: ruleset._id,
         name: ruleset.name,
-        group_id: ruleset.group_id,
         image_cover: 'https://example.com/collaborative-cover.jpg',
       })
     ).resolves.toMatchObject({
@@ -76,13 +75,9 @@ describe('group collaboration permissions', () => {
         name: 'MemberRename',
       })
     ).rejects.toThrow('Only the ruleset owner can rename this ruleset');
-    await expect(
-      member.mutation(api.rulesets.update, {
-        id: ruleset._id,
-        name: ruleset.name,
-        group_id: null,
-      })
-    ).rejects.toThrow('Only the ruleset owner can change its group');
+    await expect(member.mutation(api.rulesets.setGroup, { id: ruleset._id, group_id: null })).rejects.toThrow(
+      'Only the ruleset owner can change its group'
+    );
     await expect(member.mutation(api.rulesets.softDelete, { id: ruleset._id })).rejects.toThrow('Not authorized');
   });
 });

--- a/convex/collaborativeAccess.test.ts
+++ b/convex/collaborativeAccess.test.ts
@@ -756,20 +756,12 @@ describe('collaborative access moderation commands', () => {
     ).rejects.toThrow('Cannot remove the group owner');
 
     await assetOwner.mutation(api.factions.setGroup, { id: ids.factionId, group_id: null });
-    await assetOwner.mutation(api.rulesets.update, {
-      id: ids.rulesetId,
-      name: 'CollaborativeRuleset',
-      group_id: null,
-    });
+    await assetOwner.mutation(api.rulesets.setGroup, { id: ids.rulesetId, group_id: null });
     await expect(
       assetOwner.mutation(api.factions.setGroup, { id: ids.factionId, group_id: ids.groupId })
     ).rejects.toThrow('Not authorized for group');
     await expect(
-      assetOwner.mutation(api.rulesets.update, {
-        id: ids.rulesetId,
-        name: 'CollaborativeRuleset',
-        group_id: ids.groupId,
-      })
+      assetOwner.mutation(api.rulesets.setGroup, { id: ids.rulesetId, group_id: ids.groupId })
     ).rejects.toThrow('Not authorized for group');
 
     const added = await member.mutation(api.members.addMember, {
@@ -783,11 +775,7 @@ describe('collaborative access moderation commands', () => {
       group_id: ids.groupId,
     });
     await expect(
-      assetOwner.mutation(api.rulesets.update, {
-        id: ids.rulesetId,
-        name: 'CollaborativeRuleset',
-        group_id: ids.groupId,
-      })
+      assetOwner.mutation(api.rulesets.setGroup, { id: ids.rulesetId, group_id: ids.groupId })
     ).resolves.toMatchObject({ group_id: ids.groupId });
   });
 
@@ -829,11 +817,7 @@ describe('collaborative access moderation commands', () => {
     const assetOwner = t.withIdentity({ subject: ids.assetOwnerId });
 
     await assetOwner.mutation(api.factions.setGroup, { id: ids.factionId, group_id: null });
-    await assetOwner.mutation(api.rulesets.update, {
-      id: ids.rulesetId,
-      name: 'CollaborativeRuleset',
-      group_id: null,
-    });
+    await assetOwner.mutation(api.rulesets.setGroup, { id: ids.rulesetId, group_id: null });
 
     for (const [groupId, expectedError] of [
       [targetGroupIds.pending, 'Not authorized for group'],
@@ -844,11 +828,7 @@ describe('collaborative access moderation commands', () => {
         assetOwner.mutation(api.factions.setGroup, { id: ids.factionId, group_id: groupId })
       ).rejects.toThrow(expectedError);
       await expect(
-        assetOwner.mutation(api.rulesets.update, {
-          id: ids.rulesetId,
-          name: 'CollaborativeRuleset',
-          group_id: groupId,
-        })
+        assetOwner.mutation(api.rulesets.setGroup, { id: ids.rulesetId, group_id: groupId })
       ).rejects.toThrow(expectedError);
 
       const factionPage = await assetOwner.query(api.factions.getBySlug, {
@@ -866,11 +846,7 @@ describe('collaborative access moderation commands', () => {
       })
     ).resolves.toMatchObject({ group_id: targetGroupIds.active });
     await expect(
-      assetOwner.mutation(api.rulesets.update, {
-        id: ids.rulesetId,
-        name: 'CollaborativeRuleset',
-        group_id: targetGroupIds.active,
-      })
+      assetOwner.mutation(api.rulesets.setGroup, { id: ids.rulesetId, group_id: targetGroupIds.active })
     ).resolves.toMatchObject({ group_id: targetGroupIds.active });
 
     const factionPage = await assetOwner.query(api.factions.getBySlug, {

--- a/convex/lib/collaborativeAccess.ts
+++ b/convex/lib/collaborativeAccess.ts
@@ -368,6 +368,11 @@ export async function requireGroupReassignment(
   message = 'Not authorized'
 ) {
   await requireAuthenticatedViewerId(ctx);
+  /*
+   * Both branches call the same function on purpose, and this is not redundant: `loadCollaborativeAccess` is
+   * overloaded per subject kind, so handing it the union resolves to no overload and collapses `access` to `never`.
+   * The test discriminates the union first so each call picks its own overload.
+   */
   const access =
     subject.kind === 'faction'
       ? await loadCollaborativeAccess(ctx, subject)

--- a/convex/lib/collaborativeAccess.ts
+++ b/convex/lib/collaborativeAccess.ts
@@ -326,10 +326,14 @@ export async function requireFactionUpdate(
   return access;
 }
 
+/**
+ * Authorizes an edit to a ruleset's own content — its name, cover and description.
+ * Group assignment is deliberately not among them: it is a different capability with a different audience, so it goes through `requireGroupReassignment` from `rulesets.setGroup` instead, the same route factions already take.
+ */
 export async function requireRulesetUpdate(
   ctx: MutationCtx,
   rulesetId: Id<'rulesets'>,
-  proposedChange: { name: string; groupId?: Id<'groups'> | null }
+  proposedChange: { name: string }
 ) {
   await requireAuthenticatedViewerId(ctx);
   const access = await loadCollaborativeAccess(ctx, { kind: 'ruleset', id: rulesetId });
@@ -342,31 +346,26 @@ export async function requireRulesetUpdate(
   if (proposedChange.name !== access.subject.name && !access.viewerAccess.capabilities.rename) {
     throw new Error('Only the ruleset owner can rename this ruleset');
   }
-  if (proposedChange.groupId !== undefined && proposedChange.groupId !== access.subject.group_id) {
-    if (!access.viewerAccess.capabilities.changeGroup) {
-      throw new Error('Only the ruleset owner can change its group');
-    }
-    if (proposedChange.groupId !== null) {
-      await requireAssignableGroup(ctx, proposedChange.groupId);
-    }
-  }
   return access;
 }
 
 export function requireGroupReassignment(
   ctx: MutationCtx,
   subject: { kind: 'faction'; id: Id<'factions'> },
-  targetGroupId: Id<'groups'> | null
+  targetGroupId: Id<'groups'> | null,
+  message?: string
 ): Promise<LoadedFactionAccess>;
 export function requireGroupReassignment(
   ctx: MutationCtx,
   subject: { kind: 'ruleset'; id: Id<'rulesets'> },
-  targetGroupId: Id<'groups'> | null
+  targetGroupId: Id<'groups'> | null,
+  message?: string
 ): Promise<LoadedRulesetAccess>;
 export async function requireGroupReassignment(
   ctx: MutationCtx,
   subject: { kind: 'faction'; id: Id<'factions'> } | { kind: 'ruleset'; id: Id<'rulesets'> },
-  targetGroupId: Id<'groups'> | null
+  targetGroupId: Id<'groups'> | null,
+  message = 'Not authorized'
 ) {
   await requireAuthenticatedViewerId(ctx);
   const access =
@@ -378,7 +377,7 @@ export async function requireGroupReassignment(
     throw new Error(`${label} with id ${subject.id} not found`);
   }
   if (!access.viewerAccess.capabilities.changeGroup) {
-    throw new Error('Not authorized');
+    throw new Error(message);
   }
   if (targetGroupId !== null) {
     await requireAssignableGroup(ctx, targetGroupId);

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -6,6 +6,7 @@ import { query } from './_generated/server';
 import { mutation } from './functions';
 import {
   requireAssignableGroup,
+  requireGroupReassignment,
   requireRulesetMaintenance,
   requireRulesetSoftDelete,
   requireRulesetUpdate,
@@ -38,19 +39,12 @@ function rulesetInputFrom(args: { name: string; description?: string }) {
  * That is what lets `update` serve as a partial patcher without a caller that only moves the group blanking a description.
  * The shape is inferred rather than restated, so adding a field here cannot drift from the type that describes it.
  */
-function rulesetUpdatePatch(fields: {
-  name: string;
-  slug: string;
-  description?: string;
-  group_id?: Id<'groups'> | null;
-  image_cover?: string | null;
-}) {
+function rulesetUpdatePatch(fields: { name: string; slug: string; description?: string; image_cover?: string | null }) {
   return {
     name: fields.name,
     slug: fields.slug,
     updated_at: nowIso(),
     ...(fields.description === undefined ? {} : { description: fields.description }),
-    ...(fields.group_id === undefined ? {} : { group_id: fields.group_id }),
     ...(fields.image_cover === undefined ? {} : { image_cover: fields.image_cover }),
   };
 }
@@ -188,7 +182,6 @@ export const update = mutation({
     id: v.id('rulesets'),
     name: v.string(),
     description: v.optional(v.string()),
-    group_id: v.optional(v.union(v.id('groups'), v.null())),
     image_cover: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
@@ -198,10 +191,7 @@ export const update = mutation({
       throw new Error(msg || 'Invalid ruleset input');
     }
     const normalizedName = parsed.data.name;
-    const access = await requireRulesetUpdate(ctx, args.id, {
-      name: normalizedName,
-      groupId: args.group_id,
-    });
+    const access = await requireRulesetUpdate(ctx, args.id, { name: normalizedName });
     const ruleset = access.subject;
 
     const duplicate = await ctx.db
@@ -218,13 +208,42 @@ export const update = mutation({
         name: normalizedName,
         slug: await resolveUniqueRulesetSlug(ctx, normalizedName, args.id),
         description: parsed.data.description,
-        group_id: args.group_id,
         image_cover: args.image_cover,
       })
     );
     const updated = await ctx.db.get(ruleset._id);
     if (!updated) {
       throw new Error('Failed to update ruleset');
+    }
+    return updated;
+  },
+});
+
+/**
+ * Moves a ruleset between maintaining groups, or clears its assignment with `null`.
+ * Separate from `update` on purpose: assigning a group is the owner's `changeGroup` capability rather than the content edit any active member may make, and a caller here cannot express a name or a description at all — so moving a group can never overwrite either.
+ * `factions.setGroup` is the same shape.
+ */
+export const setGroup = mutation({
+  args: {
+    id: v.id('rulesets'),
+    group_id: v.union(v.id('groups'), v.null()),
+  },
+  handler: async (ctx, args) => {
+    const access = await requireGroupReassignment(
+      ctx,
+      { kind: 'ruleset', id: args.id },
+      args.group_id,
+      'Only the ruleset owner can change its group'
+    );
+
+    await ctx.db.patch(access.subject._id, {
+      group_id: args.group_id,
+      updated_at: nowIso(),
+    });
+    const updated = await ctx.db.get(access.subject._id);
+    if (!updated) {
+      throw new Error('Failed to update ruleset group');
     }
     return updated;
   },

--- a/src/app/db/rulesets.ts
+++ b/src/app/db/rulesets.ts
@@ -199,7 +199,7 @@ export function useCreateRuleset() {
 
 export function useUpdateRuleset() {
   const mutation = useLiveMutation<
-    { id: string; name: string; description?: string; group_id?: string | null; image_cover?: string | null },
+    { id: string; name: string; description?: string; image_cover?: string | null },
     RulesetRow
   >(api.rulesets.update);
   return {
@@ -208,7 +208,6 @@ export function useUpdateRuleset() {
       variables: {
         input: Ruleset;
         id: string;
-        groupId?: string | null;
         imageCover?: string | null;
       },
       options?: {
@@ -220,7 +219,6 @@ export function useUpdateRuleset() {
         {
           id: variables.id,
           ...rulesetInputSchema.parse(variables.input),
-          group_id: variables.groupId,
           image_cover: variables.imageCover,
         },
         {
@@ -233,25 +231,37 @@ export function useUpdateRuleset() {
           onError: (error) => options?.onError?.(error),
         }
       ),
-    mutateAsync: async ({
-      input,
-      id,
-      groupId,
-      imageCover,
-    }: {
-      input: Ruleset;
-      id: string;
-      groupId?: string | null;
-      imageCover?: string | null;
-    }) => {
+    mutateAsync: async ({ input, id, imageCover }: { input: Ruleset; id: string; imageCover?: string | null }) => {
       const validated = rulesetInputSchema.parse(input);
       const entry = await mutation.mutateAsync({
         id,
         ...validated,
-        group_id: groupId,
         image_cover: imageCover,
       });
       return { ...entry, id: entry._id, name: validated.name };
+    },
+  };
+}
+
+/** Moves a ruleset between maintaining groups, or clears the assignment with `null`. The peer of `useSetFactionGroup`. */
+export function useSetRulesetGroup() {
+  const mutation = useLiveMutation<{ id: string; group_id: string | null }, RulesetRow>(api.rulesets.setGroup);
+  return {
+    ...mutation,
+    mutate: (
+      variables: { id: string; groupId: string | null },
+      options?: { onSuccess?: (entry: RulesetEntry) => void; onError?: (error: Error) => void }
+    ) =>
+      mutation.mutate(
+        { id: variables.id, group_id: variables.groupId },
+        {
+          onSuccess: (entry) => options?.onSuccess?.(toRulesetEntry(entry)),
+          onError: (error) => options?.onError?.(error),
+        }
+      ),
+    mutateAsync: async ({ id, groupId }: { id: string; groupId: string | null }) => {
+      const entry = await mutation.mutateAsync({ id, group_id: groupId });
+      return toRulesetEntry(entry);
     },
   };
 }

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -27,7 +27,7 @@ import type { FactionEntry } from '@db/factions';
 import { loadGroupDetailBySlug, useDeleteGroup, useGroupDetailBySlug } from '@db/groups';
 import type { GroupDetailPageData, MembershipState } from '@db/groups';
 import { useGroupMembershipWorkflow } from '@db/members';
-import { useRulesetsOwnedForGroupAssign, useUpdateRuleset } from '@db/rulesets';
+import { useRulesetsOwnedForGroupAssign, useSetRulesetGroup } from '@db/rulesets';
 import type { RulesetEntry } from '@db/rulesets';
 
 import styles from './index.module.css';
@@ -62,7 +62,7 @@ function GroupDetailPage() {
   const membershipWorkflow = useGroupMembershipWorkflow();
   const deleteGroup = useDeleteGroup();
   const setFactionGroup = useSetFactionGroup();
-  const updateRuleset = useUpdateRuleset();
+  const setRulesetGroup = useSetRulesetGroup();
 
   if (groupData.isError) {
     return (
@@ -148,11 +148,7 @@ function GroupDetailPage() {
   };
 
   const handleAssignRuleset = async (item: AssetAssignOption) => {
-    await updateRuleset.mutateAsync({
-      id: item.id,
-      input: { name: item.name },
-      groupId,
-    });
+    await setRulesetGroup.mutateAsync({ id: item.id, groupId });
   };
 
   return (
@@ -240,7 +236,7 @@ function GroupDetailPage() {
               action={
                 isActiveMember ? (
                   <RulesetAssignPicker
-                    disabled={updateRuleset.isPending}
+                    disabled={setRulesetGroup.isPending}
                     currentGroupId={groupId}
                     currentGroupName={group.name}
                     onAssign={handleAssignRuleset}

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -52,7 +52,7 @@ import {
 
 import { useGroupMembershipWorkflow } from '@db/members';
 import { useCurrentProfile } from '@db/profiles';
-import { loadRulesetDetailPage, useDeleteRuleset, useRulesetDetailPage, useUpdateRuleset } from '@db/rulesets';
+import { loadRulesetDetailPage, useDeleteRuleset, useRulesetDetailPage, useSetRulesetGroup } from '@db/rulesets';
 import { Token as FactionToken } from '@game/assets/faction/token/Token';
 
 import styles from '../RulesetDetail.module.css';
@@ -128,8 +128,7 @@ function RulesetDetailPage() {
   const page = pageQuery.data;
   const profile = useCurrentProfile();
   const deleteRuleset = useDeleteRuleset();
-  const updateRuleset = useUpdateRuleset();
-  const assignRulesetGroup = useUpdateRuleset();
+  const setRulesetGroup = useSetRulesetGroup();
   const membershipWorkflow = useGroupMembershipWorkflow();
 
   if (loaderData.notFound || !page) {
@@ -164,7 +163,7 @@ function RulesetDetailPage() {
   const canRequestMembership = viewerAccess.capabilities.requestMembership;
   const answeredFaqCount = page.faqItems.filter((item) => item.accepted_answer_id != null).length;
   const mutationError =
-    deleteRuleset.error?.message ?? membershipWorkflow.request.error?.message ?? updateRuleset.error?.message;
+    deleteRuleset.error?.message ?? membershipWorkflow.request.error?.message ?? setRulesetGroup.error?.message;
   const canChangeGroup = viewerAccess.capabilities.changeGroup;
   const hasAssignment = r.group_id != null;
   const actionVisibility = {
@@ -294,18 +293,13 @@ function RulesetDetailPage() {
                     noun="group"
                     triggerLabel="Assign group"
                     icon={<UsersRound size={17} aria-hidden />}
-                    disabled={assignRulesetGroup.isPending}
+                    disabled={setRulesetGroup.isPending}
                     options={page.assignableGroups.map((group) => ({
                       value: group.id,
                       label: `${group.name} (${group.slug})`,
                     }))}
                     onAssign={async (nextGroupId) => {
-                      await assignRulesetGroup.mutateAsync({
-                        id: r._id,
-                        input: { name: r.name },
-                        groupId: nextGroupId,
-                        imageCover: r.image_cover ?? null,
-                      });
+                      await setRulesetGroup.mutateAsync({ id: r._id, groupId: nextGroupId });
                     }}
                     title="Assign Group"
                     descriptionLines={[
@@ -320,16 +314,9 @@ function RulesetDetailPage() {
                     color="red"
                     variant="light"
                     size="lg"
-                    disabled={updateRuleset.isPending}
+                    disabled={setRulesetGroup.isPending}
                     onClick={() =>
-                      void updateRuleset
-                        .mutateAsync({
-                          id: r._id,
-                          input: { name: r.name },
-                          groupId: null,
-                          imageCover: r.image_cover ?? null,
-                        })
-                        .catch(() => undefined)
+                      void setRulesetGroup.mutateAsync({ id: r._id, groupId: null }).catch(() => undefined)
                     }
                     icon={<UserRoundMinus size={17} aria-hidden />}
                   />


### PR DESCRIPTION
Group assignment stops riding `rulesets.update` and gets its own mutation, mirroring `factions.setGroup`.

Resolves #428. Part of the map in #426.

## Why

Moving a ruleset between groups meant sending its name. The group detail page passed `input: { name: item.name }` — a name lifted from a *picker label* — purely to satisfy the signature, and the ruleset toolbar resent the name and the cover URL on every assign and clear. Each was a chance to overwrite content the caller never meant to touch.

Two things made the shape of the fix obvious rather than a matter of taste:

- **`factions.setGroup` already exists in exactly this shape** — id plus a nullable group id, authorized by `requireGroupReassignment`. Rulesets were the odd one out.
- **`requireGroupReassignment` already carried a `{ kind: 'ruleset' }` overload that no caller used.** The ruleset branch had been written in anticipation and left sitting. This PR connects it.

The description floor arriving in #438 would only have turned that latent hazard into a hard failure — every one of those callers would have started throwing on any ruleset still holding the backfilled empty string.

## What changed

- **`convex/rulesets.ts`** — `setGroup` patches `group_id` and `updated_at`, nothing else. `update` loses its `group_id` argument, and `rulesetUpdatePatch` loses that branch. `create` keeps its `group_id`, because choosing a group while creating is a different act and `factions.create` does the same.
- **`convex/lib/collaborativeAccess.ts`** — `requireRulesetUpdate` drops its group branch and authorizes content edits only. Each mutation now checks exactly one capability: `edit`/`rename` for `update`, `changeGroup` for `setGroup`. `requireGroupReassignment` gains an optional `message` — the convention its sibling `require*Capability` helpers already use — so the ruleset path keeps saying *"Only the ruleset owner can change its group"* rather than degrading to a bare *"Not authorized"*.
- **`src/app/db/rulesets.ts`** — `useSetRulesetGroup`, the peer of `useSetFactionGroup`. `useUpdateRuleset` loses `groupId`.
- **Both call sites moved** — the group detail page's "add my ruleset", now a one-liner symmetric with `handleAssignFaction`, and the ruleset toolbar's assign and clear.

## Tests: migrated, none added

Removing the argument broke eight existing call sites at compile time, in `collaborativeAccess.test.ts` and `collaborationPermissions.test.ts` — the confidence stack finding every one of them is the point. They call `setGroup` now, and the faction/ruleset assertions read as symmetric pairs.

Nothing new was added: that `update` can no longer touch a group is a type guarantee, not behaviour worth asserting at runtime (ADR-0002).

One coverage gap left deliberately, and noted on #428 for the map's test-coverage question rather than fixed by reflex: `e2e/group-asset-assign.spec.ts` drives the *faction* assign path only, so the ruleset leg of that page has no e2e. The popover mechanics are shared and the difference is which mutation is called, which is typechecked and seam-tested.

## Verification

`typecheck`, `lint`, `format:check`, `knip`, `check:app-layout`, `check:convex-skip`, `check:css-orphans`, `publisher:release:verify` (no manifest diff), and the full suite at 469 tests — all green. Net 18 lines lighter across 7 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated controls for assigning, changing, or removing a ruleset’s group.
  - Group changes now submit only the selected ruleset and group details.

- **Bug Fixes**
  - Improved loading and error feedback during group assignment and removal.
  - Restricted ruleset group reassignment to authorized owners.
  - Improved handling of unassigned and invalid group targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->