### PR TITLE
The drift check learns the Images binding

### DIFF
--- a/scripts/cloudflare-live-drift.test.ts
+++ b/scripts/cloudflare-live-drift.test.ts
@@ -24,6 +24,7 @@ function liveBindings() {
   return [
     { name: 'ASSET_BUCKET', type: 'r2_bucket', bucket_name: 'tanstack-start-faction-sheet-assets' },
     { name: 'BROWSER', type: 'browser' },
+    { name: 'IMAGES', type: 'images' },
     { name: 'ASSETS', type: 'assets' },
     { name: 'CF_VERSION_METADATA', type: 'version_metadata' },
     { name: 'ASSET_PUBLISHER_CACHE_TOKEN_SECRET', type: 'secret_text' },
@@ -168,7 +169,7 @@ describe('Cloudflare live drift check', () => {
     ).resolves.toEqual({
       worker: WORKER,
       domainCount: 1,
-      bindingCount: 12,
+      bindingCount: 13,
       secretCount: 2,
       cronCount: 1,
       queueCount: 1,

--- a/scripts/cloudflare-live-drift.ts
+++ b/scripts/cloudflare-live-drift.ts
@@ -168,6 +168,8 @@ function expectedBindings(wrangler: JsonRecord): string[] {
   bindings.push(`${string(assets.binding, 'Wrangler assets binding')}|assets|`);
   const browser = record(wrangler.browser, 'Wrangler browser');
   bindings.push(`${string(browser.binding, 'Wrangler browser binding')}|browser|`);
+  const images = record(wrangler.images, 'Wrangler images');
+  bindings.push(`${string(images.binding, 'Wrangler images binding')}|images|`);
   const versionMetadata = record(wrangler.version_metadata, 'Wrangler version metadata');
   bindings.push(`${string(versionMetadata.binding, 'Wrangler version metadata binding')}|version_metadata|`);
   for (const entry of array(wrangler.r2_buckets, 'Wrangler R2 bindings')) {


### PR DESCRIPTION
Unblocks the required `audit` check repo-wide: since tonight's slice-1 deploy put the `IMAGES` binding on the live Worker, every PR's drift check fails with `unexpected IMAGES|images|`, because `expectedBindings` had no parser branch for the images binding type. One branch added, fixture and count updated in the test. Gates: drift test 6/6, typecheck, lint, format.

This gates «Assets 2/3» (#582)'s required audit check, which is how it surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)