### PR TITLE
Add a ColumnsWithRailLayout and move the ruleset page onto it

### DIFF
--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -26,6 +26,7 @@ import { StatusBadge } from '@ui/content/StatusBadge';
 import { TopicIcon } from '@ui/content/TopicIcon';
 import { AssignPopover } from '@ui/control/AssignPopover';
 import { IconAction } from '@ui/control/IconAction';
+import { ColumnsWithRailLayout } from '@ui/layout/ColumnsWithRailLayout';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { FaqList } from '@ui/list/FaqList';
 import { Stats } from '@ui/list/Stats';
@@ -338,253 +339,258 @@ function RulesetDetailPage() {
         </Toolbar>
       </PageLayout.Toolbar>
       <PageLayout.Content>
-        <Box className={styles.detailGrid}>
-          <Stack gap="xl" className={styles.primaryColumn}>
-            {mutationError ? (
-              <Alert color="red" title="The change could not be saved" role="alert">
-                {mutationError}
-              </Alert>
-            ) : null}
+        <ColumnsWithRailLayout>
+          <ColumnsWithRailLayout.Primary>
+            <Stack gap="xl">
+              {mutationError ? (
+                <Alert color="red" title="The change could not be saved" role="alert">
+                  {mutationError}
+                </Alert>
+              ) : null}
 
-            <Section id="overview" icon={<BookOpen size={20} aria-hidden />} title="About this ruleset">
-              <Surface padding="lg">
-                <ProposedContent label="Planned content · new fields required">
-                  <Text>
-                    A concise introduction explaining the ruleset&apos;s purpose, intended audience, and how it differs
-                    from the base game.
-                  </Text>
-                  <Text c="dimmed">
-                    Compatibility should identify the base edition or parent ruleset, required expansions, and whether
-                    this ruleset can be mixed with other variants.
+              <Section id="overview" icon={<BookOpen size={20} aria-hidden />} title="About this ruleset">
+                <Surface padding="lg">
+                  <ProposedContent label="Planned content · new fields required">
+                    <Text>
+                      A concise introduction explaining the ruleset&apos;s purpose, intended audience, and how it
+                      differs from the base game.
+                    </Text>
+                    <Text c="dimmed">
+                      Compatibility should identify the base edition or parent ruleset, required expansions, and whether
+                      this ruleset can be mixed with other variants.
+                    </Text>
+                  </ProposedContent>
+                </Surface>
+              </Section>
+
+              <Section
+                id="rules"
+                icon={<TopicIcon topic="rules" size={20} />}
+                title="Rules and variants"
+                description="Proposed structured rule sections would make the ruleset useful before the FAQ has accumulated questions."
+              >
+                <Stack gap="md">
+                  {[
+                    ['Setup changes', 'Changes to preparation, starting resources, map state, and player count.'],
+                    ['Core rule changes', 'The rules that override or extend the base game during normal play.'],
+                    ['Victory and end game', 'Changed victory conditions, turn limits, tie breakers, or scoring.'],
+                    ['Optional variants', 'Clearly optional modules that groups may enable independently.'],
+                  ].map(([title, description]) => (
+                    <Card key={title} title={title}>
+                      <Text size="sm" c="dimmed">
+                        {description}
+                      </Text>
+                    </Card>
+                  ))}
+                </Stack>
+              </Section>
+
+              <Section id="factions" icon={<Layers3 size={20} aria-hidden />} title="Included factions">
+                {page.factions.length > 0 ? (
+                  <SimpleGrid cols={{ base: 1, lg: 2 }} spacing="md">
+                    {page.factions.map((f) => (
+                      <Spotlight
+                        key={f.factionId}
+                        media={
+                          f.identity ? (
+                            <FactionToken logo={f.identity.logo} background={f.identity.background} />
+                          ) : (
+                            <TopicIcon topic="identity" size={24} />
+                          )
+                        }
+                        title={f.name}
+                        meta="Details, components, and special rules"
+                        renderRoot={(rootProps) => (
+                          <Link {...rootProps} to="/factions/$factionId" params={{ factionId: f.urlSlug }} />
+                        )}
+                      />
+                    ))}
+                  </SimpleGrid>
+                ) : (
+                  <Surface padding="lg">
+                    <Text size="sm" c="dimmed">
+                      No factions have been added to this ruleset yet.
+                    </Text>
+                  </Surface>
+                )}
+              </Section>
+            </Stack>
+          </ColumnsWithRailLayout.Primary>
+
+          <ColumnsWithRailLayout.Secondary>
+            <Section
+              id="faq"
+              icon={<CircleHelp size={20} aria-hidden />}
+              title="Community FAQ"
+              description="Browse community questions and accepted answers."
+            >
+              <TextInput
+                value={search.q ?? ''}
+                onChange={(event) => handleFaqSearchChange(event.currentTarget.value)}
+                placeholder="Search questions…"
+                aria-label="Search FAQ questions"
+                leftSection={<Search size={16} aria-hidden />}
+                leftSectionPointerEvents="none"
+                rightSectionWidth="8rem"
+                rightSectionPointerEvents="all"
+                size="md"
+                radius="md"
+                classNames={{ wrapper: styles.faqFilterWrapper }}
+                rightSection={
+                  <Select
+                    value={search.tag ?? '__all__'}
+                    onChange={handleFaqTagChange}
+                    data={[
+                      { value: '__all__', label: 'All tags' },
+                      ...FAQ_TAG_VALUES.map((tag) => ({
+                        value: tag,
+                        label: FAQ_TAG_LABELS[tag],
+                      })),
+                    ]}
+                    aria-label="Filter FAQ by tag"
+                    allowDeselect={false}
+                    variant="unstyled"
+                    size="sm"
+                    rightSectionWidth="2rem"
+                    comboboxProps={{ shadow: 'md' }}
+                    classNames={{
+                      root: styles.faqTagSelect,
+                      wrapper: styles.faqTagSelectWrapper,
+                      input: styles.faqTagSelectInput,
+                    }}
+                  />
+                }
+              />
+              <FaqList
+                items={page.faqItems}
+                rulesetSlug={r.slug}
+                searchQuery={search.q ?? ''}
+                selectedTag={search.tag}
+                onOpenQuestion={(questionSlug) =>
+                  navigate({
+                    to: '/rulesets/$rulesetSlug/faq/$questionSlug',
+                    params: { rulesetSlug: r.slug, questionSlug },
+                  })
+                }
+              />
+            </Section>
+          </ColumnsWithRailLayout.Secondary>
+
+          <ColumnsWithRailLayout.Rail>
+            <Stack gap="md" component="aside" aria-label="Ruleset details" miw={0}>
+              <Card icon={<ListTree size={20} aria-hidden />} title="At a glance">
+                <Stats
+                  items={[
+                    {
+                      key: 'factions',
+                      icon: <Layers3 size={17} aria-hidden />,
+                      value: page.factions.length,
+                      label: `${page.factions.length} ${page.factions.length === 1 ? 'faction' : 'factions'}`,
+                    },
+                    {
+                      key: 'questions',
+                      icon: <CircleHelp size={17} aria-hidden />,
+                      value: page.faqItems.length,
+                      label: `${page.faqItems.length} ${page.faqItems.length === 1 ? 'question' : 'questions'}`,
+                    },
+                    {
+                      key: 'answered',
+                      icon: <CheckCircle2 size={17} aria-hidden />,
+                      value: answeredFaqCount,
+                      label: `${answeredFaqCount} answered ${answeredFaqCount === 1 ? 'question' : 'questions'}`,
+                    },
+                    {
+                      key: 'version',
+                      icon: <FileText size={17} aria-hidden />,
+                      value: '—',
+                      label: 'Version not specified',
+                    },
+                  ]}
+                />
+              </Card>
+
+              <Card icon={<UsersRound size={20} aria-hidden />} title="Stewardship">
+                <Stack gap="sm">
+                  <Box>
+                    <Eyebrow>Owner</Eyebrow>
+                    {page.owner ? (
+                      <ProfileLink
+                        slug={page.owner.slug}
+                        username={page.owner.username}
+                        avatar_url={page.owner.avatar_url}
+                      />
+                    ) : (
+                      <Text size="sm">Unknown</Text>
+                    )}
+                  </Box>
+                  <Divider />
+                  {!assignedGroup ? (
+                    <Text size="sm" c="dimmed">
+                      No maintaining group.
+                    </Text>
+                  ) : (
+                    <Stack gap="sm">
+                      <Box>
+                        <Eyebrow>Maintaining group</Eyebrow>
+                        {assignedGroup.slug ? (
+                          <Anchor
+                            fw={600}
+                            renderRoot={(rootProps) => (
+                              <Link {...rootProps} to="/groups/$groupSlug" params={{ groupSlug: assignedGroup.slug }} />
+                            )}
+                          >
+                            {assignedGroup.name}
+                          </Anchor>
+                        ) : (
+                          <Text fw={600}>{assignedGroup.name}</Text>
+                        )}
+                      </Box>
+                      <Group justify="space-between" gap="xs">
+                        <Text size="sm" c="dimmed">
+                          Your membership
+                        </Text>
+                        <StatusBadge
+                          tone={
+                            membershipStatus === 'active'
+                              ? 'positive'
+                              : membershipStatus === 'pending'
+                                ? 'pending'
+                                : 'neutral'
+                          }
+                        >
+                          {membershipStatus === 'active'
+                            ? 'Active'
+                            : membershipStatus === 'pending'
+                              ? 'Pending'
+                              : 'Not a member'}
+                        </StatusBadge>
+                      </Group>
+                      {canRequestMembership ? (
+                        <Button
+                          type="button"
+                          variant="light"
+                          leftSection={<UserPlus size={16} aria-hidden />}
+                          loading={membershipWorkflow.request.isPending}
+                          onClick={() => void membershipWorkflow.request.run(assignedGroup.id).catch(() => undefined)}
+                        >
+                          Request membership
+                        </Button>
+                      ) : null}
+                    </Stack>
+                  )}
+                </Stack>
+              </Card>
+
+              <Card icon={<FileText size={20} aria-hidden />} title="Resources">
+                <ProposedContent label="Proposed content">
+                  <Text size="sm" c="dimmed">
+                    Printable rules, release notes, and a version history could live here.
                   </Text>
                 </ProposedContent>
-              </Surface>
-            </Section>
-
-            <Section
-              id="rules"
-              icon={<TopicIcon topic="rules" size={20} />}
-              title="Rules and variants"
-              description="Proposed structured rule sections would make the ruleset useful before the FAQ has accumulated questions."
-            >
-              <Stack gap="md">
-                {[
-                  ['Setup changes', 'Changes to preparation, starting resources, map state, and player count.'],
-                  ['Core rule changes', 'The rules that override or extend the base game during normal play.'],
-                  ['Victory and end game', 'Changed victory conditions, turn limits, tie breakers, or scoring.'],
-                  ['Optional variants', 'Clearly optional modules that groups may enable independently.'],
-                ].map(([title, description]) => (
-                  <Card key={title} title={title}>
-                    <Text size="sm" c="dimmed">
-                      {description}
-                    </Text>
-                  </Card>
-                ))}
-              </Stack>
-            </Section>
-
-            <Section id="factions" icon={<Layers3 size={20} aria-hidden />} title="Included factions">
-              {page.factions.length > 0 ? (
-                <SimpleGrid cols={{ base: 1, lg: 2 }} spacing="md">
-                  {page.factions.map((f) => (
-                    <Spotlight
-                      key={f.factionId}
-                      media={
-                        f.identity ? (
-                          <FactionToken logo={f.identity.logo} background={f.identity.background} />
-                        ) : (
-                          <TopicIcon topic="identity" size={24} />
-                        )
-                      }
-                      title={f.name}
-                      meta="Details, components, and special rules"
-                      renderRoot={(rootProps) => (
-                        <Link {...rootProps} to="/factions/$factionId" params={{ factionId: f.urlSlug }} />
-                      )}
-                    />
-                  ))}
-                </SimpleGrid>
-              ) : (
-                <Surface padding="lg">
-                  <Text size="sm" c="dimmed">
-                    No factions have been added to this ruleset yet.
-                  </Text>
-                </Surface>
-              )}
-            </Section>
-          </Stack>
-
-          <Section
-            id="faq"
-            className={styles.communityColumn}
-            icon={<CircleHelp size={20} aria-hidden />}
-            title="Community FAQ"
-            description="Browse community questions and accepted answers."
-          >
-            <TextInput
-              value={search.q ?? ''}
-              onChange={(event) => handleFaqSearchChange(event.currentTarget.value)}
-              placeholder="Search questions…"
-              aria-label="Search FAQ questions"
-              leftSection={<Search size={16} aria-hidden />}
-              leftSectionPointerEvents="none"
-              rightSectionWidth="8rem"
-              rightSectionPointerEvents="all"
-              size="md"
-              radius="md"
-              classNames={{ wrapper: styles.faqFilterWrapper }}
-              rightSection={
-                <Select
-                  value={search.tag ?? '__all__'}
-                  onChange={handleFaqTagChange}
-                  data={[
-                    { value: '__all__', label: 'All tags' },
-                    ...FAQ_TAG_VALUES.map((tag) => ({
-                      value: tag,
-                      label: FAQ_TAG_LABELS[tag],
-                    })),
-                  ]}
-                  aria-label="Filter FAQ by tag"
-                  allowDeselect={false}
-                  variant="unstyled"
-                  size="sm"
-                  rightSectionWidth="2rem"
-                  comboboxProps={{ shadow: 'md' }}
-                  classNames={{
-                    root: styles.faqTagSelect,
-                    wrapper: styles.faqTagSelectWrapper,
-                    input: styles.faqTagSelectInput,
-                  }}
-                />
-              }
-            />
-            <FaqList
-              items={page.faqItems}
-              rulesetSlug={r.slug}
-              searchQuery={search.q ?? ''}
-              selectedTag={search.tag}
-              onOpenQuestion={(questionSlug) =>
-                navigate({
-                  to: '/rulesets/$rulesetSlug/faq/$questionSlug',
-                  params: { rulesetSlug: r.slug, questionSlug },
-                })
-              }
-            />
-          </Section>
-
-          <Stack gap="md" component="aside" aria-label="Ruleset details" miw={0} className={styles.detailsColumn}>
-            <Card icon={<ListTree size={20} aria-hidden />} title="At a glance">
-              <Stats
-                items={[
-                  {
-                    key: 'factions',
-                    icon: <Layers3 size={17} aria-hidden />,
-                    value: page.factions.length,
-                    label: `${page.factions.length} ${page.factions.length === 1 ? 'faction' : 'factions'}`,
-                  },
-                  {
-                    key: 'questions',
-                    icon: <CircleHelp size={17} aria-hidden />,
-                    value: page.faqItems.length,
-                    label: `${page.faqItems.length} ${page.faqItems.length === 1 ? 'question' : 'questions'}`,
-                  },
-                  {
-                    key: 'answered',
-                    icon: <CheckCircle2 size={17} aria-hidden />,
-                    value: answeredFaqCount,
-                    label: `${answeredFaqCount} answered ${answeredFaqCount === 1 ? 'question' : 'questions'}`,
-                  },
-                  {
-                    key: 'version',
-                    icon: <FileText size={17} aria-hidden />,
-                    value: '—',
-                    label: 'Version not specified',
-                  },
-                ]}
-              />
-            </Card>
-
-            <Card icon={<UsersRound size={20} aria-hidden />} title="Stewardship">
-              <Stack gap="sm">
-                <Box>
-                  <Eyebrow>Owner</Eyebrow>
-                  {page.owner ? (
-                    <ProfileLink
-                      slug={page.owner.slug}
-                      username={page.owner.username}
-                      avatar_url={page.owner.avatar_url}
-                    />
-                  ) : (
-                    <Text size="sm">Unknown</Text>
-                  )}
-                </Box>
-                <Divider />
-                {!assignedGroup ? (
-                  <Text size="sm" c="dimmed">
-                    No maintaining group.
-                  </Text>
-                ) : (
-                  <Stack gap="sm">
-                    <Box>
-                      <Eyebrow>Maintaining group</Eyebrow>
-                      {assignedGroup.slug ? (
-                        <Anchor
-                          fw={600}
-                          renderRoot={(rootProps) => (
-                            <Link {...rootProps} to="/groups/$groupSlug" params={{ groupSlug: assignedGroup.slug }} />
-                          )}
-                        >
-                          {assignedGroup.name}
-                        </Anchor>
-                      ) : (
-                        <Text fw={600}>{assignedGroup.name}</Text>
-                      )}
-                    </Box>
-                    <Group justify="space-between" gap="xs">
-                      <Text size="sm" c="dimmed">
-                        Your membership
-                      </Text>
-                      <StatusBadge
-                        tone={
-                          membershipStatus === 'active'
-                            ? 'positive'
-                            : membershipStatus === 'pending'
-                              ? 'pending'
-                              : 'neutral'
-                        }
-                      >
-                        {membershipStatus === 'active'
-                          ? 'Active'
-                          : membershipStatus === 'pending'
-                            ? 'Pending'
-                            : 'Not a member'}
-                      </StatusBadge>
-                    </Group>
-                    {canRequestMembership ? (
-                      <Button
-                        type="button"
-                        variant="light"
-                        leftSection={<UserPlus size={16} aria-hidden />}
-                        loading={membershipWorkflow.request.isPending}
-                        onClick={() => void membershipWorkflow.request.run(assignedGroup.id).catch(() => undefined)}
-                      >
-                        Request membership
-                      </Button>
-                    ) : null}
-                  </Stack>
-                )}
-              </Stack>
-            </Card>
-
-            <Card icon={<FileText size={20} aria-hidden />} title="Resources">
-              <ProposedContent label="Proposed content">
-                <Text size="sm" c="dimmed">
-                  Printable rules, release notes, and a version history could live here.
-                </Text>
-              </ProposedContent>
-            </Card>
-          </Stack>
-        </Box>
+              </Card>
+            </Stack>
+          </ColumnsWithRailLayout.Rail>
+        </ColumnsWithRailLayout>
       </PageLayout.Content>
     </PageLayout>
   );

