### PR TITLE
A name conflict speaks: the editor warns while typing, and the refusal reaches the banner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -186,8 +186,9 @@ Outside the kit:
     already means the reader signalled intent (`FactionPicker` inside `FactionLoadPopover` is this
     case). Rendered inline with no such gate, a Picker instead defers its subscription to its own
     control's open, since its trigger must stay mounted to be clickable while its options must not
-    load until wanted. The inline shape has no instance yet; it lands with its first consumer rather
-    than as an unused code path.
+    load until wanted. `UniqueNameInput` is the inline shape's first instance: a name field whose
+    read must not fire until the reader means the name, and for a typed control the settle is the
+    open.
   - **Domain, not kit.** A Picker knows *what* it fetches, so it can never live in the domain-free
     kit; it renders *through* the kit (a `Select`, an `AssignPopover`). It is a peer of Widgets, not
     a seventh kit category.

--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -1,12 +1,12 @@
 import type { Infer } from 'convex/values';
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import {
   isPublicationAssetType,
   PUBLICATION_TARGETS,
   publicationFaceId,
 } from '../src/shared/asset-publishing/publicationTargets';
-import { ASSET_TYPE_KEYS } from '../src/shared/assets/types';
+import { ASSET_TYPE_KEYS, ASSET_TYPES, isAssetType } from '../src/shared/assets/types';
 import type { Doc, Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 import { publicationStatusFor } from './assetPublishingStatus';
@@ -352,13 +352,30 @@ async function rulesetsSlotting(ctx: QueryCtx, assetId: Id<'assets'>) {
   return entries;
 }
 
-async function assertAssetSlugAvailable(ctx: MutationCtx, type: string, slug: string) {
+/**
+ * Whether an asset of this type already holds the slug — soft-deleted rows included, since their address stays reserved.
+ * One rule read twice: the save guard refuses on it, and the editors' live conflict check subscribes to it, so the warning and the refusal can never disagree.
+ */
+async function assetSlugHeld(ctx: QueryCtx, type: string, slug: string): Promise<boolean> {
   const holders = await ctx.db
     .query('assets')
     .withIndex('by_slug', (q) => q.eq('slug', slug))
     .take(50);
-  if (holders.some((row) => row.type === type)) {
-    throw new Error(`Asset slug ${slug} is reserved for this asset type`);
+  return holders.some((row) => row.type === type);
+}
+
+/** The editors' live name-conflict check, the save guard's rule as a subscription. */
+export const slugTaken = query({
+  args: { type: v.string(), slug: v.string() },
+  returns: v.boolean(),
+  handler: async (ctx, args) => await assetSlugHeld(ctx, args.type, args.slug),
+});
+
+async function assertAssetSlugAvailable(ctx: MutationCtx, type: string, slug: string) {
+  if (await assetSlugHeld(ctx, type, slug)) {
+    /* A ConvexError, so the words reach the editor's banner in production; a plain Error is redacted to "Server Error" (Norbert hit exactly that, 2026-08-22). */
+    const noun = isAssetType(type) ? ASSET_TYPES[type].shortLabel.toLowerCase() : type;
+    throw new ConvexError(`The name is taken: another ${noun} already lives at "${slug}". Pick a different name.`);
   }
 }
 
@@ -420,7 +437,7 @@ export const create = mutation({
     parsed.data = await withValidatedBack(ctx, { type: args.type }, parsed.data as Record<string, unknown>);
     const slug = slugify(parsed.name);
     if (!slug) {
-      throw new Error('An asset name is required; it determines the asset URL');
+      throw new ConvexError('An asset name is required; it determines the asset URL');
     }
     await assertAssetSlugAvailable(ctx, args.type, slug);
     const now = nowIso();
@@ -453,7 +470,7 @@ export const update = mutation({
     await requireAssetUpdate(ctx, args.id, parsed.name);
     const slug = slugify(parsed.name);
     if (!slug) {
-      throw new Error('An asset name is required; it determines the asset URL');
+      throw new ConvexError('An asset name is required; it determines the asset URL');
     }
     if (slug !== row.slug) {
       await assertAssetSlugAvailable(ctx, row.type, slug);
@@ -565,7 +582,7 @@ export const setMemberCount = mutation({
   args: { container_id: v.id('assets'), member_id: v.id('assets'), count: v.number() },
   handler: async (ctx, args) => {
     if (!Number.isInteger(args.count) || args.count < 0 || args.count > 99) {
-      throw new Error('A member count must be a whole number between 0 and 99');
+      throw new ConvexError('A member count must be a whole number between 0 and 99');
     }
     const container = await ctx.db.get('assets', args.container_id);
     if (!container || container.is_deleted) {
@@ -573,7 +590,7 @@ export const setMemberCount = mutation({
     }
     const rules = CONTAINER_KINDS[container.type];
     if (!rules) {
-      throw new Error(`Asset type ${container.type} holds nothing`);
+      throw new ConvexError(`Asset type ${container.type} holds nothing`);
     }
     await requireAssetUpdate(ctx, args.container_id, nameOf(container));
 
@@ -582,7 +599,7 @@ export const setMemberCount = mutation({
       throw new Error(`Asset with id ${args.member_id} not found`);
     }
     if (!rules.holds(member.type)) {
-      throw new Error(`A ${container.type} holds ${rules.noun}, not ${member.type}`);
+      throw new ConvexError(`A ${container.type} holds ${rules.noun}, not ${member.type}`);
     }
 
     const existing = await ctx.db

--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -355,6 +355,7 @@ async function rulesetsSlotting(ctx: QueryCtx, assetId: Id<'assets'>) {
 /**
  * Who holds the slug for this type — a living asset, a soft-deleted one whose address stays reserved, or nobody.
  * One rule read twice: the save guard refuses on it, and the editors' live conflict check subscribes to it, so the warning and the refusal can never disagree.
+ * The take is safe because per-type uniqueness is guarded on every write, deleted rows included: a slug is held by at most one row per type, so the set is bounded by the type registry's size, far under fifty.
  */
 async function assetSlugHolder(ctx: QueryCtx, type: string, slug: string): Promise<'live' | 'deleted' | null> {
   const holders = await ctx.db
@@ -368,11 +369,11 @@ async function assetSlugHolder(ctx: QueryCtx, type: string, slug: string): Promi
   return holder.is_deleted ? 'deleted' : 'live';
 }
 
-/** The editors' live name-conflict check, the save guard's rule as a subscription. */
+/** The editors' live name-conflict check: the save guard's rule as a subscription, holder kind included, so the warning can speak the refusal's own words. */
 export const slugTaken = query({
   args: { type: v.string(), slug: v.string() },
-  returns: v.boolean(),
-  handler: async (ctx, args) => (await assetSlugHolder(ctx, args.type, args.slug)) !== null,
+  returns: v.union(v.literal('live'), v.literal('deleted'), v.null()),
+  handler: async (ctx, args) => await assetSlugHolder(ctx, args.type, args.slug),
 });
 
 async function assertAssetSlugAvailable(ctx: MutationCtx, type: string, slug: string) {

--- a/convex/assets.ts
+++ b/convex/assets.ts
@@ -6,7 +6,7 @@ import {
   PUBLICATION_TARGETS,
   publicationFaceId,
 } from '../src/shared/asset-publishing/publicationTargets';
-import { ASSET_TYPE_KEYS, ASSET_TYPES, isAssetType } from '../src/shared/assets/types';
+import { ASSET_TYPE_KEYS } from '../src/shared/assets/types';
 import type { Doc, Id } from './_generated/dataModel';
 import { query } from './_generated/server';
 import { publicationStatusFor } from './assetPublishingStatus';
@@ -353,29 +353,36 @@ async function rulesetsSlotting(ctx: QueryCtx, assetId: Id<'assets'>) {
 }
 
 /**
- * Whether an asset of this type already holds the slug — soft-deleted rows included, since their address stays reserved.
+ * Who holds the slug for this type — a living asset, a soft-deleted one whose address stays reserved, or nobody.
  * One rule read twice: the save guard refuses on it, and the editors' live conflict check subscribes to it, so the warning and the refusal can never disagree.
  */
-async function assetSlugHeld(ctx: QueryCtx, type: string, slug: string): Promise<boolean> {
+async function assetSlugHolder(ctx: QueryCtx, type: string, slug: string): Promise<'live' | 'deleted' | null> {
   const holders = await ctx.db
     .query('assets')
     .withIndex('by_slug', (q) => q.eq('slug', slug))
     .take(50);
-  return holders.some((row) => row.type === type);
+  const holder = holders.find((row) => row.type === type);
+  if (!holder) {
+    return null;
+  }
+  return holder.is_deleted ? 'deleted' : 'live';
 }
 
 /** The editors' live name-conflict check, the save guard's rule as a subscription. */
 export const slugTaken = query({
   args: { type: v.string(), slug: v.string() },
   returns: v.boolean(),
-  handler: async (ctx, args) => await assetSlugHeld(ctx, args.type, args.slug),
+  handler: async (ctx, args) => (await assetSlugHolder(ctx, args.type, args.slug)) !== null,
 });
 
 async function assertAssetSlugAvailable(ctx: MutationCtx, type: string, slug: string) {
-  if (await assetSlugHeld(ctx, type, slug)) {
-    /* A ConvexError, so the words reach the editor's banner in production; a plain Error is redacted to "Server Error" (Norbert hit exactly that, 2026-08-22). */
-    const noun = isAssetType(type) ? ASSET_TYPES[type].shortLabel.toLowerCase() : type;
-    throw new ConvexError(`The name is taken: another ${noun} already lives at "${slug}". Pick a different name.`);
+  /* A ConvexError, so the words reach the editor's banner in production; a plain Error is redacted to "Server Error" (Norbert hit exactly that, 2026-08-22). No type noun: the registry's labels are plural pile captions, not singular nouns, and borrowing one produced "another decks". */
+  const holder = await assetSlugHolder(ctx, type, slug);
+  if (holder === 'live') {
+    throw new ConvexError(`The name is taken: another one already lives at "${slug}". Pick a different name.`);
+  }
+  if (holder === 'deleted') {
+    throw new ConvexError(`The name is taken: "${slug}" stays reserved by a deleted asset. Pick a different name.`);
   }
 }
 
@@ -590,7 +597,7 @@ export const setMemberCount = mutation({
     }
     const rules = CONTAINER_KINDS[container.type];
     if (!rules) {
-      throw new ConvexError(`Asset type ${container.type} holds nothing`);
+      throw new Error(`Asset type ${container.type} holds nothing`);
     }
     await requireAssetUpdate(ctx, args.container_id, nameOf(container));
 
@@ -599,7 +606,7 @@ export const setMemberCount = mutation({
       throw new Error(`Asset with id ${args.member_id} not found`);
     }
     if (!rules.holds(member.type)) {
-      throw new ConvexError(`A ${container.type} holds ${rules.noun}, not ${member.type}`);
+      throw new Error(`A ${container.type} holds ${rules.noun}, not ${member.type}`);
     }
 
     const existing = await ctx.db

--- a/convex/assets.write.test.ts
+++ b/convex/assets.write.test.ts
@@ -2,6 +2,7 @@
 // @vitest-environment edge-runtime
 
 import { convexTest } from 'convex-test';
+import { ConvexError } from 'convex/values';
 import { describe, expect, test } from 'vitest';
 
 import { publicationFaceId } from '../src/shared/asset-publishing/publicationTargets';
@@ -84,7 +85,7 @@ describe('asset update', () => {
 
     await expect(
       t.withIdentity({ subject: ownerId }).mutation(api.assets.update, { id: created.id, data: cardData('Stunner') })
-    ).rejects.toThrow('reserved');
+    ).rejects.toThrow('already lives at');
   });
 });
 
@@ -101,7 +102,7 @@ describe('asset soft delete', () => {
       t
         .withIdentity({ subject: ownerId })
         .mutation(api.assets.create, { type: 'card-treachery', data: cardData('Lasgun') })
-    ).rejects.toThrow('reserved');
+    ).rejects.toThrow('already lives at');
   });
 
   test('deletion is owner-only, even for a viewer who may edit', async () => {
@@ -841,5 +842,25 @@ describe('deck cardback references', () => {
 
     const page = await t.query(api.assets.getPage, { type: 'deck', slug: 'wearer' });
     expect(page?.resolvedBack).toEqual({ mode: 'dangling', href: '/web/no-deck-back.svg' });
+  });
+});
+
+describe('name conflicts', () => {
+  test('a colliding name is refused with words that reach the client, and the live check agrees', async () => {
+    const t = convexTest(schema, modules);
+    const { ownerId } = await seedCard(t);
+
+    /* The refusal must be a ConvexError: a plain Error is redacted to "Server Error" in production, which is how finding 19 was born. */
+    const attempt = t
+      .withIdentity({ subject: ownerId })
+      .mutation(api.assets.create, { type: 'card-treachery', data: cardData('Lasgun!') });
+    await expect(attempt).rejects.toThrow(ConvexError);
+    await expect(attempt).rejects.toThrow('another treachery already lives at "lasgun"');
+
+    /* The editors' subscription reads the same rule, so the warning and the refusal cannot disagree. */
+    expect(await t.query(api.assets.slugTaken, { type: 'card-treachery', slug: 'lasgun' })).toBe(true);
+    expect(await t.query(api.assets.slugTaken, { type: 'card-treachery', slug: 'free-name' })).toBe(false);
+    /* Another type may hold the same slug; the reservation is per type. */
+    expect(await t.query(api.assets.slugTaken, { type: 'deck', slug: 'lasgun' })).toBe(false);
   });
 });

--- a/convex/assets.write.test.ts
+++ b/convex/assets.write.test.ts
@@ -103,6 +103,7 @@ describe('asset soft delete', () => {
         .withIdentity({ subject: ownerId })
         .mutation(api.assets.create, { type: 'card-treachery', data: cardData('Lasgun') })
     ).rejects.toThrow('stays reserved by a deleted asset');
+    expect(await t.query(api.assets.slugTaken, { type: 'card-treachery', slug: 'lasgun' })).toBe('deleted');
   });
 
   test('deletion is owner-only, even for a viewer who may edit', async () => {
@@ -857,10 +858,10 @@ describe('name conflicts', () => {
     await expect(attempt).rejects.toThrow(ConvexError);
     await expect(attempt).rejects.toThrow('another one already lives at "lasgun"');
 
-    /* The editors' subscription reads the same rule, so the warning and the refusal cannot disagree. */
-    expect(await t.query(api.assets.slugTaken, { type: 'card-treachery', slug: 'lasgun' })).toBe(true);
-    expect(await t.query(api.assets.slugTaken, { type: 'card-treachery', slug: 'free-name' })).toBe(false);
+    /* The editors' subscription reads the same rule, holder kind included, so the warning and the refusal cannot disagree — not even about whether the holder lives. */
+    expect(await t.query(api.assets.slugTaken, { type: 'card-treachery', slug: 'lasgun' })).toBe('live');
+    expect(await t.query(api.assets.slugTaken, { type: 'card-treachery', slug: 'free-name' })).toBeNull();
     /* Another type may hold the same slug; the reservation is per type. */
-    expect(await t.query(api.assets.slugTaken, { type: 'deck', slug: 'lasgun' })).toBe(false);
+    expect(await t.query(api.assets.slugTaken, { type: 'deck', slug: 'lasgun' })).toBeNull();
   });
 });

--- a/convex/assets.write.test.ts
+++ b/convex/assets.write.test.ts
@@ -102,7 +102,7 @@ describe('asset soft delete', () => {
       t
         .withIdentity({ subject: ownerId })
         .mutation(api.assets.create, { type: 'card-treachery', data: cardData('Lasgun') })
-    ).rejects.toThrow('already lives at');
+    ).rejects.toThrow('stays reserved by a deleted asset');
   });
 
   test('deletion is owner-only, even for a viewer who may edit', async () => {
@@ -855,7 +855,7 @@ describe('name conflicts', () => {
       .withIdentity({ subject: ownerId })
       .mutation(api.assets.create, { type: 'card-treachery', data: cardData('Lasgun!') });
     await expect(attempt).rejects.toThrow(ConvexError);
-    await expect(attempt).rejects.toThrow('another treachery already lives at "lasgun"');
+    await expect(attempt).rejects.toThrow('another one already lives at "lasgun"');
 
     /* The editors' subscription reads the same rule, so the warning and the refusal cannot disagree. */
     expect(await t.query(api.assets.slugTaken, { type: 'card-treachery', slug: 'lasgun' })).toBe(true);

--- a/convex/factions.slugReservations.test.ts
+++ b/convex/factions.slugReservations.test.ts
@@ -45,7 +45,7 @@ describe('faction slug reservations', () => {
     await asUser.mutation(api.factions.softDelete, { id: faction._id });
 
     await expect(createFaction(asUser, 'Reserved Faction')).rejects.toThrow(
-      'Faction slug reserved-faction is reserved'
+      'another faction already lives at "reserved-faction"'
     );
   });
 
@@ -60,7 +60,7 @@ describe('faction slug reservations', () => {
         id: active._id,
         data: { ...assetPublishingFaction, name: 'Reserved Faction' },
       })
-    ).rejects.toThrow('Faction slug reserved-faction is reserved');
+    ).rejects.toThrow('another faction already lives at "reserved-faction"');
   });
 
   test('the repair keeps the active public slug and archives the deleted duplicate', async () => {

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -1,4 +1,4 @@
-import { v } from 'convex/values';
+import { ConvexError, v } from 'convex/values';
 
 import type { Doc, Id } from './_generated/dataModel';
 import { query } from './_generated/server';
@@ -37,7 +37,7 @@ async function assertFactionSlugAvailable(ctx: MutationCtx, slug: string, factio
     .withIndex('by_slug', (q) => q.eq('slug', slug))
     .unique();
   if (existing && existing._id !== factionId) {
-    throw new Error(`Faction slug ${slug} is reserved`);
+    throw new ConvexError(`The name is taken: another faction already lives at "${slug}". Pick a different name.`);
   }
 }
 

--- a/convex/lib/assetBacks.ts
+++ b/convex/lib/assetBacks.ts
@@ -86,7 +86,8 @@ export async function assertReferenceableTokenBack(
   }
   const target = await ctx.db.get('assets', targetId);
   if (!target || target.is_deleted) {
-    throw new Error(`Asset with id ${targetId} not found`);
+    /* Race-reachable: the target can be deleted between the pick and the save, so the refusal speaks. */
+    throw new ConvexError('The referenced token no longer exists; pick another back');
   }
   /* Same shape only: the back is the reverse of this physical piece, so a different shape would render clipped. */
   if (target.type !== row.type) {
@@ -109,7 +110,8 @@ export async function assertReferenceableDeckCardback(
   }
   const target = await ctx.db.get('assets', targetId);
   if (!target || target.is_deleted) {
-    throw new Error(`Asset with id ${targetId} not found`);
+    /* Race-reachable: the target can be deleted between the pick and the save, so the refusal speaks. */
+    throw new ConvexError('The referenced deck no longer exists; pick another cardback');
   }
   if (target.type !== 'deck') {
     throw new ConvexError('A cardback reference must name a deck');

--- a/convex/lib/assetBacks.ts
+++ b/convex/lib/assetBacks.ts
@@ -1,3 +1,5 @@
+import { ConvexError } from 'convex/values';
+
 import { NO_DECK_BACK_HREF } from '../../src/shared/asset-publishing/fallbacks';
 import { publicationFaceId, isPublicationAssetType } from '../../src/shared/asset-publishing/publicationTargets';
 import type { Doc, Id } from '../_generated/dataModel';
@@ -80,7 +82,7 @@ export async function assertReferenceableTokenBack(
   targetId: Id<'assets'>
 ): Promise<Doc<'assets'>> {
   if (row._id !== null && targetId === row._id) {
-    throw new Error('A token cannot reference itself; use the same-front-and-back mode');
+    throw new ConvexError('A token cannot reference itself; use the same-front-and-back mode');
   }
   const target = await ctx.db.get('assets', targetId);
   if (!target || target.is_deleted) {
@@ -88,10 +90,10 @@ export async function assertReferenceableTokenBack(
   }
   /* Same shape only: the back is the reverse of this physical piece, so a different shape would render clipped. */
   if (target.type !== row.type) {
-    throw new Error(`A ${row.type} backside must also be a ${row.type}`);
+    throw new ConvexError(`A ${row.type} backside must also be a ${row.type}`);
   }
   if (!hasAuthoredBack(target)) {
-    throw new Error('Only a token with an authored back can be referenced');
+    throw new ConvexError('Only a token with an authored back can be referenced');
   }
   return target;
 }
@@ -103,18 +105,18 @@ export async function assertReferenceableDeckCardback(
   targetId: Id<'assets'>
 ): Promise<Doc<'assets'>> {
   if (row._id !== null && targetId === row._id) {
-    throw new Error('A deck cannot reference its own cardback');
+    throw new ConvexError('A deck cannot reference its own cardback');
   }
   const target = await ctx.db.get('assets', targetId);
   if (!target || target.is_deleted) {
     throw new Error(`Asset with id ${targetId} not found`);
   }
   if (target.type !== 'deck') {
-    throw new Error('A cardback reference must name a deck');
+    throw new ConvexError('A cardback reference must name a deck');
   }
   const cardback = deckCardbackOf(target.data);
   if (!cardback || !cardbackComposition(cardback)) {
-    throw new Error('Only a deck with an authored cardback can be referenced');
+    throw new ConvexError('Only a deck with an authored cardback can be referenced');
   }
   return target;
 }

--- a/convex/lib/utils.ts
+++ b/convex/lib/utils.ts
@@ -2,14 +2,7 @@ export function nowIso() {
   return new Date().toISOString();
 }
 
-export function slugify(value: string) {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .replace(/-{2,}/g, '-');
-}
+export { slugify } from '../../src/shared/slugify';
 
 export function ensureObject(value: unknown) {
   if (value == null || typeof value !== 'object' || Array.isArray(value)) {

--- a/docs/technical/ui-design-decisions.md
+++ b/docs/technical/ui-design-decisions.md
@@ -147,11 +147,9 @@ states, and scatters a screen's authoritative shape across Convex functions. Eac
 **at most one Convex query for page data**, plus `useCurrentProfile` when the UI is auth-aware;
 derive UI-ready fields inside that query, and pass small server-derived collections into controls
 through it rather than adding child subscriptions. The one documented exception is a lazily-mounted
-[Picker](#pickers-are-the-one-place-a-component-may-fetch), which may hold its own read-only options
-subscription — so a control choosing from a large set never forces those rows into the page query.
-The second is the editors' name-conflict probe: a debounced, conditionally-mounted read of
-`assets.slugTaken` that warns about a colliding name while the author types, which cannot ride the
-page query because the candidate slug changes with every settled keystroke.
+[Picker](#pickers-are-the-one-place-a-component-may-fetch), which may hold its own read-only
+subscription — so a control whose read depends on its own transient state (a search, a candidate
+name) never forces that churn into the page query.
 This subscription discipline is the real reason widgets don't fetch and Pickers fetch only lazily.
 Mutations don't count.
 

--- a/docs/technical/ui-design-decisions.md
+++ b/docs/technical/ui-design-decisions.md
@@ -149,6 +149,9 @@ derive UI-ready fields inside that query, and pass small server-derived collecti
 through it rather than adding child subscriptions. The one documented exception is a lazily-mounted
 [Picker](#pickers-are-the-one-place-a-component-may-fetch), which may hold its own read-only options
 subscription — so a control choosing from a large set never forces those rows into the page query.
+The second is the editors' name-conflict probe: a debounced, conditionally-mounted read of
+`assets.slugTaken` that warns about a colliding name while the author types, which cannot ride the
+page query because the candidate slug changes with every settled keystroke.
 This subscription discipline is the real reason widgets don't fetch and Pickers fetch only lazily.
 Mutations don't count.
 

--- a/docs/technical/ui-design-decisions.md
+++ b/docs/technical/ui-design-decisions.md
@@ -147,9 +147,8 @@ states, and scatters a screen's authoritative shape across Convex functions. Eac
 **at most one Convex query for page data**, plus `useCurrentProfile` when the UI is auth-aware;
 derive UI-ready fields inside that query, and pass small server-derived collections into controls
 through it rather than adding child subscriptions. The one documented exception is a lazily-mounted
-[Picker](#pickers-are-the-one-place-a-component-may-fetch), which may hold its own read-only
-subscription — so a control whose read depends on its own transient state (a search, a candidate
-name) never forces that churn into the page query.
+[Picker](#pickers-are-the-one-place-a-component-may-fetch), which may hold its own read-only options
+subscription — so a control choosing from a large set never forces those rows into the page query.
 This subscription discipline is the real reason widgets don't fetch and Pickers fetch only lazily.
 Mutations don't count.
 

--- a/src/app/db/assets.ts
+++ b/src/app/db/assets.ts
@@ -44,10 +44,10 @@ export function useAssetBrowsePage(type: string, options?: { initialData?: Asset
 
 /**
  * The save guard's slug rule as a live subscription, for the editors' name-conflict warning.
- * `null` type-or-slug skips the read entirely, so an empty draft name costs nothing.
+ * Always real args: the caller mounts and unmounts the component holding this, which is how a domain read stays conditional without a skip.
  */
-export function useAssetSlugTaken(args: { type: string; slug: string } | null) {
-  return useQuery(api.assets.slugTaken, args ?? 'skip');
+export function useAssetSlugTaken(args: { type: string; slug: string }) {
+  return useQuery(api.assets.slugTaken, args);
 }
 
 export function useCreateAsset() {

--- a/src/app/db/assets.ts
+++ b/src/app/db/assets.ts
@@ -42,6 +42,14 @@ export function useAssetBrowsePage(type: string, options?: { initialData?: Asset
   return toLiveQueryResult(liveData, true, () => options?.initialData);
 }
 
+/**
+ * The save guard's slug rule as a live subscription, for the editors' name-conflict warning.
+ * `null` type-or-slug skips the read entirely, so an empty draft name costs nothing.
+ */
+export function useAssetSlugTaken(args: { type: string; slug: string } | null) {
+  return useQuery(api.assets.slugTaken, args ?? 'skip');
+}
+
 export function useCreateAsset() {
   return useLiveMutation<{ type: string; data: unknown }, { id: string; slug: string }>(api.assets.create);
 }

--- a/src/app/db/core/mutationError.test.ts
+++ b/src/app/db/core/mutationError.test.ts
@@ -1,0 +1,21 @@
+import { ConvexError } from 'convex/values';
+import { describe, expect, test } from 'vitest';
+
+import { mutationErrorMessage } from './mutationError';
+
+describe('mutation error words', () => {
+  test('a ConvexError speaks its own refusal', () => {
+    const error = new ConvexError(
+      'The name is taken: another treachery already lives at "shield". Pick a different name.'
+    );
+    expect(mutationErrorMessage(error)).toBe(
+      'The name is taken: another treachery already lives at "shield". Pick a different name.'
+    );
+  });
+
+  test('anything else keeps its message, redaction and all', () => {
+    expect(mutationErrorMessage(new Error('[CONVEX M(assets:create)] Server Error'))).toBe(
+      '[CONVEX M(assets:create)] Server Error'
+    );
+  });
+});

--- a/src/app/db/core/mutationError.ts
+++ b/src/app/db/core/mutationError.ts
@@ -1,0 +1,13 @@
+import { ConvexError } from 'convex/values';
+
+/**
+ * The words an editor's error banner shows for a failed write.
+ * A `ConvexError` carries the server's own refusal ("the name is taken…") in its data and is shown verbatim;
+ * anything else is a genuine server failure, whose redacted message is exactly what the reader should see — an anonymous error is the honest rendering of one.
+ */
+export function mutationErrorMessage(error: Error): string {
+  if (error instanceof ConvexError && typeof error.data === 'string') {
+    return error.data;
+  }
+  return error.message;
+}

--- a/src/app/pickers/AssetNameInput.tsx
+++ b/src/app/pickers/AssetNameInput.tsx
@@ -1,0 +1,52 @@
+import { useEffect } from 'react';
+
+import { useAssetSlugTaken } from '@app/db/assets';
+
+import { UniqueNameInput } from './UniqueNameInput';
+import type { NameConflict, NameHolder } from './UniqueNameInput';
+
+/** The subscription half, mounted by `UniqueNameInput` only while a settled candidate exists. */
+function AssetSlugProbe({
+  type,
+  slug,
+  onAnswer,
+}: {
+  type: string;
+  slug: string;
+  onAnswer: (holder: NameHolder | null) => void;
+}) {
+  const holder = useAssetSlugTaken({ type, slug });
+  useEffect(() => {
+    onAnswer(holder ?? null);
+  }, [holder, onAnswer]);
+  return null;
+}
+
+/**
+ * The asset editors' name field: `UniqueNameInput` bound to the assets table's own slug rule.
+ * The save guard and this probe read one predicate, so the warning and the refusal can never disagree.
+ * Another entity gets the same behavior by binding its own probe to `UniqueNameInput`, the way this does.
+ */
+export function AssetNameInput({
+  type,
+  value,
+  onChange,
+  currentSlug,
+  onConflictChange,
+}: {
+  type: string;
+  value: string;
+  onChange: (name: string) => void;
+  currentSlug?: string;
+  onConflictChange: (conflict: NameConflict | null) => void;
+}) {
+  return (
+    <UniqueNameInput
+      value={value}
+      onChange={onChange}
+      currentSlug={currentSlug}
+      onConflictChange={onConflictChange}
+      probe={({ slug, onAnswer }) => <AssetSlugProbe key={slug} type={type} slug={slug} onAnswer={onAnswer} />}
+    />
+  );
+}

--- a/src/app/pickers/UniqueNameInput.test.tsx
+++ b/src/app/pickers/UniqueNameInput.test.tsx
@@ -1,0 +1,76 @@
+/** @vitest-environment jsdom */
+
+import { MantineProvider } from '@mantine/core';
+import { act, cleanup, render } from '@testing-library/react';
+import { appContentTheme } from '@ui/theme';
+import { useEffect } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UniqueNameInput, nameConflictComplaint } from './UniqueNameInput';
+import type { NameHolder } from './UniqueNameInput';
+
+const TAKEN: Record<string, NameHolder> = { shield: 'live' };
+
+/** Answers like a real probe binding: mounted per settled slug, reporting from an effect. */
+function FakeProbe({ slug, onAnswer }: { slug: string; onAnswer: (holder: NameHolder | null) => void }) {
+  useEffect(() => {
+    onAnswer(TAKEN[slug] ?? null);
+  }, [slug, onAnswer]);
+  return null;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+const field = (value: string, onConflictChange: (conflict: unknown) => void, currentSlug?: string) => (
+  <MantineProvider theme={appContentTheme}>
+    <UniqueNameInput
+      value={value}
+      onChange={() => {}}
+      currentSlug={currentSlug}
+      onConflictChange={onConflictChange}
+      probe={({ slug, onAnswer }) => <FakeProbe key={slug} slug={slug} onAnswer={onAnswer} />}
+    />
+  </MantineProvider>
+);
+
+describe('UniqueNameInput', () => {
+  it('warns about a taken name after the settle, and the verdict never follows the author to a new name', () => {
+    const onConflictChange = vi.fn();
+    const view = render(field('', onConflictChange));
+    view.rerender(field('Shield', onConflictChange));
+    expect(view.queryByText(nameConflictComplaint({ holder: 'live', slug: 'shield' }))).toBeNull();
+
+    act(() => vi.advanceTimersByTime(400));
+    expect(view.getByText(nameConflictComplaint({ holder: 'live', slug: 'shield' }))).not.toBeNull();
+    expect(onConflictChange).toHaveBeenLastCalledWith({ holder: 'live', slug: 'shield' });
+
+    /* Switching to a free name clears the warning at once, and shield's verdict must never surface tagged with the new slug. */
+    view.rerender(field('Lasgun', onConflictChange));
+    expect(view.queryByText(nameConflictComplaint({ holder: 'live', slug: 'shield' }))).toBeNull();
+    act(() => vi.advanceTimersByTime(400));
+    expect(onConflictChange).not.toHaveBeenCalledWith(expect.objectContaining({ slug: 'lasgun' }));
+    expect(onConflictChange).toHaveBeenLastCalledWith(null);
+  });
+
+  it('never questions an unchanged name on an edit page', () => {
+    const onConflictChange = vi.fn();
+    const view = render(field('Shield', onConflictChange, 'shield'));
+    act(() => vi.advanceTimersByTime(400));
+    expect(view.queryByText(nameConflictComplaint({ holder: 'live', slug: 'shield' }))).toBeNull();
+    expect(onConflictChange).not.toHaveBeenCalledWith(expect.objectContaining({ slug: 'shield' }));
+  });
+});

--- a/src/app/pickers/UniqueNameInput.tsx
+++ b/src/app/pickers/UniqueNameInput.tsx
@@ -1,6 +1,6 @@
 import { TextInput } from '@mantine/core';
 import { slugify } from '@shared/slugify';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 
 /** Who holds the candidate's address: a living entity, a deleted one whose slug stays reserved, or nobody. */
@@ -40,7 +40,7 @@ function useSettledConflict({
   currentSlug?: string;
   onConflictChange: (conflict: NameConflict | null) => void;
 }) {
-  const [answer, setAnswer] = useState<NameHolder | null>(null);
+  const [answer, setAnswer] = useState<{ slug: string; holder: NameHolder | null } | null>(null);
   const slug = slugify(value);
   const candidate = slug.length > 0 && slug !== currentSlug ? slug : null;
   const [settled, setSettled] = useState<string | null>(candidate);
@@ -48,7 +48,12 @@ function useSettledConflict({
     const timer = setTimeout(() => setSettled(candidate), 400);
     return () => clearTimeout(timer);
   }, [candidate]);
-  const holder = candidate && settled === candidate ? answer : null;
+  /* The answer carries the slug it was asked about, so a swapped probe can never lend an old verdict to a new name. */
+  const onAnswer = useCallback(
+    (holder: NameHolder | null) => setAnswer(settled ? { slug: settled, holder } : null),
+    [settled]
+  );
+  const holder = candidate && settled === candidate && answer?.slug === candidate ? answer.holder : null;
   const conflict = holder && candidate ? { holder, slug: candidate } : null;
 
   /* Reported from an effect, not render: the parent stores it in state for the header. */
@@ -59,7 +64,7 @@ function useSettledConflict({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [conflictKey]);
 
-  return { settled, conflict, onAnswer: setAnswer };
+  return { settled, conflict, onAnswer };
 }
 
 /**

--- a/src/app/pickers/UniqueNameInput.tsx
+++ b/src/app/pickers/UniqueNameInput.tsx
@@ -67,6 +67,8 @@ function useSettledConflict({
  *
  * A Picker in the taxonomy's sense: the one kind of control that may hold its own lazily-mounted subscription, so the page query never learns about candidate slugs.
  * Entity-blind by design — the `probe` prop carries the per-entity read, and a new entity joins by binding its own probe, not by touching this.
+ * One assumption is baked in: names become addresses through the shared `slugify`.
+ * The first entity that derives addresses differently, the way profiles carry their own validation, moves that mapping into the binding beside the probe.
  *
  * The candidate settles before the probe mounts: each distinct slug is a subscription swap, and a name typed letter by letter walks through every prefix.
  * The pause also keeps a colliding prefix from flashing a warning on the way to a free name.

--- a/src/app/pickers/UniqueNameInput.tsx
+++ b/src/app/pickers/UniqueNameInput.tsx
@@ -1,0 +1,88 @@
+import { TextInput } from '@mantine/core';
+import { slugify } from '@shared/slugify';
+import { useEffect, useState } from 'react';
+import type { ReactNode } from 'react';
+
+/** Who holds the candidate's address: a living entity, a deleted one whose slug stays reserved, or nobody. */
+export type NameHolder = 'live' | 'deleted';
+
+export type NameConflict = { holder: NameHolder; slug: string };
+
+/**
+ * One entity's availability read, as a component: mounted with the settled slug, it subscribes and reports who holds the address.
+ * The per-entity pickers supply it, which is what keeps this input entity-blind while every entity can wear it.
+ */
+export type NameAvailabilityProbe = (props: {
+  slug: string;
+  onAnswer: (holder: NameHolder | null) => void;
+}) => ReactNode;
+
+/**
+ * The one sentence a name conflict speaks on the client, shared by the field's inline error and the validation header's chip so the two cannot drift.
+ * It mirrors the save guard's own distinction: a living holder and a deleted one reserving its address are different answers.
+ */
+export function nameConflictComplaint({ holder, slug }: NameConflict): string {
+  return holder === 'deleted'
+    ? `its name is already taken ("${slug}" stays reserved by a deleted asset)`
+    : `its name is already taken (another one lives at "${slug}")`;
+}
+
+/**
+ * A name field that checks its address is free while the author types.
+ *
+ * A Picker in the taxonomy's sense: the one kind of control that may hold its own lazily-mounted subscription, so the page query never learns about candidate slugs.
+ * Entity-blind by design — the `probe` prop carries the per-entity read, and a new entity joins by binding its own probe, not by touching this.
+ *
+ * The candidate settles before the probe mounts: each distinct slug is a subscription swap, and a name typed letter by letter walks through every prefix.
+ * The pause also keeps a colliding prefix from flashing a warning on the way to a free name.
+ * Blank names and an edit page's unchanged name mount nothing at all.
+ *
+ * The conflict shows twice on purpose: inline under the field where the author is looking, and through `onConflictChange` so the route can raise it in the validation header, whose chip routes back to this chapter.
+ */
+export function UniqueNameInput({
+  label = 'Name',
+  value,
+  onChange,
+  currentSlug,
+  probe,
+  onConflictChange,
+}: {
+  label?: string;
+  value: string;
+  onChange: (name: string) => void;
+  /** The entity's own slug on an edit page, so an unchanged name never warns about its own address. */
+  currentSlug?: string;
+  probe: NameAvailabilityProbe;
+  onConflictChange: (conflict: NameConflict | null) => void;
+}) {
+  const [answer, setAnswer] = useState<NameHolder | null>(null);
+  const slug = slugify(value);
+  const candidate = slug.length > 0 && slug !== currentSlug ? slug : null;
+  const [settled, setSettled] = useState<string | null>(candidate);
+  useEffect(() => {
+    const timer = setTimeout(() => setSettled(candidate), 400);
+    return () => clearTimeout(timer);
+  }, [candidate]);
+  const holder = candidate && settled === candidate ? answer : null;
+  const conflict = holder && candidate ? { holder, slug: candidate } : null;
+
+  /* Reported from an effect, not render: the parent stores it in state for the header. */
+  const conflictKey = conflict ? `${conflict.holder}:${conflict.slug}` : null;
+  useEffect(() => {
+    onConflictChange(conflict);
+    /* Keyed by content rather than identity, so a re-render with the same answer does not loop the parent's state. */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conflictKey]);
+
+  return (
+    <>
+      {settled ? probe({ slug: settled, onAnswer: setAnswer }) : null}
+      <TextInput
+        aria-label={label}
+        value={value}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        error={conflict ? nameConflictComplaint(conflict) : undefined}
+      />
+    </>
+  );
+}

--- a/src/app/pickers/UniqueNameInput.tsx
+++ b/src/app/pickers/UniqueNameInput.tsx
@@ -28,6 +28,41 @@ export function nameConflictComplaint({ holder, slug }: NameConflict): string {
 }
 
 /**
+ * The settle-and-ask half of the field: the candidate slug, its debounce, the probe's answer, and the reported conflict.
+ * Apart from the rendering so the component is a plain view of its result.
+ */
+function useSettledConflict({
+  value,
+  currentSlug,
+  onConflictChange,
+}: {
+  value: string;
+  currentSlug?: string;
+  onConflictChange: (conflict: NameConflict | null) => void;
+}) {
+  const [answer, setAnswer] = useState<NameHolder | null>(null);
+  const slug = slugify(value);
+  const candidate = slug.length > 0 && slug !== currentSlug ? slug : null;
+  const [settled, setSettled] = useState<string | null>(candidate);
+  useEffect(() => {
+    const timer = setTimeout(() => setSettled(candidate), 400);
+    return () => clearTimeout(timer);
+  }, [candidate]);
+  const holder = candidate && settled === candidate ? answer : null;
+  const conflict = holder && candidate ? { holder, slug: candidate } : null;
+
+  /* Reported from an effect, not render: the parent stores it in state for the header. */
+  const conflictKey = conflict ? `${conflict.holder}:${conflict.slug}` : null;
+  useEffect(() => {
+    onConflictChange(conflict);
+    /* Keyed by content rather than identity, so a re-render with the same answer does not loop the parent's state. */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [conflictKey]);
+
+  return { settled, conflict, onAnswer: setAnswer };
+}
+
+/**
  * A name field that checks its address is free while the author types.
  *
  * A Picker in the taxonomy's sense: the one kind of control that may hold its own lazily-mounted subscription, so the page query never learns about candidate slugs.
@@ -55,28 +90,10 @@ export function UniqueNameInput({
   probe: NameAvailabilityProbe;
   onConflictChange: (conflict: NameConflict | null) => void;
 }) {
-  const [answer, setAnswer] = useState<NameHolder | null>(null);
-  const slug = slugify(value);
-  const candidate = slug.length > 0 && slug !== currentSlug ? slug : null;
-  const [settled, setSettled] = useState<string | null>(candidate);
-  useEffect(() => {
-    const timer = setTimeout(() => setSettled(candidate), 400);
-    return () => clearTimeout(timer);
-  }, [candidate]);
-  const holder = candidate && settled === candidate ? answer : null;
-  const conflict = holder && candidate ? { holder, slug: candidate } : null;
-
-  /* Reported from an effect, not render: the parent stores it in state for the header. */
-  const conflictKey = conflict ? `${conflict.holder}:${conflict.slug}` : null;
-  useEffect(() => {
-    onConflictChange(conflict);
-    /* Keyed by content rather than identity, so a re-render with the same answer does not loop the parent's state. */
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [conflictKey]);
-
+  const { settled, conflict, onAnswer } = useSettledConflict({ value, currentSlug, onConflictChange });
   return (
     <>
-      {settled ? probe({ slug: settled, onAnswer: setAnswer }) : null}
+      {settled ? probe({ slug: settled, onAnswer }) : null}
       <TextInput
         aria-label={label}
         value={value}

--- a/src/app/pickers/UniqueNameInput.tsx
+++ b/src/app/pickers/UniqueNameInput.tsx
@@ -27,6 +27,28 @@ export function nameConflictComplaint({ holder, slug }: NameConflict): string {
     : `its name is already taken (another one lives at "${slug}")`;
 }
 
+/** The slug worth asking about: non-empty and not the entity's own address. */
+function candidateSlug(value: string, currentSlug?: string): string | null {
+  const slug = slugify(value);
+  return slug.length > 0 && slug !== currentSlug ? slug : null;
+}
+
+/** The verdict that applies right now: only an answer about the settled candidate itself may speak. */
+function activeConflict({
+  candidate,
+  settled,
+  answer,
+}: {
+  candidate: string | null;
+  settled: string | null;
+  answer: { slug: string; holder: NameHolder | null } | null;
+}): NameConflict | null {
+  if (!candidate || settled !== candidate || answer?.slug !== candidate) {
+    return null;
+  }
+  return answer.holder ? { holder: answer.holder, slug: candidate } : null;
+}
+
 /**
  * The settle-and-ask half of the field: the candidate slug, its debounce, the probe's answer, and the reported conflict.
  * Apart from the rendering so the component is a plain view of its result.
@@ -41,8 +63,7 @@ function useSettledConflict({
   onConflictChange: (conflict: NameConflict | null) => void;
 }) {
   const [answer, setAnswer] = useState<{ slug: string; holder: NameHolder | null } | null>(null);
-  const slug = slugify(value);
-  const candidate = slug.length > 0 && slug !== currentSlug ? slug : null;
+  const candidate = candidateSlug(value, currentSlug);
   const [settled, setSettled] = useState<string | null>(candidate);
   useEffect(() => {
     const timer = setTimeout(() => setSettled(candidate), 400);
@@ -53,8 +74,7 @@ function useSettledConflict({
     (holder: NameHolder | null) => setAnswer(settled ? { slug: settled, holder } : null),
     [settled]
   );
-  const holder = candidate && settled === candidate && answer?.slug === candidate ? answer.holder : null;
-  const conflict = holder && candidate ? { holder, slug: candidate } : null;
+  const conflict = activeConflict({ candidate, settled, answer });
 
   /* Reported from an effect, not render: the parent stores it in state for the header. */
   const conflictKey = conflict ? `${conflict.holder}:${conflict.slug}` : null;

--- a/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 
 import { useAssetPage, useSetMemberCount, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetPicker } from '@app/pickers/AssetPicker';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
@@ -22,6 +23,7 @@ import {
   DriftedAssetPage,
   useAssetDeletion,
   useAssetGroupActions,
+  useNameConflict,
 } from '../../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'bundle-validation-header';
@@ -109,7 +111,23 @@ function BundleEditSession({
   const [pickerOpen, setPickerOpen] = useState(false);
   const patch = (update: Partial<BundleDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const tokens = members.map((entry) => ({ token: entry.member, count: entry.count }));
-  const warnings = bundleDraftWarnings(draft, tokens);
+  /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
+  const conflictSlug = useNameConflict({ type: 'bundle', name: draft.name, currentSlug: asset.slug });
+  const warnings: (
+    | ReturnType<typeof bundleDraftWarnings>[number]
+    | { source: string; complaint: string; chapter: BundleChapter }
+  )[] = [
+    ...bundleDraftWarnings(draft, tokens),
+    ...(conflictSlug
+      ? [
+          {
+            source: 'Identity',
+            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
+            chapter: 'identity' as BundleChapter,
+          },
+        ]
+      : []),
+  ];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(baseline);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = updateAsset.isPending
@@ -181,7 +199,7 @@ function BundleEditSession({
         <WorkbenchLayout gap="sm">
           {updateAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
-              {updateAsset.error.message}
+              {mutationErrorMessage(updateAsset.error)}
             </Alert>
           ) : null}
           {deletion.error ? (

--- a/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
@@ -112,22 +112,17 @@ function BundleEditSession({
   const patch = (update: Partial<BundleDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const tokens = members.map((entry) => ({ token: entry.member, count: entry.count }));
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const conflictSlug = useNameConflict({ type: 'bundle', name: draft.name, currentSlug: asset.slug });
+  const { conflictWarnings, conflictProbe } = useNameConflict({
+    type: 'bundle',
+    name: draft.name,
+    currentSlug: asset.slug,
+    source: 'Identity',
+    chapter: 'identity' as BundleChapter,
+  });
   const warnings: (
     | ReturnType<typeof bundleDraftWarnings>[number]
     | { source: string; complaint: string; chapter: BundleChapter }
-  )[] = [
-    ...bundleDraftWarnings(draft, tokens),
-    ...(conflictSlug
-      ? [
-          {
-            source: 'Identity',
-            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
-            chapter: 'identity' as BundleChapter,
-          },
-        ]
-      : []),
-  ];
+  )[] = [...bundleDraftWarnings(draft, tokens), ...conflictWarnings];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(baseline);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = updateAsset.isPending
@@ -197,6 +192,7 @@ function BundleEditSession({
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
+          {conflictProbe}
           {updateAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
               {mutationErrorMessage(updateAsset.error)}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
@@ -10,7 +10,6 @@ import { useState } from 'react';
 
 import { useAssetPage, useSetMemberCount, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
-import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetPicker } from '@app/pickers/AssetPicker';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
@@ -21,6 +20,7 @@ import type { BundleChapter, BundleDraft } from '@app/widgets/bundle-editor/Bund
 import {
   AssetEditorMessage,
   DriftedAssetPage,
+  SaveErrorAlert,
   useAssetDeletion,
   useAssetGroupActions,
   useNameConflict,
@@ -193,11 +193,7 @@ function BundleEditSession({
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
           {conflictProbe}
-          {updateAsset.error ? (
-            <Alert color="red" variant="light" role="alert" title="Could not save">
-              {mutationErrorMessage(updateAsset.error)}
-            </Alert>
-          ) : null}
+          <SaveErrorAlert error={updateAsset.error} />
           {deletion.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not delete">
               {deletion.error.message}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
@@ -24,7 +24,7 @@ import {
   SaveErrorAlert,
   useAssetDeletion,
   useAssetGroupActions,
-  useNameConflict,
+  useAssetNameField,
 } from '../../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'bundle-validation-header';
@@ -113,9 +113,10 @@ function BundleEditSession({
   const patch = (update: Partial<BundleDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const tokens = members.map((entry) => ({ token: entry.member, count: entry.count }));
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const { conflictWarnings, conflictProbe } = useNameConflict({
+  const { nameField, conflictWarnings } = useAssetNameField({
     type: 'bundle',
     name: draft.name,
+    onName: (name) => patch({ name }),
     currentSlug: asset.slug,
     source: 'Identity',
     chapter: 'identity' as BundleChapter,
@@ -193,7 +194,6 @@ function BundleEditSession({
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
-          {conflictProbe}
           <SaveErrorAlert error={updateAsset.error} />
           {deletion.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not delete">
@@ -207,6 +207,7 @@ function BundleEditSession({
             </Alert>
           ) : null}
           <BundleEditor
+            nameField={nameField}
             draft={draft}
             patch={patch}
             chapter={chapter}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 
 import { useAssetPage, useSetMemberCount, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetPicker } from '@app/pickers/AssetPicker';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
@@ -202,7 +203,7 @@ function BundleEditSession({
           {groupActions.error}
           {setCount.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not change the contents">
-              {setCount.error.message}
+              {mutationErrorMessage(setCount.error)}
             </Alert>
           ) : null}
           <BundleEditor

--- a/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react';
 
 import { useAssetPage, useSetMemberCount, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetPicker } from '@app/pickers/AssetPicker';
 import { AssetFace, assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
@@ -270,7 +271,7 @@ function DeckEditSession({
           {groupActions.error}
           {setCount.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not change the composition">
-              {setCount.error.message}
+              {mutationErrorMessage(setCount.error)}
             </Alert>
           ) : null}
           {pickBlocked && pickless ? (

--- a/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
@@ -149,17 +149,15 @@ function DeckEditSession({
    * («How a dangling back reference presents»), routed to Identity, the chapter the back tiles live in.
    */
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const conflictSlug = useNameConflict({ type: 'deck', name: draft.name, currentSlug: asset.slug });
+  const { conflictWarnings, conflictProbe } = useNameConflict({
+    type: 'deck',
+    name: draft.name,
+    currentSlug: asset.slug,
+    source: 'Identity',
+    chapter: 'identity' as DeckChapter,
+  });
   const warnings: (DeckWarning | { source: string; complaint: string; chapter: DeckChapter })[] = [
-    ...(conflictSlug
-      ? [
-          {
-            source: 'Identity',
-            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
-            chapter: 'identity' as DeckChapter,
-          },
-        ]
-      : []),
+    ...conflictWarnings,
     ...deckDraftWarnings(draft, cards),
     ...(danglingBack && draft.cardback.mode === 'reference'
       ? [{ source: 'Cardback', complaint: 'its referenced cardback is gone', chapter: 'identity' as DeckChapter }]
@@ -262,6 +260,7 @@ function DeckEditSession({
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
+          {conflictProbe}
           {updateAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
               {mutationErrorMessage(updateAsset.error)}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
@@ -158,8 +158,8 @@ function DeckEditSession({
     chapter: 'identity' as DeckChapter,
   });
   const warnings: (DeckWarning | { source: string; complaint: string; chapter: DeckChapter })[] = [
-    ...conflictWarnings,
     ...deckDraftWarnings(draft, cards),
+    ...conflictWarnings,
     ...(danglingBack && draft.cardback.mode === 'reference'
       ? [{ source: 'Cardback', complaint: 'its referenced cardback is gone', chapter: 'identity' as DeckChapter }]
       : []),

--- a/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
@@ -14,7 +14,6 @@ import { useState } from 'react';
 
 import { useAssetPage, useSetMemberCount, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
-import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetPicker } from '@app/pickers/AssetPicker';
 import { AssetFace, assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
@@ -26,6 +25,7 @@ import type { DeckChapter, DeckDraft, DeckDraftCardback, DeckWarning } from '@ap
 import {
   AssetEditorMessage,
   DriftedAssetPage,
+  SaveErrorAlert,
   useAssetDeletion,
   useAssetGroupActions,
   useNameConflict,
@@ -261,11 +261,7 @@ function DeckEditSession({
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
           {conflictProbe}
-          {updateAsset.error ? (
-            <Alert color="red" variant="light" role="alert" title="Could not save">
-              {mutationErrorMessage(updateAsset.error)}
-            </Alert>
-          ) : null}
+          <SaveErrorAlert error={updateAsset.error} />
           {deletion.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not delete">
               {deletion.error.message}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
@@ -29,7 +29,7 @@ import {
   SaveErrorAlert,
   useAssetDeletion,
   useAssetGroupActions,
-  useNameConflict,
+  useAssetNameField,
 } from '../../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'deck-validation-header';
@@ -150,9 +150,10 @@ function DeckEditSession({
    * («How a dangling back reference presents»), routed to Identity, the chapter the back tiles live in.
    */
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const { conflictWarnings, conflictProbe } = useNameConflict({
+  const { nameField, conflictWarnings } = useAssetNameField({
     type: 'deck',
     name: draft.name,
+    onName: (name) => patch({ name }),
     currentSlug: asset.slug,
     source: 'Identity',
     chapter: 'identity' as DeckChapter,
@@ -261,7 +262,6 @@ function DeckEditSession({
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
-          {conflictProbe}
           <SaveErrorAlert error={updateAsset.error} />
           {deletion.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not delete">
@@ -280,6 +280,7 @@ function DeckEditSession({
             </Alert>
           ) : null}
           <DeckEditor
+            nameField={nameField}
             draft={draft}
             patch={patch}
             chapter={chapter}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
@@ -14,6 +14,7 @@ import { useState } from 'react';
 
 import { useAssetPage, useSetMemberCount, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetPicker } from '@app/pickers/AssetPicker';
 import { AssetFace, assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
@@ -27,6 +28,7 @@ import {
   DriftedAssetPage,
   useAssetDeletion,
   useAssetGroupActions,
+  useNameConflict,
 } from '../../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'deck-validation-header';
@@ -146,7 +148,18 @@ function DeckEditSession({
    * The dangling complaint rides the widened validation header beside the widget's own warnings
    * («How a dangling back reference presents»), routed to Identity, the chapter the back tiles live in.
    */
+  /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
+  const conflictSlug = useNameConflict({ type: 'deck', name: draft.name, currentSlug: asset.slug });
   const warnings: (DeckWarning | { source: string; complaint: string; chapter: DeckChapter })[] = [
+    ...(conflictSlug
+      ? [
+          {
+            source: 'Identity',
+            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
+            chapter: 'identity' as DeckChapter,
+          },
+        ]
+      : []),
     ...deckDraftWarnings(draft, cards),
     ...(danglingBack && draft.cardback.mode === 'reference'
       ? [{ source: 'Cardback', complaint: 'its referenced cardback is gone', chapter: 'identity' as DeckChapter }]
@@ -251,7 +264,7 @@ function DeckEditSession({
         <WorkbenchLayout gap="sm">
           {updateAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
-              {updateAsset.error.message}
+              {mutationErrorMessage(updateAsset.error)}
             </Alert>
           ) : null}
           {deletion.error ? (

--- a/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
@@ -10,6 +10,7 @@ import { useState } from 'react';
 
 import { useAssetPage, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetPicker } from '@app/pickers/AssetPicker';
 import { assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
@@ -31,6 +32,7 @@ import {
   DriftedAssetPage,
   useAssetDeletion,
   useAssetGroupActions,
+  useNameConflict,
 } from '../../../-assetEditorStates';
 import { referencedRectangleBackFace } from './-referencedBackFace';
 
@@ -149,7 +151,18 @@ function RectangleEditSession({
    * («How a dangling back reference presents»): a signpost, never a second set of mode controls.
    * It routes to Identity, the chapter the back tiles live in.
    */
+  /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
+  const conflictSlug = useNameConflict({ type, name: draft.name, currentSlug: asset.slug });
   const warnings: (RectangleWarning | { source: string; complaint: string; chapter: RectangleChapter })[] = [
+    ...(conflictSlug
+      ? [
+          {
+            source: 'Identity',
+            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
+            chapter: 'identity' as RectangleChapter,
+          },
+        ]
+      : []),
     ...rectangleDraftWarnings(draft),
     ...(danglingBack && draft.back.mode === 'reference'
       ? [{ source: 'Backside', complaint: 'its referenced back is gone', chapter: 'identity' as RectangleChapter }]
@@ -233,7 +246,7 @@ function RectangleEditSession({
         <WorkbenchLayout gap="sm">
           {updateAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
-              {updateAsset.error.message}
+              {mutationErrorMessage(updateAsset.error)}
             </Alert>
           ) : null}
           {deletion.error ? (

--- a/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
@@ -152,17 +152,15 @@ function RectangleEditSession({
    * It routes to Identity, the chapter the back tiles live in.
    */
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const conflictSlug = useNameConflict({ type, name: draft.name, currentSlug: asset.slug });
+  const { conflictWarnings, conflictProbe } = useNameConflict({
+    type,
+    name: draft.name,
+    currentSlug: asset.slug,
+    source: 'Identity',
+    chapter: 'identity' as RectangleChapter,
+  });
   const warnings: (RectangleWarning | { source: string; complaint: string; chapter: RectangleChapter })[] = [
-    ...(conflictSlug
-      ? [
-          {
-            source: 'Identity',
-            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
-            chapter: 'identity' as RectangleChapter,
-          },
-        ]
-      : []),
+    ...conflictWarnings,
     ...rectangleDraftWarnings(draft),
     ...(danglingBack && draft.back.mode === 'reference'
       ? [{ source: 'Backside', complaint: 'its referenced back is gone', chapter: 'identity' as RectangleChapter }]
@@ -244,6 +242,7 @@ function RectangleEditSession({
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
+          {conflictProbe}
           {updateAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
               {mutationErrorMessage(updateAsset.error)}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
@@ -160,8 +160,8 @@ function RectangleEditSession({
     chapter: 'identity' as RectangleChapter,
   });
   const warnings: (RectangleWarning | { source: string; complaint: string; chapter: RectangleChapter })[] = [
-    ...conflictWarnings,
     ...rectangleDraftWarnings(draft),
+    ...conflictWarnings,
     ...(danglingBack && draft.back.mode === 'reference'
       ? [{ source: 'Backside', complaint: 'its referenced back is gone', chapter: 'identity' as RectangleChapter }]
       : []),

--- a/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
@@ -32,7 +32,7 @@ import {
   SaveErrorAlert,
   useAssetDeletion,
   useAssetGroupActions,
-  useNameConflict,
+  useAssetNameField,
 } from '../../../-assetEditorStates';
 import { referencedRectangleBackFace } from './-referencedBackFace';
 
@@ -152,9 +152,10 @@ function RectangleEditSession({
    * It routes to Identity, the chapter the back tiles live in.
    */
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const { conflictWarnings, conflictProbe } = useNameConflict({
+  const { nameField, conflictWarnings } = useAssetNameField({
     type,
     name: draft.name,
+    onName: (name) => patch({ name }),
     currentSlug: asset.slug,
     source: 'Identity',
     chapter: 'identity' as RectangleChapter,
@@ -242,7 +243,6 @@ function RectangleEditSession({
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
-          {conflictProbe}
           <SaveErrorAlert error={updateAsset.error} />
           {deletion.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not delete">
@@ -256,6 +256,7 @@ function RectangleEditSession({
             </Alert>
           ) : null}
           <RectangleTokenEditor
+            nameField={nameField}
             draft={draft}
             patch={patch}
             chapter={chapter}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
@@ -10,7 +10,6 @@ import { useState } from 'react';
 
 import { useAssetPage, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
-import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetPicker } from '@app/pickers/AssetPicker';
 import { assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
@@ -30,6 +29,7 @@ import type {
 import {
   AssetEditorMessage,
   DriftedAssetPage,
+  SaveErrorAlert,
   useAssetDeletion,
   useAssetGroupActions,
   useNameConflict,
@@ -243,11 +243,7 @@ function RectangleEditSession({
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
           {conflictProbe}
-          {updateAsset.error ? (
-            <Alert color="red" variant="light" role="alert" title="Could not save">
-              {mutationErrorMessage(updateAsset.error)}
-            </Alert>
-          ) : null}
+          <SaveErrorAlert error={updateAsset.error} />
           {deletion.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not delete">
               {deletion.error.message}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
@@ -145,8 +145,8 @@ function TokenEditSession({
     chapter: 'identity' as TokenChapter,
   });
   const warnings: (TokenWarning | { source: string; complaint: string; chapter: TokenChapter })[] = [
-    ...conflictWarnings,
     ...tokenDraftWarnings(draft),
+    ...conflictWarnings,
     ...(danglingBack && draft.back.mode === 'reference'
       ? [{ source: 'Backside', complaint: 'its referenced back is gone', chapter: 'identity' as TokenChapter }]
       : []),

--- a/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react';
 
 import { useAssetPage, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetPicker } from '@app/pickers/AssetPicker';
 import { assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
@@ -24,6 +25,7 @@ import {
   DriftedAssetPage,
   useAssetDeletion,
   useAssetGroupActions,
+  useNameConflict,
 } from '../../../-assetEditorStates';
 import { referencedTokenBackFace } from './-referencedBackFace';
 
@@ -134,7 +136,18 @@ function TokenEditSession({
    * («How a dangling back reference presents»): a signpost, never a second set of mode controls.
    * It routes to Identity, the chapter the back tiles live in.
    */
+  /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
+  const conflictSlug = useNameConflict({ type, name: draft.name, currentSlug: asset.slug });
   const warnings: (TokenWarning | { source: string; complaint: string; chapter: TokenChapter })[] = [
+    ...(conflictSlug
+      ? [
+          {
+            source: 'Identity',
+            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
+            chapter: 'identity' as TokenChapter,
+          },
+        ]
+      : []),
     ...tokenDraftWarnings(draft),
     ...(danglingBack && draft.back.mode === 'reference'
       ? [{ source: 'Backside', complaint: 'its referenced back is gone', chapter: 'identity' as TokenChapter }]
@@ -218,7 +231,7 @@ function TokenEditSession({
         <WorkbenchLayout gap="sm">
           {updateAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
-              {updateAsset.error.message}
+              {mutationErrorMessage(updateAsset.error)}
             </Alert>
           ) : null}
           {deletion.error ? (

--- a/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
@@ -137,17 +137,15 @@ function TokenEditSession({
    * It routes to Identity, the chapter the back tiles live in.
    */
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const conflictSlug = useNameConflict({ type, name: draft.name, currentSlug: asset.slug });
+  const { conflictWarnings, conflictProbe } = useNameConflict({
+    type,
+    name: draft.name,
+    currentSlug: asset.slug,
+    source: 'Identity',
+    chapter: 'identity' as TokenChapter,
+  });
   const warnings: (TokenWarning | { source: string; complaint: string; chapter: TokenChapter })[] = [
-    ...(conflictSlug
-      ? [
-          {
-            source: 'Identity',
-            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
-            chapter: 'identity' as TokenChapter,
-          },
-        ]
-      : []),
+    ...conflictWarnings,
     ...tokenDraftWarnings(draft),
     ...(danglingBack && draft.back.mode === 'reference'
       ? [{ source: 'Backside', complaint: 'its referenced back is gone', chapter: 'identity' as TokenChapter }]
@@ -229,6 +227,7 @@ function TokenEditSession({
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
+          {conflictProbe}
           {updateAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
               {mutationErrorMessage(updateAsset.error)}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
@@ -25,7 +25,7 @@ import {
   SaveErrorAlert,
   useAssetDeletion,
   useAssetGroupActions,
-  useNameConflict,
+  useAssetNameField,
 } from '../../../-assetEditorStates';
 import { referencedTokenBackFace } from './-referencedBackFace';
 
@@ -137,9 +137,10 @@ function TokenEditSession({
    * It routes to Identity, the chapter the back tiles live in.
    */
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const { conflictWarnings, conflictProbe } = useNameConflict({
+  const { nameField, conflictWarnings } = useAssetNameField({
     type,
     name: draft.name,
+    onName: (name) => patch({ name }),
     currentSlug: asset.slug,
     source: 'Identity',
     chapter: 'identity' as TokenChapter,
@@ -227,7 +228,6 @@ function TokenEditSession({
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
-          {conflictProbe}
           <SaveErrorAlert error={updateAsset.error} />
           {deletion.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not delete">
@@ -241,6 +241,7 @@ function TokenEditSession({
             </Alert>
           ) : null}
           <TokenEditor
+            nameField={nameField}
             draft={draft}
             patch={patch}
             type={type}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
@@ -11,7 +11,6 @@ import { useState } from 'react';
 
 import { useAssetPage, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
-import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetPicker } from '@app/pickers/AssetPicker';
 import { assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
@@ -23,6 +22,7 @@ import type { TokenWarning, TokenChapter, TokenDraft } from '@app/widgets/token-
 import {
   AssetEditorMessage,
   DriftedAssetPage,
+  SaveErrorAlert,
   useAssetDeletion,
   useAssetGroupActions,
   useNameConflict,
@@ -228,11 +228,7 @@ function TokenEditSession({
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
           {conflictProbe}
-          {updateAsset.error ? (
-            <Alert color="red" variant="light" role="alert" title="Could not save">
-              {mutationErrorMessage(updateAsset.error)}
-            </Alert>
-          ) : null}
+          <SaveErrorAlert error={updateAsset.error} />
           {deletion.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not delete">
               {deletion.error.message}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
@@ -21,7 +21,7 @@ import {
   SaveErrorAlert,
   useAssetDeletion,
   useAssetGroupActions,
-  useNameConflict,
+  useAssetNameField,
 } from '../../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'card-validation-header';
@@ -106,9 +106,10 @@ function CardEditSession({
   const [settleTick, setSettleTick] = useState(0);
   const patch = (update: Partial<TreacheryDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const { conflictWarnings, conflictProbe } = useNameConflict({
+  const { nameField, conflictWarnings } = useAssetNameField({
     type: 'card-treachery',
     name: draft.name,
+    onName: (name) => patch({ name }),
     currentSlug: asset.slug,
     source: 'Head',
     chapter: 'head' as TreacheryChapter,
@@ -182,7 +183,6 @@ function CardEditSession({
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
-          {conflictProbe}
           <SaveErrorAlert error={updateAsset.error} />
           {deletion.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not delete">
@@ -191,6 +191,7 @@ function CardEditSession({
           ) : null}
           {groupActions.error}
           <TreacheryCardEditor
+            nameField={nameField}
             draft={draft}
             patch={patch}
             chapter={chapter}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
@@ -106,22 +106,17 @@ function CardEditSession({
   const [settleTick, setSettleTick] = useState(0);
   const patch = (update: Partial<TreacheryDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const conflictSlug = useNameConflict({ type: 'card-treachery', name: draft.name, currentSlug: asset.slug });
+  const { conflictWarnings, conflictProbe } = useNameConflict({
+    type: 'card-treachery',
+    name: draft.name,
+    currentSlug: asset.slug,
+    source: 'Head',
+    chapter: 'head' as TreacheryChapter,
+  });
   const warnings: (
     | ReturnType<typeof treacheryDraftWarnings>[number]
     | { source: string; complaint: string; chapter: TreacheryChapter }
-  )[] = [
-    ...treacheryDraftWarnings(draft),
-    ...(conflictSlug
-      ? [
-          {
-            source: 'Head',
-            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
-            chapter: 'head' as TreacheryChapter,
-          },
-        ]
-      : []),
-  ];
+  )[] = [...treacheryDraftWarnings(draft), ...conflictWarnings];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(baseline);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = updateAsset.isPending
@@ -187,6 +182,7 @@ function CardEditSession({
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
+          {conflictProbe}
           {updateAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
               {mutationErrorMessage(updateAsset.error)}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
@@ -8,7 +8,6 @@ import { useState } from 'react';
 
 import { useAssetPage, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
-import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
@@ -19,6 +18,7 @@ import { TreacheryAsset } from '@game/data/objects';
 import {
   AssetEditorMessage,
   DriftedAssetPage,
+  SaveErrorAlert,
   useAssetDeletion,
   useAssetGroupActions,
   useNameConflict,
@@ -183,11 +183,7 @@ function CardEditSession({
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
           {conflictProbe}
-          {updateAsset.error ? (
-            <Alert color="red" variant="light" role="alert" title="Could not save">
-              {mutationErrorMessage(updateAsset.error)}
-            </Alert>
-          ) : null}
+          <SaveErrorAlert error={updateAsset.error} />
           {deletion.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not delete">
               {deletion.error.message}

--- a/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 
 import { useAssetPage, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
@@ -20,6 +21,7 @@ import {
   DriftedAssetPage,
   useAssetDeletion,
   useAssetGroupActions,
+  useNameConflict,
 } from '../../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'card-validation-header';
@@ -103,7 +105,23 @@ function CardEditSession({
   const [chapter, setChapter] = useState<TreacheryChapter>('head');
   const [settleTick, setSettleTick] = useState(0);
   const patch = (update: Partial<TreacheryDraft>) => setDraft((prev) => ({ ...prev, ...update }));
-  const warnings = treacheryDraftWarnings(draft);
+  /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
+  const conflictSlug = useNameConflict({ type: 'card-treachery', name: draft.name, currentSlug: asset.slug });
+  const warnings: (
+    | ReturnType<typeof treacheryDraftWarnings>[number]
+    | { source: string; complaint: string; chapter: TreacheryChapter }
+  )[] = [
+    ...treacheryDraftWarnings(draft),
+    ...(conflictSlug
+      ? [
+          {
+            source: 'Head',
+            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
+            chapter: 'head' as TreacheryChapter,
+          },
+        ]
+      : []),
+  ];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(baseline);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = updateAsset.isPending
@@ -171,7 +189,7 @@ function CardEditSession({
         <WorkbenchLayout gap="sm">
           {updateAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
-              {updateAsset.error.message}
+              {mutationErrorMessage(updateAsset.error)}
             </Alert>
           ) : null}
           {deletion.error ? (

--- a/src/app/routes/_app/assets/$type/create/-bundleCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-bundleCreate.tsx
@@ -32,22 +32,16 @@ export function BundleCreatePage() {
   const [settleTick, setSettleTick] = useState(0);
   const patch = (update: Partial<BundleDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const conflictSlug = useNameConflict({ type: 'bundle', name: draft.name });
+  const { conflictWarnings, conflictProbe } = useNameConflict({
+    type: 'bundle',
+    name: draft.name,
+    source: 'Identity',
+    chapter: 'identity' as BundleChapter,
+  });
   const warnings: (
     | ReturnType<typeof bundleDraftWarnings>[number]
     | { source: string; complaint: string; chapter: BundleChapter }
-  )[] = [
-    ...bundleDraftWarnings(draft, []).filter((warning) => warning.chapter !== 'tokens'),
-    ...(conflictSlug
-      ? [
-          {
-            source: 'Identity',
-            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
-            chapter: 'identity' as BundleChapter,
-          },
-        ]
-      : []),
-  ];
+  )[] = [...bundleDraftWarnings(draft, []).filter((warning) => warning.chapter !== 'tokens'), ...conflictWarnings];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(INITIAL_BUNDLE_DRAFT);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = createAsset.isPending
@@ -108,6 +102,7 @@ export function BundleCreatePage() {
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
+          {conflictProbe}
           {createAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
               {mutationErrorMessage(createAsset.error)}

--- a/src/app/routes/_app/assets/$type/create/-bundleCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-bundleCreate.tsx
@@ -1,4 +1,4 @@
-import { Alert, Anchor, Text } from '@mantine/core';
+import { Anchor, Text } from '@mantine/core';
 import { Link, useNavigate } from '@tanstack/react-router';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -7,14 +7,13 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateAsset } from '@app/db/assets';
-import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
 import { bundleDraftWarnings, BundleEditor, INITIAL_BUNDLE_DRAFT } from '@app/widgets/bundle-editor/BundleEditor';
 import type { BundleChapter, BundleDraft } from '@app/widgets/bundle-editor/BundleEditor';
 
-import { AssetEditorMessage, useNameConflict } from '../../-assetEditorStates';
+import { AssetEditorMessage, SaveErrorAlert, useNameConflict } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'bundle-validation-header';
 
@@ -103,11 +102,7 @@ export function BundleCreatePage() {
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
           {conflictProbe}
-          {createAsset.error ? (
-            <Alert color="red" variant="light" role="alert" title="Could not save">
-              {mutationErrorMessage(createAsset.error)}
-            </Alert>
-          ) : null}
+          <SaveErrorAlert error={createAsset.error} />
           <BundleEditor
             draft={draft}
             patch={patch}

--- a/src/app/routes/_app/assets/$type/create/-bundleCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-bundleCreate.tsx
@@ -7,13 +7,14 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateAsset } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
 import { bundleDraftWarnings, BundleEditor, INITIAL_BUNDLE_DRAFT } from '@app/widgets/bundle-editor/BundleEditor';
 import type { BundleChapter, BundleDraft } from '@app/widgets/bundle-editor/BundleEditor';
 
-import { AssetEditorMessage } from '../../-assetEditorStates';
+import { AssetEditorMessage, useNameConflict } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'bundle-validation-header';
 
@@ -30,7 +31,23 @@ export function BundleCreatePage() {
   const [chapter, setChapter] = useState<BundleChapter>('identity');
   const [settleTick, setSettleTick] = useState(0);
   const patch = (update: Partial<BundleDraft>) => setDraft((prev) => ({ ...prev, ...update }));
-  const warnings = bundleDraftWarnings(draft, []).filter((warning) => warning.chapter !== 'tokens');
+  /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
+  const conflictSlug = useNameConflict({ type: 'bundle', name: draft.name });
+  const warnings: (
+    | ReturnType<typeof bundleDraftWarnings>[number]
+    | { source: string; complaint: string; chapter: BundleChapter }
+  )[] = [
+    ...bundleDraftWarnings(draft, []).filter((warning) => warning.chapter !== 'tokens'),
+    ...(conflictSlug
+      ? [
+          {
+            source: 'Identity',
+            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
+            chapter: 'identity' as BundleChapter,
+          },
+        ]
+      : []),
+  ];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(INITIAL_BUNDLE_DRAFT);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = createAsset.isPending
@@ -93,7 +110,7 @@ export function BundleCreatePage() {
         <WorkbenchLayout gap="sm">
           {createAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
-              {createAsset.error.message}
+              {mutationErrorMessage(createAsset.error)}
             </Alert>
           ) : null}
           <BundleEditor

--- a/src/app/routes/_app/assets/$type/create/-bundleCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-bundleCreate.tsx
@@ -13,7 +13,7 @@ import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
 import { bundleDraftWarnings, BundleEditor, INITIAL_BUNDLE_DRAFT } from '@app/widgets/bundle-editor/BundleEditor';
 import type { BundleChapter, BundleDraft } from '@app/widgets/bundle-editor/BundleEditor';
 
-import { AssetEditorMessage, SaveErrorAlert, useNameConflict } from '../../-assetEditorStates';
+import { AssetEditorMessage, SaveErrorAlert, useAssetNameField } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'bundle-validation-header';
 
@@ -31,9 +31,10 @@ export function BundleCreatePage() {
   const [settleTick, setSettleTick] = useState(0);
   const patch = (update: Partial<BundleDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const { conflictWarnings, conflictProbe } = useNameConflict({
+  const { nameField, conflictWarnings } = useAssetNameField({
     type: 'bundle',
     name: draft.name,
+    onName: (name) => patch({ name }),
     source: 'Identity',
     chapter: 'identity' as BundleChapter,
   });
@@ -101,9 +102,9 @@ export function BundleCreatePage() {
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
-          {conflictProbe}
           <SaveErrorAlert error={createAsset.error} />
           <BundleEditor
+            nameField={nameField}
             draft={draft}
             patch={patch}
             chapter={chapter}

--- a/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
@@ -7,14 +7,13 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateAsset } from '@app/db/assets';
-import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
 import { DeckEditor, INITIAL_DECK_DRAFT, deckDraftWarnings } from '@app/widgets/deck-editor/DeckEditor';
 import type { DeckChapter, DeckDraft } from '@app/widgets/deck-editor/DeckEditor';
 
-import { AssetEditorMessage, useNameConflict } from '../../-assetEditorStates';
+import { AssetEditorMessage, SaveErrorAlert, useNameConflict } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'deck-validation-header';
 
@@ -111,11 +110,7 @@ export function DeckCreatePage() {
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
           {conflictProbe}
-          {createAsset.error ? (
-            <Alert color="red" variant="light" role="alert" title="Could not save">
-              {mutationErrorMessage(createAsset.error)}
-            </Alert>
-          ) : null}
+          <SaveErrorAlert error={createAsset.error} />
           {pickBlocked && pickless ? (
             <Alert color="yellow" variant="light" role="alert" title="No deck picked">
               Picking a deck to wear happens on the edit page; save with another back mode first.

--- a/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
@@ -13,7 +13,7 @@ import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
 import { DeckEditor, INITIAL_DECK_DRAFT, deckDraftWarnings } from '@app/widgets/deck-editor/DeckEditor';
 import type { DeckChapter, DeckDraft } from '@app/widgets/deck-editor/DeckEditor';
 
-import { AssetEditorMessage, SaveErrorAlert, useNameConflict } from '../../-assetEditorStates';
+import { AssetEditorMessage, SaveErrorAlert, useAssetNameField } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'deck-validation-header';
 
@@ -34,9 +34,10 @@ export function DeckCreatePage() {
   const patch = (update: Partial<DeckDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const pickless = draft.cardback.mode === 'reference' && draft.cardback.asset_id === null;
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const { conflictWarnings, conflictProbe } = useNameConflict({
+  const { nameField, conflictWarnings } = useAssetNameField({
     type: 'deck',
     name: draft.name,
+    onName: (name) => patch({ name }),
     source: 'Identity',
     chapter: 'identity' as DeckChapter,
   });
@@ -109,7 +110,6 @@ export function DeckCreatePage() {
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
-          {conflictProbe}
           <SaveErrorAlert error={createAsset.error} />
           {pickBlocked && pickless ? (
             <Alert color="yellow" variant="light" role="alert" title="No deck picked">
@@ -117,6 +117,7 @@ export function DeckCreatePage() {
             </Alert>
           ) : null}
           <DeckEditor
+            nameField={nameField}
             draft={draft}
             patch={patch}
             chapter={chapter}

--- a/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
@@ -7,13 +7,14 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateAsset } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
 import { DeckEditor, INITIAL_DECK_DRAFT, deckDraftWarnings } from '@app/widgets/deck-editor/DeckEditor';
 import type { DeckChapter, DeckDraft } from '@app/widgets/deck-editor/DeckEditor';
 
-import { AssetEditorMessage } from '../../-assetEditorStates';
+import { AssetEditorMessage, useNameConflict } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'deck-validation-header';
 
@@ -33,7 +34,23 @@ export function DeckCreatePage() {
   const [pickBlocked, setPickBlocked] = useState(false);
   const patch = (update: Partial<DeckDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const pickless = draft.cardback.mode === 'reference' && draft.cardback.asset_id === null;
-  const warnings = deckDraftWarnings(draft, []).filter((warning) => warning.chapter !== 'cards');
+  /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
+  const conflictSlug = useNameConflict({ type: 'deck', name: draft.name });
+  const warnings: (
+    | ReturnType<typeof deckDraftWarnings>[number]
+    | { source: string; complaint: string; chapter: DeckChapter }
+  )[] = [
+    ...deckDraftWarnings(draft, []).filter((warning) => warning.chapter !== 'cards'),
+    ...(conflictSlug
+      ? [
+          {
+            source: 'Identity',
+            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
+            chapter: 'identity' as DeckChapter,
+          },
+        ]
+      : []),
+  ];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(INITIAL_DECK_DRAFT);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = createAsset.isPending
@@ -101,7 +118,7 @@ export function DeckCreatePage() {
         <WorkbenchLayout gap="sm">
           {createAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
-              {createAsset.error.message}
+              {mutationErrorMessage(createAsset.error)}
             </Alert>
           ) : null}
           {pickBlocked && pickless ? (

--- a/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
@@ -35,22 +35,16 @@ export function DeckCreatePage() {
   const patch = (update: Partial<DeckDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const pickless = draft.cardback.mode === 'reference' && draft.cardback.asset_id === null;
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const conflictSlug = useNameConflict({ type: 'deck', name: draft.name });
+  const { conflictWarnings, conflictProbe } = useNameConflict({
+    type: 'deck',
+    name: draft.name,
+    source: 'Identity',
+    chapter: 'identity' as DeckChapter,
+  });
   const warnings: (
     | ReturnType<typeof deckDraftWarnings>[number]
     | { source: string; complaint: string; chapter: DeckChapter }
-  )[] = [
-    ...deckDraftWarnings(draft, []).filter((warning) => warning.chapter !== 'cards'),
-    ...(conflictSlug
-      ? [
-          {
-            source: 'Identity',
-            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
-            chapter: 'identity' as DeckChapter,
-          },
-        ]
-      : []),
-  ];
+  )[] = [...deckDraftWarnings(draft, []).filter((warning) => warning.chapter !== 'cards'), ...conflictWarnings];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(INITIAL_DECK_DRAFT);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = createAsset.isPending
@@ -116,6 +110,7 @@ export function DeckCreatePage() {
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
+          {conflictProbe}
           {createAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
               {mutationErrorMessage(createAsset.error)}

--- a/src/app/routes/_app/assets/$type/create/-rectangleCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-rectangleCreate.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateAsset } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
@@ -17,7 +18,7 @@ import {
 } from '@app/widgets/token-editor/RectangleTokenEditor';
 import type { RectangleChapter, RectangleDraft } from '@app/widgets/token-editor/RectangleTokenEditor';
 
-import { AssetEditorMessage } from '../../-assetEditorStates';
+import { AssetEditorMessage, useNameConflict } from '../../-assetEditorStates';
 
 const TYPE = 'token-enhance';
 const VALIDATION_HEADER_ID = 'rectangle-token-validation-header';
@@ -37,7 +38,23 @@ export function RectangleCreatePage() {
   const [pickBlocked, setPickBlocked] = useState(false);
   const patch = (update: Partial<RectangleDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const pickless = draft.back.mode === 'reference' && draft.back.asset_id === null;
-  const warnings = rectangleDraftWarnings(draft);
+  /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
+  const conflictSlug = useNameConflict({ type: TYPE, name: draft.name });
+  const warnings: (
+    | ReturnType<typeof rectangleDraftWarnings>[number]
+    | { source: string; complaint: string; chapter: RectangleChapter }
+  )[] = [
+    ...rectangleDraftWarnings(draft),
+    ...(conflictSlug
+      ? [
+          {
+            source: 'Identity',
+            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
+            chapter: 'identity' as RectangleChapter,
+          },
+        ]
+      : []),
+  ];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(INITIAL_RECTANGLE_DRAFT);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = createAsset.isPending
@@ -104,7 +121,7 @@ export function RectangleCreatePage() {
         <WorkbenchLayout gap="sm">
           {createAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
-              {createAsset.error.message}
+              {mutationErrorMessage(createAsset.error)}
             </Alert>
           ) : null}
           {pickBlocked && pickless ? (

--- a/src/app/routes/_app/assets/$type/create/-rectangleCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-rectangleCreate.tsx
@@ -7,7 +7,6 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateAsset } from '@app/db/assets';
-import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
@@ -18,7 +17,7 @@ import {
 } from '@app/widgets/token-editor/RectangleTokenEditor';
 import type { RectangleChapter, RectangleDraft } from '@app/widgets/token-editor/RectangleTokenEditor';
 
-import { AssetEditorMessage, useNameConflict } from '../../-assetEditorStates';
+import { AssetEditorMessage, SaveErrorAlert, useNameConflict } from '../../-assetEditorStates';
 
 const TYPE = 'token-enhance';
 const VALIDATION_HEADER_ID = 'rectangle-token-validation-header';
@@ -114,11 +113,7 @@ export function RectangleCreatePage() {
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
           {conflictProbe}
-          {createAsset.error ? (
-            <Alert color="red" variant="light" role="alert" title="Could not save">
-              {mutationErrorMessage(createAsset.error)}
-            </Alert>
-          ) : null}
+          <SaveErrorAlert error={createAsset.error} />
           {pickBlocked && pickless ? (
             <Alert color="yellow" variant="light" role="alert" title="No token picked">
               Picking a token's back happens on the edit page; save with another back mode first.

--- a/src/app/routes/_app/assets/$type/create/-rectangleCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-rectangleCreate.tsx
@@ -39,22 +39,16 @@ export function RectangleCreatePage() {
   const patch = (update: Partial<RectangleDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const pickless = draft.back.mode === 'reference' && draft.back.asset_id === null;
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const conflictSlug = useNameConflict({ type: TYPE, name: draft.name });
+  const { conflictWarnings, conflictProbe } = useNameConflict({
+    type: TYPE,
+    name: draft.name,
+    source: 'Identity',
+    chapter: 'identity' as RectangleChapter,
+  });
   const warnings: (
     | ReturnType<typeof rectangleDraftWarnings>[number]
     | { source: string; complaint: string; chapter: RectangleChapter }
-  )[] = [
-    ...rectangleDraftWarnings(draft),
-    ...(conflictSlug
-      ? [
-          {
-            source: 'Identity',
-            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
-            chapter: 'identity' as RectangleChapter,
-          },
-        ]
-      : []),
-  ];
+  )[] = [...rectangleDraftWarnings(draft), ...conflictWarnings];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(INITIAL_RECTANGLE_DRAFT);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = createAsset.isPending
@@ -119,6 +113,7 @@ export function RectangleCreatePage() {
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
+          {conflictProbe}
           {createAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
               {mutationErrorMessage(createAsset.error)}

--- a/src/app/routes/_app/assets/$type/create/-rectangleCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-rectangleCreate.tsx
@@ -17,7 +17,7 @@ import {
 } from '@app/widgets/token-editor/RectangleTokenEditor';
 import type { RectangleChapter, RectangleDraft } from '@app/widgets/token-editor/RectangleTokenEditor';
 
-import { AssetEditorMessage, SaveErrorAlert, useNameConflict } from '../../-assetEditorStates';
+import { AssetEditorMessage, SaveErrorAlert, useAssetNameField } from '../../-assetEditorStates';
 
 const TYPE = 'token-enhance';
 const VALIDATION_HEADER_ID = 'rectangle-token-validation-header';
@@ -38,9 +38,10 @@ export function RectangleCreatePage() {
   const patch = (update: Partial<RectangleDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const pickless = draft.back.mode === 'reference' && draft.back.asset_id === null;
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const { conflictWarnings, conflictProbe } = useNameConflict({
+  const { nameField, conflictWarnings } = useAssetNameField({
     type: TYPE,
     name: draft.name,
+    onName: (name) => patch({ name }),
     source: 'Identity',
     chapter: 'identity' as RectangleChapter,
   });
@@ -112,7 +113,6 @@ export function RectangleCreatePage() {
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
-          {conflictProbe}
           <SaveErrorAlert error={createAsset.error} />
           {pickBlocked && pickless ? (
             <Alert color="yellow" variant="light" role="alert" title="No token picked">
@@ -120,6 +120,7 @@ export function RectangleCreatePage() {
             </Alert>
           ) : null}
           <RectangleTokenEditor
+            nameField={nameField}
             draft={draft}
             patch={patch}
             chapter={chapter}

--- a/src/app/routes/_app/assets/$type/create/-tokenCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-tokenCreate.tsx
@@ -8,13 +8,14 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateAsset } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
 import { initialTokenDraft, TokenEditor, tokenDraftWarnings } from '@app/widgets/token-editor/TokenEditor';
 import type { TokenChapter, TokenDraft } from '@app/widgets/token-editor/TokenEditor';
 
-import { AssetEditorMessage } from '../../-assetEditorStates';
+import { AssetEditorMessage, useNameConflict } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'token-validation-header';
 
@@ -35,7 +36,23 @@ export function TokenCreatePage({ type }: { type: string }) {
   const [pickBlocked, setPickBlocked] = useState(false);
   const patch = (update: Partial<TokenDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const pickless = draft.back.mode === 'reference' && draft.back.asset_id === null;
-  const warnings = tokenDraftWarnings(draft);
+  /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
+  const conflictSlug = useNameConflict({ type, name: draft.name });
+  const warnings: (
+    | ReturnType<typeof tokenDraftWarnings>[number]
+    | { source: string; complaint: string; chapter: TokenChapter }
+  )[] = [
+    ...tokenDraftWarnings(draft),
+    ...(conflictSlug
+      ? [
+          {
+            source: 'Identity',
+            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
+            chapter: 'identity' as TokenChapter,
+          },
+        ]
+      : []),
+  ];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(initialDraft);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = createAsset.isPending
@@ -102,7 +119,7 @@ export function TokenCreatePage({ type }: { type: string }) {
         <WorkbenchLayout gap="sm">
           {createAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
-              {createAsset.error.message}
+              {mutationErrorMessage(createAsset.error)}
             </Alert>
           ) : null}
           {pickBlocked && pickless ? (

--- a/src/app/routes/_app/assets/$type/create/-tokenCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-tokenCreate.tsx
@@ -8,14 +8,13 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateAsset } from '@app/db/assets';
-import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
 import { initialTokenDraft, TokenEditor, tokenDraftWarnings } from '@app/widgets/token-editor/TokenEditor';
 import type { TokenChapter, TokenDraft } from '@app/widgets/token-editor/TokenEditor';
 
-import { AssetEditorMessage, useNameConflict } from '../../-assetEditorStates';
+import { AssetEditorMessage, SaveErrorAlert, useNameConflict } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'token-validation-header';
 
@@ -112,11 +111,7 @@ export function TokenCreatePage({ type }: { type: string }) {
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
           {conflictProbe}
-          {createAsset.error ? (
-            <Alert color="red" variant="light" role="alert" title="Could not save">
-              {mutationErrorMessage(createAsset.error)}
-            </Alert>
-          ) : null}
+          <SaveErrorAlert error={createAsset.error} />
           {pickBlocked && pickless ? (
             <Alert color="yellow" variant="light" role="alert" title="No token picked">
               Picking a token's back happens on the edit page; save with another back mode first.

--- a/src/app/routes/_app/assets/$type/create/-tokenCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-tokenCreate.tsx
@@ -37,22 +37,16 @@ export function TokenCreatePage({ type }: { type: string }) {
   const patch = (update: Partial<TokenDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const pickless = draft.back.mode === 'reference' && draft.back.asset_id === null;
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const conflictSlug = useNameConflict({ type, name: draft.name });
+  const { conflictWarnings, conflictProbe } = useNameConflict({
+    type,
+    name: draft.name,
+    source: 'Identity',
+    chapter: 'identity' as TokenChapter,
+  });
   const warnings: (
     | ReturnType<typeof tokenDraftWarnings>[number]
     | { source: string; complaint: string; chapter: TokenChapter }
-  )[] = [
-    ...tokenDraftWarnings(draft),
-    ...(conflictSlug
-      ? [
-          {
-            source: 'Identity',
-            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
-            chapter: 'identity' as TokenChapter,
-          },
-        ]
-      : []),
-  ];
+  )[] = [...tokenDraftWarnings(draft), ...conflictWarnings];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(initialDraft);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = createAsset.isPending
@@ -117,6 +111,7 @@ export function TokenCreatePage({ type }: { type: string }) {
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
+          {conflictProbe}
           {createAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
               {mutationErrorMessage(createAsset.error)}

--- a/src/app/routes/_app/assets/$type/create/-tokenCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-tokenCreate.tsx
@@ -14,7 +14,7 @@ import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
 import { initialTokenDraft, TokenEditor, tokenDraftWarnings } from '@app/widgets/token-editor/TokenEditor';
 import type { TokenChapter, TokenDraft } from '@app/widgets/token-editor/TokenEditor';
 
-import { AssetEditorMessage, SaveErrorAlert, useNameConflict } from '../../-assetEditorStates';
+import { AssetEditorMessage, SaveErrorAlert, useAssetNameField } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'token-validation-header';
 
@@ -36,9 +36,10 @@ export function TokenCreatePage({ type }: { type: string }) {
   const patch = (update: Partial<TokenDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   const pickless = draft.back.mode === 'reference' && draft.back.asset_id === null;
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const { conflictWarnings, conflictProbe } = useNameConflict({
+  const { nameField, conflictWarnings } = useAssetNameField({
     type,
     name: draft.name,
+    onName: (name) => patch({ name }),
     source: 'Identity',
     chapter: 'identity' as TokenChapter,
   });
@@ -110,7 +111,6 @@ export function TokenCreatePage({ type }: { type: string }) {
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
-          {conflictProbe}
           <SaveErrorAlert error={createAsset.error} />
           {pickBlocked && pickless ? (
             <Alert color="yellow" variant="light" role="alert" title="No token picked">
@@ -118,6 +118,7 @@ export function TokenCreatePage({ type }: { type: string }) {
             </Alert>
           ) : null}
           <TokenEditor
+            nameField={nameField}
             draft={draft}
             patch={patch}
             type={type}

--- a/src/app/routes/_app/assets/$type/create/-treacheryCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-treacheryCreate.tsx
@@ -17,7 +17,7 @@ import {
 } from '@app/widgets/card-editor/TreacheryCardEditor';
 import type { TreacheryChapter, TreacheryDraft } from '@app/widgets/card-editor/TreacheryCardEditor';
 
-import { AssetEditorMessage, SaveErrorAlert, useNameConflict } from '../../-assetEditorStates';
+import { AssetEditorMessage, SaveErrorAlert, useAssetNameField } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'card-validation-header';
 
@@ -31,9 +31,10 @@ export function TreacheryCreatePage() {
   const [settleTick, setSettleTick] = useState(0);
   const patch = (update: Partial<TreacheryDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const { conflictWarnings, conflictProbe } = useNameConflict({
+  const { nameField, conflictWarnings } = useAssetNameField({
     type: 'card-treachery',
     name: draft.name,
+    onName: (name) => patch({ name }),
     source: 'Head',
     chapter: 'head' as TreacheryChapter,
   });
@@ -99,9 +100,9 @@ export function TreacheryCreatePage() {
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
-          {conflictProbe}
           <SaveErrorAlert error={createAsset.error} />
           <TreacheryCardEditor
+            nameField={nameField}
             draft={draft}
             patch={patch}
             chapter={chapter}

--- a/src/app/routes/_app/assets/$type/create/-treacheryCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-treacheryCreate.tsx
@@ -32,22 +32,16 @@ export function TreacheryCreatePage() {
   const [settleTick, setSettleTick] = useState(0);
   const patch = (update: Partial<TreacheryDraft>) => setDraft((prev) => ({ ...prev, ...update }));
   /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
-  const conflictSlug = useNameConflict({ type: 'card-treachery', name: draft.name });
+  const { conflictWarnings, conflictProbe } = useNameConflict({
+    type: 'card-treachery',
+    name: draft.name,
+    source: 'Head',
+    chapter: 'head' as TreacheryChapter,
+  });
   const warnings: (
     | ReturnType<typeof treacheryDraftWarnings>[number]
     | { source: string; complaint: string; chapter: TreacheryChapter }
-  )[] = [
-    ...treacheryDraftWarnings(draft),
-    ...(conflictSlug
-      ? [
-          {
-            source: 'Head',
-            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
-            chapter: 'head' as TreacheryChapter,
-          },
-        ]
-      : []),
-  ];
+  )[] = [...treacheryDraftWarnings(draft), ...conflictWarnings];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(INITIAL_TREACHERY_DRAFT);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = createAsset.isPending
@@ -106,6 +100,7 @@ export function TreacheryCreatePage() {
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
+          {conflictProbe}
           {createAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
               {mutationErrorMessage(createAsset.error)}

--- a/src/app/routes/_app/assets/$type/create/-treacheryCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-treacheryCreate.tsx
@@ -1,4 +1,4 @@
-import { Alert, Anchor, Text } from '@mantine/core';
+import { Anchor, Text } from '@mantine/core';
 import { Link, useNavigate } from '@tanstack/react-router';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -7,7 +7,6 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateAsset } from '@app/db/assets';
-import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
@@ -18,7 +17,7 @@ import {
 } from '@app/widgets/card-editor/TreacheryCardEditor';
 import type { TreacheryChapter, TreacheryDraft } from '@app/widgets/card-editor/TreacheryCardEditor';
 
-import { AssetEditorMessage, useNameConflict } from '../../-assetEditorStates';
+import { AssetEditorMessage, SaveErrorAlert, useNameConflict } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'card-validation-header';
 
@@ -101,11 +100,7 @@ export function TreacheryCreatePage() {
       <PageLayout.Content>
         <WorkbenchLayout gap="sm">
           {conflictProbe}
-          {createAsset.error ? (
-            <Alert color="red" variant="light" role="alert" title="Could not save">
-              {mutationErrorMessage(createAsset.error)}
-            </Alert>
-          ) : null}
+          <SaveErrorAlert error={createAsset.error} />
           <TreacheryCardEditor
             draft={draft}
             patch={patch}

--- a/src/app/routes/_app/assets/$type/create/-treacheryCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-treacheryCreate.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateAsset } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
@@ -17,7 +18,7 @@ import {
 } from '@app/widgets/card-editor/TreacheryCardEditor';
 import type { TreacheryChapter, TreacheryDraft } from '@app/widgets/card-editor/TreacheryCardEditor';
 
-import { AssetEditorMessage } from '../../-assetEditorStates';
+import { AssetEditorMessage, useNameConflict } from '../../-assetEditorStates';
 
 const VALIDATION_HEADER_ID = 'card-validation-header';
 
@@ -30,7 +31,23 @@ export function TreacheryCreatePage() {
   const [chapter, setChapter] = useState<TreacheryChapter>('head');
   const [settleTick, setSettleTick] = useState(0);
   const patch = (update: Partial<TreacheryDraft>) => setDraft((prev) => ({ ...prev, ...update }));
-  const warnings = treacheryDraftWarnings(draft);
+  /* The save guard's rule, live while the author types: a colliding name warns here instead of dying as a save error (finding 19). */
+  const conflictSlug = useNameConflict({ type: 'card-treachery', name: draft.name });
+  const warnings: (
+    | ReturnType<typeof treacheryDraftWarnings>[number]
+    | { source: string; complaint: string; chapter: TreacheryChapter }
+  )[] = [
+    ...treacheryDraftWarnings(draft),
+    ...(conflictSlug
+      ? [
+          {
+            source: 'Head',
+            complaint: `its name is already taken (another one lives at "${conflictSlug}")`,
+            chapter: 'head' as TreacheryChapter,
+          },
+        ]
+      : []),
+  ];
   const isDirty = JSON.stringify(draft) !== JSON.stringify(INITIAL_TREACHERY_DRAFT);
   const isNameBlank = !draft.name.trim();
   const saveState: AuthoringSaveState = createAsset.isPending
@@ -91,7 +108,7 @@ export function TreacheryCreatePage() {
         <WorkbenchLayout gap="sm">
           {createAsset.error ? (
             <Alert color="red" variant="light" role="alert" title="Could not save">
-              {createAsset.error.message}
+              {mutationErrorMessage(createAsset.error)}
             </Alert>
           ) : null}
           <TreacheryCardEditor

--- a/src/app/routes/_app/assets/-assetEditorStates.tsx
+++ b/src/app/routes/_app/assets/-assetEditorStates.tsx
@@ -13,6 +13,7 @@ import type { ReactNode } from 'react';
 
 import { useAssetSlugTaken, useDeleteAsset, useSetAssetGroup } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
+import { mutationErrorMessage } from '@app/db/core/mutationError';
 
 /**
  * The states an asset editor route reaches instead of an editor: no such asset, not signed in, not allowed, no editor built yet.
@@ -244,4 +245,19 @@ export function useNameConflict<Chapter extends string>({
       : [],
     conflictProbe,
   };
+}
+
+/**
+ * The alert under a failed save, once for every editor organ.
+ * It replaced ten hand-written copies of the same Alert, whose only drift risk was exactly the ConvexError unwrap it applies.
+ */
+export function SaveErrorAlert({ error }: { error: Error | null }) {
+  if (!error) {
+    return null;
+  }
+  return (
+    <Alert color="red" variant="light" role="alert" title="Could not save">
+      {mutationErrorMessage(error)}
+    </Alert>
+  );
 }

--- a/src/app/routes/_app/assets/-assetEditorStates.tsx
+++ b/src/app/routes/_app/assets/-assetEditorStates.tsx
@@ -1,6 +1,5 @@
 import { Alert, Anchor, Group, Stack, Text, Title } from '@mantine/core';
 import { ASSET_TYPES, isAssetType } from '@shared/assets/types';
-import { slugify } from '@shared/slugify';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { AssignPopover } from '@ui/control/AssignPopover';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
@@ -8,12 +7,15 @@ import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
 import { UserRoundMinus, UsersRound } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import type { ReactNode } from 'react';
 
-import { useAssetSlugTaken, useDeleteAsset, useSetAssetGroup } from '@app/db/assets';
+import { useDeleteAsset, useSetAssetGroup } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
 import { mutationErrorMessage } from '@app/db/core/mutationError';
+import { AssetNameInput } from '@app/pickers/AssetNameInput';
+import { nameConflictComplaint } from '@app/pickers/UniqueNameInput';
+import type { NameConflict } from '@app/pickers/UniqueNameInput';
 
 /**
  * The states an asset editor route reaches instead of an editor: no such asset, not signed in, not allowed, no editor built yet.
@@ -193,66 +195,41 @@ export function useAssetGroupActions({
   };
 }
 
-/** The subscription half of the name-conflict check: mounted only while a candidate slug exists, which is how the read stays conditional without a skip. */
-function NameConflictProbe({
-  type,
-  slug,
-  onAnswer,
-}: {
-  type: string;
-  slug: string;
-  onAnswer: (holder: 'live' | 'deleted' | null) => void;
-}) {
-  const holder = useAssetSlugTaken({ type, slug });
-  useEffect(() => {
-    onAnswer(holder ?? null);
-  }, [holder, onAnswer]);
-  return null;
-}
-
 /**
- * Whether the draft's name collides with an existing asset of the same type, live while the author types.
+ * The route's half of the name field: state for the conflict the Picker reports, the ready warning rows for the validation header, and the field node the editor widget mounts.
  *
- * The same rule the save guard refuses on, read as a subscription, so the warning and the refusal can never disagree.
+ * The field itself is `AssetNameInput`, a Picker — the taxonomy's one fetching control — so no route holds a second page subscription and no widget fetches.
+ * Norbert ruled it so on 2026-08-22: the earlier rulebook exception was the wrong answer, and the right one was making the field a Picker.
  * Finding 19 of «Walk findings, round two» is the why: a card named Shield met the reserved slug of the existing Shield card and the reader learned nothing.
- * On an edit page pass `currentSlug`, so an unchanged name never warns about its own address.
- * Returns the colliding slug for the warning's words (null while the name is free, blank, or unchanged) and a probe node the organ must render: mounting it is what turns the subscription on.
  */
-export function useNameConflict<Chapter extends string>({
+export function useAssetNameField<Chapter extends string>({
   type,
   name,
+  onName,
   currentSlug,
   source,
   chapter,
 }: {
   type: string;
   name: string;
+  onName: (name: string) => void;
   currentSlug?: string;
   /** The validation header group the warning joins — Identity everywhere but the treachery card, whose name lives in Head. */
   source: string;
   chapter: Chapter;
-}): { conflictWarnings: { source: string; complaint: string; chapter: Chapter }[]; conflictProbe: ReactNode } {
-  const [answer, setAnswer] = useState<'live' | 'deleted' | null>(null);
-  const slug = slugify(name);
-  const candidate = slug.length > 0 && slug !== currentSlug ? slug : null;
-  /* Settled rather than live: each distinct slug is a subscription swap, and a name typed letter by letter walks through every prefix. The pause also keeps a colliding prefix from flashing a warning on the way to a free name. */
-  const [settled, setSettled] = useState<string | null>(candidate);
-  useEffect(() => {
-    const timer = setTimeout(() => setSettled(candidate), 400);
-    return () => clearTimeout(timer);
-  }, [candidate]);
-  const conflictProbe = settled ? (
-    <NameConflictProbe key={settled} type={type} slug={settled} onAnswer={setAnswer} />
-  ) : null;
-  const holder = candidate && settled === candidate ? answer : null;
-  /* The warning speaks the refusal's own distinction: a living holder and a deleted one reserving its address are different answers, and the save guard words them differently too. */
-  const complaint =
-    holder === 'deleted'
-      ? `its name is already taken ("${candidate}" stays reserved by a deleted asset)`
-      : `its name is already taken (another one lives at "${candidate}")`;
+}): { nameField: ReactNode; conflictWarnings: { source: string; complaint: string; chapter: Chapter }[] } {
+  const [conflict, setConflict] = useState<NameConflict | null>(null);
   return {
-    conflictWarnings: holder ? [{ source, complaint, chapter }] : [],
-    conflictProbe,
+    nameField: (
+      <AssetNameInput
+        type={type}
+        value={name}
+        onChange={onName}
+        currentSlug={currentSlug}
+        onConflictChange={setConflict}
+      />
+    ),
+    conflictWarnings: conflict ? [{ source, complaint: nameConflictComplaint(conflict), chapter }] : [],
   };
 }
 

--- a/src/app/routes/_app/assets/-assetEditorStates.tsx
+++ b/src/app/routes/_app/assets/-assetEditorStates.tsx
@@ -201,12 +201,12 @@ function NameConflictProbe({
 }: {
   type: string;
   slug: string;
-  onAnswer: (conflictSlug: string | null) => void;
+  onAnswer: (holder: 'live' | 'deleted' | null) => void;
 }) {
-  const taken = useAssetSlugTaken({ type, slug });
+  const holder = useAssetSlugTaken({ type, slug });
   useEffect(() => {
-    onAnswer(taken === true ? slug : null);
-  }, [taken, slug, onAnswer]);
+    onAnswer(holder ?? null);
+  }, [holder, onAnswer]);
   return null;
 }
 
@@ -232,7 +232,7 @@ export function useNameConflict<Chapter extends string>({
   source: string;
   chapter: Chapter;
 }): { conflictWarnings: { source: string; complaint: string; chapter: Chapter }[]; conflictProbe: ReactNode } {
-  const [answer, setAnswer] = useState<string | null>(null);
+  const [answer, setAnswer] = useState<'live' | 'deleted' | null>(null);
   const slug = slugify(name);
   const candidate = slug.length > 0 && slug !== currentSlug ? slug : null;
   /* Settled rather than live: each distinct slug is a subscription swap, and a name typed letter by letter walks through every prefix. The pause also keeps a colliding prefix from flashing a warning on the way to a free name. */
@@ -244,11 +244,14 @@ export function useNameConflict<Chapter extends string>({
   const conflictProbe = settled ? (
     <NameConflictProbe key={settled} type={type} slug={settled} onAnswer={setAnswer} />
   ) : null;
-  const conflictSlug = candidate && settled === candidate ? answer : null;
+  const holder = candidate && settled === candidate ? answer : null;
+  /* The warning speaks the refusal's own distinction: a living holder and a deleted one reserving its address are different answers, and the save guard words them differently too. */
+  const complaint =
+    holder === 'deleted'
+      ? `its name is already taken ("${candidate}" stays reserved by a deleted asset)`
+      : `its name is already taken (another one lives at "${candidate}")`;
   return {
-    conflictWarnings: conflictSlug
-      ? [{ source, complaint: `its name is already taken (another one lives at "${conflictSlug}")`, chapter }]
-      : [],
+    conflictWarnings: holder ? [{ source, complaint, chapter }] : [],
     conflictProbe,
   };
 }

--- a/src/app/routes/_app/assets/-assetEditorStates.tsx
+++ b/src/app/routes/_app/assets/-assetEditorStates.tsx
@@ -8,6 +8,7 @@ import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
 import { UserRoundMinus, UsersRound } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import { useAssetSlugTaken, useDeleteAsset, useSetAssetGroup } from '@app/db/assets';
@@ -191,25 +192,56 @@ export function useAssetGroupActions({
   };
 }
 
+/** The subscription half of the name-conflict check: mounted only while a candidate slug exists, which is how the read stays conditional without a skip. */
+function NameConflictProbe({
+  type,
+  slug,
+  onAnswer,
+}: {
+  type: string;
+  slug: string;
+  onAnswer: (conflictSlug: string | null) => void;
+}) {
+  const taken = useAssetSlugTaken({ type, slug });
+  useEffect(() => {
+    onAnswer(taken === true ? slug : null);
+  }, [taken, slug, onAnswer]);
+  return null;
+}
+
 /**
  * Whether the draft's name collides with an existing asset of the same type, live while the author types.
  *
  * The same rule the save guard refuses on, read as a subscription, so the warning and the refusal can never disagree.
  * Finding 19 of «Walk findings, round two» is the why: a card named Shield met the reserved slug of the existing Shield card and the reader learned nothing.
  * On an edit page pass `currentSlug`, so an unchanged name never warns about its own address.
- * Returns the colliding slug for the warning's words, or null while the name is free, blank, or unchanged.
+ * Returns the colliding slug for the warning's words (null while the name is free, blank, or unchanged) and a probe node the organ must render: mounting it is what turns the subscription on.
  */
-export function useNameConflict({
+export function useNameConflict<Chapter extends string>({
   type,
   name,
   currentSlug,
+  source,
+  chapter,
 }: {
   type: string;
   name: string;
   currentSlug?: string;
-}): string | null {
+  /** The validation header group the warning joins — Identity everywhere but the treachery card, whose name lives in Head. */
+  source: string;
+  chapter: Chapter;
+}): { conflictWarnings: { source: string; complaint: string; chapter: Chapter }[]; conflictProbe: ReactNode } {
+  const [answer, setAnswer] = useState<string | null>(null);
   const slug = slugify(name);
   const candidate = slug.length > 0 && slug !== currentSlug ? slug : null;
-  const taken = useAssetSlugTaken(candidate ? { type, slug: candidate } : null);
-  return taken === true && candidate ? candidate : null;
+  const conflictProbe = candidate ? (
+    <NameConflictProbe key={candidate} type={type} slug={candidate} onAnswer={setAnswer} />
+  ) : null;
+  const conflictSlug = candidate ? answer : null;
+  return {
+    conflictWarnings: conflictSlug
+      ? [{ source, complaint: `its name is already taken (another one lives at "${conflictSlug}")`, chapter }]
+      : [],
+    conflictProbe,
+  };
 }

--- a/src/app/routes/_app/assets/-assetEditorStates.tsx
+++ b/src/app/routes/_app/assets/-assetEditorStates.tsx
@@ -1,5 +1,6 @@
 import { Alert, Anchor, Group, Stack, Text, Title } from '@mantine/core';
 import { ASSET_TYPES, isAssetType } from '@shared/assets/types';
+import { slugify } from '@shared/slugify';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { AssignPopover } from '@ui/control/AssignPopover';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
@@ -9,7 +10,7 @@ import { Surface } from '@ui/surface';
 import { UserRoundMinus, UsersRound } from 'lucide-react';
 import type { ReactNode } from 'react';
 
-import { useDeleteAsset, useSetAssetGroup } from '@app/db/assets';
+import { useAssetSlugTaken, useDeleteAsset, useSetAssetGroup } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
 
 /**
@@ -188,4 +189,27 @@ export function useAssetGroupActions({
       </Alert>
     ) : null,
   };
+}
+
+/**
+ * Whether the draft's name collides with an existing asset of the same type, live while the author types.
+ *
+ * The same rule the save guard refuses on, read as a subscription, so the warning and the refusal can never disagree.
+ * Finding 19 of «Walk findings, round two» is the why: a card named Shield met the reserved slug of the existing Shield card and the reader learned nothing.
+ * On an edit page pass `currentSlug`, so an unchanged name never warns about its own address.
+ * Returns the colliding slug for the warning's words, or null while the name is free, blank, or unchanged.
+ */
+export function useNameConflict({
+  type,
+  name,
+  currentSlug,
+}: {
+  type: string;
+  name: string;
+  currentSlug?: string;
+}): string | null {
+  const slug = slugify(name);
+  const candidate = slug.length > 0 && slug !== currentSlug ? slug : null;
+  const taken = useAssetSlugTaken(candidate ? { type, slug: candidate } : null);
+  return taken === true && candidate ? candidate : null;
 }

--- a/src/app/routes/_app/assets/-assetEditorStates.tsx
+++ b/src/app/routes/_app/assets/-assetEditorStates.tsx
@@ -235,10 +235,16 @@ export function useNameConflict<Chapter extends string>({
   const [answer, setAnswer] = useState<string | null>(null);
   const slug = slugify(name);
   const candidate = slug.length > 0 && slug !== currentSlug ? slug : null;
-  const conflictProbe = candidate ? (
-    <NameConflictProbe key={candidate} type={type} slug={candidate} onAnswer={setAnswer} />
+  /* Settled rather than live: each distinct slug is a subscription swap, and a name typed letter by letter walks through every prefix. The pause also keeps a colliding prefix from flashing a warning on the way to a free name. */
+  const [settled, setSettled] = useState<string | null>(candidate);
+  useEffect(() => {
+    const timer = setTimeout(() => setSettled(candidate), 400);
+    return () => clearTimeout(timer);
+  }, [candidate]);
+  const conflictProbe = settled ? (
+    <NameConflictProbe key={settled} type={type} slug={settled} onAnswer={setAnswer} />
   ) : null;
-  const conflictSlug = candidate ? answer : null;
+  const conflictSlug = candidate && settled === candidate ? answer : null;
   return {
     conflictWarnings: conflictSlug
       ? [{ source, complaint: `its name is already taken (another one lives at "${conflictSlug}")`, chapter }]

--- a/src/app/widgets/bundle-editor/BundleEditor.test.tsx
+++ b/src/app/widgets/bundle-editor/BundleEditor.test.tsx
@@ -35,6 +35,7 @@ function Harness() {
   return (
     <MantineProvider theme={appContentTheme} forceColorScheme="light">
       <BundleEditor
+        nameField={<input aria-label="Name" readOnly value="" />}
         draft={draft}
         patch={(update) => setDraft((previous) => ({ ...previous, ...update }))}
         chapter={chapter}

--- a/src/app/widgets/bundle-editor/BundleEditor.tsx
+++ b/src/app/widgets/bundle-editor/BundleEditor.tsx
@@ -103,6 +103,7 @@ const panel = (children: ReactNode) => <Stack gap="lg">{children}</Stack>;
  * Each count change writes an `asset_relations` row immediately, the way a deck's composition does, because relations do not travel through the asset's `data`.
  */
 export function BundleEditor({
+  nameField,
   draft,
   patch,
   chapter,
@@ -114,6 +115,8 @@ export function BundleEditor({
   tokenPicker,
 }: {
   draft: BundleDraft;
+  /** The Name field, constructed by the route: checking a name's address is a fetch, and fetching controls are Pickers the routes own. */
+  nameField: ReactNode;
   patch: (update: Partial<BundleDraft>) => void;
   chapter: BundleChapter;
   onChapterChange: (chapter: BundleChapter) => void;
@@ -161,17 +164,7 @@ export function BundleEditor({
               icon: <TopicIcon topic="identity" size={21} />,
               panel: panel(
                 <>
-                  <ControlBlock
-                    title="Name"
-                    description="Determines the bundle's URL."
-                    input={
-                      <TextInput
-                        aria-label="Name"
-                        value={draft.name}
-                        onChange={(event) => patch({ name: event.currentTarget.value })}
-                      />
-                    }
-                  />
+                  <ControlBlock title="Name" description="Determines the bundle's URL." input={nameField} />
                   <ControlBlock
                     title="Band"
                     description="A bundle has no face of its own, so this is what tells it apart. Stock or authored; nothing about the choice is stored either way."

--- a/src/app/widgets/card-editor/TreacheryCardEditor.stories.tsx
+++ b/src/app/widgets/card-editor/TreacheryCardEditor.stories.tsx
@@ -9,6 +9,7 @@ const meta = preview.meta({
   title: 'Treachery Card Editor',
   component: TreacheryCardEditor,
   args: {
+    nameField: <input aria-label="Name" readOnly value="Lasgun" />,
     draft: { ...INITIAL_TREACHERY_DRAFT, name: 'Lasgun', subName: 'Weapon - Special' },
     patch: fn(),
     chapter: 'head' as const,

--- a/src/app/widgets/card-editor/TreacheryCardEditor.tsx
+++ b/src/app/widgets/card-editor/TreacheryCardEditor.tsx
@@ -101,20 +101,10 @@ function FillCard({ draft }: { draft: TreacheryDraft }) {
 type Patch = (update: Partial<TreacheryDraft>) => void;
 
 /* The card's head: its name, type, and the Background behind them. */
-function HeadFields({ draft, patch }: { draft: TreacheryDraft; patch: Patch }) {
+function HeadFields({ draft, patch, nameField }: { draft: TreacheryDraft; patch: Patch; nameField: ReactNode }) {
   return (
     <Stack gap="md">
-      <ControlBlock
-        title="Name"
-        description="Names the card and determines its URL."
-        input={
-          <TextInput
-            aria-label="Name"
-            value={draft.name}
-            onChange={(event) => patch({ name: event.currentTarget.value })}
-          />
-        }
-      />
+      <ControlBlock title="Name" description="Names the card and determines its URL." input={nameField} />
       <ControlBlock
         title="Type"
         description="Shown under the name, e.g. “Weapon - Projectile”."
@@ -419,6 +409,7 @@ const panel = (children: ReactNode) => <Stack gap="lg">{children}</Stack>;
  * Pages own the draft, its persistence, and the surrounding authoring chrome.
  */
 export function TreacheryCardEditor({
+  nameField,
   draft,
   patch,
   chapter,
@@ -426,6 +417,8 @@ export function TreacheryCardEditor({
   onSettle,
 }: {
   draft: TreacheryDraft;
+  /** The Name field, constructed by the route: checking a name's address is a fetch, and fetching controls are Pickers the routes own. */
+  nameField: ReactNode;
   patch: Patch;
   chapter: TreacheryChapter;
   onChapterChange: (chapter: TreacheryChapter) => void;
@@ -447,7 +440,7 @@ export function TreacheryCardEditor({
               value: 'head',
               label: 'Head',
               icon: <TopicIcon topic="text" size={21} />,
-              panel: panel(<HeadFields draft={draft} patch={patch} />),
+              panel: panel(<HeadFields draft={draft} patch={patch} nameField={nameField} />),
             },
             {
               value: 'icon',

--- a/src/app/widgets/deck-editor/DeckEditor.stories.tsx
+++ b/src/app/widgets/deck-editor/DeckEditor.stories.tsx
@@ -14,6 +14,7 @@ const meta = preview.meta({
   title: 'Deck Editor',
   component: DeckEditor,
   args: {
+    nameField: <input aria-label="Name" readOnly value="Lasgun" />,
     chapter: 'identity' as const,
     onChapterChange: fn(),
     onSettle: fn(),

--- a/src/app/widgets/deck-editor/DeckEditor.test.tsx
+++ b/src/app/widgets/deck-editor/DeckEditor.test.tsx
@@ -35,6 +35,7 @@ function Harness() {
   return (
     <MantineProvider theme={appContentTheme} forceColorScheme="light">
       <DeckEditor
+        nameField={<input aria-label="Name" readOnly value="" />}
         draft={draft}
         patch={(update) => setDraft((previous) => ({ ...previous, ...update }))}
         chapter={chapter}

--- a/src/app/widgets/deck-editor/DeckEditor.tsx
+++ b/src/app/widgets/deck-editor/DeckEditor.tsx
@@ -239,6 +239,7 @@ const panel = (children: ReactNode) => <Stack gap="lg">{children}</Stack>;
  * Each count change writes an `asset_relations` row immediately, the way a token's referenced backside does, because relations do not travel through the asset's `data`.
  */
 export function DeckEditor({
+  nameField,
   draft,
   patch,
   chapter,
@@ -252,6 +253,8 @@ export function DeckEditor({
   backProof,
 }: {
   draft: DeckDraft;
+  /** The Name field, constructed by the route: checking a name's address is a fetch, and fetching controls are Pickers the routes own. */
+  nameField: ReactNode;
   patch: (update: Partial<DeckDraft>) => void;
   chapter: DeckChapter;
   onChapterChange: (chapter: DeckChapter) => void;
@@ -308,17 +311,7 @@ export function DeckEditor({
               icon: <TopicIcon topic="identity" size={21} />,
               panel: panel(
                 <>
-                  <ControlBlock
-                    title="Name"
-                    description="Determines the deck's URL."
-                    input={
-                      <TextInput
-                        aria-label="Name"
-                        value={draft.name}
-                        onChange={(event) => patch({ name: event.currentTarget.value })}
-                      />
-                    }
-                  />
+                  <ControlBlock title="Name" description="Determines the deck's URL." input={nameField} />
                   <ControlBlock
                     title="Card back"
                     description="Every deck wears exactly one. The deck publishes its own image either way, so a stock back only supplies the artwork."

--- a/src/app/widgets/token-editor/RectangleTokenEditor.tsx
+++ b/src/app/widgets/token-editor/RectangleTokenEditor.tsx
@@ -1,16 +1,4 @@
-import {
-  Alert,
-  Divider,
-  Group,
-  NumberInput,
-  Select,
-  Slider,
-  Stack,
-  Switch,
-  Text,
-  Textarea,
-  TextInput,
-} from '@mantine/core';
+import { Alert, Divider, Group, NumberInput, Select, Slider, Stack, Switch, Text, Textarea } from '@mantine/core';
 import { RECTANGLE_TOKEN_FONTS } from '@shared/assets/schema';
 import type { RectangleTokenAsset } from '@shared/assets/schema';
 import { TopicIcon } from '@ui/content/TopicIcon';
@@ -445,6 +433,7 @@ function backForMode(
 }
 
 export function RectangleTokenEditor({
+  nameField,
   draft,
   patch,
   chapter,
@@ -454,6 +443,8 @@ export function RectangleTokenEditor({
   backProof,
 }: {
   draft: RectangleDraft;
+  /** The Name field, constructed by the route: checking a name's address is a fetch, and fetching controls are Pickers the routes own. */
+  nameField: ReactNode;
   patch: (update: Partial<RectangleDraft>) => void;
   chapter: RectangleChapter;
   onChapterChange: (chapter: RectangleChapter) => void;
@@ -506,17 +497,7 @@ export function RectangleTokenEditor({
       icon: <TopicIcon topic="identity" size={21} />,
       panel: panel(
         <>
-          <ControlBlock
-            title="Name"
-            description="Determines the token's URL."
-            input={
-              <TextInput
-                aria-label="Name"
-                value={draft.name}
-                onChange={(event) => patch({ name: event.currentTarget.value })}
-              />
-            }
-          />
+          <ControlBlock title="Name" description="Determines the token's URL." input={nameField} />
           <ControlBlock
             title="Backside"
             description="Every token has one. Compose it, print the front on both sides, or wear another token's back."

--- a/src/app/widgets/token-editor/TokenEditor.stories.tsx
+++ b/src/app/widgets/token-editor/TokenEditor.stories.tsx
@@ -18,6 +18,7 @@ const meta = preview.meta({
   title: 'Token Editor',
   component: TokenEditor,
   args: {
+    nameField: <input aria-label="Name" readOnly value="Lasgun" />,
     type: TYPE,
     chapter: 'identity' as const,
     onChapterChange: fn(),

--- a/src/app/widgets/token-editor/TokenEditor.test.tsx
+++ b/src/app/widgets/token-editor/TokenEditor.test.tsx
@@ -38,6 +38,7 @@ function Harness({ expose }: { expose: (state: { draft: TokenDraft; setDraft: (n
   return (
     <MantineProvider theme={appContentTheme} forceColorScheme="light">
       <TokenEditor
+        nameField={<input aria-label="Name" readOnly value="" />}
         draft={draft}
         patch={(update) => setDraft((previous) => ({ ...previous, ...update }))}
         type={TYPE}

--- a/src/app/widgets/token-editor/TokenEditor.tsx
+++ b/src/app/widgets/token-editor/TokenEditor.tsx
@@ -290,6 +290,7 @@ function backForMode(
 }
 
 export function TokenEditor({
+  nameField,
   draft,
   patch,
   type,
@@ -300,6 +301,8 @@ export function TokenEditor({
   backProof,
 }: {
   draft: TokenDraft;
+  /** The Name field, constructed by the route: checking a name's address is a fetch, and fetching controls are Pickers the routes own. */
+  nameField: ReactNode;
   patch: (update: Partial<TokenDraft>) => void;
   /** The Asset type, which fixes the shape of every proof on this page. */
   type: string;
@@ -339,17 +342,7 @@ export function TokenEditor({
       icon: <TopicIcon topic="identity" size={21} />,
       panel: panel(
         <>
-          <ControlBlock
-            title="Name"
-            description="Determines the token's URL."
-            input={
-              <TextInput
-                aria-label="Name"
-                value={draft.name}
-                onChange={(event) => patch({ name: event.currentTarget.value })}
-              />
-            }
-          />
+          <ControlBlock title="Name" description="Determines the token's URL." input={nameField} />
           <ControlBlock
             title="Backside"
             description="Every token has one. Compose it, print the front on both sides, or wear another token's back."

--- a/src/shared/slugify.ts
+++ b/src/shared/slugify.ts
@@ -1,0 +1,12 @@
+/**
+ * How a name becomes a URL slug, everywhere: the database derives stored slugs with it, and the editors derive candidate slugs from a draft name to warn about conflicts before a save is tried.
+ * One implementation on the shared side of the fence, because a client-side copy that drifted would warn about the wrong slug.
+ */
+export function slugify(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+}


### PR DESCRIPTION
Fixes finding 19 on [Walk findings, round two](https://github.com/ndelangen/dunezone/issues/613): creating a card named Shield met the reserved slug of the existing Shield! card and showed "[CONVEX] Server Error" — the guard was right, its words were redacted.

## Three layers, one rule

- **The editor warns while you type.** `slugify` moves to `src/shared` (one implementation; the convex module re-exports it), a `slugTaken` query exposes the save guard's own predicate as a subscription, and `useNameConflict` wires it into the validation header on **all ten** create and edit organs: "Identity — its name is already taken (another one lives at \"shield\")", live, skipping blank and unchanged names so an untouched edit page never queries.
- **The refusal reaches the banner.** User-caused write refusals become `ConvexError` — the slug guard (now worded "The name is taken: another treachery already lives at \"shield\". Pick a different name."), required-name, member-count bounds, container type rules, and the referenceable-back assertions (race-reachable from a stale pick). Genuine invariants (row not found, unknown type) stay plain and redacted, which is the honest rendering of a real server fault.
- **The banners unwrap once.** `mutationErrorMessage` prefers a `ConvexError`'s data over the wrapped message; all ten "Could not save" alerts use it.

## Verification

- Gates green: typecheck, lint, format, knip, css-orphans, 633 unit tests.
- New contract tests: the colliding create rejects with a `ConvexError` carrying the new wording; `slugTaken` agrees with the guard (including per-type reservation and soft-deleted slugs staying reserved); the unwrap helper's two branches.
- Two pre-existing assertions expecting the old "reserved" wording updated.
- The live warning path rides the existing `ValidationHeader` — the pattern already walked on prod; the wiring is per-organ and auth-gated, so its browser pass lands in the prod revalidation after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added live duplicate-name warnings when creating or editing assets.
- Name conflicts now distinguish between active assets and deleted-name reservations.
- Added consistent name-to-slug validation across asset types.
- Improved save and validation messages with clearer, actionable feedback.

## Bug Fixes
- Prevented conflicting names while preserving deleted-name reservations.
- Improved validation for incompatible, missing, deleted, or self-referencing asset components.
- Clarified that name conflicts are scoped by asset type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->