### PR TITLE
Repair staged migration deployment checks

### DIFF
--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -180,11 +180,6 @@
       "id": "account_lifecycle_verify_v1",
       "phase": "widen",
       "requires": ["account_lifecycle_profiles_v1"]
-    },
-    {
-      "id": "account_lifecycle_profile_narrow",
-      "phase": "narrow",
-      "requires": ["account_lifecycle_profiles_v1", "account_lifecycle_verify_v1"]
     }
   ]
 }

--- a/docs/convex-migrations.md
+++ b/docs/convex-migrations.md
@@ -54,7 +54,7 @@ Rules:
 - `id`: unique migration or narrow guard identifier
 - `phase`:
   - `widen`: auto-started in deploy
-  - `narrow`: schema-narrow checkpoint gated on completed widen work
+  - `narrow`: schema-narrow checkpoint added with the later release that performs the narrowing
 - `requires`: widen migration ids that must be `success + isDone=true` before narrow is allowed
 
 ## Automated production flow
@@ -63,7 +63,7 @@ Rules:
    `bun run migrations:narrow-check` against the currently deployed migration entrypoints.
 2. Deploy widen- or narrow-compatible Convex code: `bun run convex:deploy`.
 3. Deploy workflow runs `bun run migrations:deploy`.
-4. That command starts the required widen migrations, polls readiness, and syncs status snapshots.
+4. That command starts every listed widen migration, polls all of them to readiness, and syncs status snapshots.
 5. Deploy fails if any narrow prerequisite or required migration is incomplete, failed, or times out.
 
 ## Strict local dev startup

--- a/scripts/migration-guards.ts
+++ b/scripts/migration-guards.ts
@@ -178,7 +178,7 @@ async function ensureRequiredMigrationsReady({
 async function deployMode(timeoutMs: number, intervalMs: number, useProd: boolean) {
   const manifest = await loadManifest();
   const idsToRun = deploySet(manifest.entries);
-  const required = requiredForAnyNarrow(manifest.entries);
+  const required = idsToRun;
 
   if (idsToRun.length === 0) {
     throw new Error('No widen migrations defined in migration-guards.json');
@@ -200,7 +200,7 @@ async function deployMode(timeoutMs: number, intervalMs: number, useProd: boolea
 async function devStrictMode(timeoutMs: number, intervalMs: number) {
   const manifest = await loadManifest();
   const idsToRun = deploySet(manifest.entries);
-  const required = requiredForAnyNarrow(manifest.entries);
+  const required = idsToRun;
 
   if (idsToRun.length === 0) {
     throw new Error('No widen migrations defined in migration-guards.json');

--- a/scripts/migration-guards.ts
+++ b/scripts/migration-guards.ts
@@ -183,9 +183,6 @@ async function deployMode(timeoutMs: number, intervalMs: number, useProd: boolea
   if (idsToRun.length === 0) {
     throw new Error('No widen migrations defined in migration-guards.json');
   }
-  if (required.length === 0) {
-    throw new Error('No required migration IDs found for narrow guards');
-  }
 
   await ensureRequiredMigrationsReady({
     idsToRun,
@@ -204,9 +201,6 @@ async function devStrictMode(timeoutMs: number, intervalMs: number) {
 
   if (idsToRun.length === 0) {
     throw new Error('No widen migrations defined in migration-guards.json');
-  }
-  if (required.length === 0) {
-    throw new Error('No required migration IDs found for narrow guards');
   }
 
   await ensureRequiredMigrationsReady({


### PR DESCRIPTION
## What changed

- keep future account-lifecycle narrowing out of the widen-stage manifest
- wait for every listed widen migration after Convex code is deployed
- clarify the staged migration contract in the runbook

## Why

The account-lifecycle widen release added migration IDs that the previously deployed Convex code could not know. The pre-deploy narrow guard therefore failed before the new migration entrypoints could be deployed. This restores the intended order without weakening the existing fail-closed narrow check.

## Verification

- production migrations:narrow-check against the currently deployed Convex code
- migrations:static-check
- typecheck
- repository checks
- 81 test files, 492 tests