### PR TITLE
Assets 2/3: the kit additions

### DIFF
--- a/src/app/ui/content/TopicIcon.stories.tsx
+++ b/src/app/ui/content/TopicIcon.stories.tsx
@@ -39,7 +39,7 @@ export const InheritedColor = meta.story({
   render: (args) => (
     <div style={{ display: 'flex', alignItems: 'center', gap: 24, color: '#c2410c' }}>
       <TopicIcon {...args} />
-      <TopicIcon topic="background" size={args.size} />
+      <TopicIcon topic="face" size={args.size} />
     </div>
   ),
 });

--- a/src/app/ui/content/TopicIcon.test.tsx
+++ b/src/app/ui/content/TopicIcon.test.tsx
@@ -5,7 +5,6 @@ import { TopicIcon } from './TopicIcon';
 import type { TopicIconTopic } from './TopicIcon';
 
 const MASK_TOPICS: Array<[TopicIconTopic, string]> = [
-  ['identity', '/vector/icon/eye.svg'],
   ['hero', '/vector/generic/ceasar.svg'],
   ['leaders', '/vector/icon/traitor.svg'],
   ['alliance', '/vector/icon/alliance.svg'],
@@ -18,7 +17,7 @@ const MASK_TOPICS: Array<[TopicIconTopic, string]> = [
   ['fate', '/vector/icon/fate.svg'],
 ];
 
-const COMPONENT_TOPICS: TopicIconTopic[] = ['background', 'setup', 'rulesets'];
+const COMPONENT_TOPICS: TopicIconTopic[] = ['face', 'text', 'setup', 'rulesets'];
 
 describe('TopicIcon', () => {
   it.each(MASK_TOPICS)('renders the %s asset as a current-color mask', (topic, src) => {

--- a/src/app/ui/content/TopicIcon.test.tsx
+++ b/src/app/ui/content/TopicIcon.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import { TopicIcon } from './TopicIcon';
+import { TOPIC_ICON_TOPICS, TopicIcon } from './TopicIcon';
 import type { TopicIconTopic } from './TopicIcon';
 
 const MASK_TOPICS: Array<[TopicIconTopic, string]> = [
@@ -19,7 +19,18 @@ const MASK_TOPICS: Array<[TopicIconTopic, string]> = [
 
 const COMPONENT_TOPICS: TopicIconTopic[] = ['face', 'text', 'setup', 'rulesets'];
 
+/*
+ * Derived from the registry rather than written beside it, so a topic added there is tested here
+ * without anyone remembering to extend a list. The named cases above keep their sharper assertions.
+ */
+const ALL_TOPICS = TOPIC_ICON_TOPICS;
+
 describe('TopicIcon', () => {
+  it.each(ALL_TOPICS)('renders the %s topic at all', (topic) => {
+    const markup = renderToStaticMarkup(<TopicIcon topic={topic} />);
+    expect(markup.length).toBeGreaterThan(0);
+  });
+
   it.each(MASK_TOPICS)('renders the %s asset as a current-color mask', (topic, src) => {
     const markup = renderToStaticMarkup(<TopicIcon topic={topic} />);
 

--- a/src/app/ui/content/TopicIcon.tsx
+++ b/src/app/ui/content/TopicIcon.tsx
@@ -1,9 +1,17 @@
-import { BookOpen, Image as ImageIcon } from 'lucide-react';
+import { BookOpen, Boxes, Image as ImageIcon, Info, Signature, Type } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 const TOPIC_ICON_DEFINITIONS = {
-  identity: { kind: 'mask', src: '/vector/icon/eye.svg' },
-  background: { kind: 'component', component: ImageIcon },
+  /* Every authoring surface opens on an Identity chapter: what a thing is called, and what it fundamentally is. */
+  identity: { kind: 'component', component: Signature },
+  /* Off-face prose (CONTEXT.md: About), on every asset editor and every detail page. */
+  about: { kind: 'component', component: Info },
+  /* What a container holds. A deck's cards and a bundle's tokens are the same idea at the same place in the tabs. */
+  contents: { kind: 'component', component: Boxes },
+  /* What a face is composed of, before anything is written on it. Four tabs across the two token editors. */
+  face: { kind: 'component', component: ImageIcon },
+  /* Words on an artifact: a card's Head, an enhance token's per-face text. Both editors had hand-picked the same glyph. */
+  text: { kind: 'component', component: Type },
   hero: { kind: 'mask', src: '/vector/generic/ceasar.svg' },
   leaders: { kind: 'mask', src: '/vector/icon/traitor.svg' },
   alliance: { kind: 'mask', src: '/vector/icon/alliance.svg' },

--- a/src/app/ui/control/AssignPopover.tsx
+++ b/src/app/ui/control/AssignPopover.tsx
@@ -264,6 +264,8 @@ export function AssignPopover({ icon, size = 'lg', ...body }: AssignPopoverProps
         <IconAction
           label={body.triggerLabel ?? body.title ?? `Assign ${body.noun}`}
           variant="light"
+          /* Neutral, not the primary colour: red on a toolbar means destructive and nothing else, and this sits beside a delete. */
+          color="gray"
           size={size}
           disabled={body.disabled}
           onClick={() => setOpened((current) => !current)}

--- a/src/app/ui/control/ConfirmDeleteAction.stories.tsx
+++ b/src/app/ui/control/ConfirmDeleteAction.stories.tsx
@@ -1,0 +1,88 @@
+import preview from '@sb/preview';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+import { ConfirmDeleteAction } from './ConfirmDeleteAction';
+
+const meta = preview.meta({
+  component: ConfirmDeleteAction,
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'light', grid: false } },
+  args: {
+    label: 'Delete faction',
+    prompt: 'Delete faction?',
+    pending: false,
+    onConfirm: fn(),
+  },
+});
+
+/** Collapsed: one red glyph among the other toolbar actions, carrying its name for people who cannot see it. */
+export const Default = meta.story({});
+
+/** Clicking the glyph replaces it in place with the question and its two answers. No dialog, no lost context. */
+export const Confirming = meta.story({
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(page.getByRole('button', { name: 'Delete faction' }));
+
+    const question = await page.findByRole('group', { name: 'Delete faction' });
+    await expect(question).toHaveTextContent('Delete faction?');
+    await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
+    /* The swap must hand focus over, or a keyboard reader is stranded on an unmounted node. */
+    await waitFor(() => expect(question).toHaveFocus());
+  },
+});
+
+/** Confirming fires the caller's intent once. The component neither deletes anything nor closes itself. */
+export const Confirmed = meta.story({
+  play: async ({ args, canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(page.getByRole('button', { name: 'Delete faction' }));
+    await userEvent.click(await page.findByRole('button', { name: 'Delete' }));
+
+    await expect(args.onConfirm).toHaveBeenCalledTimes(1);
+    await expect(page.getByRole('group', { name: 'Delete faction' })).toBeVisible();
+  },
+});
+
+/** Cancel collapses it back to the glyph and returns focus there, so a misclick costs nothing. */
+export const Cancelled = meta.story({
+  play: async ({ args, canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(page.getByRole('button', { name: 'Delete faction' }));
+    await userEvent.click(await page.findByRole('button', { name: 'Cancel' }));
+
+    const trigger = await page.findByRole('button', { name: 'Delete faction' });
+    await waitFor(() => expect(trigger).toHaveFocus());
+    await expect(args.onConfirm).not.toHaveBeenCalled();
+  },
+});
+
+/** While the deletion is in flight the confirm latches, so an impatient second click cannot fire it twice. Cancel stays live: it closes the asking, and there is no abort channel it could reach. */
+export const Pending = meta.story({
+  args: { pending: true },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(page.getByRole('button', { name: 'Delete faction' }));
+
+    await waitFor(() => expect(page.getByRole('button', { name: 'Delete' })).toBeDisabled());
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeEnabled();
+  },
+});
+
+/** The words follow whatever is being deleted, and the question is where a page names a consequence the trigger cannot carry. */
+export const OtherWords = meta.story({
+  args: { label: 'Retire deck', prompt: 'Retire this deck for everyone?', confirmLabel: 'Retire' },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(page.getByRole('button', { name: 'Retire deck' }));
+
+    const question = await page.findByRole('group', { name: 'Retire deck' });
+    await expect(question).toHaveTextContent('Retire this deck for everyone?');
+    await expect(page.getByRole('button', { name: 'Retire' })).toBeVisible();
+  },
+});

--- a/src/app/ui/control/ConfirmDeleteAction.test.tsx
+++ b/src/app/ui/control/ConfirmDeleteAction.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { MantineProvider } from '@mantine/core';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { appContentTheme } from '@ui/theme';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { ConfirmDeleteAction } from './ConfirmDeleteAction';
+
+window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+function renderAction(onConfirm: () => void, pending = false) {
+  return render(
+    <MantineProvider theme={appContentTheme} forceColorScheme="light">
+      <ConfirmDeleteAction label="Delete card" prompt="Delete card?" pending={pending} onConfirm={onConfirm} />
+    </MantineProvider>
+  );
+}
+
+describe('ConfirmDeleteAction', () => {
+  test('a double click fires the destructive callback once', () => {
+    const onConfirm = vi.fn();
+    renderAction(onConfirm);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete card' }));
+    const confirm = screen.getByRole('button', { name: 'Delete' });
+    /* The caller's pending arrives a render later; both clicks land in that gap. */
+    fireEvent.click(confirm);
+    fireEvent.click(confirm);
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/ui/control/ConfirmDeleteAction.tsx
+++ b/src/app/ui/control/ConfirmDeleteAction.tsx
@@ -49,6 +49,16 @@ export function ConfirmDeleteAction({
   onConfirm,
 }: ConfirmDeleteActionProps) {
   const [confirming, setConfirming] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [sawPending, setSawPending] = useState(false);
+  /* Reset during render, the search box's pattern: when the caller's round trip ends, a failed delete gets its retry back. */
+  if (pending && !sawPending) {
+    setSawPending(true);
+  }
+  if (!pending && sawPending) {
+    setSawPending(false);
+    setSubmitted(false);
+  }
   const triggerRef = useRef<HTMLButtonElement>(null);
   const questionRef = useRef<HTMLDivElement>(null);
   /* Only a cancel should pull focus back to the glyph; the first render has nothing to return to. */
@@ -83,11 +93,38 @@ export function ConfirmDeleteAction({
   }
 
   return (
-    <Group ref={questionRef} gap={4} wrap="nowrap" role="group" aria-label={label} tabIndex={-1}>
+    <Group
+      ref={questionRef}
+      gap={4}
+      wrap="nowrap"
+      role="group"
+      aria-label={label}
+      tabIndex={-1}
+      /* Escape closes the asking the way it closes every popover here; the focus effect then hands focus back to the trigger. */
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          setConfirming(false);
+        }
+      }}
+    >
       <Text size="xs" c="red" fw={700}>
         {prompt}
       </Text>
-      <Button type="button" color="red" size="compact-xs" loading={pending} onClick={onConfirm}>
+      <Button
+        type="button"
+        color="red"
+        size="compact-xs"
+        loading={pending || submitted}
+        onClick={() => {
+          /*
+           * Latched locally before the callback: the caller's pending arrives a render later, and the gap is where a double click fires a destructive callback twice.
+           * Focus moves to the group in the same breath, because the loading button is about to disable and a disabled element drops keyboard focus to the document.
+           */
+          setSubmitted(true);
+          questionRef.current?.focus();
+          onConfirm();
+        }}
+      >
         {confirmLabel}
       </Button>
       {/* Cancel stays live during an in-flight delete on purpose: there is no abort channel to reach, and latching it would trap the reader here with no exit if the round trip stalls. It closes the asking, never the mutation. The caller's navigation or error alert reports the outcome. */}

--- a/src/app/ui/control/ConfirmDeleteAction.tsx
+++ b/src/app/ui/control/ConfirmDeleteAction.tsx
@@ -1,0 +1,99 @@
+import { Button, Group, Text } from '@mantine/core';
+import { Trash2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { IconAction } from './IconAction';
+
+export interface ConfirmDeleteActionProps {
+  /**
+   * What gets deleted, as a verb phrase, for example "Delete faction".
+   * This is the trigger's accessible name and the name of the confirmation that replaces it.
+   */
+  label: string;
+  /**
+   * The question, shown beside the confirm button, for example "Delete faction?".
+   * Required rather than derived from `label`: it is the only sentence in the two-step, and the one place a page can name a consequence the terse trigger cannot carry ("Delete card?
+   * Its publications stay.").
+   */
+  prompt: string;
+  /** The confirm button's word. Override only when "Delete" would be a lie. */
+  confirmLabel?: string;
+  /** True while the deletion is in flight. Latches the confirm button so a second click cannot fire it twice. */
+  pending: boolean;
+  /** Fires once the reader has confirmed. The caller owns the mutation and wherever it navigates afterwards. */
+  onConfirm: () => void;
+}
+
+/**
+ * Deletes something, having asked first.
+ *
+ * Callers own what is deleted and the words for it;
+ * this owns the two-step shape.
+ * A red glyph expands in place into a question and a pair of answers, and collapses again on cancel.
+ *
+ * The asking is in place rather than in a dialog, deliberately.
+ * A toolbar action that opens one loses the row it belongs to, and `window.confirm` cannot be styled, tested, or dismissed by keyboard the way the rest of the app can.
+ * See docs/technical/ui-design-decisions.md, "Destructive confirmation asks in place".
+ * The mid-confirm state lives here because it is furniture around committing the action, not something a caller ever needs to read.
+ *
+ * Swapping the trigger for the question would strand keyboard focus on an unmounted node, so the swap hands focus over in both directions.
+ * Focus goes to the question on open and back to the glyph on cancel, the same contract `AssignPopover` gets from Mantine's `returnFocus`.
+ * Focus lands on the group rather than the confirm button on purpose.
+ * A held Enter would otherwise repeat straight through onto "Delete".
+ */
+export function ConfirmDeleteAction({
+  label,
+  prompt,
+  confirmLabel = 'Delete',
+  pending,
+  onConfirm,
+}: ConfirmDeleteActionProps) {
+  const [confirming, setConfirming] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const questionRef = useRef<HTMLDivElement>(null);
+  /* Only a cancel should pull focus back to the glyph; the first render has nothing to return to. */
+  const wasConfirming = useRef(false);
+
+  useEffect(() => {
+    switch (true) {
+      case confirming:
+        questionRef.current?.focus();
+        break;
+      case wasConfirming.current:
+        triggerRef.current?.focus();
+        break;
+      default:
+        break;
+    }
+    wasConfirming.current = confirming;
+  }, [confirming]);
+
+  if (!confirming) {
+    return (
+      <IconAction
+        ref={triggerRef}
+        label={label}
+        variant="light"
+        color="red"
+        size="lg"
+        onClick={() => setConfirming(true)}
+        icon={<Trash2 size={17} aria-hidden />}
+      />
+    );
+  }
+
+  return (
+    <Group ref={questionRef} gap={4} wrap="nowrap" role="group" aria-label={label} tabIndex={-1}>
+      <Text size="xs" c="red" fw={700}>
+        {prompt}
+      </Text>
+      <Button type="button" color="red" size="compact-xs" loading={pending} onClick={onConfirm}>
+        {confirmLabel}
+      </Button>
+      {/* Cancel stays live during an in-flight delete on purpose: there is no abort channel to reach, and latching it would trap the reader here with no exit if the round trip stalls. It closes the asking, never the mutation. The caller's navigation or error alert reports the outcome. */}
+      <Button type="button" variant="subtle" color="gray" size="compact-xs" onClick={() => setConfirming(false)}>
+        Cancel
+      </Button>
+    </Group>
+  );
+}

--- a/src/app/ui/control/ListLengthActions.tsx
+++ b/src/app/ui/control/ListLengthActions.tsx
@@ -1,5 +1,43 @@
 import { ActionIcon, Group, Tooltip } from '@mantine/core';
 import { Minus, Plus } from 'lucide-react';
+import type { Ref } from 'react';
+
+/**
+ * The small green plus this app grows collections with, on its own.
+ *
+ * Extracted so the treatment is owned once.
+ * Nine widgets reach it through `ListLengthActions`, and a picker that opens rather than appends wants the same affordance without the minus beside it (Norbert, 2026-08-20).
+ * Takes a `ref` because a picker mounts it as a popover target.
+ * @public until the pages slice of the assets stack lands (wayfinder #568).
+ */
+export function AddAction({
+  label,
+  disabled = false,
+  onClick,
+  ref,
+}: {
+  label: string;
+  disabled?: boolean;
+  onClick?: () => void;
+  ref?: Ref<HTMLButtonElement>;
+}) {
+  return (
+    <Tooltip label={label}>
+      <ActionIcon
+        ref={ref}
+        type="button"
+        variant="light"
+        color="green"
+        size="sm"
+        aria-label={label}
+        disabled={disabled}
+        onClick={onClick}
+      >
+        <Plus size={15} aria-hidden />
+      </ActionIcon>
+    </Tooltip>
+  );
+}
 
 export interface ListLengthActionsProps {
   addLabel: string;
@@ -39,19 +77,7 @@ export function ListLengthActions({
           <Minus size={15} aria-hidden />
         </ActionIcon>
       </Tooltip>
-      <Tooltip label={addLabel}>
-        <ActionIcon
-          type="button"
-          variant="light"
-          color="green"
-          size="sm"
-          aria-label={addLabel}
-          disabled={addDisabled}
-          onClick={onAdd}
-        >
-          <Plus size={15} aria-hidden />
-        </ActionIcon>
-      </Tooltip>
+      <AddAction label={addLabel} disabled={addDisabled} onClick={onAdd} />
     </Group>
   );
 }

--- a/src/app/ui/control/ListLengthActions.tsx
+++ b/src/app/ui/control/ListLengthActions.tsx
@@ -2,6 +2,8 @@ import { ActionIcon, Group, Tooltip } from '@mantine/core';
 import { Minus, Plus } from 'lucide-react';
 import type { Ref } from 'react';
 
+import { IconAction } from './IconAction';
+
 /**
  * The small green plus this app grows collections with, on its own.
  *
@@ -22,20 +24,16 @@ export function AddAction({
   ref?: Ref<HTMLButtonElement>;
 }) {
   return (
-    <Tooltip label={label}>
-      <ActionIcon
-        ref={ref}
-        type="button"
-        variant="light"
-        color="green"
-        size="sm"
-        aria-label={label}
-        disabled={disabled}
-        onClick={onClick}
-      >
-        <Plus size={15} aria-hidden />
-      </ActionIcon>
-    </Tooltip>
+    <IconAction
+      ref={ref}
+      label={label}
+      variant="light"
+      color="green"
+      size="sm"
+      disabled={disabled}
+      onClick={onClick}
+      icon={<Plus size={15} aria-hidden />}
+    />
   );
 }
 

--- a/src/app/ui/layout/CanvasScale.stories.tsx
+++ b/src/app/ui/layout/CanvasScale.stories.tsx
@@ -1,0 +1,37 @@
+import { Box } from '@mantine/core';
+import preview from '@sb/preview';
+
+import { CanvasScale } from './CanvasScale';
+
+const meta = preview.meta({
+  component: CanvasScale,
+  args: {
+    canvasWidth: 900,
+    canvasHeight: 1263,
+    children: (
+      <Box
+        w={900}
+        h={1263}
+        style={{
+          display: 'grid',
+          placeItems: 'center',
+          background: 'linear-gradient(135deg, #17383d, #d3ab63)',
+          color: '#fff',
+          fontSize: 120,
+        }}
+      >
+        900 × 1263
+      </Box>
+    ),
+  },
+});
+
+export const CardCanvas = meta.story({});
+
+export const NarrowContainer = meta.story({
+  render: (args) => (
+    <Box w={220}>
+      <CanvasScale {...args} />
+    </Box>
+  ),
+});

--- a/src/app/ui/layout/CanvasScale.tsx
+++ b/src/app/ui/layout/CanvasScale.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import type { PropsWithChildren } from 'react';
 
 /**
- * Fits a fixed-size canvas — a game renderer drawing in card-space pixels — to the container's width: the frame keeps the canvas aspect and clips it while the canvas renders at native size and scales down.
+ * Fits a fixed-size canvas — a game renderer drawing in card-space pixels — to the container's width: the frame keeps the canvas aspect and clips it while the canvas renders at native size and scales to fit, down in a rail and up in a wide mount, which stays crisp because the renderers are DOM and vector rather than raster.
  * Pure placement;
  * the caller decorates the frame (radius, shadow) through `frameClassName`.
  */

--- a/src/app/ui/layout/CanvasScale.tsx
+++ b/src/app/ui/layout/CanvasScale.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+import type { PropsWithChildren } from 'react';
+
+/**
+ * Fits a fixed-size canvas — a game renderer drawing in card-space pixels — to the container's width: the frame keeps the canvas aspect and clips it while the canvas renders at native size and scales down.
+ * Pure placement;
+ * the caller decorates the frame (radius, shadow) through `frameClassName`.
+ */
+export function CanvasScale({
+  canvasWidth,
+  canvasHeight,
+  frameClassName,
+  children,
+}: PropsWithChildren<{
+  canvasWidth: number;
+  canvasHeight: number;
+  frameClassName?: string;
+}>) {
+  const [width, setWidth] = useState(0);
+  const [node, setNode] = useState<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!node) {
+      return;
+    }
+    const observer = new ResizeObserver(([entry]) => setWidth(entry?.contentRect.width ?? 0));
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [node]);
+  return (
+    <div ref={setNode} style={{ width: '100%' }}>
+      {width > 0 && (
+        <div
+          className={frameClassName}
+          style={{
+            width,
+            height: width * (canvasHeight / canvasWidth),
+            position: 'relative',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              width: canvasWidth,
+              height: canvasHeight,
+              transform: `scale(${width / canvasWidth})`,
+              transformOrigin: 'top left',
+              pointerEvents: 'none',
+            }}
+          >
+            {children}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/ui/layout/PageLayout.architecture.test.ts
+++ b/src/app/ui/layout/PageLayout.architecture.test.ts
@@ -17,7 +17,7 @@ function listRouteFiles(directory: string): string[] {
 }
 
 function mountsPageLayout(source: string): boolean {
-  return source.includes('<PageLayout');
+  return /<PageLayout[\s/>.]/.test(source);
 }
 
 /**
@@ -28,13 +28,18 @@ function mountsPageLayout(source: string): boolean {
  */
 function delegatesToPageLayout(path: string, source: string): boolean {
   const directory = dirname(path);
-  return [...source.matchAll(/from\s+'(\.[^']+)'/g)]
-    .flatMap((match) => {
-      const base = resolve(directory, match[1] ?? '');
-      return [`${base}.tsx`, `${base}/index.tsx`];
-    })
-    .filter((candidate) => existsSync(candidate))
-    .some((candidate) => mountsPageLayout(readFileSync(candidate, 'utf8')));
+  return (
+    [...source.matchAll(/import\s+\{([^}]+)\}\s+from\s+'(\.[^']+)'/g)]
+      .flatMap((match) => {
+        const names = (match[1] ?? '').split(',').map((name) => name.replace(/\s+as\s+\w+/, '').trim());
+        const base = resolve(directory, match[2] ?? '');
+        return [`${base}.tsx`, `${base}/index.tsx`].map((candidate) => ({ candidate, names }));
+      })
+      .filter(({ candidate }) => existsSync(candidate))
+      /* The delegate must be rendered, not merely imported: a route borrowing a button from a file that happens to mount the layout for someone else is not delegating its page to it. */
+      .filter(({ names }) => names.some((name) => new RegExp(`<${name}[\\s/>]`).test(source)))
+      .some(({ candidate }) => mountsPageLayout(readFileSync(candidate, 'utf8')))
+  );
 }
 
 describe('PageLayout route contract', () => {

--- a/src/app/ui/layout/PageLayout.architecture.test.ts
+++ b/src/app/ui/layout/PageLayout.architecture.test.ts
@@ -1,5 +1,5 @@
-import { readdirSync, readFileSync } from 'node:fs';
-import { relative, resolve } from 'node:path';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
@@ -16,6 +16,27 @@ function listRouteFiles(directory: string): string[] {
   });
 }
 
+function mountsPageLayout(source: string): boolean {
+  return source.includes('<PageLayout');
+}
+
+/**
+ * Whether a route hands its page off to something that mounts the layout for it.
+ *
+ * A route that dispatches on a param renders no page of its own, exactly like an `Outlet` passthrough, so it cannot contain `<PageLayout` and should not have to.
+ * Resolving one hop keeps the rule real rather than granting such routes a blanket exemption: the file it delegates to still has to mount the layout.
+ */
+function delegatesToPageLayout(path: string, source: string): boolean {
+  const directory = dirname(path);
+  return [...source.matchAll(/from\s+'(\.[^']+)'/g)]
+    .flatMap((match) => {
+      const base = resolve(directory, match[1] ?? '');
+      return [`${base}.tsx`, `${base}/index.tsx`];
+    })
+    .filter((candidate) => existsSync(candidate))
+    .some((candidate) => mountsPageLayout(readFileSync(candidate, 'utf8')));
+}
+
 describe('PageLayout route contract', () => {
   /*
    * Allowlisted source-scan (ADR-0001): "every terminal visual route mounts PageLayout" is a real
@@ -24,13 +45,15 @@ describe('PageLayout route contract', () => {
    */
   it('keeps terminal visual routes on PageLayout', () => {
     const routes = listRouteFiles(appRoutesDirectory).map((path) => ({
+      path,
       relativePath: relative(appRoutesDirectory, path),
       source: readFileSync(path, 'utf8'),
     }));
     const violations = routes
       .filter(({ source }) => source.includes('component:'))
       .filter(({ source }) => !source.includes('<Outlet />') && !source.includes('component: Outlet'))
-      .filter(({ source }) => !source.includes('<PageLayout'))
+      .filter(({ source }) => !mountsPageLayout(source))
+      .filter(({ path, source }) => !delegatesToPageLayout(path, source))
       .map(({ relativePath }) => relativePath);
 
     expect(violations).toEqual([]);

--- a/src/app/ui/layout/WorkbenchLayout.module.css
+++ b/src/app/ui/layout/WorkbenchLayout.module.css
@@ -1,0 +1,95 @@
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--mantine-spacing-md);
+  width: 100%;
+  max-width: 78rem;
+  margin: 0 auto;
+}
+
+.root[data-gap="sm"] {
+  gap: var(--mantine-spacing-sm);
+}
+
+.region {
+  container: workbench / inline-size;
+  min-width: 0;
+}
+
+.workbench {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(17rem, 21rem);
+  align-items: start;
+  width: 100%;
+  min-width: 0;
+}
+
+.chapters {
+  min-width: 0;
+}
+
+.rail {
+  min-width: 0;
+  padding-left: var(--mantine-spacing-md);
+}
+
+/* The desk the artifact sits on. Surface owns the pane itself; this is only what makes it a desk:
+   it follows you down a long chapter form, sitting below the chrome by the shell's own offset.
+   Children stretch to the rail's width, so a proof fills the rail rather than shrinking to content. */
+.desk {
+  position: sticky;
+  top: calc(var(--app-shell-header-offset, 0px) + 5.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: var(--mantine-spacing-md);
+}
+
+@container workbench (max-width: 70em) {
+  .workbench {
+    grid-template-columns: minmax(0, 1fr) minmax(14rem, 17rem);
+  }
+}
+
+@container workbench (max-width: 58em) {
+  .workbench {
+    grid-template-columns: minmax(0, 1fr) minmax(13rem, 15rem);
+  }
+
+  .rail {
+    padding-left: 0.6rem;
+  }
+}
+
+/*
+ * The rail stays beside the chapters. It holds the artifact being drawn, and the whole shape of these pages is
+ * edit on one side and watch it change on the other, so hiding it made an author on a phone compose blind, and
+ * stacking it below made them scroll away from the artifact to reach the fields.
+ *
+ * The space is bought from the chapters instead. `ConnectedTabs` swaps its 11.5rem vertical tab rail for a
+ * stepper bar once its own column falls under 34rem, which inside a narrowed workbench happens on its own.
+ * Norbert, 2026-08-21: "keep the rail, and show the mobile connectedtabs to save space". That is the column to
+ * spend, because a chapter list is navigation a reader can page through and the proof is what they came to see.
+ *
+ * The desk keeps following, since side by side survives and there is something to sit beside.
+ */
+@container workbench (max-width: 44em) {
+  .workbench {
+    grid-template-columns: minmax(0, 1fr) minmax(9rem, 11rem);
+  }
+
+  .rail {
+    padding-left: 0.5rem;
+  }
+}
+
+/*
+ * On a phone the rail yields rather than leaves.
+ * At the step above, a 9 to 11rem rail took half of a 375px screen and left 175px of form, which is a column you
+ * can read but not author in. Here it drops to a thumbnail: still a proof that shows a colour or a symbol
+ * changing, which is what the side-by-side is for, while the fields get the room to be fields.
+ */
+@container workbench (max-width: 30em) {
+  .workbench {
+    grid-template-columns: minmax(0, 1fr) minmax(5.5rem, 7rem);
+  }
+}

--- a/src/app/ui/layout/WorkbenchLayout.module.css
+++ b/src/app/ui/layout/WorkbenchLayout.module.css
@@ -29,6 +29,8 @@
 }
 
 .rail {
+  /* Stretched against the grid's start alignment, or the rail is only as tall as its desk and the desk's sticky range is zero: an inert sticky inherited from the faction stylesheet and found by review. */
+  align-self: stretch;
   min-width: 0;
   padding-left: var(--mantine-spacing-md);
 }
@@ -44,13 +46,13 @@
   gap: var(--mantine-spacing-md);
 }
 
-@container workbench (max-width: 70em) {
+@container workbench (max-width: 70rem) {
   .workbench {
     grid-template-columns: minmax(0, 1fr) minmax(14rem, 17rem);
   }
 }
 
-@container workbench (max-width: 58em) {
+@container workbench (max-width: 58rem) {
   .workbench {
     grid-template-columns: minmax(0, 1fr) minmax(13rem, 15rem);
   }
@@ -72,7 +74,7 @@
  *
  * The desk keeps following, since side by side survives and there is something to sit beside.
  */
-@container workbench (max-width: 44em) {
+@container workbench (max-width: 44rem) {
   .workbench {
     grid-template-columns: minmax(0, 1fr) minmax(9rem, 11rem);
   }
@@ -88,7 +90,7 @@
  * can read but not author in. Here it drops to a thumbnail: still a proof that shows a colour or a symbol
  * changing, which is what the side-by-side is for, while the fields get the room to be fields.
  */
-@container workbench (max-width: 30em) {
+@container workbench (max-width: 30rem) {
   .workbench {
     grid-template-columns: minmax(0, 1fr) minmax(5.5rem, 7rem);
   }

--- a/src/app/ui/layout/WorkbenchLayout.stories.tsx
+++ b/src/app/ui/layout/WorkbenchLayout.stories.tsx
@@ -10,7 +10,7 @@ const meta = preview.meta({
     docs: {
       description: {
         component:
-          'The authoring workbench: a capped reading column, and a two-column region placing chapters beside a sticky artifact rail. The rail narrows in steps with the viewport and leaves entirely below 48em.',
+          'The authoring workbench: a capped reading column, and a two-column region placing chapters beside a sticky artifact rail. The rail narrows in steps as its own container narrows; at the narrowest step the chapters column hands its width to the rail and ConnectedTabs collapses to its stepper, so the proof stays beside the fields at every width.',
       },
     },
   },

--- a/src/app/ui/layout/WorkbenchLayout.stories.tsx
+++ b/src/app/ui/layout/WorkbenchLayout.stories.tsx
@@ -10,7 +10,7 @@ const meta = preview.meta({
     docs: {
       description: {
         component:
-          'The authoring workbench: a capped reading column, and a two-column region placing chapters beside a sticky artifact rail. The rail narrows in steps as its own container narrows; at the narrowest step the chapters column hands its width to the rail and ConnectedTabs collapses to its stepper, so the proof stays beside the fields at every width.',
+          'The authoring workbench: a capped reading column, and a two-column region placing chapters beside a sticky artifact rail. The rail narrows in steps as its own container narrows; below the stepper threshold the chapters column hands width to the rail and ConnectedTabs collapses to its stepper, and at the narrowest step the rail yields to a thumbnail, so the proof stays beside the fields at every width.',
       },
     },
   },

--- a/src/app/ui/layout/WorkbenchLayout.stories.tsx
+++ b/src/app/ui/layout/WorkbenchLayout.stories.tsx
@@ -1,0 +1,43 @@
+import preview from '@sb/preview';
+
+import { LayoutSlotPlaceholder } from './LayoutSlotPlaceholder.stories.fixture';
+import { WorkbenchLayout } from './WorkbenchLayout';
+
+const meta = preview.meta({
+  component: WorkbenchLayout,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'The authoring workbench: a capped reading column, and a two-column region placing chapters beside a sticky artifact rail. The rail narrows in steps with the viewport and leaves entirely below 48em.',
+      },
+    },
+  },
+});
+
+/** The capped column alone: toolbar, warnings and editor flow down one centred track. */
+export const ReadingColumn = meta.story({
+  render: () => (
+    <WorkbenchLayout>
+      <LayoutSlotPlaceholder name="toolbar" minHeight={56} />
+      <LayoutSlotPlaceholder name="editor" minHeight={360} />
+    </WorkbenchLayout>
+  ),
+});
+
+/** Chapters beside the rail, the shape every editor shares. */
+export const ChaptersBesideRail = meta.story({
+  render: () => (
+    <WorkbenchLayout gap="sm">
+      <WorkbenchLayout.Workbench>
+        <WorkbenchLayout.Chapters>
+          <LayoutSlotPlaceholder name="chapters" minHeight={480} />
+        </WorkbenchLayout.Chapters>
+        <WorkbenchLayout.Rail>
+          <LayoutSlotPlaceholder name="rail" minHeight={240} />
+        </WorkbenchLayout.Rail>
+      </WorkbenchLayout.Workbench>
+    </WorkbenchLayout>
+  ),
+});

--- a/src/app/ui/layout/WorkbenchLayout.tsx
+++ b/src/app/ui/layout/WorkbenchLayout.tsx
@@ -1,0 +1,83 @@
+import clsx from 'clsx';
+import { Children, isValidElement } from 'react';
+import type { FocusEventHandler, PropsWithChildren, ReactNode } from 'react';
+
+import styles from './WorkbenchLayout.module.css';
+
+function Chapters(_: PropsWithChildren): null {
+  return null;
+}
+
+function Rail(_: PropsWithChildren): null {
+  return null;
+}
+
+/**
+ * The two-column region of the workbench: chapters beside a sticky artifact rail.
+ * The rail narrows in steps as its own container narrows and stays beside the chapters all the way down, because it holds the thing being drawn.
+ * The space at the narrow steps comes from `ConnectedTabs` collapsing its tab rail to a stepper, and then from the rail itself becoming a thumbnail.
+ * its desk stretches children to the rail's width, so a proof fills the rail rather than shrinking to content.
+ * The desk holds however many artifacts an editor stacks, and the count may change while mounted: a token draws two faces and loses one when its backside becomes a reference.
+ * The blur handler rides the grid because settling a draft when focus leaves the form is the editors' shared idiom.
+ */
+function Workbench({
+  children,
+  onBlurCapture,
+}: PropsWithChildren<{ onBlurCapture?: FocusEventHandler<HTMLDivElement> }>) {
+  let chapters: ReactNode = null;
+  let rail: ReactNode = null;
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) {
+      return;
+    }
+    if (child.type === Chapters) {
+      chapters = (child.props as PropsWithChildren).children;
+      return;
+    }
+    if (child.type === Rail) {
+      rail = (child.props as PropsWithChildren).children;
+    }
+  });
+
+  return (
+    <div className={styles.region}>
+      <div className={styles.workbench} onBlurCapture={onBlurCapture}>
+        <div className={styles.chapters}>{chapters}</div>
+        <div className={styles.rail}>
+          <div className={styles.desk}>{rail}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The authoring workbench, one owner for the layout every editor page shares.
+ * The root is the capped reading column the page's toolbar, warnings and editor flow down;
+ * `Workbench` splits an editor into chapters beside the sticky rail.
+ * Lifted from the faction editor's stylesheet, which had the canonical version of what five asset editors re-spelled inline.
+ */
+function WorkbenchLayoutBase({
+  gap = 'md',
+  className,
+  children,
+}: PropsWithChildren<{ gap?: 'sm' | 'md'; className?: string }>) {
+  return (
+    <div className={clsx(styles.root, className)} data-gap={gap === 'sm' ? 'sm' : undefined}>
+      {children}
+    </div>
+  );
+}
+
+type WorkbenchLayoutComponent = typeof WorkbenchLayoutBase & {
+  Workbench: typeof Workbench;
+  Chapters: typeof Chapters;
+  Rail: typeof Rail;
+};
+
+export const WorkbenchLayout = Object.assign(WorkbenchLayoutBase, {
+  Workbench,
+  Chapters,
+  Rail,
+}) as WorkbenchLayoutComponent;

--- a/src/app/ui/surface/ConnectedTabs.tsx
+++ b/src/app/ui/surface/ConnectedTabs.tsx
@@ -12,6 +12,17 @@ export interface ConnectedTabsItem<Value extends string> {
   value: Value;
   /** Words, so a string: the narrow layout puts this same text inside a native select. */
   label: string;
+  /**
+   * A simple, single-colour icon, and nothing else.
+   *
+   * Never a rendered artifact, a live preview of the panel's content, or an image of an authored asset.
+   * Four editors had drifted into using the tab as a second proof, and each read as clever alone and as noise in a row of tabs.
+   * The rail beside an editor is where a proof belongs (Norbert, 2026-08-20).
+   *
+   * In practice: a lucide component, or a `TopicIcon` for a chapter concept that recurs across editors.
+   * Both draw in `currentColor`, and `identity`, `about` and `contents` are already mapped.
+   * The rule is "A tab icon is an icon, never a proof" in docs/technical/ui-design-decisions.md.
+   */
   icon: ReactNode;
   indicator?: ReactNode;
   disabled?: boolean;

--- a/src/app/ui/surface/SectionedSurface.module.css
+++ b/src/app/ui/surface/SectionedSurface.module.css
@@ -1,6 +1,7 @@
 /* The pane clips its own rows so the first and last hairlines meet the rounded corner. */
 .surface {
   overflow: hidden;
+  container: sectioned-surface / inline-size;
 }
 
 .list {
@@ -10,6 +11,15 @@
 .rowCell {
   min-width: 0;
   color: inherit;
+}
+
+/* The row inset is Mantine's `horizontalSpacing="md"`, which is right at reading widths and
+   costly on a phone. It halves where the pane is narrow, giving the row its width back.
+   Unlayered, so this beats Mantine's layered padding without `!important`. */
+@container sectioned-surface (max-width: 34rem) {
+  .rowCell {
+    padding-inline: var(--space-2);
+  }
 }
 
 .interactiveRow {

--- a/src/app/ui/surface/SectionedSurface.module.css
+++ b/src/app/ui/surface/SectionedSurface.module.css
@@ -22,6 +22,10 @@
   }
 }
 
+.interactiveRow:hover {
+  background-color: var(--mantine-color-default-hover);
+}
+
 .interactiveRow {
   cursor: pointer;
 }

--- a/src/app/ui/surface/SectionedSurface.tsx
+++ b/src/app/ui/surface/SectionedSurface.tsx
@@ -1,5 +1,4 @@
 import { Table } from '@mantine/core';
-import { Children, isValidElement } from 'react';
 import type { KeyboardEvent, MouseEvent, ReactNode } from 'react';
 
 import styles from './SectionedSurface.module.css';
@@ -22,27 +21,23 @@ export interface SectionedSurfaceProps {
  * Prefer this over stacking several `Surface`s: dividing one pane is how a collection stays a single object, and surfaces never nest.
  */
 export function SectionedSurface({ children }: SectionedSurfaceProps) {
-  /* Hover highlight promises a click. Rows that are not activatable must not glow, so the
-     highlight follows whether any row carries `onActivate` — a purely informational pane
-     stays still under the pointer. */
-  const anyRowActivates = Children.toArray(children).some(
-    (child) => isValidElement<SectionedSurfaceRowProps>(child) && child.type === Row && child.props.onActivate != null
-  );
+  /* Hover highlight promises a click, so it lives on the interactive rows themselves rather than
+     on the table: a table-level highlight glows every row once any row activates, and a purely
+     informational row beside an activatable one must stay still under the pointer. */
   return (
     <Surface className={styles.surface}>
-      <Table
-        withRowBorders
-        highlightOnHover={anyRowActivates}
-        horizontalSpacing="md"
-        verticalSpacing="md"
-        className={styles.list}
-      >
+      <Table withRowBorders horizontalSpacing="md" verticalSpacing="md" className={styles.list}>
         <Table.Tbody>{children}</Table.Tbody>
       </Table>
     </Surface>
   );
 }
 
+/*
+ * Rows must be direct `SectionedSurface.Row` children: the interactive treatment keys on the element
+ * type, so a row reaching this table through a caller's wrapper component or a Fragment renders
+ * without its activation affordances rather than failing loudly.
+ */
 interface SectionedSurfaceRowProps {
   /**
    * The entry, as one slot.

--- a/src/app/ui/surface/SectionedSurface.tsx
+++ b/src/app/ui/surface/SectionedSurface.tsx
@@ -1,4 +1,5 @@
 import { Table } from '@mantine/core';
+import { Children, isValidElement } from 'react';
 import type { KeyboardEvent, MouseEvent, ReactNode } from 'react';
 
 import styles from './SectionedSurface.module.css';
@@ -21,9 +22,21 @@ export interface SectionedSurfaceProps {
  * Prefer this over stacking several `Surface`s: dividing one pane is how a collection stays a single object, and surfaces never nest.
  */
 export function SectionedSurface({ children }: SectionedSurfaceProps) {
+  /* Hover highlight promises a click. Rows that are not activatable must not glow, so the
+     highlight follows whether any row carries `onActivate` — a purely informational pane
+     stays still under the pointer. */
+  const anyRowActivates = Children.toArray(children).some(
+    (child) => isValidElement<SectionedSurfaceRowProps>(child) && child.type === Row && child.props.onActivate != null
+  );
   return (
     <Surface className={styles.surface}>
-      <Table withRowBorders highlightOnHover horizontalSpacing="md" verticalSpacing="md" className={styles.list}>
+      <Table
+        withRowBorders
+        highlightOnHover={anyRowActivates}
+        horizontalSpacing="md"
+        verticalSpacing="md"
+        className={styles.list}
+      >
         <Table.Tbody>{children}</Table.Tbody>
       </Table>
     </Surface>


### PR DESCRIPTION
Slice 2 of 3 of the assets stack, on `main` now that «Assets 1/3» (#580) has merged.

The kit additions the asset pages compose: `WorkbenchLayout` (one owner of the editor workbench: container-query steps, stepper-beside narrow form), `CanvasScale`, `ConfirmDeleteAction` with two-way focus handoff, `TopicIcon`'s grown vocabulary, `AddAction`, and control refinements.

**This slice has no page callers yet** — nothing is visible in the app until the pages slice (#583). Each component ships with its stories, which is where a reviewer should look for the effect. Deploying alone is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added accessible two-step confirmation for destructive actions, including customizable prompts and loading states.
  - Added responsive canvas scaling for fitting fixed-size content into narrow containers.
  - Added reusable workbench layouts with chapters, rails, configurable spacing, and responsive columns.
  - Added reusable add controls with tooltips and optional disabled states.
  - Expanded topic icon coverage for identity, about, contents, face, and text topics.

- **UI Improvements**
  - Improved narrow-pane spacing and limited hover highlighting to actionable rows.
  - Refined icon action coloring for clearer visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->