### PR TITLE
Regenerate Convex API declarations

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -21,6 +21,7 @@ import type * as lib_applicationTriggers from "../lib/applicationTriggers.js";
 import type * as lib_collaborativeAccess from "../lib/collaborativeAccess.js";
 import type * as lib_collaborativeAccessValidators from "../lib/collaborativeAccessValidators.js";
 import type * as lib_decalRetune from "../lib/decalRetune.js";
+import type * as lib_defaultGroupPreference from "../lib/defaultGroupPreference.js";
 import type * as lib_factionCatalogue from "../lib/factionCatalogue.js";
 import type * as lib_factionData from "../lib/factionData.js";
 import type * as lib_factionInput from "../lib/factionInput.js";
@@ -75,6 +76,7 @@ declare const fullApi: ApiFromModules<{
   "lib/collaborativeAccess": typeof lib_collaborativeAccess;
   "lib/collaborativeAccessValidators": typeof lib_collaborativeAccessValidators;
   "lib/decalRetune": typeof lib_decalRetune;
+  "lib/defaultGroupPreference": typeof lib_defaultGroupPreference;
   "lib/factionCatalogue": typeof lib_factionCatalogue;
   "lib/factionData": typeof lib_factionData;
   "lib/factionInput": typeof lib_factionInput;


### PR DESCRIPTION
## Summary

Regenerate the checked-in Convex API declaration after adding `convex/lib/defaultGroupPreference.ts`. This restores an exact clean checkout after deploy-time Convex codegen so the production Worker release can proceed.

The required fail-closed prevention gate remains separate in #536. This pull request contains no product or workflow changes.

## Validation

- canonical Convex codegen is idempotent
- `bun run check`
- `bun run generate:images && bun run typecheck`
- production publisher preflight against the clean repair commit