### PR TITLE
Align profile editor controls with established patterns

### DIFF
--- a/e2e/profile-edit.spec.ts
+++ b/e2e/profile-edit.spec.ts
@@ -25,8 +25,14 @@ test('profile editing connects settings, previews avatars, and persists appearan
   await page.goto('/profiles/' + userA.slug + '/edit');
   const save = page.getByRole('button', { name: 'Save profile' });
   await expect(save).toBeDisabled();
+  await expect(save.locator('svg')).toBeVisible();
 
-  const avatarUrl = page.getByLabel('Avatar image URL');
+  const displayNameHelp = page.getByRole('group', { name: 'Display name *' }).getByRole('img', { name: 'Help' });
+  await displayNameHelp.hover();
+  await expect(page.getByRole('tooltip')).toContainText('Letters and numbers only');
+
+  const avatarUrl = page.getByRole('textbox', { name: 'Avatar image URL' });
+  await avatarUrl.focus();
   await avatarUrl.fill('');
   await expect(page.getByRole('status')).toContainText('Enter an avatar URL to see a preview.');
 
@@ -46,11 +52,17 @@ test('profile editing connects settings, previews avatars, and persists appearan
 
   await page.getByRole('tab', { name: 'Creation defaults' }).click();
   await expect(page.getByRole('combobox', { name: 'Default Group' })).toBeVisible();
+  const defaultGroupHelp = page.getByRole('group', { name: 'Default Group' }).getByRole('img', { name: 'Help' });
+  await defaultGroupHelp.hover();
+  await expect(page.getByRole('tooltip')).toContainText('New rulesets and factions use this Group');
 
   await page.getByRole('tab', { name: 'Account' }).click();
   await expect(page.getByRole('link', { name: 'Delete account' })).toBeVisible();
 
   await page.getByRole('tab', { name: 'Appearance' }).click();
+  const motionHelp = page.getByRole('group', { name: 'Ambient motion' }).getByRole('img', { name: 'Help' });
+  await motionHelp.hover();
+  await expect(page.getByRole('tooltip')).toContainText('The masthead video and the turning dice');
   await page.getByText('Dark', { exact: true }).click();
   await expect.poll(() => page.evaluate(() => localStorage.getItem('dunezone-color-scheme'))).toBe('dark');
   await expect(page.locator('html')).toHaveAttribute('data-mantine-color-scheme', 'dark');

--- a/src/app/routes/_app/profiles/$profileSlug/-edit.test.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/-edit.test.tsx
@@ -141,13 +141,27 @@ describe('profile settings page', () => {
     expect(save.closest('form')).toBeNull();
     expect(document.getElementById(formId as string)?.tagName).toBe('FORM');
     expect(save.disabled).toBe(true);
+    expect(save.querySelector('svg')).not.toBeNull();
+
+    const displayNameControl = view.getByRole('group', { name: 'Display name *' });
+    expect(displayNameControl.getAttribute('aria-describedby')).toBeTruthy();
+    expect(displayNameControl.querySelector('[role="img"][aria-label="Help"]')).not.toBeNull();
 
     await chooseTab(view, 'Creation defaults');
     expect(view.getByRole('combobox', { name: 'Default Group' })).not.toBeNull();
+    expect(
+      view.getByRole('group', { name: 'Default Group' }).querySelector('[role="img"][aria-label="Help"]')
+    ).not.toBeNull();
 
     await chooseTab(view, 'Appearance');
     expect(view.getByRole('radiogroup', { name: 'Ambient motion' })).not.toBeNull();
     expect(view.getByRole('radiogroup', { name: 'Color scheme' })).not.toBeNull();
+    expect(
+      view.getByRole('group', { name: 'Ambient motion' }).querySelector('[role="img"][aria-label="Help"]')
+    ).not.toBeNull();
+    expect(
+      view.getByRole('group', { name: 'Color scheme' }).querySelector('[role="img"][aria-label="Help"]')
+    ).not.toBeNull();
     await chooseTab(view, 'Account');
     expect(view.getByRole('link', { name: 'Delete account' })).not.toBeNull();
   });

--- a/src/app/routes/_app/profiles/$profileSlug/edit.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/edit.tsx
@@ -3,13 +3,14 @@ import { profileSlugBaseFromName, profileUserEditFormSchema } from '@shared/prof
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
 import { SlugRenameNotice } from '@ui/content/SlugRenameNotice';
+import { ControlBlock } from '@ui/control/ControlBlock';
 import { IconAction } from '@ui/control/IconAction';
 import { SubmitAction } from '@ui/control/SubmitAction';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
 import { ConnectedTabs } from '@ui/surface/ConnectedTabs';
 import { Toolbar } from '@ui/surface/Toolbar';
-import { ArrowLeft, CircleUserRound, Palette, Trash2, User, UsersRound } from 'lucide-react';
+import { ArrowLeft, CircleUserRound, Palette, Save, Trash2, User, UsersRound } from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
 
 import { useCurrentProfile, useUpdateCurrentProfile } from '@db/profiles';
@@ -107,26 +108,20 @@ function PreferenceSegments<Value extends string>({
   value: Value;
   onChange: (next: Value) => void;
 }) {
-  const labelId = useId();
-  const noteId = useId();
-
   return (
-    <Stack gap={4}>
-      <Text fw={650} id={labelId}>
-        {label}
-      </Text>
-      <Text c="dimmed" id={noteId} size="sm">
-        {note}
-      </Text>
-      <SegmentedControl
-        aria-labelledby={labelId}
-        aria-describedby={noteId}
-        data={[...options]}
-        value={value}
-        onChange={(next) => onChange(next as Value)}
-        fullWidth
-      />
-    </Stack>
+    <ControlBlock
+      title={label}
+      description={note}
+      input={
+        <SegmentedControl
+          aria-label={label}
+          data={[...options]}
+          value={value}
+          onChange={(next) => onChange(next as Value)}
+          fullWidth
+        />
+      }
+    />
   );
 }
 
@@ -237,10 +232,8 @@ function EditableProfilePage({ initial }: { initial: CurrentProfileEntry }) {
       panel: (
         <Stack gap="md">
           {panelError}
-          <TextInput
-            ref={usernameRef}
-            label="Display name"
-            required
+          <ControlBlock
+            title="Display name *"
             description={
               <>
                 Letters and numbers only, 5–30 characters, not all capitals.
@@ -256,25 +249,37 @@ function EditableProfilePage({ initial }: { initial: CurrentProfileEntry }) {
                 ) : null}
               </>
             }
-            value={username}
-            onChange={(event) => setUsername(event.target.value)}
-            autoComplete="nickname"
-            maxLength={30}
+            input={
+              <TextInput
+                ref={usernameRef}
+                aria-label="Display name"
+                required
+                value={username}
+                onChange={(event) => setUsername(event.target.value)}
+                autoComplete="nickname"
+                maxLength={30}
+              />
+            }
           />
-          <TextInput
-            ref={avatarUrlRef}
-            label="Avatar image URL"
-            required
+          <ControlBlock
+            title="Avatar image URL *"
             description={
               <>
                 Must be a full <code>https://</code> URL.
               </>
             }
-            type="url"
-            value={avatarUrl}
-            onChange={(event) => setAvatarUrl(event.target.value)}
-            placeholder="https://…"
-            autoComplete="off"
+            input={
+              <TextInput
+                ref={avatarUrlRef}
+                aria-label="Avatar image URL"
+                required
+                type="url"
+                value={avatarUrl}
+                onChange={(event) => setAvatarUrl(event.target.value)}
+                placeholder="https://…"
+                autoComplete="off"
+              />
+            }
           />
           <AvatarPreview avatarUrl={avatarUrl} username={username} />
         </Stack>
@@ -287,20 +292,25 @@ function EditableProfilePage({ initial }: { initial: CurrentProfileEntry }) {
       panel: (
         <Stack gap="md">
           {panelError}
-          <Select
-            ref={defaultGroupRef}
-            label="Default Group"
+          <ControlBlock
+            title="Default Group"
             description="New rulesets and factions use this Group when it is still available. You can change an item’s Group after its first save."
-            value={defaultGroupId ?? ''}
-            onChange={(value) => {
-              setDefaultGroupId(value || null);
-              setDefaultGroupChanged(true);
-            }}
-            data={[
-              { value: '', label: 'No default Group' },
-              ...initial.default_group_options.map((group) => ({ value: group.id, label: group.name })),
-            ]}
-            clearable
+            input={
+              <Select
+                ref={defaultGroupRef}
+                aria-label="Default Group"
+                value={defaultGroupId ?? ''}
+                onChange={(value) => {
+                  setDefaultGroupId(value || null);
+                  setDefaultGroupChanged(true);
+                }}
+                data={[
+                  { value: '', label: 'No default Group' },
+                  ...initial.default_group_options.map((group) => ({ value: group.id, label: group.name })),
+                ]}
+                clearable
+              />
+            }
           />
         </Stack>
       ),
@@ -386,7 +396,12 @@ function EditableProfilePage({ initial }: { initial: CurrentProfileEntry }) {
         />
       </Toolbar.Left>
       <Toolbar.Right>
-        <SubmitAction form={formId} pending={update.isPending} disabled={!isDirty} size="lg">
+        <SubmitAction
+          form={formId}
+          pending={update.isPending}
+          disabled={!isDirty}
+          icon={<Save size={17} aria-hidden />}
+        >
           Save profile
         </SubmitAction>
       </Toolbar.Right>

--- a/src/app/ui/control/ControlBlock.tsx
+++ b/src/app/ui/control/ControlBlock.tsx
@@ -8,7 +8,7 @@ import styles from './ControlBlock.module.css';
 export interface ControlBlockProps {
   title: string;
   /** Reserved for a constraint or consequence the control itself cannot show; surfaces behind the (?) help icon. */
-  description?: string;
+  description?: ReactNode;
   tool?: ReactNode;
   input: ReactNode;
 }

--- a/src/app/ui/control/SubmitAction.tsx
+++ b/src/app/ui/control/SubmitAction.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@mantine/core';
 import type { ButtonProps } from '@mantine/core';
+import type { ReactNode } from 'react';
 
 export interface SubmitActionProps {
   /** What saving means here — "Save group". A verb phrase, because it is a promise to act. */
@@ -12,6 +13,8 @@ export interface SubmitActionProps {
   pendingLabel?: string;
   /** Associates the action with a form elsewhere in the page, such as a PageLayout toolbar. */
   form?: string;
+  /** Optional glyph placed before the action label. */
+  icon?: ReactNode;
   size?: ButtonProps['size'];
 }
 
@@ -30,6 +33,7 @@ export function SubmitAction({
   disabled = false,
   pendingLabel = 'Saving…',
   form,
+  icon,
   size,
 }: SubmitActionProps) {
   return (
@@ -39,6 +43,7 @@ export function SubmitAction({
       variant="filled"
       color="confirm"
       size={size}
+      leftSection={icon}
       loading={pending}
       disabled={disabled || pending}
     >


### PR DESCRIPTION
## What changed

- make Profile, Creation defaults, and Appearance controls use the shared question-mark help pattern instead of persistent descriptions
- align Save profile with the faction editor's confirm button size and Save glyph
- preserve the existing form association, pending state, default Group behavior, appearance persistence, avatar preview, and one-query page contract
- extend route and browser coverage for the help controls and Save affordance

## Verification

- `bun run typecheck`
- `bun run check`
- `bun run knip`
- `bun run test` with 506 passing tests
- `bun run publisher:release:verify`
- `PLAYWRIGHT_HEADLESS=true bun run e2e:local` with 9 passing tests

Closes #562

Part of #540
