### PR TITLE
Have FactionPicker report which faction was picked

### DIFF
--- a/src/app/pickers/FactionPicker.tsx
+++ b/src/app/pickers/FactionPicker.tsx
@@ -21,22 +21,32 @@ function formatZodIssues(err: { issues: readonly { path: PropertyKey[]; message:
     .join('\n');
 }
 
+/**
+ * What crosses back out when a faction is chosen: which row it was, and its parsed data.
+ * The row's identifiers are the point — `data` alone cannot say *which* faction was picked, since a faction's id and public slug live on the row and never inside its payload.
+ */
+interface PickedFaction {
+  id: string;
+  slug: string;
+  data: Faction;
+}
+
 export interface FactionPickerProps {
   /** When provided, excludes the row with this faction URL slug from the picker. */
   currentPublicSlug?: string;
-  onLoaded: (loaded: Faction) => void;
+  onPick: (picked: PickedFaction) => void;
   onCancel: () => void;
 }
 
 /**
- * A Picker: the connected control that fetches the viewer's loadable factions, lets one be chosen, and hands the parsed faction back through `onLoaded`.
+ * A Picker: the connected control that fetches the viewer's loadable factions, lets one be chosen, and hands the choice back through `onPick`.
  * It fetches its own options (and the viewer context its own affordances need) — read-only, never mutating — and its caller mounts it lazily so the subscription lives only while it is on screen.
  * Here that caller is `FactionLoadPopover`, which mounts this only while the popover is open, so the picker subscribes the moment it appears (the container already gated the mount and opening the popover is the intent signal).
  * An inline caller with no such gate would instead defer the subscription to its own control's open;
  * see the Pickers section in
  * AGENTS.md.
  */
-export function FactionPicker({ currentPublicSlug, onLoaded, onCancel }: FactionPickerProps) {
+export function FactionPicker({ currentPublicSlug, onPick, onCancel }: FactionPickerProps) {
   const picker = useFactionLoadPicker();
 
   const [selectedId, setSelectedId] = useState('');
@@ -86,7 +96,7 @@ export function FactionPicker({ currentPublicSlug, onLoaded, onCancel }: Faction
       return;
     }
     setError(null);
-    onLoaded(structuredClone(parsed.data));
+    onPick({ id: selectedRow.id, slug: selectedRow.slug, data: structuredClone(parsed.data) });
   };
 
   return (

--- a/src/app/widgets/faction-editor/FactionLoadPopover.tsx
+++ b/src/app/widgets/faction-editor/FactionLoadPopover.tsx
@@ -16,6 +16,8 @@ export interface FactionLoadPopoverProps {
  * The toolbar affordance that opens `FactionPicker`.
  * It owns nothing but the open state and the trigger: the picker is mounted only while the popover is open, so its subscription lives only that long.
  * This shell fetches nothing itself — it hands the picker its exclusion slug and a callback, and closes on load or cancel.
+ *
+ * The editor wants a draft, not a row, so this is where the picked faction's identifiers are dropped: the picker reports *which* faction was chosen, and loading one into a draft only needs its data.
  */
 export function FactionLoadPopover({ disabled, currentPublicSlug, onLoaded }: FactionLoadPopoverProps) {
   const [opened, setOpened] = useState(false);
@@ -47,8 +49,8 @@ export function FactionLoadPopover({ disabled, currentPublicSlug, onLoaded }: Fa
           <FactionPicker
             currentPublicSlug={currentPublicSlug}
             onCancel={() => setOpened(false)}
-            onLoaded={(loaded) => {
-              onLoaded(loaded);
+            onPick={(picked) => {
+              onLoaded(picked.data);
               setOpened(false);
             }}
           />


### PR DESCRIPTION
The picker's callback now identifies the chosen faction instead of handing back only its payload.

Resolves #432. Part of the map in #426. With #433, unblocks the write path in #435.

## Why

`onLoaded` emitted `structuredClone(parsed.data)`, and `Faction` is `FactionInput` — the `factions.data` payload alone. A faction's id and public slug live on the **row**, never inside that payload, so the picker held `selectedRow.id` internally and threw the answer away at the membrane. Anything that wants to *link* a faction rather than copy its fields needs precisely that discarded id.

It now emits `{ id, slug, data }` through `onPick` — named for what the control does rather than for what its first caller did with the result, matching the `onPick`-style callback AGENTS.md describes for Pickers.

`FactionLoadPopover` keeps its editor-facing `onLoaded(faction)`, so it becomes the single place the identifiers are dropped: loading a draft needs the data, not the row. Neither route changes.

## Deliberately not in this PR

The ticket also listed two generalisations: caller-supplied copy (*"Load existing faction"*, *"Replace this unsaved draft?"*) and widening the exclusion from one `currentPublicSlug` to every already-linked faction. Both wait for #435, where the second caller actually lands.

Props with no consumer are the unused code paths AGENTS.md warns about — and `knip` made the same argument unprompted, flagging `PickedFaction` as an exported type nobody imports. It is internal until something needs its name.

## One consequence recorded for #435

The picker still parses the chosen row with `FactionInputSchema`, which carries **authoring** semantics — it requires a name, where `CanonicalFactionStoredSchema` permits a blank one. That is right for the editor: you should not load an unparseable draft. For linking it may be wrong, since a historical faction with a blank name would become impossible to add to a ruleset. Left as-is here rather than guessed at; noted on #435 so it is decided with the linking UI in front of you.

## Verification

`typecheck`, `lint`, `format:check`, `knip`, and the suite at 469 tests — all green. Two files, 18 lines added.

`publisher:release:verify` not run: `src/app/pickers` and `src/app/widgets` are outside the capture bundle's import graph, so they cannot move the renderer manifest — unlike #446, where `src/shared/factions/schema.ts` could and did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)