--- a/src/app/routes/_app/rulesets/RulesetDetail.module.css
+++ b/src/app/routes/_app/rulesets/RulesetDetail.module.css
@@ -51,24 +51,6 @@
   color: var(--color-text, var(--mantine-color-dark-8));
 }
 
-.detailGrid {
-  display: grid;
-  grid-template-areas: "primary community details";
-  grid-template-columns: minmax(0, 5fr) minmax(0, 4fr) minmax(14rem, 3fr);
-  gap: var(--mantine-spacing-xl);
-  align-items: start;
-}
-
-.primaryColumn {
-  grid-area: primary;
-  min-width: 0;
-}
-
-.communityColumn {
-  grid-area: community;
-  min-width: 0;
-}
-
 .faqFilterWrapper {
   border-radius: var(--mantine-radius-md);
   box-shadow: var(--mantine-shadow-sm);
@@ -93,29 +75,7 @@
   font-weight: 700;
 }
 
-.detailsColumn {
-  grid-area: details;
-  min-width: 0;
-}
-
-@media (max-width: 62em) {
-  .detailGrid {
-    grid-template-areas:
-      "primary details"
-      "primary community";
-    grid-template-columns: minmax(0, 3fr) minmax(18rem, 2fr);
-  }
-}
-
 @media (max-width: 48em) {
-  .detailGrid {
-    grid-template-areas:
-      "primary"
-      "community"
-      "details";
-    grid-template-columns: minmax(0, 1fr);
-  }
-
   .pageHead {
     align-items: flex-start;
     gap: var(--mantine-spacing-md);

--- a/src/app/ui/layout/ColumnsWithRailLayout.module.css
+++ b/src/app/ui/layout/ColumnsWithRailLayout.module.css
@@ -1,0 +1,52 @@
+.root {
+  container: columns-with-rail-layout / inline-size;
+  min-width: 0;
+}
+
+/* One reading column until there is room for more: primary, then secondary, then the rail. */
+.layout {
+  display: grid;
+  grid-template-areas:
+    "primary"
+    "secondary"
+    "rail";
+  grid-template-columns: minmax(0, 1fr);
+  gap: var(--mantine-spacing-xl);
+  align-items: start;
+}
+
+.layout > * {
+  min-width: 0;
+}
+
+.primary {
+  grid-area: primary;
+}
+
+.secondary {
+  grid-area: secondary;
+}
+
+.rail {
+  grid-area: rail;
+}
+
+/*
+ * The middle stage: the rail rises beside the secondary column while the primary keeps its own width down the left.
+ * The rail leads, because it is the summary the two columns beneath it elaborate.
+ */
+@container columns-with-rail-layout (min-width: 48rem) {
+  .layout {
+    grid-template-areas:
+      "primary rail"
+      "primary secondary";
+    grid-template-columns: minmax(0, 3fr) minmax(18rem, 2fr);
+  }
+}
+
+@container columns-with-rail-layout (min-width: 62rem) {
+  .layout {
+    grid-template-areas: "primary secondary rail";
+    grid-template-columns: minmax(0, 5fr) minmax(0, 4fr) minmax(14rem, 3fr);
+  }
+}

--- a/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
+++ b/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
@@ -17,35 +17,57 @@ const meta = preview.meta({
   },
 });
 
-const slots = (
-  <>
-    <ColumnsWithRailLayout.Primary>
-      <LayoutSlotPlaceholder name="primary" minHeight={420} />
-    </ColumnsWithRailLayout.Primary>
-    <ColumnsWithRailLayout.Secondary>
-      <LayoutSlotPlaceholder name="secondary" minHeight={320} />
-    </ColumnsWithRailLayout.Secondary>
-    <ColumnsWithRailLayout.Rail>
-      <LayoutSlotPlaceholder name="rail" minHeight={240} />
-    </ColumnsWithRailLayout.Rail>
-  </>
-);
-
 /** Widest: three columns, the rail last and narrowest. */
 export const ThreeColumns = meta.story({
-  render: () => <ColumnsWithRailLayout>{slots}</ColumnsWithRailLayout>,
+  render: () => (
+    <ColumnsWithRailLayout>
+      <ColumnsWithRailLayout.Primary>
+        <LayoutSlotPlaceholder name="primary" minHeight={420} />
+      </ColumnsWithRailLayout.Primary>
+      <ColumnsWithRailLayout.Secondary>
+        <LayoutSlotPlaceholder name="secondary" minHeight={320} />
+      </ColumnsWithRailLayout.Secondary>
+      <ColumnsWithRailLayout.Rail>
+        <LayoutSlotPlaceholder name="rail" minHeight={240} />
+      </ColumnsWithRailLayout.Rail>
+    </ColumnsWithRailLayout>
+  ),
   globals: { viewport: { value: 'appDesktop' } },
 });
 
 /** The middle stage: the primary column holds its width while the rail and secondary stack beside it. */
 export const RailBesidePrimary = meta.story({
-  render: () => <ColumnsWithRailLayout>{slots}</ColumnsWithRailLayout>,
+  render: () => (
+    <ColumnsWithRailLayout>
+      <ColumnsWithRailLayout.Primary>
+        <LayoutSlotPlaceholder name="primary" minHeight={420} />
+      </ColumnsWithRailLayout.Primary>
+      <ColumnsWithRailLayout.Secondary>
+        <LayoutSlotPlaceholder name="secondary" minHeight={320} />
+      </ColumnsWithRailLayout.Secondary>
+      <ColumnsWithRailLayout.Rail>
+        <LayoutSlotPlaceholder name="rail" minHeight={240} />
+      </ColumnsWithRailLayout.Rail>
+    </ColumnsWithRailLayout>
+  ),
   globals: { viewport: { value: 'appConstrained' } },
 });
 
 /** Narrowest: one reading column, primary first and the rail last. Driven by the container, not the viewport. */
 export const Stacked = meta.story({
-  render: () => <ColumnsWithRailLayout>{slots}</ColumnsWithRailLayout>,
+  render: () => (
+    <ColumnsWithRailLayout>
+      <ColumnsWithRailLayout.Primary>
+        <LayoutSlotPlaceholder name="primary" minHeight={420} />
+      </ColumnsWithRailLayout.Primary>
+      <ColumnsWithRailLayout.Secondary>
+        <LayoutSlotPlaceholder name="secondary" minHeight={320} />
+      </ColumnsWithRailLayout.Secondary>
+      <ColumnsWithRailLayout.Rail>
+        <LayoutSlotPlaceholder name="rail" minHeight={240} />
+      </ColumnsWithRailLayout.Rail>
+    </ColumnsWithRailLayout>
+  ),
   globals: { viewport: { value: 'appMobile' } },
 });
 

--- a/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
+++ b/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
@@ -1,0 +1,71 @@
+import { Image, Stack, Text } from '@mantine/core';
+import preview from '@sb/preview';
+
+import { ColumnsWithRailLayout } from './ColumnsWithRailLayout';
+import { LayoutSlotPlaceholder } from './LayoutSlotPlaceholder.stories.fixture';
+
+const meta = preview.meta({
+  component: ColumnsWithRailLayout,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Places two reading columns beside a narrow rail, top-aligned, and gives the columns up in two stages as its own container narrows: first the rail rises beside the secondary column, then everything stacks. Its parent owns page width and outer spacing.',
+      },
+    },
+  },
+});
+
+const slots = (
+  <>
+    <ColumnsWithRailLayout.Primary>
+      <LayoutSlotPlaceholder name="primary" minHeight={420} />
+    </ColumnsWithRailLayout.Primary>
+    <ColumnsWithRailLayout.Secondary>
+      <LayoutSlotPlaceholder name="secondary" minHeight={320} />
+    </ColumnsWithRailLayout.Secondary>
+    <ColumnsWithRailLayout.Rail>
+      <LayoutSlotPlaceholder name="rail" minHeight={240} />
+    </ColumnsWithRailLayout.Rail>
+  </>
+);
+
+/** Widest: three columns, the rail last and narrowest. */
+export const ThreeColumns = meta.story({
+  render: () => <ColumnsWithRailLayout>{slots}</ColumnsWithRailLayout>,
+  globals: { viewport: { value: 'appDesktop' } },
+});
+
+/** The middle stage: the primary column holds its width while the rail and secondary stack beside it. */
+export const RailBesidePrimary = meta.story({
+  render: () => <ColumnsWithRailLayout>{slots}</ColumnsWithRailLayout>,
+  globals: { viewport: { value: 'appConstrained' } },
+});
+
+/** Narrowest: one reading column, primary first and the rail last. Driven by the container, not the viewport. */
+export const Stacked = meta.story({
+  render: () => <ColumnsWithRailLayout>{slots}</ColumnsWithRailLayout>,
+  globals: { viewport: { value: 'appMobile' } },
+});
+
+/** An unbreakable word and an oversized image must both respect the column they are given. */
+export const IntrinsicSizingStress = meta.story({
+  render: () => (
+    <ColumnsWithRailLayout>
+      <ColumnsWithRailLayout.Primary>
+        <Stack gap="md">
+          <Text>DuneZoneLayoutStressCaseWithAnUnbrokenFactionNameThatMustRespectItsAllocatedContainer</Text>
+          <Image alt="Intrinsic sizing test" mah={320} src="/web/tablet1.jpg" w={1400} />
+        </Stack>
+      </ColumnsWithRailLayout.Primary>
+      <ColumnsWithRailLayout.Secondary>
+        <LayoutSlotPlaceholder name="secondary" minHeight={320} />
+      </ColumnsWithRailLayout.Secondary>
+      <ColumnsWithRailLayout.Rail>
+        <LayoutSlotPlaceholder name="rail" minHeight={240} />
+      </ColumnsWithRailLayout.Rail>
+    </ColumnsWithRailLayout>
+  ),
+  globals: { viewport: { value: 'appDesktop' } },
+});

