### PR TITLE
Give FactionCard an action adornment

### DIFF
--- a/src/app/ui/block/FactionCard.module.css
+++ b/src/app/ui/block/FactionCard.module.css
@@ -1,3 +1,19 @@
+.root {
+  position: relative;
+  min-width: 0;
+}
+
+/*
+ * Above the caption's z-index so the control is never overlapped, and top-left because the token, hero, leaders and
+ * name already hold the other corners.
+ */
+.action {
+  position: absolute;
+  top: 3%;
+  left: 3%;
+  z-index: 5;
+}
+
 .card {
   position: relative;
   display: block;

--- a/src/app/ui/block/FactionCard.stories.tsx
+++ b/src/app/ui/block/FactionCard.stories.tsx
@@ -1,5 +1,7 @@
 import preview from '@sb/preview';
 import { assetPublishingFaction } from '@shared/factions/fixtures/assetPublishingFaction';
+import { IconAction } from '@ui/control/IconAction';
+import { EllipsisVertical } from 'lucide-react';
 import { expect, within } from 'storybook/test';
 
 import type { FactionCatalogueEntry } from '@db/factions';
@@ -87,4 +89,28 @@ export const ContentStress = meta.story({
       </div>
     ),
   ],
+});
+
+/** With an adornment: a control that acts on the faction where it is listed, top-left because the other corners are taken. */
+export const WithAction = meta.story({
+  args: {
+    action: (
+      <IconAction
+        label="Faction actions"
+        variant="light"
+        color="gray"
+        size="sm"
+        icon={<EllipsisVertical size={15} aria-hidden />}
+      />
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+    const actionButton = canvas.getByRole('button', { name: 'Faction actions' });
+
+    await expect(actionButton).toBeVisible();
+    /* The whole point of the adornment being a sibling: clicking it cannot navigate, because it is not inside the link. */
+    await expect(link.contains(actionButton)).toBe(false);
+  },
 });

--- a/src/app/ui/block/FactionCard.tsx
+++ b/src/app/ui/block/FactionCard.tsx
@@ -2,6 +2,7 @@ import { Text, UnstyledButton } from '@mantine/core';
 import { Link } from '@tanstack/react-router';
 import { effectiveComplexity } from '@ui/content/complexity';
 import { ComplexityGlyph } from '@ui/content/ComplexityGlyph';
+import type { ReactNode } from 'react';
 
 import type { FactionCatalogueEntry } from '@db/factions';
 import { LeaderToken } from '@game/assets/faction/leader/Leader';
@@ -21,50 +22,62 @@ import styles from './FactionCard.module.css';
 export function FactionCard({
   faction,
   selectedRulesetSlug,
+  action,
 }: {
   faction: FactionCatalogueEntry;
   selectedRulesetSlug?: string;
+  /**
+   * An adornment, not a slot: a control that acts on this faction where it is listed — a menu, a remove button.
+   * It renders as a sibling of the link rather than inside it, since a button within an anchor is neither valid nor clickable without navigating, and it is positioned top-left because the other three corners carry the faction's own identity: its token, its hero, its leaders and name.
+   */
+  action?: ReactNode;
 }) {
   const { name, logo, background, hero, leaders } = faction.data;
   const rulesetLabel = factionRulesetLabel(faction, selectedRulesetSlug);
 
   return (
-    <UnstyledButton
-      className={styles.card}
-      renderRoot={(rootProps) => <Link {...rootProps} to="/factions/$factionId" params={{ factionId: faction.slug }} />}
-    >
-      <BackgroundRenderer background={background} className={styles.artwork}>
-        <div className={styles.shade} />
-        <div className={styles.factionToken} aria-hidden>
-          <FactionToken logo={logo} background={background} />
-        </div>
-        <div className={styles.cast} aria-hidden>
-          <div className={styles.hero}>
-            <LeaderToken {...hero} strength={undefined} background={background} logo={logo} />
+    /* Exists to position the adornment against the tile; the link keeps its own bounds so its hit area never grows. */
+    <div className={styles.root}>
+      <UnstyledButton
+        className={styles.card}
+        renderRoot={(rootProps) => (
+          <Link {...rootProps} to="/factions/$factionId" params={{ factionId: faction.slug }} />
+        )}
+      >
+        <BackgroundRenderer background={background} className={styles.artwork}>
+          <div className={styles.shade} />
+          <div className={styles.factionToken} aria-hidden>
+            <FactionToken logo={logo} background={background} />
           </div>
-          <div className={styles.leaders}>
-            {leaders.slice(0, 3).map((leader, index) => (
-              <span key={`${leader.name}-${leader.image}-${index}`}>
-                <LeaderToken {...leader} background={background} logo={logo} />
-              </span>
-            ))}
+          <div className={styles.cast} aria-hidden>
+            <div className={styles.hero}>
+              <LeaderToken {...hero} strength={undefined} background={background} logo={logo} />
+            </div>
+            <div className={styles.leaders}>
+              {leaders.slice(0, 3).map((leader, index) => (
+                <span key={`${leader.name}-${leader.image}-${index}`}>
+                  <LeaderToken {...leader} background={background} logo={logo} />
+                </span>
+              ))}
+            </div>
           </div>
-        </div>
-        <div className={styles.caption}>
-          <div className={styles.captionText}>
-            <Text className={styles.name} fw={800} size="lg" lineClamp={2}>
-              {name}
-            </Text>
-            {rulesetLabel ? (
-              <Text className={styles.ruleset} size="xs" lineClamp={1}>
-                {rulesetLabel}
+          <div className={styles.caption}>
+            <div className={styles.captionText}>
+              <Text className={styles.name} fw={800} size="lg" lineClamp={2}>
+                {name}
               </Text>
-            ) : null}
+              {rulesetLabel ? (
+                <Text className={styles.ruleset} size="xs" lineClamp={1}>
+                  {rulesetLabel}
+                </Text>
+              ) : null}
+            </div>
+            <ComplexityGlyph score={effectiveComplexity(faction.data.complexity)} />
           </div>
-          <ComplexityGlyph score={effectiveComplexity(faction.data.complexity)} />
-        </div>
-      </BackgroundRenderer>
-    </UnstyledButton>
+        </BackgroundRenderer>
+      </UnstyledButton>
+      {action ? <div className={styles.action}>{action}</div> : null}
+    </div>
   );
 }
 


### PR DESCRIPTION
`FactionCard` can now carry a control that acts on the faction where it is listed.

Resolves #433. Part of the map in #426. Unblocks the write path in #435.

## The constraint

The whole tile is a link — `UnstyledButton` rendered as the router's `Link`. A button placed inside it is neither valid HTML nor clickable without navigating. So the adornment renders as a **sibling** of the link, inside a positioned root that wraps both, which keeps the link's own bounds and stops its hit area growing.

`AGENTS.md` sanctions this shape explicitly: an action stays `ReactNode` in every category and never counts against a slot budget. Alignment lives in `FactionCard.module.css`, so callers layer no pixels of their own.

## Top-left, not top-right

The ticket said top-right. That corner is taken: `.factionToken` sits at `top: 3%; right: 3%` at 20% width — the faction's own token, the thing that identifies the card at a glance — and the caption's right edge holds the `ComplexityGlyph`. The hero occupies bottom-right, the leaders and name the bottom.

Top-left is the one genuinely empty corner, and it reads as chrome precisely because everything identifying the faction lives on the other three. The alternative was shifting the token on every card in the catalogue to make room for a control that only one page shows.

## Unchanged for existing callers

The catalogue and the editor preview pass no `action` and render exactly as before — same artwork, same accessible name on the link, same grid behaviour. The positioned root is a plain block, so the card's `aspect-ratio: 1` still drives its size inside `FactionList`'s grid.

## Tests

One new story, pure args in keeping with the file. Its `play` asserts the button is visible **and not a descendant of the link** — the invariant the sibling arrangement exists to guarantee.

I checked that assertion earns its place: moving the adornment inside the `UnstyledButton` makes it fail (`expected true to be false`), so it covers the mistake rather than merely passing beside it.

## Verification

`typecheck`, `lint`, `format:check`, `knip`, `check:css-orphans` (52 stylesheets, no orphans), the suite at 469 tests, and the card's five stories under the Storybook runner — all green.

`publisher:release:verify` not run: `src/app/ui/**` is outside the capture bundle's import graph, as #443 confirmed when it added files there and `publisher_release` passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Faction cards now support optional action controls, such as an overflow menu.
  * Action controls appear above the card artwork and remain separate from the card link, preventing accidental navigation.
* **Style**
  * Added positioning and layering improvements to ensure action controls are clearly visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->