### PR TITLE
Rework the layout's middle stage: reading columns stack, rail keeps its column

### DIFF
--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -221,7 +221,17 @@ function RulesetDetailPage() {
           the breadcrumb, the title and the meta line all share one left edge instead of the title starting indented.
         */}
         <Group wrap="nowrap" align="center" gap="md" className={styles.pageHead}>
-          <Avatar src={r.image_cover} alt={`Cover for ${r.name}`} name={r.name} radius="md" size={48} color="dune" />
+          {/* The media matches the text block's height rather than a fixed size, so the band reads as one unit. */}
+          <div className={styles.pageHeadMedia}>
+            <Avatar
+              src={r.image_cover}
+              alt={`Cover for ${r.name}`}
+              name={r.name}
+              radius="md"
+              size="100%"
+              color="dune"
+            />
+          </div>
           <Stack gap={4} className={styles.pageHeadText}>
             <Anchor size="sm" fw={600} renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>
               Rulesets

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -216,56 +216,59 @@ function RulesetDetailPage() {
   return (
     <PageLayout>
       <PageLayout.Header size="compact">
-        <Stack gap={4} className={styles.pageHead}>
-          <Anchor size="sm" fw={600} renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>
-            Rulesets
-          </Anchor>
-          {/* The cover is the ruleset's identity, so it rides with the name; at 32px the row stays one text line tall. */}
-          <Group gap="sm" wrap="nowrap" align="center">
-            <Avatar src={r.image_cover} alt={`Cover for ${r.name}`} name={r.name} radius="md" size={32} color="dune" />
+        {/*
+          The identity pattern the faction and profile detail pages already use: the media sits in its own column, so
+          the breadcrumb, the title and the meta line all share one left edge instead of the title starting indented.
+        */}
+        <Group wrap="nowrap" align="center" gap="md" className={styles.pageHead}>
+          <Avatar src={r.image_cover} alt={`Cover for ${r.name}`} name={r.name} radius="md" size={48} color="dune" />
+          <Stack gap={4} className={styles.pageHeadText}>
+            <Anchor size="sm" fw={600} renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>
+              Rulesets
+            </Anchor>
             <Title order={1} className={styles.rulesetTitle}>
               {r.name}
             </Title>
-          </Group>
-          {/*
+            {/*
             One line carrying everything the old "At a glance" and "Stewardship" cards said.
             The sizes are level on purpose: this row centres its children, and a 12px label among 14-16px text reads as
             misaligned even when every box is perfectly centred.
           */}
-          <Group gap="sm" wrap="wrap" align="center">
-            <Text size="sm" c="dimmed">
-              Maintained by
-            </Text>
-            {page.owner ? (
-              <ProfileLink slug={page.owner.slug} username={page.owner.username} avatar_url={page.owner.avatar_url} />
-            ) : (
-              <Text size="sm">Unknown</Text>
-            )}
-            {assignedGroup ? (
-              <Group gap={6} wrap="nowrap" align="center">
-                {/* A glyph, not an avatar: the `groups` table carries no image, and this only has to say "a group". */}
-                <UsersRound size={15} aria-hidden />
-                <Anchor
-                  size="sm"
-                  fw={600}
-                  /* White, not the accent: this line sits on artwork, where the accent loses against the sand. */
-                  c="white"
-                  renderRoot={(rootProps) => (
-                    <Link {...rootProps} to="/groups/$groupSlug" params={{ groupSlug: assignedGroup.slug }} />
-                  )}
-                >
-                  {assignedGroup.name}
-                </Anchor>
-              </Group>
-            ) : (
+            <Group gap="sm" wrap="wrap" align="center">
               <Text size="sm" c="dimmed">
-                No maintaining group
+                Maintained by
               </Text>
-            )}
-            {membershipBadge ? <StatusBadge tone={membershipBadge.tone}>{membershipBadge.label}</StatusBadge> : null}
-            <Stats items={headerStats} orientation="row" />
-          </Group>
-        </Stack>
+              {page.owner ? (
+                <ProfileLink slug={page.owner.slug} username={page.owner.username} avatar_url={page.owner.avatar_url} />
+              ) : (
+                <Text size="sm">Unknown</Text>
+              )}
+              {assignedGroup ? (
+                <Group gap={6} wrap="nowrap" align="center">
+                  {/* A glyph, not an avatar: the `groups` table carries no image, and this only has to say "a group". */}
+                  <UsersRound size={15} aria-hidden />
+                  <Anchor
+                    size="sm"
+                    fw={600}
+                    /* White, not the accent: this line sits on artwork, where the accent loses against the sand. */
+                    c="white"
+                    renderRoot={(rootProps) => (
+                      <Link {...rootProps} to="/groups/$groupSlug" params={{ groupSlug: assignedGroup.slug }} />
+                    )}
+                  >
+                    {assignedGroup.name}
+                  </Anchor>
+                </Group>
+              ) : (
+                <Text size="sm" c="dimmed">
+                  No maintaining group
+                </Text>
+              )}
+              {membershipBadge ? <StatusBadge tone={membershipBadge.tone}>{membershipBadge.label}</StatusBadge> : null}
+              <Stats items={headerStats} orientation="row" />
+            </Group>
+          </Stack>
+        </Group>
       </PageLayout.Header>
       <PageLayout.Toolbar>
         <Toolbar>

--- a/src/app/routes/_app/rulesets/RulesetDetail.module.css
+++ b/src/app/routes/_app/rulesets/RulesetDetail.module.css
@@ -12,6 +12,19 @@
 }
 
 /*
+ * A fixed square per breakpoint, sized to the three lines of text beside it — the same approach and the same steps as
+ * the faction detail page's symbol rule.
+ * Deliberately not computed from the text: `align-self: stretch` with an `aspect-ratio` is circular, since the square's
+ * width would come from the row height while the row height comes from its tallest item, and the media grows without
+ * bound. Matching by design is what the pattern already does.
+ */
+.pageHeadMedia {
+  flex: 0 0 6rem;
+  width: 6rem;
+  height: 6rem;
+}
+
+/*
  * A description is authored in a textarea, so the author's own line breaks are the only structure it carries.
  * `pre-line` keeps them while still collapsing runs of spaces and wrapping normally.
  */
@@ -50,6 +63,12 @@
 
 /* The band's own gaps come from the header's `Stack`; only the title size and the edge padding change with width. */
 @media (max-width: 48em) {
+  .pageHeadMedia {
+    flex-basis: 4.75rem;
+    width: 4.75rem;
+    height: 4.75rem;
+  }
+
   .rulesetTitle {
     font-size: 1.35rem;
   }
@@ -58,5 +77,11 @@
 @media (max-width: 30em) {
   .pageHead {
     padding-inline: 0;
+  }
+
+  .pageHeadMedia {
+    flex-basis: 3.75rem;
+    width: 3.75rem;
+    height: 3.75rem;
   }
 }

--- a/src/app/routes/_app/rulesets/RulesetDetail.module.css
+++ b/src/app/routes/_app/rulesets/RulesetDetail.module.css
@@ -6,6 +6,11 @@
   color: var(--color-text, var(--mantine-color-dark-8));
 }
 
+/* The text column beside the media: everything in it shares this left edge. */
+.pageHeadText {
+  min-width: 0;
+}
+
 /*
  * A description is authored in a textarea, so the author's own line breaks are the only structure it carries.
  * `pre-line` keeps them while still collapsing runs of spaces and wrapping normally.

--- a/src/app/ui/layout/ColumnsWithRailLayout.module.css
+++ b/src/app/ui/layout/ColumnsWithRailLayout.module.css
@@ -32,16 +32,16 @@
 }
 
 /*
- * The middle stage: the primary keeps its own width down the left while the other two stack beside it.
- * Secondary leads and the rail drops below it, because secondary is the column that reads *with* the primary — a
- * discussion beside the prose it discusses — while a rail is a list you scan once you have finished reading.
+ * The middle stage: the two reading columns merge into one and the rail keeps a column of its own.
+ * Primary and secondary are both prose a reader works down, so stacking them preserves that order — description, then
+ * the discussion of it — while the rail is a list to scan alongside, which is exactly what it was in three columns.
  */
 @container columns-with-rail-layout (min-width: 48rem) {
   .layout {
     grid-template-areas:
-      "primary secondary"
-      "primary rail";
-    grid-template-columns: minmax(0, 3fr) minmax(18rem, 2fr);
+      "primary rail"
+      "secondary rail";
+    grid-template-columns: minmax(0, 3fr) minmax(14rem, 2fr);
   }
 }
 

--- a/src/app/ui/layout/ColumnsWithRailLayout.module.css
+++ b/src/app/ui/layout/ColumnsWithRailLayout.module.css
@@ -32,14 +32,15 @@
 }
 
 /*
- * The middle stage: the rail rises beside the secondary column while the primary keeps its own width down the left.
- * The rail leads, because it is the summary the two columns beneath it elaborate.
+ * The middle stage: the primary keeps its own width down the left while the other two stack beside it.
+ * Secondary leads and the rail drops below it, because secondary is the column that reads *with* the primary — a
+ * discussion beside the prose it discusses — while a rail is a list you scan once you have finished reading.
  */
 @container columns-with-rail-layout (min-width: 48rem) {
   .layout {
     grid-template-areas:
-      "primary rail"
-      "primary secondary";
+      "primary secondary"
+      "primary rail";
     grid-template-columns: minmax(0, 3fr) minmax(18rem, 2fr);
   }
 }

