### PR TITLE
The login trace survives the runner, and the login retries instead of shrugging

### DIFF
--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -398,3 +398,4 @@ jobs:
             ${{ github.workspace }}/test-results
             ${{ github.workspace }}/.playwright/app.log
             ${{ github.workspace }}/.playwright/build.log
+            ${{ github.workspace }}/.playwright/*.zip

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -40,13 +40,44 @@ async function loginWithLocalAuth(baseUrl: string, credentials: Credentials) {
     if (navigationError) {
       throw navigationError;
     }
-    await page.getByRole('textbox', { name: /email/i }).fill(credentials.email);
-    await page.getByLabel(/password/i).fill(credentials.password);
-    await page.getByTestId('local-auth-submit').click();
-    await Promise.race([
-      page.waitForURL((url: URL) => !url.pathname.endsWith('/auth/login')),
-      page.getByRole('heading', { name: /you're signed in/i }).waitFor(),
-    ]);
+    /*
+     * Three shorter attempts instead of one 30s wait, re-filling each time (issue #585).
+     * The suspected cause, unproven until a retained trace shows it: the login form is controlled, so a
+     * fill that lands before hydration types into DOM the state never saw, and hydration then resets the
+     * inputs to empty; the submit either errors on blank credentials or native-navigates back to the same
+     * URL, and either way the page sits on /auth/login for the full timeout.
+     * Re-filling after the reset makes the attempt whole; the retry also covers any other transient,
+     * and a failure that survives all three now ships its trace instead of a shrug.
+     */
+    let loginError: unknown = new Error('login never attempted');
+    for (let attempt = 1; attempt <= 3; attempt += 1) {
+      try {
+        await page.getByRole('textbox', { name: /email/i }).fill(credentials.email);
+        await page.getByLabel(/password/i).fill(credentials.password);
+        await page.getByTestId('local-auth-submit').click();
+        await Promise.race([
+          page.waitForURL((url: URL) => !url.pathname.endsWith('/auth/login'), { timeout: 10_000 }),
+          page.getByRole('heading', { name: /you're signed in/i }).waitFor({ timeout: 10_000 }),
+        ]);
+        loginError = null;
+        break;
+      } catch (error) {
+        loginError = error;
+        console.warn(
+          `[globalSetup] login attempt ${attempt} for ${credentials.email} did not leave /auth/login; retrying`
+        );
+        /* A native submit may have reloaded the page with the credentials in the query; start clean. */
+        await page.goto(`${baseUrl}/auth/login`, { waitUntil: 'domcontentloaded', timeout: 10_000 });
+        /* A login that completed just as the attempt timed out bounces this visit away from the form; that is success, not a retry. */
+        if (!new URL(page.url()).pathname.endsWith('/auth/login')) {
+          loginError = null;
+          break;
+        }
+      }
+    }
+    if (loginError) {
+      throw loginError;
+    }
     await context.storageState({ path: credentials.storageStatePath });
     console.log(`[globalSetup] saved storage state -> ${credentials.storageStatePath}`);
     await context.tracing.stop({ path: `${traceBase}-success.zip` });

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -67,9 +67,19 @@ async function loginWithLocalAuth(baseUrl: string, credentials: Credentials) {
           `[globalSetup] login attempt ${attempt} for ${credentials.email} did not leave /auth/login; retrying`
         );
         /* A native submit may have reloaded the page with the credentials in the query; start clean. */
-        await page.goto(`${baseUrl}/auth/login`, { waitUntil: 'domcontentloaded', timeout: 10_000 });
-        /* A login that completed just as the attempt timed out bounces this visit away from the form; that is success, not a retry. */
-        if (!new URL(page.url()).pathname.endsWith('/auth/login')) {
+        try {
+          await page.goto(`${baseUrl}/auth/login`, { waitUntil: 'domcontentloaded', timeout: 10_000 });
+        } catch {
+          /* A wedged server is context for the login failure, not a better error; keep the informative one for the trace's filing. */
+          continue;
+        }
+        /*
+         * A login that completed just as the attempt timed out shows either success signal on this
+         * visit, the same two the race above accepts: bounced off the form, or the signed-in heading
+         * on the login route. Either is success, not a retry.
+         */
+        const offLoginRoute = !new URL(page.url()).pathname.endsWith('/auth/login');
+        if (offLoginRoute || (await page.getByRole('heading', { name: /you're signed in/i }).isVisible())) {
           loginError = null;
           break;
         }


### PR DESCRIPTION
Fixes [#585](https://github.com/ndelangen/dunezone/issues/585) per its own sizing: trace retention first, hang hardening second.

- `.playwright/*.zip` joins the e2e artifact upload, so the trace the global setup already writes and names in its failure message survives the runner. Success traces ride along at 14-day retention; that is the cost of the literal one-line ask.
- The login's single 30 second wait becomes three 10 second attempts that re-fill the form each time. The suspected cause is named in the comment as unproven until a retained trace shows it: the login form is controlled, so a fill landing before hydration types into DOM the state never saw, hydration resets the inputs, and the submit either errors on blank credentials or native-navigates back to `/auth/login`, which matches every observed symptom including why parallel distinct-user logins succeed. Each retry starts from a clean visit, and a login that completed just as its attempt timed out is recognised as success rather than retried into a spurious failure.

Proof: full local e2e suite 9/9 with all ten setup logins first-attempt; typecheck, oxlint, oxfmt clean. actionlint covers the workflow edit in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)