### PR TITLE
Require every publisher font before capture

### DIFF
--- a/src/app/styles/fonts.css
+++ b/src/app/styles/fonts.css
@@ -45,7 +45,7 @@
     url("/font/advokat-modern.woff2") format("woff2"),
     url("/font/advokat-modern.woff") format("woff");
   font-weight: normal;
-  font-style: italic;
+  font-style: normal;
 }
 
 @font-face {
@@ -55,7 +55,7 @@
     url("/font/busorama.woff2") format("woff2"),
     url("/font/busorama.woff") format("woff");
   font-weight: normal;
-  font-style: italic;
+  font-style: normal;
 }
 
 @font-face {
@@ -65,7 +65,7 @@
     url("/font/trebuchet.woff2") format("woff2"),
     url("/font/trebuchet.woff") format("woff");
   font-weight: normal;
-  font-style: italic;
+  font-style: normal;
 }
 
 /* App shell: body text vs headings (game modules keep their own font-family) */

--- a/src/shared/asset-publishing/publisher-fonts.ts
+++ b/src/shared/asset-publishing/publisher-fonts.ts
@@ -4,8 +4,12 @@ export const requiredPublisherFontFaces = [
   { family: 'Caladea', weight: '700', style: 'normal' },
   { family: 'Caladea', weight: '700', style: 'italic' },
   { family: 'C_Copperplate_Gothic', weight: '400', style: 'normal' },
-  { family: 'C_Advokat_Modern', weight: '400', style: 'italic' },
-  { family: 'C_Trebuchet', weight: '400', style: 'italic' },
+  { family: 'C_Copperplate_Gothic_Heavy', weight: '400', style: 'normal' },
+  { family: 'C_Desdemona', weight: '400', style: 'normal' },
+  { family: 'C_Candara', weight: '400', style: 'normal' },
+  { family: 'C_Advokat_Modern', weight: '400', style: 'normal' },
+  { family: 'C_Busorama', weight: '400', style: 'normal' },
+  { family: 'C_Trebuchet', weight: '400', style: 'normal' },
 ] as const;
 
 export type PublisherFontFaceSet = {

--- a/workers/publisher/fonts.test.ts
+++ b/workers/publisher/fonts.test.ts
@@ -45,11 +45,13 @@ function fontSet(missing?: (typeof requiredPublisherFontFaces)[number]): Publish
 
 describe('publisher self-hosted font readiness', () => {
   test('requires every renderer family, weight, and style to be loaded', async () => {
-    const busorama = requiredPublisherFontFaces.find((face) => face.family === 'C_Busorama');
-    expect(busorama).toBeDefined();
-
     await expect(assertRequiredPublisherFonts(fontSet())).resolves.toBeUndefined();
-    await expect(assertRequiredPublisherFonts(fontSet(busorama))).rejects.toThrow(/C_Busorama 400 normal/);
+
+    for (const face of requiredPublisherFontFaces) {
+      await expect(assertRequiredPublisherFonts(fontSet(face))).rejects.toThrow(
+        new RegExp(`${face.family} ${face.weight} ${face.style}`)
+      );
+    }
   });
 
   test('rejects Chromium-style substitution even when check reports true', async () => {

--- a/workers/publisher/fonts.test.ts
+++ b/workers/publisher/fonts.test.ts
@@ -44,11 +44,12 @@ function fontSet(missing?: (typeof requiredPublisherFontFaces)[number]): Publish
 }
 
 describe('publisher self-hosted font readiness', () => {
-  test('requires every sheet family, weight, and style to be loaded', async () => {
+  test('requires every renderer family, weight, and style to be loaded', async () => {
+    const busorama = requiredPublisherFontFaces.find((face) => face.family === 'C_Busorama');
+    expect(busorama).toBeDefined();
+
     await expect(assertRequiredPublisherFonts(fontSet())).resolves.toBeUndefined();
-    await expect(assertRequiredPublisherFonts(fontSet(requiredPublisherFontFaces[3]))).rejects.toThrow(
-      /Caladea 700 italic/
-    );
+    await expect(assertRequiredPublisherFonts(fontSet(busorama))).rejects.toThrow(/C_Busorama 400 normal/);
   });
 
   test('rejects Chromium-style substitution even when check reports true', async () => {

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,12 +4,12 @@
 // sharp version), so this file is reproducible on any machine (wayfinder #269).
 export const rendererManifest = {
   schemaVersion: 2,
-  rendererIdentity: 'faction-sheet/sha256:c772bacb119c4f1e3de50799cc0b28ac548a1afeddbf8352d21a3c4aa492d138',
-  digest: 'c772bacb119c4f1e3de50799cc0b28ac548a1afeddbf8352d21a3c4aa492d138',
+  rendererIdentity: 'faction-sheet/sha256:36fd2de1c953b0bfe34a8bd41e562efda9ca036d443625dfb54ee0c147fc4931',
+  digest: '36fd2de1c953b0bfe34a8bd41e562efda9ca036d443625dfb54ee0c147fc4931',
   components: {
     sources: '5289b6254320530ee857ff2912681e9d6a30135dbb3a92239296365f53397813',
     toolchain: '862154f6813aeaa0fd73c238ef8c80b979c289b6a9da8685e2495cf86586e9ed',
-    code: '3697eac0775d798951120b14b1d14b637ea3f7db8b5fe2ba1dff77f8617428cf',
+    code: 'abacecbb2159d7b4038a6c6de80f81635e493d68242d7daa247a780f001bf8ad',
     contract: '2920714c87493d104342355dda2b956202259513c78ce6195670034f31a656a6',
   },
   contract: {


### PR DESCRIPTION
## What changed

- Declare Advokat Modern, Busorama, and Trebuchet with the normal style their bundled font files provide.
- Require all seven custom renderer font faces before browser capture starts.
- Cover a missing Busorama face in the publisher font gate test.
- Refresh the renderer manifest for the capture bundle change.

## Verification

- `bun run publisher:test`
- `bun x vitest run workers/publisher/fonts.test.ts`
- `bun run typecheck`
- `bun run check`
- `bun run knip`
- `bun run workers/publisher/font-regression.ts`
- `bun run publisher:capture-contract-regression`
- `bun run publisher:release:verify`

The full unit suite has one pre-existing failure in `ConnectedTabs.test.tsx`; it reproduces in isolation and does not touch this patch.

Closes #563