--- a/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
+++ b/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
@@ -11,7 +11,7 @@ const meta = preview.meta({
     docs: {
       description: {
         component:
-          'Places two reading columns beside a narrow rail, top-aligned, and gives the columns up in two stages as its own container narrows: first secondary and the rail stack beside the primary, then everything falls into one column. Its parent owns page width and outer spacing.',
+          'Places two reading columns beside a narrow rail, top-aligned, and gives the columns up in two stages as its own container narrows: first the reading columns merge into one while the rail keeps its column, then everything falls into a single column. Its parent owns page width and outer spacing.',
       },
     },
   },
@@ -35,8 +35,8 @@ export const ThreeColumns = meta.story({
   globals: { viewport: { value: 'appDesktop' } },
 });
 
-/** The middle stage: the primary holds its width, secondary sits beside it, and the rail drops below secondary. */
-export const SecondaryBesidePrimary = meta.story({
+/** The middle stage: the reading columns stack into one, with the rail still alongside them. */
+export const ReadingColumnsStacked = meta.story({
   render: () => (
     <ColumnsWithRailLayout>
       <ColumnsWithRailLayout.Primary>

--- a/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
+++ b/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
@@ -11,7 +11,7 @@ const meta = preview.meta({
     docs: {
       description: {
         component:
-          'Places two reading columns beside a narrow rail, top-aligned, and gives the columns up in two stages as its own container narrows: first the rail rises beside the secondary column, then everything stacks. Its parent owns page width and outer spacing.',
+          'Places two reading columns beside a narrow rail, top-aligned, and gives the columns up in two stages as its own container narrows: first secondary and the rail stack beside the primary, then everything falls into one column. Its parent owns page width and outer spacing.',
       },
     },
   },
@@ -35,8 +35,8 @@ export const ThreeColumns = meta.story({
   globals: { viewport: { value: 'appDesktop' } },
 });
 
-/** The middle stage: the primary column holds its width while the rail and secondary stack beside it. */
-export const RailBesidePrimary = meta.story({
+/** The middle stage: the primary holds its width, secondary sits beside it, and the rail drops below secondary. */
+export const SecondaryBesidePrimary = meta.story({
   render: () => (
     <ColumnsWithRailLayout>
       <ColumnsWithRailLayout.Primary>

--- a/src/app/ui/layout/ColumnsWithRailLayout.tsx
+++ b/src/app/ui/layout/ColumnsWithRailLayout.tsx
@@ -22,8 +22,8 @@ function Rail(_: PropsWithChildren): null {
  * Distinct from `TriptychLayout`, which centres its slots vertically around a middle panel holding artwork.
  * Here every slot is text a reader works down, so they align to the top and the rail keeps a floor width rather than a share of the room.
  *
- * It gives up its columns in two stages instead of one: first the rail moves up beside the secondary column while the primary keeps its width, and only then does everything stack.
- * That middle stage exists because collapsing a narrow rail straight into the reading flow buries it below content it was meant to sit beside.
+ * It gives up its columns in two stages instead of one: first secondary and the rail stack beside the primary, which keeps its width, and only then does everything fall into a single column.
+ * That middle stage exists because collapsing three columns straight into one buries the rail below everything else, and it puts secondary directly beside the primary — a discussion beside the prose it discusses — leaving the rail as the list you scan afterwards.
  *
  * Callers own what goes in each slot and the page width around it;
  * this owns only where the three regions sit.

--- a/src/app/ui/layout/ColumnsWithRailLayout.tsx
+++ b/src/app/ui/layout/ColumnsWithRailLayout.tsx
@@ -22,8 +22,9 @@ function Rail(_: PropsWithChildren): null {
  * Distinct from `TriptychLayout`, which centres its slots vertically around a middle panel holding artwork.
  * Here every slot is text a reader works down, so they align to the top and the rail keeps a floor width rather than a share of the room.
  *
- * It gives up its columns in two stages instead of one: first secondary and the rail stack beside the primary, which keeps its width, and only then does everything fall into a single column.
- * That middle stage exists because collapsing three columns straight into one buries the rail below everything else, and it puts secondary directly beside the primary — a discussion beside the prose it discusses — leaving the rail as the list you scan afterwards.
+ * It gives up its columns in two stages instead of one: first the two reading columns merge into one while the rail keeps a column of its own, and only then does everything fall into a single column.
+ * That middle stage exists because collapsing three columns straight into one buries the rail below everything else.
+ * Merging primary into secondary keeps the order a reader wants — the prose, then the discussion of it — and leaves the rail where it already was, alongside.
  *
  * Callers own what goes in each slot and the page width around it;
  * this owns only where the three regions sit.


### PR DESCRIPTION
`ColumnsWithRailLayout`'s two-column stage gave way on the wrong axis, and the ruleset header's left edge went ragged in the re-cut. Both fixed.

Part of the map in #426, following the re-cut in #449.

## 1. The middle stage gave way on the wrong axis

Between 48rem and 62rem the layout was `"primary rail" / "primary secondary"` — the rail taking a *row* beside the primary, with secondary stranded underneath it. So at tablet widths the FAQ was landing below a list of faction cards instead of following the prose it discusses.

The thing that should give way is the split between the two **reading** columns, not the rail's column:

```
grid-template-areas:
  "primary rail"
  "secondary rail";
```

Primary then secondary down the left — the order a reader wants, the prose and then the discussion of it — while the rail keeps the column it already had in the three-column stage. Its minimum narrows from 18rem to 14rem now that it is a genuine column rather than a half-width row.

Three columns above 62rem and the single column below 48rem are unchanged.

## 2. The ruleset header's ragged left edge

#449 put the cover avatar inline with the title, which indented the title 40px while the breadcrumb and the meta line stayed at the band's left edge. **Measured left-edge spread: 71px.**

The media now sits in its own column with the three rows stacked beside it, sharing one left edge — **measured spread: 0px**. The avatar goes to 48px, which its own column affords without changing the band's height (inline, 40px was already enough to make the compact band clip its breadcrumb).

This is the pattern the faction detail page already uses and the profile detail page hand-rolls again, which is now tracked as #451.

## A note on the comments

The layout's JSDoc, story description and story name have been rewritten twice in this branch, because the arrangement changed twice. Each time the old sentence explained a rationale that no longer applied — the first version justified rail-first as "the summary the two columns beneath it elaborate", which stopped being true the moment #449 moved faction tiles into the rail. A stale rationale is worse than none, since the next reader trusts it.

## Verification

`typecheck`, `lint`, `format:check`, `check:css-orphans`, the layout's unit tests, and its four stories under the Storybook runner — all green. Confirmed on the running page at 900px (reading columns stacked, rail alongside), at 768px (single column), and at desktop width (three columns, header edge flush).

`publisher:release:verify` not run: `src/app/ui/**` and `src/app/routes/**` are both outside the capture bundle's import graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)