### PR TITLE
Narrow the ruleset description to a required field

### DIFF
--- a/convex/collaborationPermissions.test.ts
+++ b/convex/collaborationPermissions.test.ts
@@ -49,6 +49,7 @@ async function collaborationFixture() {
   const contributor = t.withIdentity({ subject: ids.contributorId });
   const ruleset = await owner.mutation(api.rulesets.create, {
     name: 'CollaborativeRuleset',
+    description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
     group_id: ids.groupId,
     image_cover: null,
   });
@@ -63,6 +64,7 @@ describe('group collaboration permissions', () => {
       member.mutation(api.rulesets.update, {
         id: ruleset._id,
         name: ruleset.name,
+        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
         image_cover: 'https://example.com/collaborative-cover.jpg',
       })
     ).resolves.toMatchObject({
@@ -73,6 +75,7 @@ describe('group collaboration permissions', () => {
       member.mutation(api.rulesets.update, {
         id: ruleset._id,
         name: 'MemberRename',
+        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       })
     ).rejects.toThrow('Only the ruleset owner can rename this ruleset');
     await expect(member.mutation(api.rulesets.setGroup, { id: ruleset._id, group_id: null })).rejects.toThrow(

--- a/convex/collaborativeAccess.test.ts
+++ b/convex/collaborativeAccess.test.ts
@@ -91,6 +91,7 @@ async function groupAccessFixture() {
     });
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'Collaborative Ruleset',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       slug: 'collaborative-ruleset',
       created_at: now,
       updated_at: now,

--- a/convex/e2e.ts
+++ b/convex/e2e.ts
@@ -148,6 +148,8 @@ export const seedBaseline = mutation({
 
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'E2EBaselineRuleset',
+      /* Long enough to clear the authoring floor, so a spec may save this ruleset's settings form without rewriting it. */
+      description: 'The baseline ruleset the end-to-end specs share, seeded with enough prose to satisfy the floor.',
       slug: 'e2ebaselineruleset',
       created_at: now,
       updated_at: now,

--- a/convex/factions.authoringRoundTrip.test.ts
+++ b/convex/factions.authoringRoundTrip.test.ts
@@ -254,6 +254,7 @@ describe('faction authoring full-field round trip', () => {
     await t.run(async (ctx) => {
       const id = await ctx.db.insert('rulesets', {
         name: 'Canonical transition proof',
+        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
         slug: 'canonical-transition-proof',
         created_at: '2026-07-23T12:00:00.000Z',
         updated_at: '2026-07-23T12:00:00.000Z',

--- a/convex/factions.catalogue.test.ts
+++ b/convex/factions.catalogue.test.ts
@@ -17,6 +17,7 @@ describe('faction catalogue page', () => {
       const ownerId = await ctx.db.insert('users', { name: 'Catalogue owner' });
       const advancedId = await ctx.db.insert('rulesets', {
         name: 'Advanced',
+        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
         slug: 'advanced',
         created_at: '2026-07-01T00:00:00.000Z',
         updated_at: '2026-07-01T00:00:00.000Z',
@@ -27,6 +28,7 @@ describe('faction catalogue page', () => {
       });
       await ctx.db.insert('rulesets', {
         name: 'Empty',
+        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
         slug: 'empty',
         created_at: '2026-07-01T00:00:00.000Z',
         updated_at: '2026-07-01T00:00:00.000Z',
@@ -37,6 +39,7 @@ describe('faction catalogue page', () => {
       });
       await ctx.db.insert('rulesets', {
         name: 'Deleted',
+        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
         slug: 'deleted',
         created_at: '2026-07-01T00:00:00.000Z',
         updated_at: '2026-07-01T00:00:00.000Z',

--- a/convex/faq.questionPage.test.ts
+++ b/convex/faq.questionPage.test.ts
@@ -44,6 +44,7 @@ async function seedQuestionPage(t: ReturnType<typeof convexTest>): Promise<SeedR
 
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'Advanced',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       slug: 'advanced',
       created_at: at(1),
       updated_at: at(1),

--- a/convex/faq.test.ts
+++ b/convex/faq.test.ts
@@ -37,6 +37,7 @@ async function faqFixture() {
   const outsider = t.withIdentity({ subject: ids.outsiderId });
   const ruleset = await owner.mutation(api.rulesets.create, {
     name: 'FAQBehaviorRuleset',
+    description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
     group_id: null,
     image_cover: null,
   });
@@ -247,6 +248,7 @@ describe('FAQ lifecycle', () => {
     const outsider = t.withIdentity({ subject: ids.outsiderId });
     const ruleset = await rulesetOwner.mutation(api.rulesets.create, {
       name: 'CollaborativeFAQRuleset',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       group_id: ids.groupId,
       image_cover: null,
     });
@@ -386,6 +388,7 @@ describe('FAQ lifecycle', () => {
     const asUser = t.withIdentity({ subject: userId });
     const ruleset = await asUser.mutation(api.rulesets.create, {
       name: 'LargeFAQRuleset',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       group_id: null,
       image_cover: null,
     });
@@ -443,6 +446,7 @@ describe('FAQ lifecycle', () => {
     const asUser = t.withIdentity({ subject: userId });
     const ruleset = await asUser.mutation(api.rulesets.create, {
       name: 'LargeAnswerRuleset',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       group_id: null,
       image_cover: null,
     });

--- a/convex/groupAssignPicker.test.ts
+++ b/convex/groupAssignPicker.test.ts
@@ -98,6 +98,7 @@ async function seedRulesets(ctx: MutationCtx, seeded: Awaited<ReturnType<typeof 
 
   const unassignedRulesetId = await ctx.db.insert('rulesets', {
     name: 'UnassignedRuleset',
+    description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
     slug: 'unassigned-ruleset',
     created_at: now,
     updated_at: now,
@@ -108,6 +109,7 @@ async function seedRulesets(ctx: MutationCtx, seeded: Awaited<ReturnType<typeof 
   });
   await ctx.db.insert('rulesets', {
     name: 'DeletedRuleset',
+    description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
     slug: 'deleted-ruleset',
     created_at: now,
     updated_at: now,
@@ -118,6 +120,7 @@ async function seedRulesets(ctx: MutationCtx, seeded: Awaited<ReturnType<typeof 
   });
   await ctx.db.insert('rulesets', {
     name: 'SomeoneElsesRuleset',
+    description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
     slug: 'someone-elses-ruleset',
     created_at: now,
     updated_at: now,

--- a/convex/groups.softDeletion.test.ts
+++ b/convex/groups.softDeletion.test.ts
@@ -73,6 +73,7 @@ async function softDeletionFixture() {
     });
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'Collaborative Ruleset',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       slug: 'collaborative-ruleset',
       created_at: now,
       updated_at: now,
@@ -209,6 +210,7 @@ describe('Group soft deletion lifecycle', () => {
     await expect(
       assetOwner.mutation(api.rulesets.create, {
         name: 'OrphanRuleset',
+        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
         group_id: ids.groupId,
         image_cover: null,
       })

--- a/convex/homepage.test.ts
+++ b/convex/homepage.test.ts
@@ -34,6 +34,7 @@ describe('homepage page data', () => {
     });
     const ruleset = await asUser.mutation(api.rulesets.create, {
       name: 'HomepageRuleset',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       group_id: null,
       image_cover: null,
     });

--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -86,6 +86,11 @@
       "requires": ["rulesets_slug_v1"]
     },
     {
+      "id": "rulesets_description_narrow",
+      "phase": "narrow",
+      "requires": ["rulesets_description_v1"]
+    },
+    {
       "id": "faq_item_slug_narrow",
       "phase": "narrow",
       "requires": ["faq_item_slug_v1"]

--- a/convex/migrations.groupsSoftDelete.test.ts
+++ b/convex/migrations.groupsSoftDelete.test.ts
@@ -50,6 +50,7 @@ describe('Group lifecycle audit', () => {
       });
       const rulesetId = await ctx.db.insert('rulesets', {
         name: 'GroupedRuleset',
+        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
         slug: 'groupedruleset',
         created_at: now,
         updated_at: now,

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -167,20 +167,11 @@ export const rulesets_slug_v1 = migrations.define({
   },
 });
 
-/**
- * Backfills `description` so the field can narrow to a required `v.string()`.
- * Empty is the deliberate value: a generated placeholder would be indistinguishable from prose someone wrote, and the
- * 50-character floor in `rulesetDescriptionSchema` applies to what is written, never to what is inherited.
- */
+/** Retains the completed `description` backfill identity; the narrowed schema now enforces what it filled in. */
 export const rulesets_description_v1 = migrations.define({
   table: 'rulesets',
   batchSize: 50,
-  migrateOne: async (_ctx, row) => {
-    if (typeof (row as { description?: unknown }).description === 'string') {
-      return;
-    }
-    return { description: '' };
-  },
+  migrateOne: async () => undefined,
 });
 
 export const faq_item_slug_v1 = migrations.define({

--- a/convex/profiles.detail.test.ts
+++ b/convex/profiles.detail.test.ts
@@ -131,6 +131,7 @@ async function seedProfileDetail(t: ReturnType<typeof convexTest>): Promise<Seed
 
     const advancedRulesetId = await ctx.db.insert('rulesets', {
       name: 'Advanced',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       slug: 'advanced',
       created_at: at(1),
       updated_at: at(1),
@@ -141,6 +142,7 @@ async function seedProfileDetail(t: ReturnType<typeof convexTest>): Promise<Seed
     });
     const basicRulesetId = await ctx.db.insert('rulesets', {
       name: 'Basic',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       slug: 'basic',
       created_at: at(1),
       updated_at: at(1),
@@ -151,6 +153,7 @@ async function seedProfileDetail(t: ReturnType<typeof convexTest>): Promise<Seed
     });
     const deletedRulesetId = await ctx.db.insert('rulesets', {
       name: 'Deleted',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       slug: 'deleted',
       created_at: at(1),
       updated_at: at(1),

--- a/convex/profiles.test.ts
+++ b/convex/profiles.test.ts
@@ -61,6 +61,7 @@ test('profile list includes activity counts', async () => {
     });
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'Rules',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       slug: 'rules',
       created_at: '2026-07-19T00:00:00.000Z',
       updated_at: '2026-07-19T00:00:00.000Z',
@@ -116,6 +117,7 @@ test('profile detail returns the newest bounded FAQ activity', async () => {
     });
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'FAQ activity',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       slug: 'faq-activity',
       created_at: '2026-08-05T00:00:00.000Z',
       updated_at: '2026-08-05T00:00:00.000Z',

--- a/convex/rulesets.description.test.ts
+++ b/convex/rulesets.description.test.ts
@@ -20,39 +20,22 @@ function rulesetTest() {
   return t;
 }
 
-async function ownedRuleset(description?: string) {
+async function ownedRuleset() {
   const t = rulesetTest();
   const ownerId = await t.run(async (ctx) => await ctx.db.insert('users', { name: 'Ruleset owner' }));
   const owner = t.withIdentity({ subject: ownerId });
   const ruleset = await owner.mutation(api.rulesets.create, {
     name: 'DescriptionRuleset',
-    ...(description === undefined ? {} : { description }),
+    description: VALID_DESCRIPTION,
     group_id: null,
     image_cover: null,
   });
-  return { owner, ruleset };
+  return { t, owner, ruleset };
 }
 
 describe('ruleset descriptions', () => {
-  test('a ruleset created without one carries the backfill value', async () => {
-    const { ruleset } = await ownedRuleset();
-
-    expect(ruleset.description).toBe('');
-  });
-
-  test('an update that omits the description leaves the stored one intact', async () => {
-    const { owner, ruleset } = await ownedRuleset(VALID_DESCRIPTION);
-
-    const renamed = await owner.mutation(api.rulesets.update, {
-      id: ruleset._id,
-      name: 'RenamedRuleset',
-    });
-
-    expect(renamed.description).toBe(VALID_DESCRIPTION);
-  });
-
   test('a description below the floor is rejected', async () => {
-    const { owner, ruleset } = await ownedRuleset(VALID_DESCRIPTION);
+    const { owner, ruleset } = await ownedRuleset();
 
     await expect(
       owner.mutation(api.rulesets.update, {
@@ -61,5 +44,33 @@ describe('ruleset descriptions', () => {
         description: 'Too short.',
       })
     ).rejects.toThrow(/at least 50 characters/);
+  });
+
+  /*
+   * The tolerated case the narrowed schema still has to carry: rows that predate the field hold the empty string the
+   * backfill gave them, and must stay readable even though nothing may write one.
+   * No mutation can produce this state any more, so it is set up directly.
+   */
+  test('a row left holding the backfilled empty description is still readable', async () => {
+    const t = rulesetTest();
+    const rulesetId = await t.run(async (ctx) => {
+      const ownerId = await ctx.db.insert('users', { name: 'Ruleset owner' });
+      return await ctx.db.insert('rulesets', {
+        name: 'PredatesTheField',
+        description: '',
+        slug: 'predates-the-field',
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        owner_id: ownerId,
+        group_id: null,
+        is_deleted: false,
+        image_cover: null,
+      });
+    });
+
+    await expect(t.query(api.rulesets.get, { id: rulesetId })).resolves.toMatchObject({
+      name: 'PredatesTheField',
+      description: '',
+    });
   });
 });

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -27,24 +27,17 @@ async function getRulesetById(ctx: QueryCtx | MutationCtx, id: Id<'rulesets'>) {
 }
 
 /**
- * The authoring shape `rulesetInputSchema` parses, built from mutation args.
- * An omitted `description` stays omitted rather than becoming `undefined`, because the schema is strict and the difference carries meaning: absent means "not part of this write", not "blank it".
- */
-function rulesetInputFrom(args: { name: string; description?: string }) {
-  return args.description === undefined ? { name: args.name } : { name: args.name, description: args.description };
-}
-
-/**
- * The patch an update writes, with one rule for every optional field: absent from the caller means absent from the patch.
- * That is what lets `update` serve as a partial patcher without a caller that only moves the group blanking a description.
+ * The patch an update writes.
+ * `image_cover` keeps the absent-means-untouched rule, since clearing a cover is expressed as `null`;
+ * name and description are required of every write, so they are always part of the patch.
  * The shape is inferred rather than restated, so adding a field here cannot drift from the type that describes it.
  */
-function rulesetUpdatePatch(fields: { name: string; slug: string; description?: string; image_cover?: string | null }) {
+function rulesetUpdatePatch(fields: { name: string; slug: string; description: string; image_cover?: string | null }) {
   return {
     name: fields.name,
     slug: fields.slug,
+    description: fields.description,
     updated_at: nowIso(),
-    ...(fields.description === undefined ? {} : { description: fields.description }),
     ...(fields.image_cover === undefined ? {} : { image_cover: fields.image_cover }),
   };
 }
@@ -130,13 +123,13 @@ export const listByFaction = query({
 export const create = mutation({
   args: {
     name: v.string(),
-    description: v.optional(v.string()),
+    description: v.string(),
     group_id: v.union(v.id('groups'), v.null()),
     image_cover: v.union(v.string(), v.null()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuthUserId(ctx);
-    const parsed = rulesetInputSchema.safeParse(rulesetInputFrom(args));
+    const parsed = rulesetInputSchema.safeParse({ name: args.name, description: args.description });
     if (!parsed.success) {
       const msg = parsed.error.issues.map((i) => i.message).join(' ');
       throw new Error(msg || 'Invalid ruleset input');
@@ -159,8 +152,7 @@ export const create = mutation({
     const slug = await resolveUniqueRulesetSlug(ctx, normalizedName);
     const _id = await ctx.db.insert('rulesets', {
       name: normalizedName,
-      /** Empty until the create form collects one; the backfilled value for every row that predates the field. */
-      description: parsed.data.description ?? '',
+      description: parsed.data.description,
       slug,
       owner_id: userId,
       group_id: args.group_id,
@@ -181,11 +173,11 @@ export const update = mutation({
   args: {
     id: v.id('rulesets'),
     name: v.string(),
-    description: v.optional(v.string()),
+    description: v.string(),
     image_cover: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
-    const parsed = rulesetInputSchema.safeParse(rulesetInputFrom(args));
+    const parsed = rulesetInputSchema.safeParse({ name: args.name, description: args.description });
     if (!parsed.success) {
       const msg = parsed.error.issues.map((i) => i.message).join(' ');
       throw new Error(msg || 'Invalid ruleset input');

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -101,11 +101,11 @@ export default defineSchema({
     name: v.string(),
     slug: v.string(),
     /**
-     * Widen phase of `rulesets_description_v1`: optional only until every row is backfilled, then narrowed to a required `v.string()`.
-     * Empty is the backfilled value for rows that predate the field and is tolerated on read;
+     * Narrowed by `rulesets_description_narrow` once every row carried a value.
+     * Empty is what the backfill gave rows that predate the field, and it stays readable;
      * anything written goes through `rulesetDescriptionSchema`, which demands 50 characters.
      */
-    description: v.optional(v.string()),
+    description: v.string(),
     created_at: v.string(),
     updated_at: v.string(),
     owner_id: v.id('users'),

--- a/convex/statistics.test.ts
+++ b/convex/statistics.test.ts
@@ -49,6 +49,7 @@ test('maintains global and per-ruleset totals through wrapped writes', async () 
     });
     const activeRulesetId = await ctx.db.insert('rulesets', {
       name: 'Active ruleset',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       slug: 'active-ruleset',
       created_at: '2026-08-04T10:00:00.000Z',
       updated_at: '2026-08-04T10:00:00.000Z',
@@ -59,6 +60,7 @@ test('maintains global and per-ruleset totals through wrapped writes', async () 
     });
     const deletedRulesetId = await ctx.db.insert('rulesets', {
       name: 'Deleted ruleset',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       slug: 'deleted-ruleset',
       created_at: '2026-08-04T10:00:00.000Z',
       updated_at: '2026-08-04T10:00:00.000Z',
@@ -159,6 +161,7 @@ test('backfills Statistics resumably and rebuilds after later writes bypass trig
     });
     const insertedRulesetId = await ctx.db.insert('rulesets', {
       name: 'Dashboard ruleset',
+      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
       slug: 'dashboard-ruleset',
       created_at: '2026-08-04T10:00:00.000Z',
       updated_at: '2026-08-04T10:00:00.000Z',

--- a/src/shared/rulesets/validation.ts
+++ b/src/shared/rulesets/validation.ts
@@ -18,11 +18,10 @@ export const rulesetDescriptionSchema = z
   );
 
 /**
- * `description` is optional here only for the widen phase of `rulesets_description_v1`, so that rows predating the field stay readable.
- * There is no grace for those rows on the way out: every write goes through the floor, which means a ruleset still holding the backfilled empty string cannot be saved at all until someone writes a description.
- * Both ruleset forms enforce that before submitting, and the field narrows to required once the backfill has run in production.
+ * Every ruleset write carries both fields.
+ * There is no grace for rows that predate the description: a ruleset still holding the backfilled empty string cannot be saved at all until someone writes one, and both ruleset forms enforce that before submitting.
  */
 export const rulesetInputSchema = z.strictObject({
   name: rulesetNameSchema,
-  description: rulesetDescriptionSchema.optional(),
+  description: rulesetDescriptionSchema,
 });


### PR DESCRIPTION
The second and final release of `rulesets_description_v1`. `description` becomes a required `v.string()`.

Resolves #438. Part of the map in #426.

## Why this could not ship with the widen

`.github/workflows/deploy-main.yml` runs `migrations:narrow-check` **before** `convex:deploy`, asserting against production that every migration a narrow guard requires has completed. Shipping both entries at once fails that check on the very merge meant to run the migration. The widen released in #439, and its deploy's *Run and verify required migrations* step succeeded — that step is `runRequired` followed by `assertReadyForNarrow`, so the backfill is done and verified in prod. This release is now safe to merge.

Every row also has a value regardless of age: since #439, `create` has written `''` when no description was supplied, so nothing created after the backfill can be missing one either.

## What changed

- **`convex/schema.ts`** — `description: v.optional(v.string())` → `v.string()`.
- **`convex/migration-guards.json`** — the `rulesets_description_narrow` entry, requiring `rulesets_description_v1`.
- **`src/shared/rulesets/validation.ts`** — `description` is no longer `.optional()` in `rulesetInputSchema`.
- **`convex/rulesets.ts`** — `description` is a required argument of `create` and `update`. `rulesetInputFrom` is deleted along with the absence it existed to model, and `rulesetUpdatePatch` stops branching on it. `image_cover` keeps the absent-means-untouched rule, since clearing a cover is expressed as `null`.
- **`convex/migrations.ts`** — `rulesets_description_v1` keeps its identity as a no-op, following `groups_soft_delete_backfill_v1` and `faction_complexity_grouped_v1`. The narrowed schema now enforces what it filled in.
- **`convex/e2e.ts`** — the shared baseline ruleset is seeded with a description long enough to clear the authoring floor, so a spec can save its settings form without rewriting it first.
- **Fixtures in fourteen Convex test files** gained a description. The compiler enumerated all 26 sites; none needed judgement.

## Tests

Two cases in `rulesets.description.test.ts` are **deleted rather than fixed**, because the states they asserted are no longer expressible: nothing can create a ruleset without a description, and no update can omit one. Both are now type guarantees, and ADR-0002 asks for a test only where types cannot reach.

What replaces them is the tolerance the narrowed schema still has to carry: **a row holding the backfilled empty string must stay readable**, even though nothing may write one. That state can no longer be produced by any mutation, so the test sets it up directly.

## Verification

`typecheck`, `lint`, `format:check`, `knip`, `migrations:static-check` (33 entries), and the suite at 469 tests across 76 files — all green.

`publisher:release:verify` not run: nothing here is a renderer-manifest ingredient, and CI's `publisher_release` job checks it regardless.

## On merge

This is a schema-narrowing deploy. `migrations:narrow-check` runs first and must pass — it will, per the evidence above — and Convex then validates existing documents against the narrowed schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)