### PR TITLE
Run required CI checks for merge queue candidates

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -2,6 +2,8 @@ name: PR CI
 
 on:
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 permissions:
   contents: read
@@ -13,9 +15,9 @@ concurrency:
 jobs:
   verify:
     uses: ./.github/workflows/reusable-verify.yml
-    # Fork PRs get no secrets; codecov-action falls back to tokenless and never fails the build.
+    # Fork PRs and merge-group code get no secrets; Codecov falls back to tokenless uploads.
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ github.event_name == 'pull_request' && secrets.CODECOV_TOKEN || '' }}
 
   # Single required check owning the definition of "green"; if: always() so a skipped verify can't pass (#290).
   ci_ok:

--- a/.github/workflows/cloudflare-live-drift.yml
+++ b/.github/workflows/cloudflare-live-drift.yml
@@ -4,6 +4,8 @@ on:
   pull_request_target:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review, edited]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 permissions:
@@ -21,7 +23,7 @@ jobs:
       - name: Checkout trusted base revision
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'merge_group' && github.event.repository.default_branch || github.sha }}
           persist-credentials: false
 
       - name: Setup Bun

--- a/scripts/cloudflare-live-drift.test.ts
+++ b/scripts/cloudflare-live-drift.test.ts
@@ -137,15 +137,19 @@ function liveFetcher(
 }
 
 describe('Cloudflare live drift check', () => {
-  test('keeps the PR workflow on trusted base code with a dedicated read credential', () => {
+  test('keeps the required audit workflow on trusted code for PRs and merge groups', () => {
     const workflow = readFileSync(path.resolve(process.cwd(), '.github/workflows/cloudflare-live-drift.yml'), 'utf8');
     expect(workflow).toContain('pull_request_target:');
+    expect(workflow).toContain('merge_group:');
+    expect(workflow).toContain('types: [checks_requested]');
     expect(workflow).toContain('branches: [main]');
     expect(workflow).toContain('types: [opened, synchronize, reopened, ready_for_review, edited]');
     expect(workflow).not.toContain("github.event.pull_request.base.ref == 'main'");
     expect(workflow).toMatch(/actions\/checkout@[0-9a-f]{40} # v\d/);
     expect(workflow).toMatch(/oven-sh\/setup-bun@[0-9a-f]{40} # v[\d.]+/);
-    expect(workflow).toContain(`ref: $${'{'}{ github.sha }}`);
+    expect(workflow).toContain(
+      `ref: $${'{'}{ github.event_name == 'merge_group' && github.event.repository.default_branch || github.sha }}`
+    );
     expect(workflow).not.toContain('github.event.pull_request.base.sha');
     expect(workflow).toContain('persist-credentials: false');
     expect(workflow).toContain(`CLOUDFLARE_API_TOKEN: $${'{'}{ secrets.CLOUDFLARE_READ_API_TOKEN }}`);


### PR DESCRIPTION
## Summary
- run the required `ci_ok` workflow for merge-group candidates
- run the required `audit` status on merge groups while checking out trusted default-branch code
- withhold the Codecov token from merge-group verification
- cover the trusted audit workflow contract

## Validation
- `bun run test -- scripts/cloudflare-live-drift.test.ts`
- `bun run test`
- `bun run generate:images && bun run knip`
- `bun run check`
- `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Added validation support for merge-queue checks.
  * Updated live environment drift checks to run during merge-queue validation.
  * Preserved secure credential handling for pull-request checks.

* **Tests**
  * Expanded workflow validation to cover merge-queue triggers and branch checkout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->