--- a/src/app/ui/layout/ColumnsWithRailLayout.test.tsx
+++ b/src/app/ui/layout/ColumnsWithRailLayout.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { ColumnsWithRailLayout } from './ColumnsWithRailLayout';
+
+describe('ColumnsWithRailLayout', () => {
+  it('renders each slot, in source order', () => {
+    const markup = renderToStaticMarkup(
+      <ColumnsWithRailLayout>
+        <ColumnsWithRailLayout.Primary>
+          <p>Primary region</p>
+        </ColumnsWithRailLayout.Primary>
+        <ColumnsWithRailLayout.Secondary>
+          <p>Secondary region</p>
+        </ColumnsWithRailLayout.Secondary>
+        <ColumnsWithRailLayout.Rail>
+          <p>Rail region</p>
+        </ColumnsWithRailLayout.Rail>
+      </ColumnsWithRailLayout>
+    );
+
+    expect(markup).toContain('<p>Primary region</p>');
+    expect(markup).toContain('<p>Secondary region</p>');
+    expect(markup).toContain('<p>Rail region</p>');
+    expect(markup.indexOf('Primary region')).toBeLessThan(markup.indexOf('Secondary region'));
+    expect(markup.indexOf('Secondary region')).toBeLessThan(markup.indexOf('Rail region'));
+  });
+});

