### PR TITLE
Author ruleset descriptions on the settings and create forms

### DIFF
--- a/e2e/ruleset-lifecycle.spec.ts
+++ b/e2e/ruleset-lifecycle.spec.ts
@@ -8,6 +8,10 @@ test('owner can create and delete a ruleset in a two-user flow', async ({ page, 
   const expectedSlug = uniqueName.toLowerCase();
   await page.goto('/rulesets/create');
   await page.getByRole('textbox', { name: 'Name' }).fill(uniqueName);
+  /* Creation requires a description of at least 50 characters, with no exemption, so the button stays disabled without one. */
+  await page
+    .getByRole('textbox', { name: 'Description' })
+    .fill('A lifecycle ruleset proving that creation and deletion behave for its owner.');
   await page.getByRole('button', { name: /^create$/i }).click();
   await expect(page).toHaveURL(new RegExp(`/rulesets/${expectedSlug}$`));
 

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
@@ -1,4 +1,5 @@
-import { Anchor, Center, Group, Image, Stack, Text, TextInput, Title } from '@mantine/core';
+import { Anchor, Center, Group, Image, Stack, Text, Textarea, TextInput, Title } from '@mantine/core';
+import { RULESET_DESCRIPTION_MIN_LENGTH, rulesetDescriptionSchema } from '@shared/rulesets/validation';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
 import { SlugRenameNotice } from '@ui/content/SlugRenameNotice';
@@ -18,15 +19,24 @@ function RulesetSettings({ initial, canRename }: { initial: RulesetEntry; canRen
   const navigate = useNavigate();
   const updateRuleset = useUpdateRuleset();
   const [name, setName] = useState(initial.name);
+  const [description, setDescription] = useState(initial.description ?? '');
   const [coverUrl, setCoverUrl] = useState(initial.image_cover ?? '');
 
   const mutationError =
     updateRuleset.isError && updateRuleset.error instanceof Error ? updateRuleset.error.message : null;
+  const descriptionCheck = rulesetDescriptionSchema.safeParse(description);
+  /**
+   * The floor applies to every save, with no exemption for rows that predate the field — so a ruleset still carrying the backfilled empty string cannot be saved until someone writes a description.
+   * Shown as an error only once something has been typed;
+   * an untouched empty field is explained by the requirement line and the disabled button instead.
+   */
+  const descriptionError =
+    description.trim().length > 0 && !descriptionCheck.success ? descriptionCheck.error.issues[0]?.message : undefined;
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     const nextName = name.trim();
-    if (!nextName) {
+    if (!nextName || !descriptionCheck.success) {
       return;
     }
     const trimmedCover = coverUrl.trim();
@@ -34,7 +44,7 @@ function RulesetSettings({ initial, canRename }: { initial: RulesetEntry; canRen
     try {
       const entry = await updateRuleset.mutateAsync({
         id: initial._id,
-        input: { name: nextName },
+        input: { name: nextName, description: descriptionCheck.data },
         imageCover: trimmedCover === '' ? null : trimmedCover,
       });
       if (previousSlug !== entry.slug) {
@@ -69,6 +79,19 @@ function RulesetSettings({ initial, canRename }: { initial: RulesetEntry; canRen
         disabled={!canRename}
       />
 
+      <Textarea
+        id="ruleset-settings-description"
+        name="description"
+        label="Description"
+        description={`What this ruleset is for, and how it differs from the base game. At least ${RULESET_DESCRIPTION_MIN_LENGTH} characters — ${description.trim().length} so far.`}
+        error={descriptionError}
+        required
+        autosize
+        minRows={4}
+        value={description}
+        onChange={(event) => setDescription(event.currentTarget.value)}
+      />
+
       <TextInput
         id="ruleset-settings-cover"
         type="url"
@@ -87,7 +110,10 @@ function RulesetSettings({ initial, canRename }: { initial: RulesetEntry; canRen
       {mutationError ? <FormError title="Ruleset could not be saved">{mutationError}</FormError> : null}
 
       <Group justify="flex-end">
-        <SubmitAction pending={updateRuleset.isPending} disabled={name.trim().length === 0}>
+        <SubmitAction
+          pending={updateRuleset.isPending}
+          disabled={name.trim().length === 0 || !descriptionCheck.success}
+        >
           Save changes
         </SubmitAction>
       </Group>

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
@@ -1,7 +1,8 @@
 import { Anchor, Center, Group, Image, Stack, Text, Textarea, TextInput, Title } from '@mantine/core';
-import { RULESET_DESCRIPTION_MIN_LENGTH, rulesetDescriptionSchema } from '@shared/rulesets/validation';
+import { rulesetDescriptionSchema } from '@shared/rulesets/validation';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
+import { rulesetDescriptionHint } from '@ui/content/rulesetDescriptionHint';
 import { SlugRenameNotice } from '@ui/content/SlugRenameNotice';
 import { IconAction } from '@ui/control/IconAction';
 import { SubmitAction } from '@ui/control/SubmitAction';
@@ -83,7 +84,7 @@ function RulesetSettings({ initial, canRename }: { initial: RulesetEntry; canRen
         id="ruleset-settings-description"
         name="description"
         label="Description"
-        description={`What this ruleset is for, and how it differs from the base game. At least ${RULESET_DESCRIPTION_MIN_LENGTH} characters — ${description.trim().length} so far.`}
+        description={rulesetDescriptionHint(description)}
         error={descriptionError}
         required
         autosize

--- a/src/app/routes/_app/rulesets/create.tsx
+++ b/src/app/routes/_app/rulesets/create.tsx
@@ -1,4 +1,5 @@
-import { Button, Group, NativeSelect, Stack, TextInput } from '@mantine/core';
+import { Button, Group, NativeSelect, Stack, Textarea, TextInput } from '@mantine/core';
+import { RULESET_DESCRIPTION_MIN_LENGTH, rulesetDescriptionSchema } from '@shared/rulesets/validation';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -19,8 +20,14 @@ function CreateRulesetForm({ ownerUserId }: { ownerUserId: string }) {
   const navigate = useNavigate();
   const createRuleset = useCreateRuleset();
   const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
   const [groupId, setGroupId] = useState<string | null>(null);
   const groups = useGroupsByCreator(ownerUserId);
+
+  const descriptionCheck = rulesetDescriptionSchema.safeParse(description);
+  /** Only complain about a description that has been started and left short; an empty one is covered by the requirement line. */
+  const descriptionError =
+    description.trim().length > 0 && !descriptionCheck.success ? descriptionCheck.error.issues[0]?.message : undefined;
 
   return (
     <Stack
@@ -29,11 +36,11 @@ function CreateRulesetForm({ ownerUserId }: { ownerUserId: string }) {
       onSubmit={(e) => {
         e.preventDefault();
         const nextName = name.trim();
-        if (!nextName) {
+        if (!nextName || !descriptionCheck.success) {
           return;
         }
         createRuleset.mutate(
-          { input: { name: nextName }, groupId: groupId ?? null },
+          { input: { name: nextName, description: descriptionCheck.data }, groupId: groupId ?? null },
           {
             onSuccess: (entry) => {
               navigate({
@@ -54,6 +61,17 @@ function CreateRulesetForm({ ownerUserId }: { ownerUserId: string }) {
         value={name}
         onChange={(event) => setName(event.target.value)}
       />
+      <Textarea
+        label="Description"
+        name="description"
+        description={`What this ruleset is for, and how it differs from the base game. At least ${RULESET_DESCRIPTION_MIN_LENGTH} characters — ${description.trim().length} so far.`}
+        error={descriptionError}
+        required
+        autosize
+        minRows={4}
+        value={description}
+        onChange={(event) => setDescription(event.target.value)}
+      />
       <NativeSelect
         label="Group"
         name="group"
@@ -69,7 +87,7 @@ function CreateRulesetForm({ ownerUserId }: { ownerUserId: string }) {
           variant="filled"
           color="confirm"
           type="submit"
-          disabled={createRuleset.isPending || name.trim().length === 0}
+          disabled={createRuleset.isPending || name.trim().length === 0 || !descriptionCheck.success}
         >
           <Plus size={16} aria-hidden />
           <span>{createRuleset.isPending ? 'Creating…' : 'Create'}</span>

--- a/src/app/routes/_app/rulesets/create.tsx
+++ b/src/app/routes/_app/rulesets/create.tsx
@@ -1,6 +1,8 @@
 import { Button, Group, NativeSelect, Stack, Textarea, TextInput } from '@mantine/core';
-import { RULESET_DESCRIPTION_MIN_LENGTH, rulesetDescriptionSchema } from '@shared/rulesets/validation';
+import { rulesetDescriptionSchema } from '@shared/rulesets/validation';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { FormError } from '@ui/block/FormError';
+import { rulesetDescriptionHint } from '@ui/content/rulesetDescriptionHint';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
@@ -54,7 +56,6 @@ function CreateRulesetForm({ ownerUserId }: { ownerUserId: string }) {
     >
       <TextInput
         label="Name"
-        error={createRuleset.error?.message}
         name="name"
         required
         minLength={1}
@@ -64,13 +65,13 @@ function CreateRulesetForm({ ownerUserId }: { ownerUserId: string }) {
       <Textarea
         label="Description"
         name="description"
-        description={`What this ruleset is for, and how it differs from the base game. At least ${RULESET_DESCRIPTION_MIN_LENGTH} characters — ${description.trim().length} so far.`}
+        description={rulesetDescriptionHint(description)}
         error={descriptionError}
         required
         autosize
         minRows={4}
         value={description}
-        onChange={(event) => setDescription(event.target.value)}
+        onChange={(event) => setDescription(event.currentTarget.value)}
       />
       <NativeSelect
         label="Group"
@@ -82,6 +83,9 @@ function CreateRulesetForm({ ownerUserId }: { ownerUserId: string }) {
           ...(groups.data?.map((group) => ({ value: group.id, label: group.name })) ?? []),
         ]}
       />
+      {createRuleset.error ? (
+        <FormError title="Ruleset could not be created">{createRuleset.error.message}</FormError>
+      ) : null}
       <Group gap="xs" wrap="nowrap">
         <Button
           variant="filled"

--- a/src/app/ui/content/rulesetDescriptionHint.ts
+++ b/src/app/ui/content/rulesetDescriptionHint.ts
@@ -1,0 +1,9 @@
+import { RULESET_DESCRIPTION_MIN_LENGTH } from '@shared/rulesets/validation';
+
+/**
+ * The requirement line under a ruleset description field, with a live count of what has been written.
+ * A support module rather than a component: it turns a length into words, which is Content's job, and it lives here because both ruleset forms show the identical sentence — the floor cannot drift, since it comes from the shared schema's constant, but the wording would if each form kept its own copy.
+ */
+export function rulesetDescriptionHint(value: string) {
+  return `What this ruleset is for, and how it differs from the base game. At least ${RULESET_DESCRIPTION_MIN_LENGTH} characters — ${value.trim().length} so far.`;
+}

--- a/src/shared/rulesets/validation.ts
+++ b/src/shared/rulesets/validation.ts
@@ -7,11 +7,20 @@ const rulesetNameSchema = alphanumericNameSchema('Ruleset name');
  * Free prose, so no upper bound — the FAQ's question and answer schemas set that precedent.
  * The floor is deliberate: a description shorter than this says nothing a reader could not get from the name.
  */
-const rulesetDescriptionSchema = z.string().trim().min(50, 'Ruleset description must be at least 50 characters');
+export const RULESET_DESCRIPTION_MIN_LENGTH = 50;
+
+export const rulesetDescriptionSchema = z
+  .string()
+  .trim()
+  .min(
+    RULESET_DESCRIPTION_MIN_LENGTH,
+    `Ruleset description must be at least ${RULESET_DESCRIPTION_MIN_LENGTH} characters`
+  );
 
 /**
- * `description` is optional here only for the widen phase of `rulesets_description_v1`: rows that predate the field carry an empty string, and no caller may be forced to invent 50 characters to change a ruleset's name.
- * It narrows to required once the backfill has run in production.
+ * `description` is optional here only for the widen phase of `rulesets_description_v1`, so that rows predating the field stay readable.
+ * There is no grace for those rows on the way out: every write goes through the floor, which means a ruleset still holding the backfilled empty string cannot be saved at all until someone writes a description.
+ * Both ruleset forms enforce that before submitting, and the field narrows to required once the backfill has run in production.
  */
 export const rulesetInputSchema = z.strictObject({
   name: rulesetNameSchema,


### PR DESCRIPTION
Adds the Description field to both ruleset forms, enforcing the 50-character floor client-side.

Resolves #429. Part of the map in #426.

## Decisions this encodes

- **All three fields live on `/rulesets/x/edit`**, not inline on the detail page. Name, cover and description are all ruleset content behind the same capability, and the detail page routes every write through its toolbar — an inline editor would be its first exception, in JSX that #436 is about to re-cut.
- **Authorization is unchanged.** The name stays owner-only via `capabilities.rename` (the field is already `disabled` for members); description and cover remain editable by an active member of the maintaining group, exactly as the cover is today.
- **The floor applies to every save, with no grace.** A ruleset still holding the backfilled empty string cannot be saved until someone writes a description. That is deliberate, not an oversight.

## What changed

- **`src/shared/rulesets/validation.ts`** — `rulesetDescriptionSchema` and `RULESET_DESCRIPTION_MIN_LENGTH` are exported now that the forms consume them (AGENTS.md sanctions client-side parsing for UX feedback). The comment on `rulesetInputSchema` claimed no caller could be forced to write 50 characters to rename a ruleset — that is now false, and it says so instead.
- **Both forms** — a `Textarea` whose description carries a live character count, an error only once something short has been typed, and a submit disabled until the value clears the floor. An untouched empty field is explained by the requirement line rather than shouted at.
- **`e2e/ruleset-lifecycle.spec.ts`** — fills the new field. Without it the Create button stays disabled and the spec fails, so this is a required change rather than added coverage.

## Not here

No new unit tests. The floor itself is already asserted at the seam in `rulesets.description.test.ts`, and the forms are route-local composition with no story surface; re-asserting the same rule through React would duplicate it (ADR-0002).

`publisher:release:verify` not run: nothing in this diff is a renderer-manifest ingredient, and CI's `publisher_release` job checks it regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rulesets now require a description of at least 50 characters when creating or editing.
  * Creation and editing forms display character progress and clear validation feedback.
  * Save and submit actions remain unavailable until the ruleset name and description meet validation requirements.
  * Descriptions are now included when creating or updating rulesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->