### PR TITLE
Activate account lifecycle indexes

### DIFF
--- a/convex/accountLifecycle.widen.test.ts
+++ b/convex/accountLifecycle.widen.test.ts
@@ -149,7 +149,7 @@ describe('account lifecycle widen rollout', () => {
     });
 
     expect(userId).toBeTruthy();
-    await expect(t.query(api.migrations.accountLifecycleIndexAudit, {})).resolves.toEqual({
+    await expect(t.query(internal.migrations.accountLifecycleIndexAudit, {})).resolves.toEqual({
       ok: true,
       sampled: { activeProfiles: 1, groups: 1, factions: 1, rulesets: 1 },
     });

--- a/convex/accountLifecycle.widen.test.ts
+++ b/convex/accountLifecycle.widen.test.ts
@@ -105,6 +105,56 @@ describe('account lifecycle widen rollout', () => {
     expect(DIRECT_OWNERSHIP_KINDS.map((entry) => entry.kind)).toEqual(['group', 'faction', 'ruleset']);
   });
 
+  test('activated lifecycle indexes cover profile selection and every ownership kind', async () => {
+    const t = setup();
+    const userId = await t.run(async (ctx) => {
+      const ownerId = await ctx.db.insert('users', { account_state: 'active' });
+      await ctx.db.insert('profiles', {
+        user_id: ownerId,
+        username: 'IndexOwner',
+        avatar_url: 'https://example.com/index-owner.png',
+        account_state: 'active',
+        slug: 'index-owner',
+        created_at: now,
+        updated_at: now,
+      });
+      await ctx.db.insert('groups', {
+        name: 'Index Group',
+        slug: 'index-group',
+        created_at: now,
+        created_by: ownerId,
+        is_deleted: false,
+      });
+      await ctx.db.insert('factions', {
+        owner_id: ownerId,
+        data: assetPublishingFaction,
+        slug: 'index-faction',
+        created_at: now,
+        updated_at: now,
+        is_deleted: false,
+        group_id: null,
+      });
+      await ctx.db.insert('rulesets', {
+        owner_id: ownerId,
+        name: 'Index Ruleset',
+        slug: 'index-ruleset',
+        description: '',
+        created_at: now,
+        updated_at: now,
+        is_deleted: false,
+        group_id: null,
+        image_cover: null,
+      });
+      return ownerId;
+    });
+
+    expect(userId).toBeTruthy();
+    await expect(t.query(api.migrations.accountLifecycleIndexAudit, {})).resolves.toEqual({
+      ok: true,
+      sampled: { activeProfiles: 1, groups: 1, factions: 1, rulesets: 1 },
+    });
+  });
+
   test('inactive viewers are anonymous and inactive profiles stay out of public identity projections', async () => {
     const t = setup();
     const ids = await t.run(async (ctx) => {

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -553,7 +553,7 @@ export const groupsLifecycleAudit = internalQuery({
 });
 
 /** Proves the account lifecycle picker and direct-ownership indexes are queryable after activation. */
-export const accountLifecycleIndexAudit = query({
+export const accountLifecycleIndexAudit = internalQuery({
   args: {},
   handler: async (ctx) => {
     const [activeProfiles, groups, factions, rulesets] = await Promise.all([

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -552,6 +552,31 @@ export const groupsLifecycleAudit = internalQuery({
   },
 });
 
+/** Proves the account lifecycle picker and direct-ownership indexes are queryable after activation. */
+export const accountLifecycleIndexAudit = query({
+  args: {},
+  handler: async (ctx) => {
+    const [activeProfiles, groups, factions, rulesets] = await Promise.all([
+      ctx.db
+        .query('profiles')
+        .withIndex('by_account_state_username', (q) => q.eq('account_state', 'active'))
+        .take(1),
+      ctx.db.query('groups').withIndex('by_created_by_deleted').take(1),
+      ctx.db.query('factions').withIndex('by_owner_deleted').take(1),
+      ctx.db.query('rulesets').withIndex('by_owner_deleted').take(1),
+    ]);
+    return {
+      ok: true,
+      sampled: {
+        activeProfiles: activeProfiles.length,
+        groups: groups.length,
+        factions: factions.length,
+        rulesets: rulesets.length,
+      },
+    };
+  },
+});
+
 export const run = migrations.runner();
 
 export const runDeployMigrations = migrations.runner([

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -43,10 +43,7 @@ export default defineSchema({
   })
     .index('by_user_id', ['user_id'])
     .index('by_slug', ['slug'])
-    .index('by_account_state_username', {
-      fields: ['account_state', 'username'],
-      staged: true,
-    }),
+    .index('by_account_state_username', ['account_state', 'username']),
   groups: defineTable({
     name: v.string(),
     slug: v.string(),
@@ -57,10 +54,7 @@ export default defineSchema({
     .index('by_name', ['name'])
     .index('by_slug', ['slug'])
     .index('by_created_by', ['created_by'])
-    .index('by_created_by_deleted', {
-      fields: ['created_by', 'is_deleted'],
-      staged: true,
-    }),
+    .index('by_created_by_deleted', ['created_by', 'is_deleted']),
   group_members: defineTable({
     group_id: v.id('groups'),
     user_id: v.id('users'),


### PR DESCRIPTION
## What changed

- activate the staged profile and Group ownership indexes
- add a read-only audit for the profile picker and all three direct-ownership indexes
- cover the activated query paths in the account lifecycle suite

## Rollout stage

This is the index-activation stage of the reviewed account deletion rollout. It does not enable account deletion, narrow profile fields, or add UI.

## Verification

- focused account lifecycle tests: 6 passing
- full suite: 81 files, 493 tests
- typecheck
- repository checks
- migration static guard
- publisher release verification