### PR TITLE
The walk's findings: tiles scale, deletes hold, chrome straightens

### DIFF
--- a/docs/technical/ui-design-decisions.md
+++ b/docs/technical/ui-design-decisions.md
@@ -171,19 +171,19 @@ recognizable action with an `aria-label`; if the icon would be ambiguous, label 
 forward-moving primary, and the colour tuples in [`theme.ts`](../../src/app/ui/theme.ts).
 (`StatusBadge`'s tone scale is for state, not actions.)*
 
-### Destructive confirmation asks in place
+### Destructive actions are held, not asked twice
 
-A delete that opens a dialog takes the reader out of the row it belongs to, and the browser's own
-`window.confirm` blocks the thread and cannot be styled, tested, or dismissed by keyboard the way the
-rest of the app can. So a destructive action asks where it stands: the red glyph swaps for a question
-and a pair of answers, and swaps back on cancel. The swap hands keyboard focus over in both
-directions. An in-place swap unmounts the focused node, and without the handoff, focus restarts at
-the top of the document.
+A delete fires after its trigger is held for five seconds. Hovering says "hold to delete"; pressing
+starts a countdown that the hover text and the glyph both show ("deletion in 4.."), and releasing
+anywhere short of zero cancels with nothing fired. The keyboard holds the same way with Space or
+Enter. A question-and-answer confirm asked for a second decision; the hold asks for sustained
+intent, which is one interaction and cannot be clicked through on autopilot. On success the page
+navigates to the deleted thing's parent, since its own address just died.
 
 *Convention. The kit carries it: `ConfirmDeleteAction` in
-[`src/app/ui/control`](../../src/app/ui/control/ConfirmDeleteAction.tsx). `window.confirm` still
-stands at the group, ruleset and FAQ deletes; those are legacy pending a re-point, not a second
-sanctioned answer.*
+[`src/app/ui/control`](../../src/app/ui/control/ConfirmDeleteAction.tsx). Every delete goes through
+it; `window.confirm` remains only at non-delete confirmations (removing a member, moving an asset
+between groups) pending their own treatment.*
 
 ### A tab icon is an icon, never a proof
 

--- a/e2e/ruleset-lifecycle.spec.ts
+++ b/e2e/ruleset-lifecycle.spec.ts
@@ -31,8 +31,11 @@ test('owner can create and delete a ruleset in a two-user flow', async ({ page, 
   await expect(userBPage.getByLabel('Edit ruleset')).toHaveCount(0);
   await userB.close();
 
-  page.once('dialog', (dialog) => dialog.accept());
-  await page.getByLabel('Delete ruleset').click();
+  /* Deletes are held, not asked twice: five seconds of press, with a beat of margin for timer skew. */
+  await page.getByLabel('Delete ruleset').hover();
+  await page.mouse.down();
+  await page.waitForTimeout(5200);
+  await page.mouse.up();
   await expect(page).toHaveURL(/\/rulesets\/?$/);
   await expect(page.getByRole('link', { name: uniqueName })).toHaveCount(0);
 });

--- a/public/web/no-deck-back.svg
+++ b/public/web/no-deck-back.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1263"><rect width="900" height="1263" fill="#ffffff"/><text x="450" y="631" font-family="system-ui, sans-serif" font-size="220" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">[?]</text></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 1263"><rect width="900" height="1263" rx="50" fill="#ffffff"/><text x="450" y="631" font-family="system-ui, sans-serif" font-size="220" fill="#c8c8c8" text-anchor="middle" dominant-baseline="central">[?]</text></svg>

--- a/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
@@ -172,12 +172,7 @@ function BundleEditSession({
           context={groupActions.context}
           destructiveActions={
             access.viewerAccess.capabilities.delete ? (
-              <ConfirmDeleteAction
-                label="Delete bundle"
-                prompt="Delete bundle?"
-                pending={deletion.pending}
-                onConfirm={deletion.confirm}
-              />
+              <ConfirmDeleteAction label="Delete bundle" pending={deletion.pending} onConfirm={deletion.confirm} />
             ) : null
           }
         />

--- a/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
@@ -242,12 +242,7 @@ function DeckEditSession({
           context={groupActions.context}
           destructiveActions={
             access.viewerAccess.capabilities.delete ? (
-              <ConfirmDeleteAction
-                label="Delete deck"
-                prompt="Delete deck?"
-                pending={deletion.pending}
-                onConfirm={deletion.confirm}
-              />
+              <ConfirmDeleteAction label="Delete deck" pending={deletion.pending} onConfirm={deletion.confirm} />
             ) : null
           }
         />
@@ -311,7 +306,9 @@ function DeckEditSession({
             }
             backPicker={
               <Group gap="xs" wrap="nowrap">
-                <Text size="sm">{pickedBackDeck ? pickedBackDeck.name : 'No deck chosen yet'}</Text>
+                <Text size="sm" truncate style={{ minWidth: 0, flex: 1 }} title={pickedBackDeck?.name}>
+                  {pickedBackDeck ? pickedBackDeck.name : 'No deck chosen yet'}
+                </Text>
                 {/* Gated by the popover: the picker subscribes on mount, so it must not mount until asked for. */}
                 <Popover
                   opened={backPickerOpen}
@@ -321,7 +318,12 @@ function DeckEditSession({
                   withinPortal
                 >
                   <Popover.Target>
-                    <Button variant="light" size="compact-sm" onClick={() => setBackPickerOpen((open) => !open)}>
+                    <Button
+                      variant="light"
+                      size="compact-sm"
+                      style={{ flexShrink: 0 }}
+                      onClick={() => setBackPickerOpen((open) => !open)}
+                    >
                       {pickedBackDeck ? 'Change' : 'Choose'}
                     </Button>
                   </Popover.Target>

--- a/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
@@ -224,12 +224,7 @@ function RectangleEditSession({
           context={groupActions.context}
           destructiveActions={
             access.viewerAccess.capabilities.delete ? (
-              <ConfirmDeleteAction
-                label="Delete token"
-                prompt="Delete token?"
-                pending={deletion.pending}
-                onConfirm={deletion.confirm}
-              />
+              <ConfirmDeleteAction label="Delete token" pending={deletion.pending} onConfirm={deletion.confirm} />
             ) : null
           }
         />
@@ -260,13 +255,16 @@ function RectangleEditSession({
             onSettle={() => setSettleTick((tick) => tick + 1)}
             backPicker={(disabled) => (
               <Group gap="xs" wrap="nowrap">
-                <Text size="sm">{pickedBack ? pickedBack.name : 'No token chosen yet'}</Text>
+                <Text size="sm" truncate style={{ minWidth: 0, flex: 1 }} title={pickedBack?.name}>
+                  {pickedBack ? pickedBack.name : 'No token chosen yet'}
+                </Text>
                 {/* Gated by the popover: the picker subscribes on mount, so it must not mount until asked for. */}
                 <Popover opened={pickerOpen} onChange={setPickerOpen} width={340} position="bottom-start" withinPortal>
                   <Popover.Target>
                     <Button
                       variant="light"
                       size="compact-sm"
+                      style={{ flexShrink: 0 }}
                       disabled={disabled}
                       onClick={() => setPickerOpen((open) => !open)}
                     >

--- a/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
@@ -209,12 +209,7 @@ function TokenEditSession({
           context={groupActions.context}
           destructiveActions={
             access.viewerAccess.capabilities.delete ? (
-              <ConfirmDeleteAction
-                label="Delete token"
-                prompt="Delete token?"
-                pending={deletion.pending}
-                onConfirm={deletion.confirm}
-              />
+              <ConfirmDeleteAction label="Delete token" pending={deletion.pending} onConfirm={deletion.confirm} />
             ) : null
           }
         />
@@ -246,13 +241,16 @@ function TokenEditSession({
             onSettle={() => setSettleTick((tick) => tick + 1)}
             backPicker={(disabled) => (
               <Group gap="xs" wrap="nowrap">
-                <Text size="sm">{pickedBack ? pickedBack.name : 'No token chosen yet'}</Text>
+                <Text size="sm" truncate style={{ minWidth: 0, flex: 1 }} title={pickedBack?.name}>
+                  {pickedBack ? pickedBack.name : 'No token chosen yet'}
+                </Text>
                 {/* Gated by the popover: the picker subscribes on mount, so it must not mount until asked for. */}
                 <Popover opened={pickerOpen} onChange={setPickerOpen} width={340} position="bottom-start" withinPortal>
                   <Popover.Target>
                     <Button
                       variant="light"
                       size="compact-sm"
+                      style={{ flexShrink: 0 }}
                       disabled={disabled}
                       onClick={() => setPickerOpen((open) => !open)}
                     >

--- a/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
@@ -162,12 +162,7 @@ function CardEditSession({
           context={groupActions.context}
           destructiveActions={
             capabilities.delete ? (
-              <ConfirmDeleteAction
-                label="Delete card"
-                prompt="Delete card?"
-                pending={deletion.pending}
-                onConfirm={deletion.confirm}
-              />
+              <ConfirmDeleteAction label="Delete card" pending={deletion.pending} onConfirm={deletion.confirm} />
             ) : null
           }
         />

--- a/src/app/routes/_app/assets/$type/$slug/index.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/index.tsx
@@ -553,7 +553,6 @@ function LoadedAssetDetail({ page }: { page: AssetPage }) {
                 {capabilities.delete ? (
                   <ConfirmDeleteAction
                     label={`Delete ${asset.name}`}
-                    prompt="Delete this asset?"
                     pending={deletion.pending}
                     onConfirm={deletion.confirm}
                   />

--- a/src/app/routes/_app/assets/$type/index.module.css
+++ b/src/app/routes/_app/assets/$type/index.module.css
@@ -38,6 +38,11 @@
   min-width: 0;
 }
 
+/* The unstyled variant strips the input's own inset, which left the value flush against the segment divider. */
+.sortSegment input {
+  padding-inline: var(--mantine-spacing-sm);
+}
+
 /*
  * Side by side the search box is down to about 110px on a phone, which is unusable.
  * The faction overview has the same defect and it is not this page's to fix, so this stacks rather than inheriting it.
@@ -109,8 +114,4 @@
   .tileOpen:hover .tileArt {
     transform: none;
   }
-}
-
-.resultCount {
-  white-space: nowrap;
 }

--- a/src/app/routes/_app/assets/$type/index.module.css
+++ b/src/app/routes/_app/assets/$type/index.module.css
@@ -38,8 +38,8 @@
   min-width: 0;
 }
 
-/* The unstyled variant strips the input's own inset, which left the value flush against the segment divider. */
-.sortSegment input {
+/* The unstyled variant strips the trigger's own inset, which left the value flush against the segment divider. Mantine renders the trigger as an input today; the button alternative covers a render-mode change. */
+.sortSegment :is(input, button) {
   padding-inline: var(--mantine-spacing-sm);
 }
 

--- a/src/app/routes/_app/assets/$type/index.tsx
+++ b/src/app/routes/_app/assets/$type/index.tsx
@@ -8,7 +8,7 @@ import { CanvasScale } from '@ui/layout/CanvasScale';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
 import { Toolbar } from '@ui/surface/Toolbar';
-import { Plus, Search } from 'lucide-react';
+import { ArrowLeft, Plus, Search } from 'lucide-react';
 import { useState } from 'react';
 
 import { loadAssetBrowsePage, useAssetBrowsePage } from '@app/db/assets';
@@ -99,9 +99,15 @@ function AssetTypePage() {
           <Toolbar>
             <Toolbar.Left>
               <Group gap="sm" wrap="nowrap">
-                <Text size="sm" c="dimmed" className={styles.resultCount}>
-                  {entries.length === total ? `${total}${data.truncated ? '+' : ''}` : `${entries.length} of ${total}`}
-                </Text>
+                {/* A way back to the shelves, where a result count stood: the number told nobody anything a full grid did not (Norbert, 2026-08-21). */}
+                <IconAction
+                  label="Back to all assets"
+                  variant="light"
+                  color="gray"
+                  size="lg"
+                  icon={<ArrowLeft size={17} aria-hidden />}
+                  renderRoot={(rootProps) => <Link {...rootProps} to="/assets" />}
+                />
                 {data.inNoDeckCount === null ? null : (
                   <Button
                     size="compact-sm"

--- a/src/app/routes/_app/assets/-assetEditorStates.tsx
+++ b/src/app/routes/_app/assets/-assetEditorStates.tsx
@@ -105,12 +105,7 @@ export function DriftedAssetPage({
             </Alert>
           ) : null}
           <Group>
-            <ConfirmDeleteAction
-              label={`Delete ${noun}`}
-              prompt={`Delete ${noun}?`}
-              pending={deletion.pending}
-              onConfirm={deletion.confirm}
-            />
+            <ConfirmDeleteAction label={`Delete ${noun}`} pending={deletion.pending} onConfirm={deletion.confirm} />
           </Group>
         </>
       ) : null}

--- a/src/app/routes/_app/factions/$factionId/edit.tsx
+++ b/src/app/routes/_app/factions/$factionId/edit.tsx
@@ -226,7 +226,6 @@ function FactionEditPage() {
             canDelete ? (
               <ConfirmDeleteAction
                 label="Delete faction"
-                prompt="Delete faction?"
                 pending={deleteFaction.isPending}
                 onConfirm={() =>
                   deleteFaction.mutate({ id: faction._id }, { onSuccess: () => void navigate({ to: '/factions' }) })

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -3,24 +3,13 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { formatRelativeDate } from '@ui/content/dates';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { AssignPopover } from '@ui/control/AssignPopover';
+import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
 import { Card } from '@ui/surface/Card';
 import { Toolbar } from '@ui/surface/Toolbar';
-import {
-  ArrowLeft,
-  BookOpen,
-  Check,
-  Crown,
-  Pencil,
-  Plus,
-  Trash2,
-  UserPlus,
-  UserRoundMinus,
-  UsersRound,
-  X,
-} from 'lucide-react';
+import { ArrowLeft, BookOpen, Check, Crown, Pencil, Plus, UserPlus, UserRoundMinus, UsersRound, X } from 'lucide-react';
 
 import { useFactionsOwnedForGroupAssign, useSetFactionGroup } from '@db/factions';
 import type { FactionEntry } from '@db/factions';
@@ -135,9 +124,6 @@ function GroupDetailPage() {
   };
 
   const handleDeleteGroup = () => {
-    if (!window.confirm(`Delete group "${group.name}"? This cannot be undone.`)) {
-      return;
-    }
     deleteGroup.mutate(groupId, {
       onSuccess: () => void navigate({ to: '/profiles' }),
     });
@@ -182,14 +168,10 @@ function GroupDetailPage() {
                   />
                 ) : null}
                 {viewerAccess.capabilities.delete ? (
-                  <IconAction
+                  <ConfirmDeleteAction
                     label="Delete group"
-                    variant="light"
-                    color="red"
-                    size="lg"
-                    disabled={deleteGroup.isPending}
-                    onClick={handleDeleteGroup}
-                    icon={<Trash2 size={17} aria-hidden />}
+                    pending={deleteGroup.isPending}
+                    onConfirm={handleDeleteGroup}
                   />
                 ) : null}
               </Group>

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
@@ -3,10 +3,11 @@ import { FAQ_TAG_VALUES } from '@shared/faq/tags';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
 import { ProfileLink } from '@ui/content/ProfileLink';
+import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
-import { Check, MessageSquarePlus, Pencil, Trash2, X } from 'lucide-react';
+import { Check, MessageSquarePlus, Pencil, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { loadFaqQuestionPage, useFaqQuestionPage } from '@db/faq';
@@ -121,9 +122,6 @@ function FaqDetailPage() {
   const hasUserAnswered = !showAddAnswerForm && answers.some((a) => a.capabilities.editAnswer);
 
   const handleDeleteQuestion = () => {
-    if (!window.confirm('Delete this question and all its answers? This cannot be undone.')) {
-      return;
-    }
     void faq.deleteQuestion
       .run()
       .then(() => navigate({ to: '/rulesets/$rulesetSlug', params: { rulesetSlug } }))
@@ -136,9 +134,6 @@ function FaqDetailPage() {
   const saveAnswer = (answerId: string) => void editingSession.saveAnswer(answers.find((x) => x.id === answerId));
 
   const handleDeleteAnswer = (answerId: string) => {
-    if (!window.confirm('Delete this answer?')) {
-      return;
-    }
     void faq.deleteAnswer.run({ answerId }).catch(() => undefined);
   };
 
@@ -220,14 +215,10 @@ function FaqDetailPage() {
                         onClick={startEditQuestion}
                         icon={<Pencil size={16} aria-hidden />}
                       />
-                      <IconAction
+                      <ConfirmDeleteAction
                         label="Delete question"
-                        variant="light"
-                        color="red"
-                        size="lg"
-                        onClick={handleDeleteQuestion}
-                        disabled={faq.deleteQuestion.isPending}
-                        icon={<Trash2 size={16} aria-hidden />}
+                        pending={faq.deleteQuestion.isPending}
+                        onConfirm={handleDeleteQuestion}
                       />
                       {faq.deleteQuestion.isError && (
                         <span className={styles.error}>{faq.deleteQuestion.error?.message}</span>
@@ -380,14 +371,10 @@ function FaqDetailPage() {
                               />
                             )}
                             {a.capabilities.deleteAnswer && (
-                              <IconAction
+                              <ConfirmDeleteAction
                                 label="Delete answer"
-                                variant="light"
-                                color="red"
-                                size="lg"
-                                onClick={() => handleDeleteAnswer(a.id)}
-                                disabled={faq.deleteAnswer.isPending}
-                                icon={<Trash2 size={16} aria-hidden />}
+                                pending={faq.deleteAnswer.isPending}
+                                onConfirm={() => handleDeleteAnswer(a.id)}
                               />
                             )}
                           </Group>

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -13,6 +13,7 @@ import { ProfileLink } from '@ui/content/ProfileLink';
 import { StatusBadge } from '@ui/content/StatusBadge';
 import { TopicIcon } from '@ui/content/TopicIcon';
 import { AssignPopover } from '@ui/control/AssignPopover';
+import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
 import { ColumnsWithRailLayout } from '@ui/layout/ColumnsWithRailLayout';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -33,7 +34,6 @@ import {
   MessageCircleQuestionMark,
   Pencil,
   Search,
-  Trash2,
   UserRoundMinus,
   UsersRound,
 } from 'lucide-react';
@@ -322,9 +322,6 @@ function RulesetDetailPage() {
   };
 
   const handleDelete = () => {
-    if (!window.confirm(`Delete ruleset "${r.name}"? This cannot be undone.`)) {
-      return;
-    }
     deleteRuleset.mutate(r._id, {
       onSuccess: () => navigate({ to: '/rulesets' }),
     });
@@ -506,14 +503,10 @@ function RulesetDetailPage() {
                   />
                 ) : null}
                 {actionVisibility.canDelete ? (
-                  <IconAction
+                  <ConfirmDeleteAction
                     label="Delete ruleset"
-                    color="red"
-                    variant="light"
-                    size="lg"
-                    onClick={handleDelete}
-                    disabled={deleteRuleset.isPending}
-                    icon={<Trash2 size={17} aria-hidden />}
+                    pending={deleteRuleset.isPending}
+                    onConfirm={handleDelete}
                   />
                 ) : null}
               </Group>

--- a/src/app/ui/control/ConfirmDeleteAction.stories.tsx
+++ b/src/app/ui/control/ConfirmDeleteAction.stories.tsx
@@ -1,5 +1,5 @@
 import preview from '@sb/preview';
-import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { ConfirmDeleteAction } from './ConfirmDeleteAction';
 
@@ -9,80 +9,36 @@ const meta = preview.meta({
   globals: { backgrounds: { value: 'light', grid: false } },
   args: {
     label: 'Delete faction',
-    prompt: 'Delete faction?',
     pending: false,
     onConfirm: fn(),
   },
 });
 
-/** Collapsed: one red glyph among the other toolbar actions, carrying its name for people who cannot see it. */
+/** One red glyph among the other toolbar actions, named for people who cannot see it. Hovering says "hold to delete". */
 export const Default = meta.story({});
 
-/** Clicking the glyph replaces it in place with the question and its two answers. No dialog, no lost context. */
-export const Confirming = meta.story({
-  play: async ({ canvasElement }) => {
-    const page = within(canvasElement.ownerDocument.body);
-
-    await userEvent.click(page.getByRole('button', { name: 'Delete faction' }));
-
-    const question = await page.findByRole('group', { name: 'Delete faction' });
-    await expect(question).toHaveTextContent('Delete faction?');
-    await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
-    /* The swap must hand focus over, or a keyboard reader is stranded on an unmounted node. */
-    await waitFor(() => expect(question).toHaveFocus());
-  },
-});
-
-/** Confirming fires the caller's intent once. The component neither deletes anything nor closes itself. */
-export const Confirmed = meta.story({
+/**
+ * A press short of the five seconds fires nothing: releasing cancels the countdown.
+ * The full hold is pinned by the unit suite with fake timers, since a story should not wait five real seconds.
+ */
+export const ReleasedEarly = meta.story({
   play: async ({ args, canvasElement }) => {
     const page = within(canvasElement.ownerDocument.body);
+    const trigger = page.getByRole('button', { name: 'Delete faction' });
 
-    await userEvent.click(page.getByRole('button', { name: 'Delete faction' }));
-    await userEvent.click(await page.findByRole('button', { name: 'Delete' }));
+    await userEvent.pointer([{ keys: '[MouseLeft>]', target: trigger }]);
+    await userEvent.pointer(['[/MouseLeft]']);
 
-    await expect(args.onConfirm).toHaveBeenCalledTimes(1);
-    await expect(page.getByRole('group', { name: 'Delete faction' })).toBeVisible();
-  },
-});
-
-/** Cancel collapses it back to the glyph and returns focus there, so a misclick costs nothing. */
-export const Cancelled = meta.story({
-  play: async ({ args, canvasElement }) => {
-    const page = within(canvasElement.ownerDocument.body);
-
-    await userEvent.click(page.getByRole('button', { name: 'Delete faction' }));
-    await userEvent.click(await page.findByRole('button', { name: 'Cancel' }));
-
-    const trigger = await page.findByRole('button', { name: 'Delete faction' });
-    await waitFor(() => expect(trigger).toHaveFocus());
     await expect(args.onConfirm).not.toHaveBeenCalled();
   },
 });
 
-/** While the deletion is in flight the confirm latches, so an impatient second click cannot fire it twice. Cancel stays live: it closes the asking, and there is no abort channel it could reach. */
+/** While the deletion is in flight the trigger latches, so an impatient second hold cannot fire it twice. */
 export const Pending = meta.story({
   args: { pending: true },
   play: async ({ canvasElement }) => {
     const page = within(canvasElement.ownerDocument.body);
-
-    await userEvent.click(page.getByRole('button', { name: 'Delete faction' }));
-
-    await waitFor(() => expect(page.getByRole('button', { name: 'Delete' })).toBeDisabled());
-    await expect(page.getByRole('button', { name: 'Cancel' })).toBeEnabled();
-  },
-});
-
-/** The words follow whatever is being deleted, and the question is where a page names a consequence the trigger cannot carry. */
-export const OtherWords = meta.story({
-  args: { label: 'Retire deck', prompt: 'Retire this deck for everyone?', confirmLabel: 'Retire' },
-  play: async ({ canvasElement }) => {
-    const page = within(canvasElement.ownerDocument.body);
-
-    await userEvent.click(page.getByRole('button', { name: 'Retire deck' }));
-
-    const question = await page.findByRole('group', { name: 'Retire deck' });
-    await expect(question).toHaveTextContent('Retire this deck for everyone?');
-    await expect(page.getByRole('button', { name: 'Retire' })).toBeVisible();
+    /* Mantine's loading state disables the button, which is the latch made visible. */
+    await expect(page.getByRole('button', { name: 'Delete faction' })).toBeDisabled();
   },
 });

--- a/src/app/ui/control/ConfirmDeleteAction.test.tsx
+++ b/src/app/ui/control/ConfirmDeleteAction.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { MantineProvider } from '@mantine/core';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { appContentTheme } from '@ui/theme';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
@@ -23,22 +23,71 @@ afterEach(cleanup);
 function renderAction(onConfirm: () => void, pending = false) {
   return render(
     <MantineProvider theme={appContentTheme} forceColorScheme="light">
-      <ConfirmDeleteAction label="Delete card" prompt="Delete card?" pending={pending} onConfirm={onConfirm} />
+      <ConfirmDeleteAction label="Delete card" pending={pending} onConfirm={onConfirm} />
     </MantineProvider>
   );
 }
 
 describe('ConfirmDeleteAction', () => {
-  test('a double click fires the destructive callback once', () => {
+  test('a five second hold fires the deletion exactly once', () => {
+    vi.useFakeTimers();
     const onConfirm = vi.fn();
     renderAction(onConfirm);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Delete card' }));
-    const confirm = screen.getByRole('button', { name: 'Delete' });
-    /* The caller's pending arrives a render later; both clicks land in that gap. */
-    fireEvent.click(confirm);
-    fireEvent.click(confirm);
-
+    const trigger = screen.getByRole('button', { name: 'Delete card' });
+    fireEvent.pointerDown(trigger);
+    act(() => vi.advanceTimersByTime(4000));
+    expect(onConfirm).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1000));
     expect(onConfirm).toHaveBeenCalledTimes(1);
+    /* The countdown ended; nothing further may fire however long the press lingers. */
+    act(() => vi.advanceTimersByTime(5000));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  test('releasing early cancels with nothing fired', () => {
+    vi.useFakeTimers();
+    const onConfirm = vi.fn();
+    renderAction(onConfirm);
+
+    const trigger = screen.getByRole('button', { name: 'Delete card' });
+    fireEvent.pointerDown(trigger);
+    act(() => vi.advanceTimersByTime(3000));
+    fireEvent.pointerUp(trigger);
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onConfirm).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  test('the keyboard holds too, and a repeated keydown does not restart the countdown', () => {
+    vi.useFakeTimers();
+    const onConfirm = vi.fn();
+    renderAction(onConfirm);
+
+    const trigger = screen.getByRole('button', { name: 'Delete card' });
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    act(() => vi.advanceTimersByTime(3000));
+    /* Held keys repeat; a repeat mid-hold must not reset the clock. */
+    fireEvent.keyDown(trigger, { key: 'Enter', repeat: true });
+    act(() => vi.advanceTimersByTime(2000));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
+  test('a completed hold latches: no second hold can fire while the caller is pending', () => {
+    vi.useFakeTimers();
+    const onConfirm = vi.fn();
+    renderAction(onConfirm);
+
+    const trigger = screen.getByRole('button', { name: 'Delete card' });
+    fireEvent.pointerDown(trigger);
+    act(() => vi.advanceTimersByTime(5000));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    fireEvent.pointerUp(trigger);
+    fireEvent.pointerDown(trigger);
+    act(() => vi.advanceTimersByTime(5000));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
   });
 });

--- a/src/app/ui/control/ConfirmDeleteAction.test.tsx
+++ b/src/app/ui/control/ConfirmDeleteAction.test.tsx
@@ -35,7 +35,7 @@ describe('ConfirmDeleteAction', () => {
     renderAction(onConfirm);
 
     const trigger = screen.getByRole('button', { name: 'Delete card' });
-    fireEvent.pointerDown(trigger);
+    fireEvent.pointerDown(trigger, { isPrimary: true, button: 0 });
     act(() => vi.advanceTimersByTime(4000));
     expect(onConfirm).not.toHaveBeenCalled();
     act(() => vi.advanceTimersByTime(1000));
@@ -52,7 +52,7 @@ describe('ConfirmDeleteAction', () => {
     renderAction(onConfirm);
 
     const trigger = screen.getByRole('button', { name: 'Delete card' });
-    fireEvent.pointerDown(trigger);
+    fireEvent.pointerDown(trigger, { isPrimary: true, button: 0 });
     act(() => vi.advanceTimersByTime(3000));
     fireEvent.pointerUp(trigger);
     act(() => vi.advanceTimersByTime(10_000));
@@ -81,13 +81,52 @@ describe('ConfirmDeleteAction', () => {
     renderAction(onConfirm);
 
     const trigger = screen.getByRole('button', { name: 'Delete card' });
-    fireEvent.pointerDown(trigger);
+    fireEvent.pointerDown(trigger, { isPrimary: true, button: 0 });
     act(() => vi.advanceTimersByTime(5000));
     expect(onConfirm).toHaveBeenCalledTimes(1);
     fireEvent.pointerUp(trigger);
-    fireEvent.pointerDown(trigger);
+    fireEvent.pointerDown(trigger, { isPrimary: true, button: 0 });
     act(() => vi.advanceTimersByTime(5000));
     expect(onConfirm).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+  test('only a primary left-button press holds: right-click held forever fires nothing', () => {
+    vi.useFakeTimers();
+    const onConfirm = vi.fn();
+    renderAction(onConfirm);
+
+    const trigger = screen.getByRole('button', { name: 'Delete card' });
+    fireEvent.pointerDown(trigger, { isPrimary: true, button: 2 });
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onConfirm).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  test('losing focus mid-hold cancels: the keyup would never arrive', () => {
+    vi.useFakeTimers();
+    const onConfirm = vi.fn();
+    renderAction(onConfirm);
+
+    const trigger = screen.getByRole('button', { name: 'Delete card' });
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    act(() => vi.advanceTimersByTime(3000));
+    fireEvent.blur(trigger);
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onConfirm).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  test('unmounting mid-hold fires nothing', () => {
+    vi.useFakeTimers();
+    const onConfirm = vi.fn();
+    const { unmount } = renderAction(onConfirm);
+
+    const trigger = screen.getByRole('button', { name: 'Delete card' });
+    fireEvent.pointerDown(trigger, { isPrimary: true, button: 0 });
+    act(() => vi.advanceTimersByTime(3000));
+    unmount();
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onConfirm).not.toHaveBeenCalled();
     vi.useRealTimers();
   });
 });

--- a/src/app/ui/control/ConfirmDeleteAction.tsx
+++ b/src/app/ui/control/ConfirmDeleteAction.tsx
@@ -74,6 +74,9 @@ export function ConfirmDeleteAction({ label, pending, onConfirm }: ConfirmDelete
    * re-invoke updaters, either of which turns one completed hold into a wrong number of deletions.
    */
   const secondsLeft = useRef(0);
+  /* The interval closes over the render where the hold began; the ref keeps the fired callback current if the caller re-rendered mid-countdown. */
+  const onConfirmRef = useRef(onConfirm);
+  onConfirmRef.current = onConfirm;
   const startHold = () => {
     if (pending || submitted || timer.current) {
       return;
@@ -87,7 +90,7 @@ export function ConfirmDeleteAction({ label, pending, onConfirm }: ConfirmDelete
         stopTimer();
         setRemaining(null);
         setSubmitted(true);
-        onConfirm();
+        onConfirmRef.current();
         return;
       }
       setRemaining(secondsLeft.current);
@@ -104,10 +107,22 @@ export function ConfirmDeleteAction({ label, pending, onConfirm }: ConfirmDelete
       color="red"
       size="lg"
       loading={pending || submitted}
-      onPointerDown={startHold}
+      onPointerDown={(event) => {
+        /* Only a primary press holds: a right or middle button five seconds down must not delete. */
+        if (!event.isPrimary || event.button !== 0) {
+          return;
+        }
+        /* Touch implicitly captures the pointer, which would retarget the leave event; releasing the capture lets sliding off the trigger cancel the way it does for a mouse. Capture exists only for touch, hence the check. */
+        if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+        startHold();
+      }}
       onPointerUp={cancelHold}
       onPointerLeave={cancelHold}
       onPointerCancel={cancelHold}
+      /* Focus leaving mid-hold (Tab, window blur) takes the keyup with it; the hold must not outlive the reader's attention. */
+      onBlur={cancelHold}
       /* A held key repeats its keydown; only the first one starts the countdown. */
       onKeyDown={(event) => {
         if ((event.key === 'Enter' || event.key === ' ') && !event.repeat) {
@@ -115,7 +130,12 @@ export function ConfirmDeleteAction({ label, pending, onConfirm }: ConfirmDelete
           startHold();
         }
       }}
-      onKeyUp={cancelHold}
+      /* Only the activation key's release cancels; letting go of an unrelated key mid-hold is not a change of mind. */
+      onKeyUp={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          cancelHold();
+        }
+      }}
       /* A touch long-press would otherwise open the browser menu mid-hold. */
       onContextMenu={(event) => event.preventDefault()}
       icon={

--- a/src/app/ui/control/ConfirmDeleteAction.tsx
+++ b/src/app/ui/control/ConfirmDeleteAction.tsx
@@ -1,4 +1,4 @@
-import { Button, Group, Text } from '@mantine/core';
+import { Text } from '@mantine/core';
 import { Trash2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
@@ -7,48 +7,36 @@ import { IconAction } from './IconAction';
 export interface ConfirmDeleteActionProps {
   /**
    * What gets deleted, as a verb phrase, for example "Delete faction".
-   * This is the trigger's accessible name and the name of the confirmation that replaces it.
+   * The trigger's accessible name;
+   * the hover text says "hold to delete" and the countdown while held.
    */
   label: string;
-  /**
-   * The question, shown beside the confirm button, for example "Delete faction?".
-   * Required rather than derived from `label`: it is the only sentence in the two-step, and the one place a page can name a consequence the terse trigger cannot carry ("Delete card?
-   * Its publications stay.").
-   */
-  prompt: string;
-  /** The confirm button's word. Override only when "Delete" would be a lie. */
-  confirmLabel?: string;
-  /** True while the deletion is in flight. Latches the confirm button so a second click cannot fire it twice. */
+  /** True while the deletion is in flight. Latches the trigger so a second hold cannot fire it twice. */
   pending: boolean;
-  /** Fires once the reader has confirmed. The caller owns the mutation and wherever it navigates afterwards. */
+  /** Fires once the hold completes. The caller owns the mutation and navigates to the parent page on success. */
   onConfirm: () => void;
 }
 
+/** How long the trigger is held before the deletion fires. */
+const HOLD_SECONDS = 5;
+
 /**
- * Deletes something, having asked first.
+ * Deletes something, if you mean it for five seconds.
  *
  * Callers own what is deleted and the words for it;
- * this owns the two-step shape.
- * A red glyph expands in place into a question and a pair of answers, and collapses again on cancel.
+ * this owns the hold.
+ * Hovering says "hold to delete";
+ * pressing starts a countdown that the hover text and the glyph both show ("deletion in 4.."), and releasing anywhere short of zero cancels with nothing fired.
+ * Norbert chose the hold over the previous expand-into-a-question two-step (2026-08-21): the question asked for a second decision, while the hold asks for sustained intent, which reads as safer and is one interaction rather than two.
+ * See docs/technical/ui-design-decisions.md, "Destructive actions are held, not asked twice".
  *
- * The asking is in place rather than in a dialog, deliberately.
- * A toolbar action that opens one loses the row it belongs to, and `window.confirm` cannot be styled, tested, or dismissed by keyboard the way the rest of the app can.
- * See docs/technical/ui-design-decisions.md, "Destructive confirmation asks in place".
- * The mid-confirm state lives here because it is furniture around committing the action, not something a caller ever needs to read.
- *
- * Swapping the trigger for the question would strand keyboard focus on an unmounted node, so the swap hands focus over in both directions.
- * Focus goes to the question on open and back to the glyph on cancel, the same contract `AssignPopover` gets from Mantine's `returnFocus`.
- * Focus lands on the group rather than the confirm button on purpose.
- * A held Enter would otherwise repeat straight through onto "Delete".
+ * The keyboard holds too: Space or Enter held down runs the same countdown, releasing the key cancels.
+ * A plain click therefore does nothing, which is the point.
+ * The mid-hold state lives here because it is furniture around committing the action, not something a caller ever needs to read.
  */
-export function ConfirmDeleteAction({
-  label,
-  prompt,
-  confirmLabel = 'Delete',
-  pending,
-  onConfirm,
-}: ConfirmDeleteActionProps) {
-  const [confirming, setConfirming] = useState(false);
+export function ConfirmDeleteAction({ label, pending, onConfirm }: ConfirmDeleteActionProps) {
+  /* Seconds until the deletion fires; null while nothing is held. */
+  const [remaining, setRemaining] = useState<number | null>(null);
   const [submitted, setSubmitted] = useState(false);
   const [sawPending, setSawPending] = useState(false);
   /* Reset during render, the search box's pattern: when the caller's round trip ends, a failed delete gets its retry back. */
@@ -59,78 +47,86 @@ export function ConfirmDeleteAction({
     setSawPending(false);
     setSubmitted(false);
   }
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const questionRef = useRef<HTMLDivElement>(null);
-  /* Only a cancel should pull focus back to the glyph; the first render has nothing to return to. */
-  const wasConfirming = useRef(false);
 
-  useEffect(() => {
-    switch (true) {
-      case confirming:
-        questionRef.current?.focus();
-        break;
-      case wasConfirming.current:
-        triggerRef.current?.focus();
-        break;
-      default:
-        break;
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const stopTimer = () => {
+    if (timer.current) {
+      clearInterval(timer.current);
+      timer.current = null;
     }
-    wasConfirming.current = confirming;
-  }, [confirming]);
+  };
+  /* An unmounted countdown must not fire: the page may be navigating away for unrelated reasons. */
+  useEffect(
+    () => () => {
+      stopTimer();
+    },
+    []
+  );
 
-  if (!confirming) {
-    return (
-      <IconAction
-        ref={triggerRef}
-        label={label}
-        variant="light"
-        color="red"
-        size="lg"
-        onClick={() => setConfirming(true)}
-        icon={<Trash2 size={17} aria-hidden />}
-      />
-    );
-  }
+  const cancelHold = () => {
+    stopTimer();
+    setRemaining(null);
+  };
 
+  /*
+   * The countdown's source of truth is a ref, mirrored into state for display.
+   * Firing from inside a state updater would make the updater impure, and React batches and may
+   * re-invoke updaters, either of which turns one completed hold into a wrong number of deletions.
+   */
+  const secondsLeft = useRef(0);
+  const startHold = () => {
+    if (pending || submitted || timer.current) {
+      return;
+    }
+    secondsLeft.current = HOLD_SECONDS;
+    setRemaining(HOLD_SECONDS);
+    timer.current = setInterval(() => {
+      secondsLeft.current -= 1;
+      if (secondsLeft.current <= 0) {
+        /* Latched before the callback, the double-fire guard this control has always carried: the caller's pending arrives a render later. */
+        stopTimer();
+        setRemaining(null);
+        setSubmitted(true);
+        onConfirm();
+        return;
+      }
+      setRemaining(secondsLeft.current);
+    }, 1000);
+  };
+
+  const holding = remaining !== null;
   return (
-    <Group
-      ref={questionRef}
-      gap={4}
-      wrap="nowrap"
-      role="group"
-      aria-label={label}
-      tabIndex={-1}
-      /* Escape closes the asking the way it closes every popover here; the focus effect then hands focus back to the trigger. */
+    <IconAction
+      label={label}
+      tooltip={holding ? `deletion in ${remaining}..` : 'hold to delete'}
+      tooltipOpened={holding ? true : undefined}
+      variant="light"
+      color="red"
+      size="lg"
+      loading={pending || submitted}
+      onPointerDown={startHold}
+      onPointerUp={cancelHold}
+      onPointerLeave={cancelHold}
+      onPointerCancel={cancelHold}
+      /* A held key repeats its keydown; only the first one starts the countdown. */
       onKeyDown={(event) => {
-        if (event.key === 'Escape') {
-          setConfirming(false);
+        if ((event.key === 'Enter' || event.key === ' ') && !event.repeat) {
+          event.preventDefault();
+          startHold();
         }
       }}
-    >
-      <Text size="xs" c="red" fw={700}>
-        {prompt}
-      </Text>
-      <Button
-        type="button"
-        color="red"
-        size="compact-xs"
-        loading={pending || submitted}
-        onClick={() => {
-          /*
-           * Latched locally before the callback: the caller's pending arrives a render later, and the gap is where a double click fires a destructive callback twice.
-           * Focus moves to the group in the same breath, because the loading button is about to disable and a disabled element drops keyboard focus to the document.
-           */
-          setSubmitted(true);
-          questionRef.current?.focus();
-          onConfirm();
-        }}
-      >
-        {confirmLabel}
-      </Button>
-      {/* Cancel stays live during an in-flight delete on purpose: there is no abort channel to reach, and latching it would trap the reader here with no exit if the round trip stalls. It closes the asking, never the mutation. The caller's navigation or error alert reports the outcome. */}
-      <Button type="button" variant="subtle" color="gray" size="compact-xs" onClick={() => setConfirming(false)}>
-        Cancel
-      </Button>
-    </Group>
+      onKeyUp={cancelHold}
+      /* A touch long-press would otherwise open the browser menu mid-hold. */
+      onContextMenu={(event) => event.preventDefault()}
+      icon={
+        holding ? (
+          <Text size="sm" fw={700} aria-hidden>
+            {remaining}
+          </Text>
+        ) : (
+          <Trash2 size={17} aria-hidden />
+        )
+      }
+    />
   );
 }

--- a/src/app/ui/control/IconAction.tsx
+++ b/src/app/ui/control/IconAction.tsx
@@ -1,6 +1,6 @@
 import { ActionIcon, Tooltip } from '@mantine/core';
 import type { ActionIconProps } from '@mantine/core';
-import type { MouseEventHandler, ReactNode, Ref } from 'react';
+import type { KeyboardEventHandler, MouseEventHandler, PointerEventHandler, ReactNode, Ref } from 'react';
 
 import type { RenderRoot } from '../renderRoot';
 
@@ -15,6 +15,16 @@ export interface IconActionProps extends Pick<ActionIconProps, 'variant' | 'colo
   /** The glyph. Sized by the caller; marked decorative here, since `label` carries the meaning. */
   icon: ReactNode;
   onClick?: MouseEventHandler<HTMLButtonElement>;
+  /** Press-and-hold support, for an action whose commitment is the held duration rather than the click. */
+  onPointerDown?: PointerEventHandler<HTMLButtonElement>;
+  onPointerUp?: PointerEventHandler<HTMLButtonElement>;
+  onPointerLeave?: PointerEventHandler<HTMLButtonElement>;
+  onPointerCancel?: PointerEventHandler<HTMLButtonElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLButtonElement>;
+  onKeyUp?: KeyboardEventHandler<HTMLButtonElement>;
+  onContextMenu?: MouseEventHandler<HTMLButtonElement>;
+  /** Forces the hover text open, for the moments it carries live state (a hold's countdown). */
+  tooltipOpened?: boolean;
   /** Makes the action a link — in practice the router's `Link`. */
   renderRoot?: RenderRoot;
   /** Makes the action a plain anchor, for a destination outside the router. */
@@ -41,8 +51,16 @@ export interface IconActionProps extends Pick<ActionIconProps, 'variant' | 'colo
 export function IconAction({
   label,
   tooltip,
+  tooltipOpened,
   icon,
   onClick,
+  onPointerDown,
+  onPointerUp,
+  onPointerLeave,
+  onPointerCancel,
+  onKeyDown,
+  onKeyUp,
+  onContextMenu,
   renderRoot,
   href,
   target,
@@ -56,7 +74,7 @@ export function IconAction({
   /* Two branches rather than one spread: `component="a"` re-types the whole element, so the
      anchor form cannot carry the button-shaped ref, click handler or form binding anyway. */
   return (
-    <Tooltip label={tooltip ?? label}>
+    <Tooltip label={tooltip ?? label} opened={tooltipOpened}>
       {href == null ? (
         <ActionIcon
           {...actionIconProps}
@@ -65,6 +83,13 @@ export function IconAction({
           form={form}
           aria-label={label}
           onClick={onClick}
+          onPointerDown={onPointerDown}
+          onPointerUp={onPointerUp}
+          onPointerLeave={onPointerLeave}
+          onPointerCancel={onPointerCancel}
+          onKeyDown={onKeyDown}
+          onKeyUp={onKeyUp}
+          onContextMenu={onContextMenu}
           className={className}
           renderRoot={renderRoot}
         >

--- a/src/app/ui/control/IconAction.tsx
+++ b/src/app/ui/control/IconAction.tsx
@@ -1,6 +1,13 @@
 import { ActionIcon, Tooltip } from '@mantine/core';
 import type { ActionIconProps } from '@mantine/core';
-import type { KeyboardEventHandler, MouseEventHandler, PointerEventHandler, ReactNode, Ref } from 'react';
+import type {
+  FocusEventHandler,
+  KeyboardEventHandler,
+  MouseEventHandler,
+  PointerEventHandler,
+  ReactNode,
+  Ref,
+} from 'react';
 
 import type { RenderRoot } from '../renderRoot';
 
@@ -23,6 +30,7 @@ export interface IconActionProps extends Pick<ActionIconProps, 'variant' | 'colo
   onKeyDown?: KeyboardEventHandler<HTMLButtonElement>;
   onKeyUp?: KeyboardEventHandler<HTMLButtonElement>;
   onContextMenu?: MouseEventHandler<HTMLButtonElement>;
+  onBlur?: FocusEventHandler<HTMLButtonElement>;
   /** Forces the hover text open, for the moments it carries live state (a hold's countdown). */
   tooltipOpened?: boolean;
   /** Makes the action a link — in practice the router's `Link`. */
@@ -61,6 +69,7 @@ export function IconAction({
   onKeyDown,
   onKeyUp,
   onContextMenu,
+  onBlur,
   renderRoot,
   href,
   target,
@@ -90,6 +99,7 @@ export function IconAction({
           onKeyDown={onKeyDown}
           onKeyUp={onKeyUp}
           onContextMenu={onContextMenu}
+          onBlur={onBlur}
           className={className}
           renderRoot={renderRoot}
         >

--- a/src/app/ui/control/PreviewChoice.stories.tsx
+++ b/src/app/ui/control/PreviewChoice.stories.tsx
@@ -66,3 +66,37 @@ export const CardShaped = meta.story({
     value: 'reference',
   },
 });
+
+/** A fixed-canvas preview drawn at 900 pixels: the `canvas` option scales it to fit the tile instead of cropping a native-size corner. The inner border touching all four tile edges is the proof. */
+export const FixedCanvasPreview = meta.story({
+  args: {
+    label: 'Backside',
+    value: 'custom',
+    aspectRatio: '900 / 1263',
+    options: [
+      {
+        value: 'custom',
+        label: 'Composed here',
+        canvas: { width: 900, height: 1263 },
+        preview: (
+          <div
+            style={{
+              width: 900,
+              height: 1263,
+              background: 'linear-gradient(150deg, #8F2C1C, #27260C)',
+              border: '12px solid #E8C97B',
+              boxSizing: 'border-box',
+              display: 'grid',
+              placeItems: 'center',
+              color: '#E8C97B',
+              fontSize: 160,
+            }}
+          >
+            900px
+          </div>
+        ),
+      },
+      { value: 'reference', label: 'Reference', emptyHint: <span>Nothing yet</span> },
+    ],
+  },
+});

--- a/src/app/ui/control/PreviewChoice.tsx
+++ b/src/app/ui/control/PreviewChoice.tsx
@@ -63,7 +63,7 @@ function ContainFit({ width, height, children }: { width: number; height: number
   const scale = box ? Math.min(box.w / width, box.h / height) : 0;
   return (
     <div ref={setNode} style={{ width: '100%', height: '100%', position: 'relative', overflow: 'hidden' }}>
-      {scale > 0 && (
+      {box && scale > 0 && (
         <div
           style={{
             width,
@@ -71,8 +71,8 @@ function ContainFit({ width, height, children }: { width: number; height: number
             transform: `scale(${scale})`,
             transformOrigin: 'top left',
             position: 'absolute',
-            left: (box!.w - width * scale) / 2,
-            top: (box!.h - height * scale) / 2,
+            left: (box.w - width * scale) / 2,
+            top: (box.h - height * scale) / 2,
             pointerEvents: 'none',
           }}
         >

--- a/src/app/ui/control/PreviewChoice.tsx
+++ b/src/app/ui/control/PreviewChoice.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@mantine/core';
-import { useId } from 'react';
+import { useEffect, useId, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import styles from './PreviewChoice.module.css';
@@ -15,6 +15,12 @@ export type PreviewChoiceOption<T extends string> = {
   preview?: ReactNode;
   /** What the dashed reserved spot holds while there is nothing to preview, e.g. an icon naming the option. */
   emptyHint?: ReactNode;
+  /**
+   * The preview's own canvas size, when it draws at a fixed one (a proof drawn at 900 card-space pixels).
+   * The tile then scales it to fit rather than cropping a native-size corner, which is what a fixed canvas inside a fluid tile otherwise shows.
+   * Omitted for previews that size themselves from the box they are given.
+   */
+  canvas?: { width: number; height: number };
   /**
    * A control this option carries once it is chosen, e.g.
    * narrowing a category to one of its members.
@@ -36,6 +42,47 @@ export type PreviewChoiceOption<T extends string> = {
  * A real radio is stretched invisibly across it and does the choosing, so grouping, arrow keys and the announcement are the platform's rather than ours.
  * An option's own control is a sibling of the art inside that box, never a descendant of the thing you press to choose, which is what a nested control would have been.
  */
+/*
+ * Contain-fits a fixed-canvas preview to the tile's art box.
+ * `CanvasScale` fits width only, which is right for a rail; a tile also has a height that a control
+ * in the detail slot can shrink, so the smaller of the two ratios wins and the render centers.
+ */
+function ContainFit({ width, height, children }: { width: number; height: number; children: ReactNode }) {
+  const [node, setNode] = useState<HTMLDivElement | null>(null);
+  const [box, setBox] = useState<{ w: number; h: number } | null>(null);
+  useEffect(() => {
+    if (!node) {
+      return;
+    }
+    const observer = new ResizeObserver(([entry]) =>
+      setBox({ w: entry?.contentRect.width ?? 0, h: entry?.contentRect.height ?? 0 })
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [node]);
+  const scale = box ? Math.min(box.w / width, box.h / height) : 0;
+  return (
+    <div ref={setNode} style={{ width: '100%', height: '100%', position: 'relative', overflow: 'hidden' }}>
+      {scale > 0 && (
+        <div
+          style={{
+            width,
+            height,
+            transform: `scale(${scale})`,
+            transformOrigin: 'top left',
+            position: 'absolute',
+            left: (box!.w - width * scale) / 2,
+            top: (box!.h - height * scale) / 2,
+            pointerEvents: 'none',
+          }}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function PreviewChoice<T extends string>({
   label,
   value,
@@ -78,7 +125,13 @@ export function PreviewChoice<T extends string>({
             <div className={styles.frame} style={{ aspectRatio }} data-empty={option.preview ? undefined : true}>
               {/* Hidden from assistive technology: the caption names the option, and the picture has nothing to add. */}
               <div className={styles.art} aria-hidden>
-                {option.preview ?? option.emptyHint}
+                {option.preview && option.canvas ? (
+                  <ContainFit width={option.canvas.width} height={option.canvas.height}>
+                    {option.preview}
+                  </ContainFit>
+                ) : (
+                  (option.preview ?? option.emptyHint)
+                )}
               </div>
               {chosen && option.detail ? <div className={styles.detail}>{option.detail}</div> : null}
             </div>

--- a/src/app/widgets/deck-editor/DeckEditor.tsx
+++ b/src/app/widgets/deck-editor/DeckEditor.tsx
@@ -336,6 +336,7 @@ export function DeckEditor({
                             label: 'Stock',
                             /* Always drawable: the stock look this deck wears, or the first standing in. */
                             preview: <CardbackProof cardback={stockPreview} width={PROOF_CANVAS} />,
+                            canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('deck') },
                             detail: (
                               <Select
                                 aria-label="Which stock back"
@@ -358,12 +359,14 @@ export function DeckEditor({
                             preview: composition ? (
                               <CardbackProof cardback={composition} width={PROOF_CANVAS} />
                             ) : undefined,
+                            canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('deck') },
                             emptyHint: <Text size="xs">Not composed yet</Text>,
                           },
                           {
                             value: 'reference',
                             label: "Another deck's back",
                             preview: backProof ?? undefined,
+                            canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('deck') },
                             emptyHint: <Text size="xs">No deck chosen</Text>,
                             detail: backPicker,
                           },

--- a/src/app/widgets/deck-editor/DeckEditor.tsx
+++ b/src/app/widgets/deck-editor/DeckEditor.tsx
@@ -366,7 +366,6 @@ export function DeckEditor({
                             value: 'reference',
                             label: "Another deck's back",
                             preview: backProof ?? undefined,
-                            canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('deck') },
                             emptyHint: <Text size="xs">No deck chosen</Text>,
                             detail: backPicker,
                           },

--- a/src/app/widgets/token-editor/RectangleTokenEditor.tsx
+++ b/src/app/widgets/token-editor/RectangleTokenEditor.tsx
@@ -513,17 +513,20 @@ export function RectangleTokenEditor({
                       draft.back.mode === 'custom' ? (
                         <RectangleProof face={draft.back.face} width={PROOF_CANVAS} />
                       ) : undefined,
+                    canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('token-enhance') },
                     emptyHint: <Text size="xs">Not composed yet</Text>,
                   },
                   {
                     value: 'same',
                     label: 'Same as front',
                     preview: <RectangleProof face={draft.front} width={PROOF_CANVAS} />,
+                    canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('token-enhance') },
                   },
                   {
                     value: 'reference',
                     label: "Another token's back",
                     preview: backProof ?? undefined,
+                    canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('token-enhance') },
                     emptyHint: <Text size="xs">No token chosen</Text>,
                     detail: backPicker(false),
                   },

--- a/src/app/widgets/token-editor/RectangleTokenEditor.tsx
+++ b/src/app/widgets/token-editor/RectangleTokenEditor.tsx
@@ -526,7 +526,6 @@ export function RectangleTokenEditor({
                     value: 'reference',
                     label: "Another token's back",
                     preview: backProof ?? undefined,
-                    canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('token-enhance') },
                     emptyHint: <Text size="xs">No token chosen</Text>,
                     detail: backPicker(false),
                   },

--- a/src/app/widgets/token-editor/TokenEditor.tsx
+++ b/src/app/widgets/token-editor/TokenEditor.tsx
@@ -376,7 +376,6 @@ export function TokenEditor({
                     value: 'reference',
                     label: "Another token's back",
                     preview: backProof ?? undefined,
-                    canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect(type) },
                     emptyHint: <Text size="xs">No token chosen</Text>,
                     detail: backPicker(false),
                   },

--- a/src/app/widgets/token-editor/TokenEditor.tsx
+++ b/src/app/widgets/token-editor/TokenEditor.tsx
@@ -363,17 +363,20 @@ export function TokenEditor({
                       draft.back.mode === 'custom' ? (
                         <TokenProof face={draft.back.face} type={type} width={PROOF_CANVAS} />
                       ) : undefined,
+                    canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect(type) },
                     emptyHint: <Text size="xs">Not composed yet</Text>,
                   },
                   {
                     value: 'same',
                     label: 'Same as front',
                     preview: <TokenProof face={draft.front} type={type} width={PROOF_CANVAS} />,
+                    canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect(type) },
                   },
                   {
                     value: 'reference',
                     label: "Another token's back",
                     preview: backProof ?? undefined,
+                    canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect(type) },
                     emptyHint: <Text size="xs">No token chosen</Text>,
                     detail: backPicker(false),
                   },


### PR DESCRIPTION
Closes [Walk findings: the tiles scale, deletes are held, and the chrome straightens](https://github.com/ndelangen/dunezone/issues/611) — all six findings from Norbert's visual pass on the deployed back model, in one PR per his instruction, revalidated in production after deploy under [the walk](https://github.com/ndelangen/dunezone/issues/609).

## The six findings and their fixes

1. **Tile previews cropped instead of scaling.** `PreviewChoice` gains an optional per-option `canvas` size and contain-fits fixed-canvas previews (the proofs draw at 900 card-space pixels inside fluid tiles). All three editors pass their canvas dims. Pinned by a new story whose 900px inner border must touch all four tile edges — verified visually in Storybook before this PR opened.
2. **Reference tile detail rows clipped their buttons** ("Cho", "Char") and let the name sit over the art: the name now truncates and yields (full text in `title`), the button never shrinks, and the art shrinkage resolves with the scaling fix.
3. **The `[?]` fallback had square corners**: the SVG's own rect gains `rx=50` (the same 1/18 radius `CardFrame` draws), so every consumer — tile, detail stage, browse — inherits the card silhouette from the single source.
4. **Hold-to-delete replaces the two-step confirm, app-wide** (Norbert's spec verbatim: hover "hold to delete", five-second hold, countdown in the tooltip and on the glyph, release cancels, parent-page navigation on success). The countdown fires from the interval, not inside a state updater — an impure updater under React batching is a wrong number of deletions, which the rewritten fake-timer suite pins (hold fires once; early release fires nothing; key repeat doesn't restart; completed hold latches). The four legacy `window.confirm` deletes (group, ruleset, FAQ question, FAQ answer) join the kit control; non-delete confirms keep `window.confirm` pending their own treatment. `docs/technical/ui-design-decisions.md` rewritten to say what is true now.
5. **Browse sort select sat flush against its divider**: the unstyled variant gets its inset back.
6. **The browse toolbar's result count is gone; a back button stands there** (Norbert: do not show the counter at all).

## Gates

typecheck, oxlint `--deny-warnings`, oxfmt, knip, css-orphans, app-layout, **615 unit** (4 new hold tests), **333 story** (1 new contain-fit pin) — all green in the worktree holding the diff, node 22 pinned. No `convex/`, `src/shared` code, or publisher files change (the SVG is a committed static asset already in `COMMITTED_WEB_FILES`), so no manifest digest movement is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Destructive actions now require a five-second hold with countdown feedback for mouse and keyboard input.
  - Releasing early cancels deletion, while completed deletions navigate to the parent page.
  - Standardized hold-to-delete behavior across assets, groups, rulesets, factions, questions, and answers.
  - Added a “Back to all assets” link and improved handling of long picker labels.
  - Added fixed-canvas preview support for deck and token editors.

- **Bug Fixes**
  - Prevented duplicate deletion submissions and improved pending-state behavior.
  - Improved preview sizing and layout consistency across editor choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->