--- a/src/app/ui/layout/ColumnsWithRailLayout.tsx
+++ b/src/app/ui/layout/ColumnsWithRailLayout.tsx
@@ -1,0 +1,74 @@
+import clsx from 'clsx';
+import { Children, isValidElement } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
+
+import styles from './ColumnsWithRailLayout.module.css';
+
+function Primary(_: PropsWithChildren): null {
+  return null;
+}
+
+function Secondary(_: PropsWithChildren): null {
+  return null;
+}
+
+function Rail(_: PropsWithChildren): null {
+  return null;
+}
+
+/**
+ * Two reading columns beside a narrow rail, top-aligned, responsive by container query.
+ *
+ * Distinct from `TriptychLayout`, which centres its slots vertically around a middle panel holding artwork.
+ * Here every slot is text a reader works down, so they align to the top and the rail keeps a floor width rather than a share of the room.
+ *
+ * It gives up its columns in two stages instead of one: first the rail moves up beside the secondary column while the primary keeps its width, and only then does everything stack.
+ * That middle stage exists because collapsing a narrow rail straight into the reading flow buries it below content it was meant to sit beside.
+ *
+ * Callers own what goes in each slot and the page width around it;
+ * this owns only where the three regions sit.
+ */
+function ColumnsWithRailLayoutBase({ className, children }: PropsWithChildren<{ className?: string }>) {
+  let primary: ReactNode = null;
+  let secondary: ReactNode = null;
+  let rail: ReactNode = null;
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) {
+      return;
+    }
+    if (child.type === Primary) {
+      primary = (child.props as PropsWithChildren).children;
+      return;
+    }
+    if (child.type === Secondary) {
+      secondary = (child.props as PropsWithChildren).children;
+      return;
+    }
+    if (child.type === Rail) {
+      rail = (child.props as PropsWithChildren).children;
+    }
+  });
+
+  return (
+    <div className={clsx(styles.root, className)}>
+      <div className={styles.layout}>
+        <div className={styles.primary}>{primary}</div>
+        <div className={styles.secondary}>{secondary}</div>
+        <div className={styles.rail}>{rail}</div>
+      </div>
+    </div>
+  );
+}
+
+type ColumnsWithRailLayoutComponent = ((props: PropsWithChildren<{ className?: string }>) => ReactNode) & {
+  Primary: typeof Primary;
+  Secondary: typeof Secondary;
+  Rail: typeof Rail;
+};
+
+export const ColumnsWithRailLayout = Object.assign(ColumnsWithRailLayoutBase, {
+  Primary,
+  Secondary,
+  Rail,
+}) as ColumnsWithRailLayoutComponent;

