### PR TITLE
Back model 1 of 2: the union, the migration, the resolver, and the join

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ docs/research/
 /public/image/
 /public/web/*
 !/public/web/logo.svg
+!/public/web/no-deck-back.svg
 # generated vector output (built from media/vector by scripts/generate-vectors.ts; CI is canonical)
 /public/vector/
 /src/game/data/assetMap.generated.ts

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -21,6 +21,7 @@ import type * as homepage from "../homepage.js";
 import type * as http from "../http.js";
 import type * as lib_accountLifecycle from "../lib/accountLifecycle.js";
 import type * as lib_applicationTriggers from "../lib/applicationTriggers.js";
+import type * as lib_assetBacks from "../lib/assetBacks.js";
 import type * as lib_assetInput from "../lib/assetInput.js";
 import type * as lib_collaborativeAccess from "../lib/collaborativeAccess.js";
 import type * as lib_collaborativeAccessValidators from "../lib/collaborativeAccessValidators.js";
@@ -81,6 +82,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   "lib/accountLifecycle": typeof lib_accountLifecycle;
   "lib/applicationTriggers": typeof lib_applicationTriggers;
+  "lib/assetBacks": typeof lib_assetBacks;
   "lib/assetInput": typeof lib_assetInput;
   "lib/collaborativeAccess": typeof lib_collaborativeAccess;
   "lib/collaborativeAccessValidators": typeof lib_collaborativeAccessValidators;

--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -14,7 +14,9 @@ import { mutation } from './functions';
 import {
   assertReferenceableDeckCardback,
   assertReferenceableTokenBack,
+  authoredDeckCardback,
   deckCardbackOf,
+  legacyRelationBackId,
   resolveBackHref,
   supersedePendingBackJob,
   TOKEN_ASSET_TYPES,
@@ -65,13 +67,19 @@ function nameOf(row: Doc<'assets'>): string {
   return assetDisplayName(row);
 }
 
+/**
+ * The presentation opt-in for list surfaces, and nothing else.
+ * Passing it is what turns a reference-mode deck's `data` into the target's composition;
+ * `getPage` and every other caller must NOT pass it, because an editor reading presented data would take the target's composition for the row's own and persist the copy on save.
+ */
+type DeckBackPresentation = { deckBacks: Map<Id<'assets'>, Doc<'assets'> | null> };
+
 async function toListEntry(
   ctx: QueryCtx,
   row: Doc<'assets'>,
   /* One owner holds many assets on a page, so a caller reading hundreds of rows passes a memo and pays per owner rather than per row. */
   owners?: Map<Id<'users'>, Awaited<ReturnType<typeof profileSummary>>>,
-  /* One referenced deck backs many rows the same way, so list callers pass a second memo for the join. */
-  deckBacks?: Map<Id<'assets'>, Doc<'assets'> | null>
+  presentation?: DeckBackPresentation
 ) {
   if (owners && !owners.has(row.owner_id)) {
     owners.set(row.owner_id, await profileSummary(ctx, row.owner_id));
@@ -84,18 +92,18 @@ async function toListEntry(
     created_at: row.created_at,
     updated_at: row.updated_at,
     owner: owners ? owners.get(row.owner_id)! : await profileSummary(ctx, row.owner_id),
-    data: await presentedData(ctx, row, deckBacks),
+    data: presentation ? await presentedData(ctx, row, presentation.deckBacks) : row.data,
   };
 }
 
 /**
- * What a listing hands the client as `data`.
+ * What a listing hands the client as `data`, distinct from the stored truth the page query returns.
  *
  * A reference-mode deck has no composition of its own, so the target's authored cardback resolves in here («How browse surfaces get a referenced deck's cardback»): one memoized point read, depth one always since only authored cardbacks are referenceable, and tiles, piles and pickers render exactly what they rendered before.
- * A dangling reference presents no cardback, which the face renderer already treats as a neutral face.
+ * A dangling reference presents `cardback: null`, the marker recorded on that ticket: no other path produces it, and the face renderer treats it as a neutral face until the tile presentation lands.
  * Every other row passes through untouched.
  */
-async function presentedData(ctx: QueryCtx, row: Doc<'assets'>, deckBacks?: Map<Id<'assets'>, Doc<'assets'> | null>) {
+async function presentedData(ctx: QueryCtx, row: Doc<'assets'>, deckBacks: Map<Id<'assets'>, Doc<'assets'> | null>) {
   if (row.type !== 'deck') {
     return row.data;
   }
@@ -106,16 +114,14 @@ async function presentedData(ctx: QueryCtx, row: Doc<'assets'>, deckBacks?: Map<
   const targetId = typeof cardback.asset_id === 'string' ? (cardback.asset_id as Id<'assets'>) : null;
   let target: Doc<'assets'> | null = null;
   if (targetId) {
-    if (deckBacks?.has(targetId)) {
+    if (deckBacks.has(targetId)) {
       target = deckBacks.get(targetId) ?? null;
     } else {
       target = await ctx.db.get('assets', targetId);
-      deckBacks?.set(targetId, target);
+      deckBacks.set(targetId, target);
     }
   }
-  const targetCardback = target && !target.is_deleted && target.type === 'deck' ? deckCardbackOf(target.data) : null;
-  const resolved = targetCardback && !('mode' in targetCardback) ? targetCardback : null;
-  return { ...(row.data as Record<string, unknown>), cardback: resolved };
+  return { ...(row.data as Record<string, unknown>), cardback: target ? authoredDeckCardback(target) : null };
 }
 
 /** Bounds every catalogue read; ordinary use sits far below it. */
@@ -146,7 +152,7 @@ export const cataloguePage = query({
 
     const deckBacks = new Map<Id<'assets'>, Doc<'assets'> | null>();
     const recent = await Promise.all(
-      rows.slice(0, RECENT_LIMIT).map((row) => toListEntry(ctx, row, undefined, deckBacks))
+      rows.slice(0, RECENT_LIMIT).map((row) => toListEntry(ctx, row, undefined, { deckBacks }))
     );
     return { recent, countsByType, countsTruncated: rows.length === CATALOGUE_SCAN_LIMIT };
   },
@@ -172,7 +178,7 @@ export const listByTypes = query({
     const deckBacks = new Map<Id<'assets'>, Doc<'assets'> | null>();
     const entries = [];
     for (const row of rows) {
-      entries.push(await toListEntry(ctx, row, owners, deckBacks));
+      entries.push(await toListEntry(ctx, row, owners, { deckBacks }));
     }
     return entries;
   },
@@ -389,15 +395,6 @@ async function withValidatedBack(
     return data;
   }
   return data;
-}
-
-/** The target of a pre-migration `token-back` relation row, read only until the drop migration lands. */
-async function legacyRelationBackId(ctx: MutationCtx | QueryCtx, assetId: Id<'assets'>): Promise<string | null> {
-  const relation = await ctx.db
-    .query('asset_relations')
-    .withIndex('by_from_kind', (q) => q.eq('from_asset_id', assetId).eq('kind', TOKEN_BACK))
-    .first();
-  return relation ? relation.to_asset_id : null;
 }
 
 export const create = mutation({
@@ -816,7 +813,12 @@ export const browsePage = query({
       }
       /* No cache across rows here, unlike `decks`: two bundles sharing a token is the exception, where a deck shared across a page of cards is the rule. */
       const members = previewKind ? await memberPreviews(ctx, row._id, previewKind) : [];
-      entries.push({ ...(await toListEntry(ctx, row, owners, decks)), deckCount, deckCountCapped, members });
+      entries.push({
+        ...(await toListEntry(ctx, row, owners, { deckBacks: decks })),
+        deckCount,
+        deckCountCapped,
+        members,
+      });
     }
 
     return { entries, inNoDeckCount: counted ? inNoDeckCount : null, truncated };

--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -150,10 +150,12 @@ export const cataloguePage = query({
       countsByType[row.type] = (countsByType[row.type] ?? 0) + 1;
     }
 
+    /* Sequential like the other list readers, so the memo fills before the rows that would hit it. */
     const deckBacks = new Map<Id<'assets'>, Doc<'assets'> | null>();
-    const recent = await Promise.all(
-      rows.slice(0, RECENT_LIMIT).map((row) => toListEntry(ctx, row, undefined, { deckBacks }))
-    );
+    const recent = [];
+    for (const row of rows.slice(0, RECENT_LIMIT)) {
+      recent.push(await toListEntry(ctx, row, undefined, { deckBacks }));
+    }
     return { recent, countsByType, countsTruncated: rows.length === CATALOGUE_SCAN_LIMIT };
   },
 });

--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -11,6 +11,15 @@ import type { Doc, Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 import { publicationStatusFor } from './assetPublishingStatus';
 import { mutation } from './functions';
+import {
+  assertReferenceableDeckCardback,
+  assertReferenceableTokenBack,
+  deckCardbackOf,
+  resolveBackHref,
+  supersedePendingBackJob,
+  TOKEN_ASSET_TYPES,
+  tokenBackOf,
+} from './lib/assetBacks';
 import { assetDisplayName, assertKnownAssetType, parseAssetDataForWrite } from './lib/assetInput';
 import {
   loadAssetAccessBundle,
@@ -60,7 +69,9 @@ async function toListEntry(
   ctx: QueryCtx,
   row: Doc<'assets'>,
   /* One owner holds many assets on a page, so a caller reading hundreds of rows passes a memo and pays per owner rather than per row. */
-  owners?: Map<Id<'users'>, Awaited<ReturnType<typeof profileSummary>>>
+  owners?: Map<Id<'users'>, Awaited<ReturnType<typeof profileSummary>>>,
+  /* One referenced deck backs many rows the same way, so list callers pass a second memo for the join. */
+  deckBacks?: Map<Id<'assets'>, Doc<'assets'> | null>
 ) {
   if (owners && !owners.has(row.owner_id)) {
     owners.set(row.owner_id, await profileSummary(ctx, row.owner_id));
@@ -73,8 +84,38 @@ async function toListEntry(
     created_at: row.created_at,
     updated_at: row.updated_at,
     owner: owners ? owners.get(row.owner_id)! : await profileSummary(ctx, row.owner_id),
-    data: row.data,
+    data: await presentedData(ctx, row, deckBacks),
   };
+}
+
+/**
+ * What a listing hands the client as `data`.
+ *
+ * A reference-mode deck has no composition of its own, so the target's authored cardback resolves in here («How browse surfaces get a referenced deck's cardback»): one memoized point read, depth one always since only authored cardbacks are referenceable, and tiles, piles and pickers render exactly what they rendered before.
+ * A dangling reference presents no cardback, which the face renderer already treats as a neutral face.
+ * Every other row passes through untouched.
+ */
+async function presentedData(ctx: QueryCtx, row: Doc<'assets'>, deckBacks?: Map<Id<'assets'>, Doc<'assets'> | null>) {
+  if (row.type !== 'deck') {
+    return row.data;
+  }
+  const cardback = deckCardbackOf(row.data);
+  if (!cardback || !('mode' in cardback)) {
+    return row.data;
+  }
+  const targetId = typeof cardback.asset_id === 'string' ? (cardback.asset_id as Id<'assets'>) : null;
+  let target: Doc<'assets'> | null = null;
+  if (targetId) {
+    if (deckBacks?.has(targetId)) {
+      target = deckBacks.get(targetId) ?? null;
+    } else {
+      target = await ctx.db.get('assets', targetId);
+      deckBacks?.set(targetId, target);
+    }
+  }
+  const targetCardback = target && !target.is_deleted && target.type === 'deck' ? deckCardbackOf(target.data) : null;
+  const resolved = targetCardback && !('mode' in targetCardback) ? targetCardback : null;
+  return { ...(row.data as Record<string, unknown>), cardback: resolved };
 }
 
 /** Bounds every catalogue read; ordinary use sits far below it. */
@@ -103,7 +144,10 @@ export const cataloguePage = query({
       countsByType[row.type] = (countsByType[row.type] ?? 0) + 1;
     }
 
-    const recent = await Promise.all(rows.slice(0, RECENT_LIMIT).map((row) => toListEntry(ctx, row)));
+    const deckBacks = new Map<Id<'assets'>, Doc<'assets'> | null>();
+    const recent = await Promise.all(
+      rows.slice(0, RECENT_LIMIT).map((row) => toListEntry(ctx, row, undefined, deckBacks))
+    );
     return { recent, countsByType, countsTruncated: rows.length === CATALOGUE_SCAN_LIMIT };
   },
 });
@@ -123,11 +167,12 @@ export const listByTypes = query({
       )
     );
     const rows = perType.flat().sort((a, b) => b._creationTime - a._creationTime);
-    /* Sequential rather than Promise.all, so the owner memo fills before the rows that would hit it. */
+    /* Sequential rather than Promise.all, so the memos fill before the rows that would hit them. */
     const owners = new Map<Id<'users'>, Awaited<ReturnType<typeof profileSummary>>>();
+    const deckBacks = new Map<Id<'assets'>, Doc<'assets'> | null>();
     const entries = [];
     for (const row of rows) {
-      entries.push(await toListEntry(ctx, row, owners));
+      entries.push(await toListEntry(ctx, row, owners, deckBacks));
     }
     return entries;
   },
@@ -205,6 +250,12 @@ export const getPage = query({
        * A sidecar rather than a widening of `assetPublishingValidator`, because that validator is shared with the faction and ruleset pages, which have exactly one publication each and gain nothing from learning about faces.
        */
       backPublishing: v.union(assetPublishingValidator, v.null()),
+      /**
+       * The one server-side answer to "what is this asset's back?" («What does each back mode publish»): the mode the resolution took and the URL a consumer fetches for it, or null for a type with no back.
+       * Additive this release;
+       * the pages that draw from it land with the editor slice.
+       */
+      resolvedBack: v.union(v.object({ mode: v.string(), href: v.union(v.string(), v.null()) }), v.null()),
     })
   ),
   handler: async (ctx, args) => {
@@ -217,7 +268,7 @@ export const getPage = query({
       return null;
     }
     const access = await loadAssetAccessBundle(ctx, { kind: 'asset', row });
-    const back = TOKEN_TYPES.has(row.type) ? await tokenBackFor(ctx, row._id) : null;
+    const back = TOKEN_TYPES.has(row.type) ? await tokenBackFor(ctx, row._id, row.data) : null;
     return {
       asset: await toListEntry(ctx, row),
       viewerAccess: access.viewerAccess,
@@ -234,6 +285,7 @@ export const getPage = query({
       linkingRulesets: await rulesetsSlotting(ctx, row._id),
       assetPublishing: isPublicationAssetType(row.type) ? await publicationStatusFor(ctx, row.type, row._id) : null,
       backPublishing: await backFacePublication(ctx, row),
+      resolvedBack: await resolveBackHref(ctx, row),
     };
   },
 });
@@ -297,6 +349,57 @@ async function assertAssetSlugAvailable(ctx: MutationCtx, type: string, slug: st
   }
 }
 
+/**
+ * Save-path validation of an asset's back, the one gate every writer of it shares («The stored shape of three back modes»: one field, one writer, one rule).
+ *
+ * A token reference may arrive without its target, because today's editors still pick through `setTokenBack` and the draft only carries the mode.
+ * The stored id is preserved rather than demanded back from the client, falling through to the legacy relation row for rows the migration has not reached.
+ * A reference with no target anywhere stays a dangling reference, which resolves to the front rather than to an error, the lazy rule «Which tokens are referenceable» set.
+ */
+async function withValidatedBack(
+  ctx: MutationCtx,
+  row: { _id?: Id<'assets'>; type: string; data?: unknown },
+  data: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  if (TOKEN_TYPES.has(row.type)) {
+    const back = tokenBackOf(data);
+    if (back?.mode !== 'reference') {
+      return data;
+    }
+    const stored = typeof back.asset_id === 'string' ? back.asset_id : null;
+    const previous = row.data ? tokenBackOf(row.data) : null;
+    const carried = typeof previous?.asset_id === 'string' ? previous.asset_id : null;
+    const legacy = row._id ? await legacyRelationBackId(ctx, row._id) : null;
+    const targetId = (stored ?? carried ?? legacy) as Id<'assets'> | null;
+    if (!targetId) {
+      return data;
+    }
+    await assertReferenceableTokenBack(ctx, { _id: row._id ?? null, type: row.type }, targetId);
+    return { ...data, back: { mode: 'reference', asset_id: targetId } };
+  }
+  if (row.type === 'deck') {
+    const cardback = deckCardbackOf(data);
+    if (cardback && 'mode' in cardback && typeof cardback.asset_id === 'string') {
+      await assertReferenceableDeckCardback(
+        ctx,
+        { _id: row._id ?? null, type: row.type },
+        cardback.asset_id as Id<'assets'>
+      );
+    }
+    return data;
+  }
+  return data;
+}
+
+/** The target of a pre-migration `token-back` relation row, read only until the drop migration lands. */
+async function legacyRelationBackId(ctx: MutationCtx | QueryCtx, assetId: Id<'assets'>): Promise<string | null> {
+  const relation = await ctx.db
+    .query('asset_relations')
+    .withIndex('by_from_kind', (q) => q.eq('from_asset_id', assetId).eq('kind', TOKEN_BACK))
+    .first();
+  return relation ? relation.to_asset_id : null;
+}
+
 export const create = mutation({
   args: { type: v.string(), data: v.any() },
   returns: v.object({ id: v.id('assets'), slug: v.string() }),
@@ -304,6 +407,7 @@ export const create = mutation({
     const userId = await requireAuthUserId(ctx);
     assertKnownAssetType(args.type);
     const parsed = parseAssetDataForWrite(args.type, args.data);
+    parsed.data = await withValidatedBack(ctx, { type: args.type }, parsed.data as Record<string, unknown>);
     const slug = slugify(parsed.name);
     if (!slug) {
       throw new Error('An asset name is required; it determines the asset URL');
@@ -335,6 +439,7 @@ export const update = mutation({
     }
     /* The type is immutable: the stored row decides which schema the incoming data must satisfy. */
     const parsed = parseAssetDataForWrite(row.type, args.data);
+    parsed.data = await withValidatedBack(ctx, row, parsed.data as Record<string, unknown>);
     await requireAssetUpdate(ctx, args.id, parsed.name);
     const slug = slugify(parsed.name);
     if (!slug) {
@@ -395,16 +500,18 @@ const CONTAINER_KINDS: Record<string, { kind: string; holds: (type: string) => b
   bundle: { kind: BUNDLE_TOKEN, holds: (type) => TOKEN_TYPES.has(type), noun: 'tokens' },
 };
 
-/** Token Asset types, which are the only things that may sit on either end of a `token-back` relation. */
-const TOKEN_TYPES = new Set(['token-disc', 'token-tech', 'token-plate', 'token-enhance']);
+/** Token Asset types, from the module every back rule shares. */
+const TOKEN_TYPES = TOKEN_ASSET_TYPES;
 
 /**
- * Points a token's backside at another token, or clears the reference.
+ * Points a token's backside at another token.
  *
- * First writer of `asset_relations`, so it establishes the shape deck composition will follow: which types may link is a rule of this mutation rather than of the schema, exactly as «Deck→card reference mechanism and deletion semantics» decided when it chose one table over per-kind tables.
+ * Transitional: the reference now lives in `data.back` («The stored shape of three back modes»), and this mutation survives one release only because today's editors pick through it.
+ * It routes through the same validator as the save path, writes the same field, and clears any legacy `token-back` relation row it finds;
+ * the draft-based pick that retires it lands with the editor slice.
  *
- * `by_from_kind` is a plain index, not unique, so "at most one back per token" is enforced here by clearing what is there before inserting.
- * Nothing in the table would stop a second row.
+ * Clearing moved to the save path with the mode union, so `null` is refused rather than half-supported;
+ * no caller has ever sent it.
  */
 export const setTokenBack = mutation({
   args: { id: v.id('assets'), back_asset_id: v.union(v.id('assets'), v.null()) },
@@ -417,20 +524,10 @@ export const setTokenBack = mutation({
       throw new Error(`Asset type ${row.type} has no backside`);
     }
     await requireAssetUpdate(ctx, args.id, nameOf(row));
-
-    if (args.back_asset_id !== null) {
-      if (args.back_asset_id === args.id) {
-        throw new Error('A token cannot be its own backside');
-      }
-      const back = await ctx.db.get('assets', args.back_asset_id);
-      if (!back || back.is_deleted) {
-        throw new Error(`Asset with id ${args.back_asset_id} not found`);
-      }
-      /* Same shape only: the back is the reverse of this physical disc, so a different shape would render clipped. */
-      if (back.type !== row.type) {
-        throw new Error(`A ${row.type} backside must also be a ${row.type}`);
-      }
+    if (args.back_asset_id === null) {
+      throw new Error('Clearing a backside happens by saving another back mode');
     }
+    await assertReferenceableTokenBack(ctx, row, args.back_asset_id);
 
     const existing = await ctx.db
       .query('asset_relations')
@@ -439,32 +536,35 @@ export const setTokenBack = mutation({
     for (const relation of existing) {
       await ctx.db.delete(relation._id);
     }
-    if (args.back_asset_id !== null) {
-      await ctx.db.insert('asset_relations', {
-        from_asset_id: args.id,
-        to_asset_id: args.back_asset_id,
-        kind: TOKEN_BACK,
-        count: 1,
-      });
-    }
-    await ctx.db.patch(args.id, { updated_at: nowIso() });
+    const data = row.data as Record<string, unknown>;
+    await ctx.db.patch(args.id, {
+      data: { ...data, back: { mode: 'reference', asset_id: args.back_asset_id } },
+      updated_at: nowIso(),
+    });
+    /* Leaving an authored back supersedes its pending publication, the same rule the save path applies. */
+    await supersedePendingBackJob(ctx, row.type, args.id);
   },
 });
 
 /**
  * The token a given token uses as its backside, or null.
+ * Reads the reference from `data.back`, falling through to the legacy `token-back` relation row until
+ * `assets_back_modes_v1` has rewritten every row.
  * Filters a soft-deleted target at read time rather than cascading on delete, the rule «Deck→card reference mechanism and deletion semantics» set for every kind in this table.
  */
-async function tokenBackFor(ctx: QueryCtx, assetId: Id<'assets'>) {
-  const relation = await ctx.db
-    .query('asset_relations')
-    .withIndex('by_from_kind', (q) => q.eq('from_asset_id', assetId).eq('kind', TOKEN_BACK))
-    .first();
-  if (!relation) {
+async function tokenBackFor(ctx: QueryCtx, assetId: Id<'assets'>, data: unknown) {
+  const back = tokenBackOf(data);
+  const targetId =
+    back?.mode === 'reference' && typeof back.asset_id === 'string'
+      ? (back.asset_id as Id<'assets'>)
+      : back?.mode === 'reference'
+        ? ((await legacyRelationBackId(ctx, assetId)) as Id<'assets'> | null)
+        : null;
+  if (!targetId) {
     return null;
   }
-  const back = await ctx.db.get('assets', relation.to_asset_id);
-  return back && !back.is_deleted ? back : null;
+  const target = await ctx.db.get('assets', targetId);
+  return target && !target.is_deleted ? target : null;
 }
 
 /**
@@ -716,7 +816,7 @@ export const browsePage = query({
       }
       /* No cache across rows here, unlike `decks`: two bundles sharing a token is the exception, where a deck shared across a page of cards is the rule. */
       const members = previewKind ? await memberPreviews(ctx, row._id, previewKind) : [];
-      entries.push({ ...(await toListEntry(ctx, row, owners)), deckCount, deckCountCapped, members });
+      entries.push({ ...(await toListEntry(ctx, row, owners, decks)), deckCount, deckCountCapped, members });
     }
 
     return { entries, inNoDeckCount: counted ? inNoDeckCount : null, truncated };

--- a/convex/assets.write.test.ts
+++ b/convex/assets.write.test.ts
@@ -224,7 +224,7 @@ const tokenData = (name: string) => ({
 });
 
 describe('token backsides', () => {
-  test('a token points at another token of its own shape, and only one at a time', async () => {
+  test('a token points at another token of its own shape, in data rather than in a relation row', async () => {
     const t = convexTest(schema, modules);
     const { ownerId } = await seedCard(t);
     const owner = t.withIdentity({ subject: ownerId });
@@ -236,35 +236,49 @@ describe('token backsides', () => {
     let page = await t.query(api.assets.getPage, { type: 'token-disc', slug: 'axlotl' });
     expect(page?.backToken?.name).toBe('Sietch');
 
-    /* Re-pointing replaces rather than accumulates: the index is not unique, so the mutation clears first. */
+    /* Re-pointing replaces rather than accumulates: the reference is one field on one row. */
     await owner.mutation(api.assets.setTokenBack, { id: front.id, back_asset_id: backB.id });
     page = await t.query(api.assets.getPage, { type: 'token-disc', slug: 'axlotl' });
     expect(page?.backToken?.name).toBe('Spice');
 
-    await owner.mutation(api.assets.setTokenBack, { id: front.id, back_asset_id: null });
-    page = await t.query(api.assets.getPage, { type: 'token-disc', slug: 'axlotl' });
-    expect(page?.backToken).toBeNull();
+    /* The reference lives in data now, so no relation row exists to leak or dangle. */
+    const relations = await t.run(async (ctx) => await ctx.db.query('asset_relations').collect());
+    expect(relations).toEqual([]);
+    const stored = await t.run(async (ctx) => (await ctx.db.get('assets', front.id))?.data);
+    expect((stored as { back: unknown }).back).toEqual({ mode: 'reference', asset_id: backB.id });
+
+    /* Clearing moved to the save path with the mode union. */
+    await expect(owner.mutation(api.assets.setTokenBack, { id: front.id, back_asset_id: null })).rejects.toThrow(
+      'saving another back mode'
+    );
   });
 
-  test('the backside must be the same shape, and never the token itself', async () => {
+  test('the backside must be the same shape with an authored back, and never the token itself', async () => {
     const t = convexTest(schema, modules);
     const { ownerId, created } = await seedCard(t);
     const owner = t.withIdentity({ subject: ownerId });
     const round = await owner.mutation(api.assets.create, { type: 'token-disc', data: tokenData('Axlotl') });
     const square = await owner.mutation(api.assets.create, { type: 'token-plate', data: tokenData('Shield') });
+    const unauthored = await owner.mutation(api.assets.create, {
+      type: 'token-disc',
+      data: { ...tokenData('Mirror'), back: { mode: 'same' } },
+    });
 
     await expect(owner.mutation(api.assets.setTokenBack, { id: round.id, back_asset_id: square.id })).rejects.toThrow(
       'must also be a token-disc'
     );
     await expect(owner.mutation(api.assets.setTokenBack, { id: round.id, back_asset_id: round.id })).rejects.toThrow(
-      'cannot be its own backside'
+      'same-front-and-back'
     );
+    await expect(
+      owner.mutation(api.assets.setTokenBack, { id: round.id, back_asset_id: unauthored.id })
+    ).rejects.toThrow('authored back');
     await expect(owner.mutation(api.assets.setTokenBack, { id: created.id, back_asset_id: round.id })).rejects.toThrow(
       'has no backside'
     );
   });
 
-  test('a soft-deleted backside stops resolving without touching the relation', async () => {
+  test('a soft-deleted backside stops resolving at read time', async () => {
     const t = convexTest(schema, modules);
     const { ownerId } = await seedCard(t);
     const owner = t.withIdentity({ subject: ownerId });
@@ -276,8 +290,49 @@ describe('token backsides', () => {
 
     const page = await t.query(api.assets.getPage, { type: 'token-disc', slug: 'axlotl' });
     expect(page?.backToken).toBeNull();
-    const relations = await t.run(async (ctx) => await ctx.db.query('asset_relations').collect());
-    expect(relations).toHaveLength(1);
+    /* The stored reference stays: dangling is a read-time judgement, the soft-delete rule for every kind. */
+    const stored = await t.run(async (ctx) => (await ctx.db.get('assets', front.id))?.data);
+    expect((stored as { back: { asset_id?: string } }).back.asset_id).toBe(back.id);
+  });
+
+  test('an ordinary save preserves the picked reference the draft cannot carry', async () => {
+    const t = convexTest(schema, modules);
+    const { ownerId } = await seedCard(t);
+    const owner = t.withIdentity({ subject: ownerId });
+    const front = await owner.mutation(api.assets.create, { type: 'token-disc', data: tokenData('Axlotl') });
+    const back = await owner.mutation(api.assets.create, { type: 'token-disc', data: tokenData('Sietch') });
+    await owner.mutation(api.assets.setTokenBack, { id: front.id, back_asset_id: back.id });
+
+    /* Today's editor drafts carry the mode alone; the save path must not lose the target over that. */
+    await owner.mutation(api.assets.update, {
+      id: front.id,
+      data: { ...tokenData('Axlotl'), back: { mode: 'reference' } },
+    });
+
+    const page = await t.query(api.assets.getPage, { type: 'token-disc', slug: 'axlotl' });
+    expect(page?.backToken?.name).toBe('Sietch');
+  });
+
+  test('leaving custom mode supersedes the pending back job and schedules no new one', async () => {
+    const t = convexTest(schema, modules);
+    const { ownerId } = await seedCard(t);
+    const owner = t.withIdentity({ subject: ownerId });
+    const front = await owner.mutation(api.assets.create, { type: 'token-disc', data: tokenData('Axlotl') });
+
+    const backJobs = async () =>
+      await t.run(async (ctx) =>
+        (await ctx.db.query('publication_jobs').collect()).filter((job) => job.asset_id.endsWith('.back'))
+      );
+    expect(await backJobs()).toHaveLength(1);
+
+    await owner.mutation(api.assets.update, {
+      id: front.id,
+      data: { ...tokenData('Axlotl'), back: { mode: 'same' } },
+    });
+
+    expect(await backJobs()).toEqual([]);
+    const page = await t.query(api.assets.getPage, { type: 'token-disc', slug: 'axlotl' });
+    expect(page?.resolvedBack).toMatchObject({ mode: 'same' });
   });
 });
 
@@ -663,5 +718,70 @@ describe('bundles', () => {
     expect(await t.run(async (ctx) => await ctx.db.query('publication_jobs').collect())).toEqual([]);
     const page = await t.query(api.assets.getPage, { type: 'bundle', slug: 'tech-tokens' });
     expect(page?.assetPublishing).toBeNull();
+  });
+});
+
+describe('deck cardback references', () => {
+  test("a deck may wear another deck's authored cardback, publishing nothing of its own", async () => {
+    const t = convexTest(schema, modules);
+    const ownerId = await t.run(async (ctx) => await ctx.db.insert('users', { name: 'Deck owner' }));
+    const owner = t.withIdentity({ subject: ownerId });
+    const source = await owner.mutation(api.assets.create, { type: 'deck', data: deckData('Source') });
+    const wearer = await owner.mutation(api.assets.create, {
+      type: 'deck',
+      data: { name: 'Wearer', about: '', cardback: { mode: 'reference', asset_id: source.id } },
+    });
+
+    /* Only the authored deck publishes; the reference deck's URL is the resolver's to hand out. */
+    const jobs = await t.run(async (ctx) => await ctx.db.query('publication_jobs').collect());
+    expect(jobs.map((job) => job.asset_id)).toEqual([source.id]);
+
+    const page = await t.query(api.assets.getPage, { type: 'deck', slug: 'wearer' });
+    expect(page?.resolvedBack).toMatchObject({ mode: 'reference' });
+
+    /* List surfaces present the target's composition, so tiles render unchanged. */
+    const entries = await t.query(api.assets.listByTypes, { types: ['deck'] });
+    const presented = entries.find((entry) => entry.id === wearer.id);
+    const presentedData = presented?.data as { cardback: { name?: string } | null } | undefined;
+    expect(presentedData?.cardback?.name).toBe('Treachery');
+  });
+
+  test('a reference must name a deck whose cardback is authored', async () => {
+    const t = convexTest(schema, modules);
+    const ownerId = await t.run(async (ctx) => await ctx.db.insert('users', { name: 'Deck owner' }));
+    const owner = t.withIdentity({ subject: ownerId });
+    const source = await owner.mutation(api.assets.create, { type: 'deck', data: deckData('Source') });
+    const wearer = await owner.mutation(api.assets.create, {
+      type: 'deck',
+      data: { name: 'Wearer', about: '', cardback: { mode: 'reference', asset_id: source.id } },
+    });
+
+    await expect(
+      owner.mutation(api.assets.create, {
+        type: 'deck',
+        data: { name: 'Chained', about: '', cardback: { mode: 'reference', asset_id: wearer.id } },
+      })
+    ).rejects.toThrow('authored cardback');
+  });
+
+  test('a dangling deck reference presents no composition and resolves to the static fallback', async () => {
+    const t = convexTest(schema, modules);
+    const ownerId = await t.run(async (ctx) => await ctx.db.insert('users', { name: 'Deck owner' }));
+    const owner = t.withIdentity({ subject: ownerId });
+    const source = await owner.mutation(api.assets.create, { type: 'deck', data: deckData('Source') });
+    const wearer = await owner.mutation(api.assets.create, {
+      type: 'deck',
+      data: { name: 'Wearer', about: '', cardback: { mode: 'reference', asset_id: source.id } },
+    });
+
+    await owner.mutation(api.assets.softDelete, { id: source.id });
+
+    const entries = await t.query(api.assets.listByTypes, { types: ['deck'] });
+    const presented = entries.find((entry) => entry.id === wearer.id);
+    const presentedData = presented?.data as { cardback: unknown } | undefined;
+    expect(presentedData?.cardback).toBeNull();
+
+    const page = await t.query(api.assets.getPage, { type: 'deck', slug: 'wearer' });
+    expect(page?.resolvedBack).toEqual({ mode: 'dangling', href: '/web/no-deck-back.svg' });
   });
 });

--- a/convex/assets.write.test.ts
+++ b/convex/assets.write.test.ts
@@ -4,6 +4,7 @@
 import { convexTest } from 'convex-test';
 import { describe, expect, test } from 'vitest';
 
+import { publicationFaceId } from '../src/shared/asset-publishing/publicationTargets';
 import { api } from './_generated/api';
 import schema from './schema';
 
@@ -319,9 +320,10 @@ describe('token backsides', () => {
     const owner = t.withIdentity({ subject: ownerId });
     const front = await owner.mutation(api.assets.create, { type: 'token-disc', data: tokenData('Axlotl') });
 
+    const backId = publicationFaceId(front.id, 'back');
     const backJobs = async () =>
       await t.run(async (ctx) =>
-        (await ctx.db.query('publication_jobs').collect()).filter((job) => job.asset_id.endsWith('.back'))
+        (await ctx.db.query('publication_jobs').collect()).filter((job) => job.asset_id === backId)
       );
     expect(await backJobs()).toHaveLength(1);
 
@@ -744,6 +746,25 @@ describe('deck cardback references', () => {
     const presented = entries.find((entry) => entry.id === wearer.id);
     const presentedData = presented?.data as { cardback: { name?: string } | null } | undefined;
     expect(presentedData?.cardback?.name).toBe('Treachery');
+  });
+
+  test('the page query returns the stored reference, never the presented composition', async () => {
+    const t = convexTest(schema, modules);
+    const ownerId = await t.run(async (ctx) => await ctx.db.insert('users', { name: 'Deck owner' }));
+    const owner = t.withIdentity({ subject: ownerId });
+    const source = await owner.mutation(api.assets.create, { type: 'deck', data: deckData('Source') });
+    await owner.mutation(api.assets.create, {
+      type: 'deck',
+      data: { name: 'Wearer', about: '', cardback: { mode: 'reference', asset_id: source.id } },
+    });
+
+    /*
+     * The editor's reference guard reads this data; a presented composition here would open the deck
+     * wearing the target's cardback as its own, and a save would persist the copy.
+     */
+    const page = await t.query(api.assets.getPage, { type: 'deck', slug: 'wearer' });
+    const pageData = page?.asset.data as { cardback: unknown } | undefined;
+    expect(pageData?.cardback).toEqual({ mode: 'reference', asset_id: source.id });
   });
 
   test('a reference must name a deck whose cardback is authored', async () => {

--- a/convex/lib/assetBacks.ts
+++ b/convex/lib/assetBacks.ts
@@ -28,6 +28,31 @@ export function deckCardbackOf(data: unknown): { mode?: unknown; asset_id?: unkn
 }
 
 /**
+ * A deck row's authored cardback composition, or null when the row is not a live deck wearing one.
+ * The one judgement of "can this deck's cardback be worn by someone else", shared by the browse presentation and the resolver so the dangling rules cannot fork.
+ */
+export function authoredDeckCardback(row: Doc<'assets'>): Record<string, unknown> | null {
+  if (row.is_deleted || row.type !== 'deck') {
+    return null;
+  }
+  const cardback = deckCardbackOf(row.data);
+  return cardback && !('mode' in cardback) ? cardback : null;
+}
+
+/**
+ * The target of a pre-migration `token-back` relation row.
+ * Read only until `asset_relations_token_back_drop_v1` lands everywhere;
+ * every transitional reader shares this one fallthrough.
+ */
+export async function legacyRelationBackId(ctx: ReadCtx, assetId: Id<'assets'>): Promise<Id<'assets'> | null> {
+  const relation = await ctx.db
+    .query('asset_relations')
+    .withIndex('by_from_kind', (q) => q.eq('from_asset_id', assetId).eq('kind', 'token-back'))
+    .first();
+  return relation ? relation.to_asset_id : null;
+}
+
+/**
  * Whether a token row qualifies as a reference target («Which tokens are referenceable»): it must carry an authored back, so chains never form and the resolver never recurses.
  */
 export function hasAuthoredBack(row: Doc<'assets'>): boolean {
@@ -110,8 +135,14 @@ export async function resolveBackHref(ctx: ReadCtx, row: Doc<'assets'>): Promise
       return { mode: 'custom', href: status?.publicationHref ?? null };
     }
     if (back?.mode === 'same' || back?.mode === 'reference') {
-      const target =
-        typeof back.asset_id === 'string' ? await ctx.db.get('assets', back.asset_id as Id<'assets'>) : null;
+      /* The legacy fallthrough matches the save path's, so a pre-migration reference resolves to its target rather than reading as dangling during the deploy window. */
+      const targetId =
+        typeof back.asset_id === 'string'
+          ? (back.asset_id as Id<'assets'>)
+          : back.mode === 'reference'
+            ? await legacyRelationBackId(ctx, row._id)
+            : null;
+      const target = targetId ? await ctx.db.get('assets', targetId) : null;
       if (
         back.mode === 'reference' &&
         target &&
@@ -139,12 +170,9 @@ export async function resolveBackHref(ctx: ReadCtx, row: Doc<'assets'>): Promise
     }
     const targetId = typeof cardback.asset_id === 'string' ? (cardback.asset_id as Id<'assets'>) : null;
     const target = targetId ? await ctx.db.get('assets', targetId) : null;
-    if (target && !target.is_deleted && target.type === 'deck') {
-      const targetCardback = deckCardbackOf(target.data);
-      if (targetCardback && !('mode' in targetCardback)) {
-        const status = await publicationStatusFor(ctx, 'deck', target._id);
-        return { mode: 'reference', href: status?.publicationHref ?? null };
-      }
+    if (target && authoredDeckCardback(target)) {
+      const status = await publicationStatusFor(ctx, 'deck', target._id);
+      return { mode: 'reference', href: status?.publicationHref ?? null };
     }
     return { mode: 'dangling', href: NO_DECK_BACK_HREF };
   }

--- a/convex/lib/assetBacks.ts
+++ b/convex/lib/assetBacks.ts
@@ -1,0 +1,152 @@
+import { publicationFaceId, isPublicationAssetType } from '../../src/shared/asset-publishing/publicationTargets';
+import type { Doc, Id } from '../_generated/dataModel';
+import { publicationStatusFor } from '../assetPublishingStatus';
+import type { MutationCtx, QueryCtx } from '../types';
+import { supersedePendingPublication } from './publication';
+
+type ReadCtx = Pick<QueryCtx, 'db'> | Pick<MutationCtx, 'db'>;
+
+/** The four token types, the set every back rule ranges over. */
+export const TOKEN_ASSET_TYPES = new Set(['token-disc', 'token-tech', 'token-plate', 'token-enhance']);
+
+/**
+ * The static back a dangling deck reference falls to («What does each back mode publish»): a deployed image rather than a broken link, served beside `logo.svg` as the one other committed web asset.
+ * It carries a centred [?] rather than being blank, so a reader can tell "loaded, and wrong" from a failed load («How a dangling back reference presents»).
+ */
+export const NO_DECK_BACK_HREF = '/web/no-deck-back.svg';
+
+/** A token's stored back, read without trusting the row to satisfy the current schema. */
+export function tokenBackOf(data: unknown): { mode?: unknown; asset_id?: unknown } | null {
+  const back = (data as { back?: unknown } | null | undefined)?.back;
+  return typeof back === 'object' && back !== null ? (back as { mode?: unknown; asset_id?: unknown }) : null;
+}
+
+/** A deck's stored cardback, read the same distrustful way. The authored member has no `mode` key. */
+export function deckCardbackOf(data: unknown): { mode?: unknown; asset_id?: unknown } | Record<string, unknown> | null {
+  const cardback = (data as { cardback?: unknown } | null | undefined)?.cardback;
+  return typeof cardback === 'object' && cardback !== null ? (cardback as Record<string, unknown>) : null;
+}
+
+/**
+ * Whether a token row qualifies as a reference target («Which tokens are referenceable»): it must carry an authored back, so chains never form and the resolver never recurses.
+ */
+export function hasAuthoredBack(row: Doc<'assets'>): boolean {
+  return tokenBackOf(row.data)?.mode === 'custom';
+}
+
+/**
+ * The one validator for a token back reference, shared by the save path and the transitional `setTokenBack` so the rules cannot fork.
+ * Returns the target row on success.
+ * `_id` is null while creating, when self-reference cannot arise because the row has no id to name.
+ */
+export async function assertReferenceableTokenBack(
+  ctx: ReadCtx,
+  row: { _id: Id<'assets'> | null; type: string },
+  targetId: Id<'assets'>
+): Promise<Doc<'assets'>> {
+  if (row._id !== null && targetId === row._id) {
+    throw new Error('A token cannot reference itself; use the same-front-and-back mode');
+  }
+  const target = await ctx.db.get('assets', targetId);
+  if (!target || target.is_deleted) {
+    throw new Error(`Asset with id ${targetId} not found`);
+  }
+  /* Same shape only: the back is the reverse of this physical piece, so a different shape would render clipped. */
+  if (target.type !== row.type) {
+    throw new Error(`A ${row.type} backside must also be a ${row.type}`);
+  }
+  if (!hasAuthoredBack(target)) {
+    throw new Error('Only a token with an authored back can be referenced');
+  }
+  return target;
+}
+
+/** The deck counterpart: a cardback reference must name a deck whose cardback is authored. */
+export async function assertReferenceableDeckCardback(
+  ctx: ReadCtx,
+  row: { _id: Id<'assets'> | null; type: string },
+  targetId: Id<'assets'>
+): Promise<Doc<'assets'>> {
+  if (row._id !== null && targetId === row._id) {
+    throw new Error('A deck cannot reference its own cardback');
+  }
+  const target = await ctx.db.get('assets', targetId);
+  if (!target || target.is_deleted) {
+    throw new Error(`Asset with id ${targetId} not found`);
+  }
+  if (target.type !== 'deck') {
+    throw new Error('A cardback reference must name a deck');
+  }
+  const cardback = deckCardbackOf(target.data);
+  if (!cardback || 'mode' in cardback) {
+    throw new Error('Only a deck with an authored cardback can be referenced');
+  }
+  return target;
+}
+
+/** The `.back` variant of `supersedePendingPublication`, named once so callers cannot mis-derive the face id. */
+export async function supersedePendingBackJob(ctx: MutationCtx, assetType: string, assetId: Id<'assets'>) {
+  await supersedePendingPublication(ctx, assetType, publicationFaceId(assetId, 'back'));
+}
+
+export type ResolvedBack = {
+  mode: 'custom' | 'same' | 'reference' | 'authored-cardback' | 'dangling';
+  /** The URL a consumer fetches for the back face, or null when nothing is published yet. */
+  href: string | null;
+};
+
+/**
+ * The one server-side answer to "what is this asset's back?" («What does each back mode publish»): authored → its own `.back` artifact, same → its own front, reference → the target's back, a dangling token → its own front, a dangling deck → the static fallback image.
+ * Depth one always, since only authored backs are referenceable.
+ */
+export async function resolveBackHref(ctx: ReadCtx, row: Doc<'assets'>): Promise<ResolvedBack | null> {
+  if (TOKEN_ASSET_TYPES.has(row.type)) {
+    if (!isPublicationAssetType(row.type)) {
+      return null;
+    }
+    const back = tokenBackOf(row.data);
+    if (back?.mode === 'custom') {
+      const status = await publicationStatusFor(ctx, row.type, publicationFaceId(row._id, 'back'));
+      return { mode: 'custom', href: status?.publicationHref ?? null };
+    }
+    if (back?.mode === 'same' || back?.mode === 'reference') {
+      const target =
+        typeof back.asset_id === 'string' ? await ctx.db.get('assets', back.asset_id as Id<'assets'>) : null;
+      if (
+        back.mode === 'reference' &&
+        target &&
+        !target.is_deleted &&
+        target.type === row.type &&
+        hasAuthoredBack(target)
+      ) {
+        const status = await publicationStatusFor(ctx, row.type, publicationFaceId(target._id, 'back'));
+        return { mode: 'reference', href: status?.publicationHref ?? null };
+      }
+      /* `same`, and every way a reference can dangle, resolve to the token's own front. */
+      const status = await publicationStatusFor(ctx, row.type, row._id);
+      return { mode: back.mode === 'same' ? 'same' : 'dangling', href: status?.publicationHref ?? null };
+    }
+    return null;
+  }
+  if (row.type === 'deck') {
+    const cardback = deckCardbackOf(row.data);
+    if (!cardback) {
+      return null;
+    }
+    if (!('mode' in cardback)) {
+      const status = await publicationStatusFor(ctx, 'deck', row._id);
+      return { mode: 'authored-cardback', href: status?.publicationHref ?? null };
+    }
+    const targetId = typeof cardback.asset_id === 'string' ? (cardback.asset_id as Id<'assets'>) : null;
+    const target = targetId ? await ctx.db.get('assets', targetId) : null;
+    if (target && !target.is_deleted && target.type === 'deck') {
+      const targetCardback = deckCardbackOf(target.data);
+      if (targetCardback && !('mode' in targetCardback)) {
+        const status = await publicationStatusFor(ctx, 'deck', target._id);
+        return { mode: 'reference', href: status?.publicationHref ?? null };
+      }
+    }
+    return { mode: 'dangling', href: NO_DECK_BACK_HREF };
+  }
+  return null;
+}

--- a/convex/lib/publication.ts
+++ b/convex/lib/publication.ts
@@ -9,7 +9,7 @@ import {
 import type { FactionSheetAssetData } from '../../src/shared/asset-publishing/publication';
 import { publicationFaceId } from '../../src/shared/asset-publishing/publicationTargets';
 import type { PublicationAssetType } from '../../src/shared/asset-publishing/publicationTargets';
-import { DeckAsset, RectangleTokenAsset, TokenAsset } from '../../src/shared/assets/schema';
+import { authoredCardback, DeckAsset, RectangleTokenAsset, TokenAsset } from '../../src/shared/assets/schema';
 import type { Id } from '../_generated/dataModel';
 import type { MutationCtx, QueryCtx } from '../_generated/server';
 
@@ -32,6 +32,20 @@ export async function publicationJobsForAsset(ctx: PublicationReadCtx, assetType
     .query('publication_jobs')
     .withIndex('by_asset_type_and_asset_id', (q) => q.eq('asset_type', assetType).eq('asset_id', assetId))
     .take(4);
+}
+
+/**
+ * Removes the pending jobs for one publication id, leaving in-progress and completed work alone.
+ * This is how a save that takes a face away stops the pipeline from republishing it («The stored shape of three back modes»);
+ * completed publications stay, per #498's replaced-never-deleted rule.
+ */
+export async function supersedePendingPublication(ctx: MutationCtx, assetType: string, assetId: string) {
+  const jobs = await publicationJobsForAsset(ctx, assetType, assetId);
+  for (const job of jobs) {
+    if (job.status === 'pending') {
+      await ctx.db.delete(job._id);
+    }
+  }
 }
 
 /**
@@ -129,13 +143,24 @@ export async function enqueueAssetPublication(
      * The Cardback is lifted out of the stored deck here rather than carried whole, so the payload is exactly the publication's input.
      * `parseAssetDataForWrite` already validated this row on the way in, so the parse is a total function rather than a guard.
      */
-    case DECK_ASSET_TYPE:
+    case DECK_ASSET_TYPE: {
+      const cardback = authoredCardback(DeckAsset.parse(asset.data).cardback);
+      /*
+       * A reference-mode deck publishes nothing of its own: the resolver serves the target's URL.
+       * Any job pending for a cardback the author replaced with a reference is superseded here, the
+       * same rule a token's back follows below.
+       */
+      if (!cardback) {
+        await supersedePendingPublication(ctx, DECK_ASSET_TYPE, asset._id);
+        return null;
+      }
       return await enqueuePublicationJob(ctx, {
         assetType: DECK_ASSET_TYPE,
         assetId: asset._id,
-        assetData: { assetId: asset._id, slug: asset.slug, cardback: DeckAsset.parse(asset.data).cardback },
+        assetData: { assetId: asset._id, slug: asset.slug, cardback },
         now,
       });
+    }
     /*
      * Every token has two faces and «Token multi-face publication model» publishes them independently, so a save schedules two jobs rather than one.
      * The two face models differ, so the parse differs and the scheduling does not.
@@ -154,7 +179,7 @@ export async function enqueueAssetPublication(
 /** Both token models store their faces the same way, so scheduling them is one function over whatever a face happens to be. */
 type TokenFaces<TFace> = {
   front: TFace;
-  back: { mode: 'custom'; face: TFace } | { mode: 'reference' };
+  back: { mode: 'custom'; face: TFace } | { mode: 'same' } | { mode: 'reference'; asset_id?: string };
 };
 
 /**
@@ -162,9 +187,10 @@ type TokenFaces<TFace> = {
  *
  * The front takes the bare asset id, so a token's primary URL is the same shape as a card's.
  * An authored back takes `{id}.back`, which the target row declares and the id guard admits only for types that do.
- * A referenced back schedules nothing: it is another token's front, and that token publishes it under its own id.
+ * A `same` or `reference` back schedules nothing: the resolver serves the front or the target's own back («What does each back mode publish»).
  *
- * Switching a back from authored to referenced orphans the `.back` object rather than deleting it, which #498 accepted on the grounds that publications are replaced and never deleted.
+ * A save that leaves `custom` mode also supersedes any `.back` job still pending, so the pipeline never republishes a face the author took away («The stored shape of three back modes»).
+ * The completed `.back` object stays, which #498 accepted on the grounds that publications are replaced and never deleted.
  */
 async function enqueueTokenFaces<TFace>(
   ctx: MutationCtx,
@@ -179,14 +205,16 @@ async function enqueueTokenFaces<TFace>(
     assetData: { assetId: asset._id, slug: asset.slug, face: token.front },
     now,
   });
+  const backId = publicationFaceId(asset._id, 'back');
   if (token.back.mode === 'custom') {
-    const backId = publicationFaceId(asset._id, 'back');
     await enqueuePublicationJob(ctx, {
       assetType,
       assetId: backId,
       assetData: { assetId: backId, slug: asset.slug, face: token.back.face },
       now,
     });
+  } else {
+    await supersedePendingPublication(ctx, assetType, backId);
   }
   return front;
 }

--- a/convex/lib/publication.ts
+++ b/convex/lib/publication.ts
@@ -38,9 +38,14 @@ export async function publicationJobsForAsset(ctx: PublicationReadCtx, assetType
  * Removes the pending jobs for one publication id, leaving in-progress and completed work alone.
  * This is how a save that takes a face away stops the pipeline from republishing it («The stored shape of three back modes»);
  * completed publications stay, per #498's replaced-never-deleted rule.
+ * The window is wider than the sibling readers' four: those tolerate missing a row, while a pending job this misses republishes a removed face.
+ * The lifecycle holds rows per id to single digits (pending coalesces at enqueue, errors purge at enqueue, expired captures become errors at pickup), so the margin is safety rather than budget.
  */
 export async function supersedePendingPublication(ctx: MutationCtx, assetType: string, assetId: string) {
-  const jobs = await publicationJobsForAsset(ctx, assetType, assetId);
+  const jobs = await ctx.db
+    .query('publication_jobs')
+    .withIndex('by_asset_type_and_asset_id', (q) => q.eq('asset_type', assetType).eq('asset_id', assetId))
+    .take(64);
   for (const job of jobs) {
     if (job.status === 'pending') {
       await ctx.db.delete(job._id);

--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -195,6 +195,21 @@
       "id": "account_lifecycle_profile_narrow",
       "phase": "narrow",
       "requires": ["account_lifecycle_profiles_v1", "account_lifecycle_verify_v1"]
+    },
+    {
+      "id": "assets_back_modes_v1",
+      "phase": "widen",
+      "requires": []
+    },
+    {
+      "id": "asset_relations_token_back_drop_v1",
+      "phase": "widen",
+      "requires": ["assets_back_modes_v1"]
+    },
+    {
+      "id": "assets_back_modes_verify_v1",
+      "phase": "widen",
+      "requires": ["assets_back_modes_v1", "asset_relations_token_back_drop_v1"]
     }
   ]
 }

--- a/convex/migrations.assetsBackModes.test.ts
+++ b/convex/migrations.assetsBackModes.test.ts
@@ -1,0 +1,124 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import migrationsTest from '@convex-dev/migrations/test';
+import { convexTest } from 'convex-test';
+import { describe, expect, test } from 'vitest';
+
+import { api, internal } from './_generated/api';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+const now = '2026-08-21T00:00:00.000Z';
+
+const REQUIRED = ['assets_back_modes_v1', 'asset_relations_token_back_drop_v1', 'assets_back_modes_verify_v1'];
+
+describe('the back-modes widen, drop, and verify trio', () => {
+  test('honored references gain their target in data, every invalid class becomes same, and the relation rows drop', async () => {
+    const t = convexTest(schema, modules);
+    migrationsTest.register(t);
+
+    const ids = await t.run(async (ctx) => {
+      const ownerId = await ctx.db.insert('users', { name: 'Back owner' });
+      const base = { owner_id: ownerId, group_id: null, is_deleted: false, created_at: now, updated_at: now };
+      const token = (slug: string, back: unknown, extra?: Partial<{ type: string; is_deleted: boolean }>) =>
+        ctx.db.insert('assets', {
+          ...base,
+          type: extra?.type ?? 'token-disc',
+          is_deleted: extra?.is_deleted ?? false,
+          slug,
+          data: { name: slug, about: '', front: {}, back },
+        });
+
+      const targetAuthored = await token('target-authored', { mode: 'custom', face: {} });
+      const targetDeleted = await token('target-deleted', { mode: 'custom', face: {} }, { is_deleted: true });
+      const targetWrongType = await token('target-wrong-type', { mode: 'custom', face: {} }, { type: 'token-tech' });
+      const targetUnauthored = await token('target-unauthored', { mode: 'reference' });
+
+      const refValid = await token('ref-valid', { mode: 'reference' });
+      const refDeleted = await token('ref-deleted', { mode: 'reference' });
+      const refWrongType = await token('ref-wrong-type', { mode: 'reference' });
+      const refUnauthored = await token('ref-unauthored', { mode: 'reference' });
+      const refNoRelation = await token('ref-no-relation', { mode: 'reference' });
+      const custom = await token('stays-custom', { mode: 'custom', face: { kept: true } });
+
+      const relate = (from: typeof refValid, to: typeof refValid) =>
+        ctx.db.insert('asset_relations', { from_asset_id: from, to_asset_id: to, kind: 'token-back', count: 1 });
+      await relate(refValid, targetAuthored);
+      await relate(refDeleted, targetDeleted);
+      await relate(refWrongType, targetWrongType);
+      await relate(refUnauthored, targetUnauthored);
+
+      /* A deck membership rides along to prove the drop touches only its own kind. */
+      const deck = await ctx.db.insert('assets', { ...base, type: 'deck', slug: 'deck', data: { name: 'Deck' } });
+      const card = await ctx.db.insert('assets', {
+        ...base,
+        type: 'card-treachery',
+        slug: 'card',
+        data: { name: 'C' },
+      });
+      const membership = await ctx.db.insert('asset_relations', {
+        from_asset_id: deck,
+        to_asset_id: card,
+        kind: 'deck-card',
+        count: 3,
+      });
+
+      return { targetAuthored, refValid, refDeleted, refWrongType, refUnauthored, refNoRelation, custom, membership };
+    });
+
+    await t.mutation(internal.migrations.assets_back_modes_v1, {});
+    await t.mutation(internal.migrations.asset_relations_token_back_drop_v1, {});
+    await t.mutation(internal.migrations.assets_back_modes_verify_v1, {});
+
+    /*
+     * The deploy gate is the honest observer: the runner records per-row throws as state rather than
+     * rejecting the mutation, so a verify that failed shows up here and nowhere else.
+     */
+    await expect(t.query(api.migrations.assertReadyForNarrow, { required: REQUIRED })).resolves.toMatchObject({
+      ok: true,
+    });
+
+    await t.run(async (ctx) => {
+      const backOf = async (id: (typeof ids)['refValid']) => {
+        const row = await ctx.db.get('assets', id);
+        return (row?.data as { back: unknown } | undefined)?.back;
+      };
+      expect(await backOf(ids.refValid)).toEqual({ mode: 'reference', asset_id: ids.targetAuthored });
+      expect(await backOf(ids.refDeleted)).toEqual({ mode: 'same' });
+      expect(await backOf(ids.refWrongType)).toEqual({ mode: 'same' });
+      expect(await backOf(ids.refUnauthored)).toEqual({ mode: 'same' });
+      expect(await backOf(ids.refNoRelation)).toEqual({ mode: 'same' });
+      expect(await backOf(ids.custom)).toEqual({ mode: 'custom', face: { kept: true } });
+
+      const relations = await ctx.db.query('asset_relations').take(100);
+      expect(relations.map((row) => row.kind)).toEqual(['deck-card']);
+      expect(relations[0]?._id).toBe(ids.membership);
+    });
+  });
+
+  test('the verify alone blocks the gate while a legacy reference remains', async () => {
+    const t = convexTest(schema, modules);
+    migrationsTest.register(t);
+
+    await t.run(async (ctx) => {
+      const ownerId = await ctx.db.insert('users', { name: 'Back owner' });
+      await ctx.db.insert('assets', {
+        owner_id: ownerId,
+        group_id: null,
+        is_deleted: false,
+        created_at: now,
+        updated_at: now,
+        type: 'token-disc',
+        slug: 'legacy',
+        data: { name: 'legacy', about: '', front: {}, back: { mode: 'reference' } },
+      });
+    });
+
+    await t.mutation(internal.migrations.assets_back_modes_verify_v1, {});
+
+    await expect(t.query(api.migrations.assertReadyForNarrow, { required: REQUIRED })).rejects.toThrow(
+      'Narrow blocked'
+    );
+  });
+});

--- a/convex/migrations.assetsBackModes.test.ts
+++ b/convex/migrations.assetsBackModes.test.ts
@@ -117,8 +117,9 @@ describe('the back-modes widen, drop, and verify trio', () => {
 
     await t.mutation(internal.migrations.assets_back_modes_verify_v1, {});
 
-    await expect(t.query(api.migrations.assertReadyForNarrow, { required: REQUIRED })).rejects.toThrow(
-      'Narrow blocked'
-    );
+    /* Only the verify is required here, so the rejection proves it recorded the legacy row rather than proving the unrun siblings are absent. */
+    await expect(
+      t.query(api.migrations.assertReadyForNarrow, { required: ['assets_back_modes_verify_v1'] })
+    ).rejects.toThrow('Narrow blocked');
   });
 });

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -8,6 +8,7 @@ import type { Id } from './_generated/dataModel';
 import { internalQuery, query } from './_generated/server';
 import { internalMutation, mutation } from './functions';
 import { accountStateOf } from './lib/accountLifecycle';
+import { hasAuthoredBack, TOKEN_ASSET_TYPES, tokenBackOf } from './lib/assetBacks';
 import { DECAL_ID_RENAMES, DECAL_SCALE_FACTORS } from './lib/decalRetune';
 import {
   reconcileAnswerActivity,
@@ -59,6 +60,9 @@ const MIGRATION_IDS: Record<string, MigrationRef> = {
   assets_about_verify_v1: internal.migrations.assets_about_verify_v1,
   account_lifecycle_profiles_v1: internal.migrations.account_lifecycle_profiles_v1,
   account_lifecycle_verify_v1: internal.migrations.account_lifecycle_verify_v1,
+  assets_back_modes_v1: internal.migrations.assets_back_modes_v1,
+  asset_relations_token_back_drop_v1: internal.migrations.asset_relations_token_back_drop_v1,
+  assets_back_modes_verify_v1: internal.migrations.assets_back_modes_verify_v1,
 };
 
 type MigrationId = keyof typeof MIGRATION_IDS;
@@ -542,6 +546,80 @@ export const account_lifecycle_verify_v1 = migrations.define({
     }
     if (profile.account_state !== accountStateOf(user)) {
       throw new Error(`Lifecycle mismatch for profile ${profile._id} and user ${user._id}`);
+    }
+  },
+});
+
+/**
+ * Moves every token's back reference into its data («The stored shape of three back modes»).
+ *
+ * A reference whose relation row names a target the new rules honor gains that target's id in `data.back`;
+ * a reference the rules cannot honor (missing row, deleted target, wrong type, or a target whose own back is not authored) rewrites to `same`, the migration policy Norbert set for both invalid classes.
+ * Custom rows pass untouched, so only reference rows are rewritten.
+ */
+export const assets_back_modes_v1 = migrations.define({
+  table: 'assets',
+  batchSize: 50,
+  migrateOne: async (ctx, row) => {
+    if (!TOKEN_ASSET_TYPES.has(row.type)) {
+      return;
+    }
+    const back = tokenBackOf(row.data);
+    if (back?.mode !== 'reference' || typeof back.asset_id === 'string') {
+      return;
+    }
+    const relation = await ctx.db
+      .query('asset_relations')
+      .withIndex('by_from_kind', (q) => q.eq('from_asset_id', row._id).eq('kind', 'token-back'))
+      .first();
+    const target = relation ? await ctx.db.get('assets', relation.to_asset_id) : null;
+    const honored = target !== null && !target.is_deleted && target.type === row.type && hasAuthoredBack(target);
+    const data = row.data as Record<string, unknown>;
+    return {
+      data: {
+        ...data,
+        back: honored ? { mode: 'reference', asset_id: relation!.to_asset_id } : { mode: 'same' },
+      },
+    };
+  },
+});
+
+/** Drops the `token-back` relation rows whose targets `assets_back_modes_v1` moved into the data. */
+export const asset_relations_token_back_drop_v1 = migrations.define({
+  table: 'asset_relations',
+  batchSize: 50,
+  migrateOne: async (ctx, row) => {
+    if (row.kind !== 'token-back') {
+      return;
+    }
+    await ctx.db.delete(row._id);
+  },
+});
+
+/**
+ * Proves the move left nothing behind: every token back is one of the three modes, every reference carries its target in data, and no `token-back` relation row remains.
+ * Passing is what makes requiring `asset_id` on the reference member safe in a later release.
+ */
+export const assets_back_modes_verify_v1 = migrations.define({
+  table: 'assets',
+  batchSize: 50,
+  migrateOne: async (ctx, row) => {
+    if (!TOKEN_ASSET_TYPES.has(row.type)) {
+      return;
+    }
+    const back = tokenBackOf(row.data);
+    if (back?.mode !== 'custom' && back?.mode !== 'same' && back?.mode !== 'reference') {
+      throw new Error(`Token ${row._id} has no recognisable back mode`);
+    }
+    if (back.mode === 'reference' && typeof back.asset_id !== 'string') {
+      throw new Error(`Token ${row._id} still references through a relation row`);
+    }
+    const relation = await ctx.db
+      .query('asset_relations')
+      .withIndex('by_from_kind', (q) => q.eq('from_asset_id', row._id).eq('kind', 'token-back'))
+      .first();
+    if (relation) {
+      throw new Error(`Token ${row._id} still has a token-back relation row`);
     }
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -106,7 +106,8 @@ export default defineSchema({
     .index('by_group_deleted', ['group_id', 'is_deleted'])
     .index('by_group_id', ['group_id']),
   /**
-   * Asset↔asset references: deck→card memberships (`kind: 'deck-card'`, count = copies) and token→token backsides (`kind: 'token-back'`, count 1);
+   * Asset↔asset references: deck→card memberships (`kind: 'deck-card'`, count = copies) and bundle→token memberships;
+   * token backsides moved into `data.back` and their `token-back` rows are dropped by `asset_relations_token_back_drop_v1`;
    * future kinds join the same table.
    * Which types may link (a deck's `to` must be a card) is a rule of the link mutations — the single-table decision traded schema-level reference typing for that.
    * Soft-deleted targets stay referenced;

--- a/public/web/no-deck-back.svg
+++ b/public/web/no-deck-back.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1263"><rect width="900" height="1263" fill="#ffffff"/><text x="450" y="631" font-family="system-ui, sans-serif" font-size="220" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">[?]</text></svg>

--- a/scripts/verify-images.ts
+++ b/scripts/verify-images.ts
@@ -99,10 +99,17 @@ for (const source of sources) {
   }
 }
 
+/* Committed alongside the generated tree, not produced from media/; each names the change that added it. */
+const COMMITTED_WEB_FILES = new Set([
+  'web/logo.svg',
+  /* The dangling deck-back fallback the resolver serves («What does each back mode publish», amended by «How a dangling back reference presents»). */
+  'web/no-deck-back.svg',
+]);
+
 for (const generated of [...walk(path.join(publicRoot, 'image')), ...walk(path.join(publicRoot, 'web'))]) {
   const relative = path.relative(publicRoot, generated).split(path.sep).join('/');
-  if (relative === 'web/logo.svg') {
-    continue; // committed, not generated
+  if (COMMITTED_WEB_FILES.has(relative)) {
+    continue;
   }
   if (!expectedFiles.has(relative)) {
     failures.push(`orphan generated file: ${relative}`);

--- a/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
@@ -1,5 +1,5 @@
 import { Alert, Anchor, Popover, Text } from '@mantine/core';
-import { DeckAsset } from '@shared/assets/schema';
+import { authoredCardback, DeckAsset } from '@shared/assets/schema';
 import { ASSET_TYPE_KEYS, ASSET_TYPES } from '@shared/assets/types';
 import { Link, useNavigate } from '@tanstack/react-router';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
@@ -79,13 +79,23 @@ export function DeckEditPage({ slug, loaderData }: { slug: string; loaderData: A
     );
   }
 
+  /* A reference-mode cardback has no composition to edit; the editor that understands it lands with the back-picker slice. */
+  const cardback = authoredCardback(parsed.data.cardback);
+  if (!cardback) {
+    return (
+      <DriftedAssetPage asset={data.asset} noun="deck" canDelete={data.viewerAccess.capabilities.delete}>
+        <Text>This deck's cardback references another deck, which this editor cannot edit yet.</Text>
+      </DriftedAssetPage>
+    );
+  }
+
   return (
     <DeckEditSession
       key={data.asset.id}
       access={{ viewerAccess: data.viewerAccess, assignableGroups: data.assignableGroups }}
       asset={data.asset}
       members={data.members}
-      initialDraft={parsed.data}
+      initialDraft={{ ...parsed.data, cardback }}
     />
   );
 }

--- a/src/app/widgets/asset-face/AssetFace.test.tsx
+++ b/src/app/widgets/asset-face/AssetFace.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { MantineProvider } from '@mantine/core';
+import { cleanup, render } from '@testing-library/react';
+import { appContentTheme } from '@ui/theme';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { AssetFace } from './AssetFace';
+
+window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+function renderFace(children: ReactNode) {
+  return render(
+    <MantineProvider theme={appContentTheme} forceColorScheme="light">
+      {children}
+    </MantineProvider>
+  );
+}
+
+/*
+ * The migration rewrites production tokens to mode `same` at deploy, so this branch renders live
+ * content the moment the slice ships; the contract is pinned here because no story can hold a
+ * same-mode token until the editor able to author one lands.
+ */
+const front = {
+  background: {
+    image: '/image/texture/015.jpg',
+    colors: ['#4B4C0D', '#262B04'],
+    influence: 0.5,
+    invert: true,
+    definition: 0,
+  },
+  image: '/vector/decal/amal.svg',
+  top: 'FRONT ARC TEXT',
+  ring: true,
+};
+
+describe('a token back with mode same', () => {
+  test('draws the front face rather than the neutral fallback', () => {
+    const { container } = renderFace(
+      <AssetFace
+        type="token-disc"
+        data={{ name: 'Spice', about: '', front, back: { mode: 'same' } }}
+        name="Spice"
+        width={300}
+        side="back"
+      />
+    );
+    expect(container.textContent).toContain('FRONT ARC TEXT');
+  });
+
+  test('a dangling reference still falls to the neutral face, unchanged', () => {
+    const { container } = renderFace(
+      <AssetFace
+        type="token-disc"
+        data={{ name: 'Spice', about: '', front, back: { mode: 'reference' } }}
+        name="Spice"
+        width={300}
+        side="back"
+      />
+    );
+    expect(container.textContent).not.toContain('FRONT ARC TEXT');
+  });
+});

--- a/src/app/widgets/asset-face/AssetFace.tsx
+++ b/src/app/widgets/asset-face/AssetFace.tsx
@@ -240,17 +240,26 @@ const rectangleFaceSchema = z.object({
 /**
  * Which of a token's two faces to draw.
  * Both token models store their backside identically, so this is one rule rather than one per model.
- * A referenced back returns nothing, since it is another token's front and only the caller holds that token.
+ * A `same` back draws the front, its decided meaning.
+ * A referenced back returns nothing, since it is another token's back and only the caller holds that token.
  */
 function faceForSide<TFace>(
-  parsed: { front: TFace; back?: { mode: 'custom'; face: TFace } | { mode: 'reference' } } | undefined,
+  parsed:
+    | {
+        front: TFace;
+        back?: { mode: 'custom'; face: TFace } | { mode: 'same' } | { mode: 'reference'; asset_id?: string };
+      }
+    | undefined,
   side: AssetFaceSide
 ): TFace | undefined {
   if (!parsed) {
     return undefined;
   }
   if (side === 'back') {
-    return parsed.back?.mode === 'custom' ? parsed.back.face : undefined;
+    if (parsed.back?.mode === 'custom') {
+      return parsed.back.face;
+    }
+    return parsed.back?.mode === 'same' ? parsed.front : undefined;
   }
   return parsed.front;
 }

--- a/src/app/widgets/asset-face/AssetFace.tsx
+++ b/src/app/widgets/asset-face/AssetFace.tsx
@@ -205,10 +205,11 @@ const drawableTokenFace = z.looseObject({
 
 const tokenFaceSchema = z.object({
   front: drawableTokenFace,
-  /* A referenced back stores no face; the caller resolves it to the other token and draws that token's front. */
+  /* A referenced back stores no face; the caller resolves it to the other token. A same back repeats the front. */
   back: z
     .union([
       z.looseObject({ mode: z.literal('custom'), face: drawableTokenFace }),
+      z.looseObject({ mode: z.literal('same') }),
       z.looseObject({ mode: z.literal('reference') }),
     ])
     .optional(),
@@ -232,6 +233,7 @@ const rectangleFaceSchema = z.object({
   back: z
     .union([
       z.looseObject({ mode: z.literal('custom'), face: drawableRectangleFace }),
+      z.looseObject({ mode: z.literal('same') }),
       z.looseObject({ mode: z.literal('reference') }),
     ])
     .optional(),

--- a/src/app/widgets/deck-editor/DeckEditor.tsx
+++ b/src/app/widgets/deck-editor/DeckEditor.tsx
@@ -34,7 +34,11 @@ import type { CardbackData } from './stockCardbacks';
  */
 const PROOF_CANVAS = 900;
 
-export type DeckDraft = z.infer<typeof DeckAsset>;
+/*
+ * The editor's draft always carries an authored cardback: no editor can produce a reference until the
+ * back-picker slice lands, so the stored union's tagged member stops at the route's parse boundary.
+ */
+export type DeckDraft = Omit<z.infer<typeof DeckAsset>, 'cardback'> & { cardback: CardbackData };
 export type DeckChapter = 'identity' | 'cards' | 'about';
 
 /** One member of a deck as the editor sees it: the card itself, and how many copies. */

--- a/src/shared/assets/schema.ts
+++ b/src/shared/assets/schema.ts
@@ -171,7 +171,7 @@ function tokenBackUnion<TFace extends z.ZodType>(face: TFace) {
   return z.discriminatedUnion('mode', [
     z.strictObject({ mode: z.literal('custom'), face }),
     z.strictObject({ mode: z.literal('same') }),
-    z.strictObject({ mode: z.literal('reference'), asset_id: z.string().optional() }),
+    z.strictObject({ mode: z.literal('reference'), asset_id: z.string().min(1).optional() }),
   ]);
 }
 
@@ -212,7 +212,7 @@ export const CardBack = z.strictObject({
 export const DeckAsset = z.strictObject({
   name: z.string(),
   about: About,
-  cardback: z.union([CardBack, z.strictObject({ mode: z.literal('reference'), asset_id: z.string() })]),
+  cardback: z.union([CardBack, z.strictObject({ mode: z.literal('reference'), asset_id: z.string().min(1) })]),
 });
 
 /** The authored composition of a deck's cardback, or null when the cardback is a reference. */

--- a/src/shared/assets/schema.ts
+++ b/src/shared/assets/schema.ts
@@ -157,21 +157,36 @@ export const TokenFace = FactionSide.extend({
 });
 
 /**
+ * A token's back, parameterised by the face model since the two token schemas differ only there.
+ *
+ * Three modes, decided on «The stored shape of three back modes, and the migration»:
+ * `custom` carries an authored face, `same` repeats the front, `reference` names another token whose authored back this one wears.
+ * The target rides the data and is written at save, so the stored row is the single owner of its back;
+ * the `token-back` relation rows this replaces are dropped by `assets_back_modes_v1`.
+ *
+ * `asset_id` is optional only until that migration completes everywhere;
+ * the narrow that requires it rides a later release, the widen-migrate-narrow convention.
+ */
+function tokenBackUnion<TFace extends z.ZodType>(face: TFace) {
+  return z.discriminatedUnion('mode', [
+    z.strictObject({ mode: z.literal('custom'), face }),
+    z.strictObject({ mode: z.literal('same') }),
+    z.strictObject({ mode: z.literal('reference'), asset_id: z.string().optional() }),
+  ]);
+}
+
+/**
  * A token of any shape.
  * Shape is the Asset type rather than a field (see CONTEXT.md: Asset type), so all three shapes share this schema and differ only in how the caller clips the face.
  *
  * Every token has a back;
  * only where it comes from varies.
- * A referenced back is an `asset_relations` row rather than data, so this records the mode and, for a custom back, the face itself.
  */
 export const TokenAsset = z.strictObject({
   name: z.string(),
   about: About,
   front: TokenFace,
-  back: z.discriminatedUnion('mode', [
-    z.strictObject({ mode: z.literal('custom'), face: TokenFace }),
-    z.strictObject({ mode: z.literal('reference') }),
-  ]),
+  back: tokenBackUnion(TokenFace),
 });
 
 export const CardBack = z.strictObject({
@@ -188,12 +203,22 @@ export const CardBack = z.strictObject({
  *
  * The cardback is the renderer's own `CardBack` contract rather than a restatement of it, so the stored shape and the thing that draws it cannot drift.
  * Whether that composition came from a stock back or was authored is deliberately not stored: publication is uniform either way, so stock only supplies the render payload, and the editor recovers the choice by comparing values the same way a background preset is recovered.
+ *
+ * A cardback may instead reference another deck's authored cardback («The stored shape of three back modes»): the tagged member names the target, and the bare `CardBack` is the authored member.
+ * There is no `same` mode, since the cardback is a deck's only face.
+ * The authored member stays bare rather than wearing a `mode` tag, so every existing row and reader is already in the union;
+ * the tag arrives with the editor that can produce references.
  */
 export const DeckAsset = z.strictObject({
   name: z.string(),
   about: About,
-  cardback: CardBack,
+  cardback: z.union([CardBack, z.strictObject({ mode: z.literal('reference'), asset_id: z.string() })]),
 });
+
+/** The authored composition of a deck's cardback, or null when the cardback is a reference. */
+export function authoredCardback(cardback: z.infer<typeof DeckAsset>['cardback']): z.infer<typeof CardBack> | null {
+  return 'mode' in cardback ? null : cardback;
+}
 
 /**
  * The band across a bundle's container: the one authored thing a bundle has.
@@ -283,15 +308,12 @@ export const RectangleTokenFace = z.strictObject({
 /**
  * A rectangle token.
  *
- * It is a token by category and by backside rules, so the `back` discriminated union matches `TokenAsset` exactly and a referenced back is still an `asset_relations` row rather than data.
+ * It is a token by category and by backside rules, so the `back` union matches `TokenAsset` exactly.
  * It is not a token by face, which is why it carries its own schema rather than a branch inside `TokenAsset`.
  */
 export const RectangleTokenAsset = z.strictObject({
   name: z.string(),
   about: About,
   front: RectangleTokenFace,
-  back: z.discriminatedUnion('mode', [
-    z.strictObject({ mode: z.literal('custom'), face: RectangleTokenFace }),
-    z.strictObject({ mode: z.literal('reference') }),
-  ]),
+  back: tokenBackUnion(RectangleTokenFace),
 });

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,12 +4,12 @@
 // sharp version), so this file is reproducible on any machine (wayfinder #269).
 export const rendererManifest = {
   schemaVersion: 2,
-  rendererIdentity: 'faction-sheet/sha256:ea84ecf293dc0fd927d5f3810ced36d3b129cda0603a721a22607be7802d24b1',
-  digest: 'ea84ecf293dc0fd927d5f3810ced36d3b129cda0603a721a22607be7802d24b1',
+  rendererIdentity: 'faction-sheet/sha256:6730b534b47be2d7629b415025fd7dd2e959c1f3aefccc701e725a4dd9e21c13',
+  digest: '6730b534b47be2d7629b415025fd7dd2e959c1f3aefccc701e725a4dd9e21c13',
   components: {
     sources: '5289b6254320530ee857ff2912681e9d6a30135dbb3a92239296365f53397813',
     toolchain: '862154f6813aeaa0fd73c238ef8c80b979c289b6a9da8685e2495cf86586e9ed',
-    code: '6e8673d838a802d93a2b91b06d7cb21978a3195dfce8831354ee644ea516c75a',
+    code: '91d5c85872228ed8c15718f3d7d6f29d03dd24644132870c46ff74eeadd79e62',
     contract: '2920714c87493d104342355dda2b956202259513c78ce6195670034f31a656a6',
   },
   contract: {

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,12 +4,12 @@
 // sharp version), so this file is reproducible on any machine (wayfinder #269).
 export const rendererManifest = {
   schemaVersion: 2,
-  rendererIdentity: 'faction-sheet/sha256:6730b534b47be2d7629b415025fd7dd2e959c1f3aefccc701e725a4dd9e21c13',
-  digest: '6730b534b47be2d7629b415025fd7dd2e959c1f3aefccc701e725a4dd9e21c13',
+  rendererIdentity: 'faction-sheet/sha256:96f3270c5efbdbf9ace10c93127f406dc5c7e729b0b62e5f999bd2a71e445203',
+  digest: '96f3270c5efbdbf9ace10c93127f406dc5c7e729b0b62e5f999bd2a71e445203',
   components: {
     sources: '5289b6254320530ee857ff2912681e9d6a30135dbb3a92239296365f53397813',
     toolchain: '862154f6813aeaa0fd73c238ef8c80b979c289b6a9da8685e2495cf86586e9ed',
-    code: '91d5c85872228ed8c15718f3d7d6f29d03dd24644132870c46ff74eeadd79e62',
+    code: 'f04f454f9fb7cade24c683f3cae372f8bc71e0a106b1c8ebb0cff7c709a83dc2',
     contract: '2920714c87493d104342355dda2b956202259513c78ce6195670034f31a656a6',
   },
   contract: {


### PR DESCRIPTION
Slice 1 of 2 of the asset-back model (map [Asset backs: three modes, referencing the back](https://github.com/ndelangen/dunezone/issues/590), ticket #597): the stored shape, its migration, the back resolver, and the browse join. Slice 2 (#598) stacks on this branch with the editors, the picker, and the dangling presentation.

## What lands

- **Schema**: a token's `back` is one strict union in its data (`custom` with a face, `same`, or `reference` carrying the target's id), written once at save through one shared validator (#593). The deck cardback gains a `reference` member beside its bare authored composition. `asset_id` on the token reference member is optional this release; the narrow that requires it follows once the migration trio proves out everywhere, the widen-migrate-narrow convention.
- **Migration trio** (`assets_back_modes_v1`, `asset_relations_token_back_drop_v1`, `assets_back_modes_verify_v1`): honored references gain their target's id from their relation row; every reference the new rules cannot honor (deleted target, wrong type, unauthored target back) rewrites to `same`, Norbert's policy for both invalid classes, covering the four dangling production tokens. The `token-back` relation rows then drop, and the verify proves nothing survived.
- **Transitional `setTokenBack`**: survives one release because today's editors pick through it. It routes through the same validator as the save path, writes the same data field, clears legacy relation rows, and supersedes the pending `.back` job. One deliberate contract amendment: `null` is refused with a pointing error, since clearing moved to the save path with the mode union and no shipped caller has ever sent `null` (verified in the #574 audit and again against the current editors). The draft-based pick that retires it lands in slice 2.
- **Resolver** (#592): one server-side answer to "what is this asset's back": authored serves its own `.back`, `same` serves its own front, a reference serves the target's back, a dangling token its own front, and a dangling deck a deployed `[?]` fallback image (per #596: a blank white image is indistinguishable from a failed load). Exposed additively as `resolvedBack` on the page query.
- **Browse join** (#595): the three list queries resolve a referenced deck's cardback into the entry payload behind a per-query memo, so tiles, piles, and pickers render unchanged.
- **Publication**: a save that leaves `custom` mode schedules no `.back` job and supersedes any pending one (the absorbed #574's second layer); a reference-mode deck publishes nothing and supersedes its own pending job.

## Decided deferral, not an omission

#593's clause "migration wraps every existing deck's CardBack into the custom member" is **deferred to slice 2**, with the coordinator's approval recorded on #597. The bare `CardBack` stays the union's authored member this release, so every existing row and reader remains valid between the slice deploys; the tagged member arrives with the editor able to produce references, and the wrap rides that slice.

## Evidence

- Gates green in the working tree: typecheck, `oxlint --deny-warnings`, oxfmt, knip, 598 unit tests (12 new), 316 story tests.
- Flip-checks: the 7 new write-path behaviors fail against the pre-change code; the migration verify blocks `assertReadyForNarrow` while a legacy row remains.
- Capture contract regression passed locally (card, deck cardback, round token face, rectangle token back), and this slice commits its own renderer-manifest digest. The digest moved twice, mechanically both times: once with the slice itself, and once more when the review round's nonempty schema floors reached the capture bundle (`580628a41b5` changes only the `code`/`digest` hashes; `sources`, `toolchain`, and `contract` are untouched).
- Migration dry-run and e2e evidence in the #597 resolution comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