--- a/src/app/ui/layout/ColumnsWithRailLayout.tsx
+++ b/src/app/ui/layout/ColumnsWithRailLayout.tsx
@@ -27,6 +27,8 @@ function Rail(_: PropsWithChildren): null {
  *
  * Callers own what goes in each slot and the page width around it;
  * this owns only where the three regions sit.
+ *
+ * Pass the slots as direct children, the way every kit Layout expects them: `Children.forEach` walks arrays but not fragments, so grouping them inside a `<>…</>` yields three empty columns and no error at all.
  */
 function ColumnsWithRailLayoutBase({ className, children }: PropsWithChildren<{ className?: string }>) {
   let primary: ReactNode = null;
@@ -47,6 +49,7 @@ function ColumnsWithRailLayoutBase({ className, children }: PropsWithChildren<{ 
     }
     if (child.type === Rail) {
       rail = (child.props as PropsWithChildren).children;
+      return;
     }
   });
 


### PR DESCRIPTION
The ruleset detail page's three columns become a kit Layout with named slots and container queries.

Resolves #430. Part of the map in #426.

## Why a new Layout, not a `TriptychLayout` variant

`TriptychLayout` centres its slots vertically around a middle panel holding artwork — the homepage passes `<AnimatedLeaderToken />` to its `Center` slot, which is why `.center` is `place-items: center` and why `.centerFill` exists. The ruleset page's middle column is the FAQ: text a reader works down, top-aligned, beside a narrow rail with a floor width.

Same silhouette, different intent. A `variant` prop would have meant one component owning two alignments, two sets of ratios and two collapse behaviours — two layouts sharing a name. `TriptychLayout` and the homepage are untouched by this PR.

## What it owns

- **Named slots** — `Primary`, `Secondary`, `Rail`, following the house habit of naming slots by proportion or role (`Wide`/`Narrow`, `Sidebar`/`Content`) so nothing domain-specific leaks into the kit.
- **Container queries, not media queries** — mandatory inside `src/app/ui/layout` and enforced by `containerQueries.test.ts`. The old grid responded to the window; this responds to the room it is given.
- **A two-stage collapse, kept deliberately.** Three columns → the rail rises beside the secondary column while the primary holds its width → everything stacks. That middle stage was already shipped behaviour, and it exists because collapsing a narrow rail straight into the reading flow buries it below the content it was meant to sit beside.
- **Stories** — four, under the existing Layout root: the three arrangements plus the intrinsic-sizing stress case the other layouts carry.

## What this PR does not do

Column *contents* are unchanged. Re-cutting them — description and rulebook placeholder, Q&A, factions — is #436, so this stays a pure move and the two changes can be reviewed apart.

`.detailGrid`, `.primaryColumn`, `.communityColumn` and `.detailsColumn` are deleted from the route's CSS module; the remaining `@media` blocks there style the page header, which is viewport-scoped chrome.

## Verification

`typecheck`, `lint`, `format:check`, `check:css-orphans` (52 stylesheets, no orphans), the full suite at 469 tests, and the new story file under the Storybook runner — 4 stories, all rendering.

`publisher:release:verify` not run: nothing here is a renderer-manifest ingredient, and CI's `publisher_release` job checks it regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Redesigned ruleset detail pages with clearer primary, secondary, and rail sections.
  * Improved responsive behavior across desktop, tablet, and mobile screen sizes.
  * Preserved existing ruleset content, filtering, navigation, and actions.
  * Improved readability and content organization through more consistent spacing and alignment.

* **Testing**
  * Added responsive layout previews covering stacked, intermediate, three-column, and content-sizing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->