### PR TITLE
A faction's name warns while typing, and a new deck can wear another's back

### DIFF
--- a/convex/factions.slugReservations.test.ts
+++ b/convex/factions.slugReservations.test.ts
@@ -39,13 +39,37 @@ describe('faction slug reservations', () => {
     );
   });
 
+  /*
+   * The editor's warning and the save guard's refusal read one predicate, so this pins all three answers the query can give.
+   * Without it the two surfaces can drift and only a reader typing a taken name would notice.
+   */
+  test('factionSlugTaken answers live, deleted, and free', async () => {
+    const { asUser } = await authenticatedTest();
+    expect(await asUser.query(api.factions.factionSlugTaken, { slug: 'reserved-faction' })).toBe(null);
+
+    const faction = await createFaction(asUser, 'Reserved Faction');
+    expect(await asUser.query(api.factions.factionSlugTaken, { slug: 'reserved-faction' })).toBe('live');
+
+    await asUser.mutation(api.factions.softDelete, { id: faction._id });
+    expect(await asUser.query(api.factions.factionSlugTaken, { slug: 'reserved-faction' })).toBe('deleted');
+  });
+
+  test('a live faction refuses a colliding name in its own words', async () => {
+    const { asUser } = await authenticatedTest();
+    await createFaction(asUser, 'Reserved Faction');
+
+    await expect(createFaction(asUser, 'Reserved Faction')).rejects.toThrow(
+      'another faction already lives at "reserved-faction"'
+    );
+  });
+
   test('a soft-deleted faction keeps its slug reserved for create', async () => {
     const { asUser } = await authenticatedTest();
     const faction = await createFaction(asUser, 'Reserved Faction');
     await asUser.mutation(api.factions.softDelete, { id: faction._id });
 
     await expect(createFaction(asUser, 'Reserved Faction')).rejects.toThrow(
-      'another faction already lives at "reserved-faction"'
+      '"reserved-faction" stays reserved by a deleted faction'
     );
   });
 
@@ -60,7 +84,7 @@ describe('faction slug reservations', () => {
         id: active._id,
         data: { ...assetPublishingFaction, name: 'Reserved Faction' },
       })
-    ).rejects.toThrow('another faction already lives at "reserved-faction"');
+    ).rejects.toThrow('"reserved-faction" stays reserved by a deleted faction');
   });
 
   test('the repair keeps the active public slug and archives the deleted duplicate', async () => {

--- a/convex/factions.slugReservations.test.ts
+++ b/convex/factions.slugReservations.test.ts
@@ -43,15 +43,15 @@ describe('faction slug reservations', () => {
    * The editor's warning and the save guard's refusal read one predicate, so this pins all three answers the query can give.
    * Without it the two surfaces can drift and only a reader typing a taken name would notice.
    */
-  test('factionSlugTaken answers live, deleted, and free', async () => {
+  test('slugTaken answers live, deleted, and free', async () => {
     const { asUser } = await authenticatedTest();
-    expect(await asUser.query(api.factions.factionSlugTaken, { slug: 'reserved-faction' })).toBe(null);
+    expect(await asUser.query(api.factions.slugTaken, { slug: 'reserved-faction' })).toBe(null);
 
     const faction = await createFaction(asUser, 'Reserved Faction');
-    expect(await asUser.query(api.factions.factionSlugTaken, { slug: 'reserved-faction' })).toBe('live');
+    expect(await asUser.query(api.factions.slugTaken, { slug: 'reserved-faction' })).toBe('live');
 
     await asUser.mutation(api.factions.softDelete, { id: faction._id });
-    expect(await asUser.query(api.factions.factionSlugTaken, { slug: 'reserved-faction' })).toBe('deleted');
+    expect(await asUser.query(api.factions.slugTaken, { slug: 'reserved-faction' })).toBe('deleted');
   });
 
   test('a live faction refuses a colliding name in its own words', async () => {

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -52,7 +52,7 @@ async function factionSlugHolder(
 }
 
 /** The faction editor's live name-conflict check, the save guard's rule as a subscription. */
-export const factionSlugTaken = query({
+export const slugTaken = query({
   args: { slug: v.string() },
   returns: v.union(v.literal('live'), v.literal('deleted'), v.null()),
   handler: async (ctx, args) => await factionSlugHolder(ctx, args.slug),

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -31,13 +31,41 @@ import { enqueueFactionSheetPublication } from './lib/publication';
 import { nowIso, slugify } from './lib/utils';
 import type { MutationCtx, QueryCtx } from './types';
 
-async function assertFactionSlugAvailable(ctx: MutationCtx, slug: string, factionId?: Id<'factions'>) {
+/**
+ * Who holds this address: a living faction, a soft-deleted one whose slug stays reserved, or nobody.
+ * One rule read twice, the assets convention: the save guard refuses on it and the editor's name probe subscribes to it, so the warning and the refusal can never disagree.
+ * `exceptId` is the faction doing the asking, so renaming a faction never trips over its own address.
+ */
+async function factionSlugHolder(
+  ctx: QueryCtx,
+  slug: string,
+  exceptId?: Id<'factions'>
+): Promise<'live' | 'deleted' | null> {
   const existing = await ctx.db
     .query('factions')
     .withIndex('by_slug', (q) => q.eq('slug', slug))
     .unique();
-  if (existing && existing._id !== factionId) {
+  if (!existing || existing._id === exceptId) {
+    return null;
+  }
+  return existing.is_deleted ? 'deleted' : 'live';
+}
+
+/** The faction editor's live name-conflict check, the save guard's rule as a subscription. */
+export const factionSlugTaken = query({
+  args: { slug: v.string() },
+  returns: v.union(v.literal('live'), v.literal('deleted'), v.null()),
+  handler: async (ctx, args) => await factionSlugHolder(ctx, args.slug),
+});
+
+async function assertFactionSlugAvailable(ctx: MutationCtx, slug: string, factionId?: Id<'factions'>) {
+  /* ConvexError, so the words reach the editor's banner in production rather than being redacted to "Server Error". */
+  const holder = await factionSlugHolder(ctx, slug, factionId);
+  if (holder === 'live') {
     throw new ConvexError(`The name is taken: another faction already lives at "${slug}". Pick a different name.`);
+  }
+  if (holder === 'deleted') {
+    throw new ConvexError(`The name is taken: "${slug}" stays reserved by a deleted faction. Pick a different name.`);
   }
 }
 

--- a/e2e/faction-lifecycle.spec.ts
+++ b/e2e/faction-lifecycle.spec.ts
@@ -74,7 +74,7 @@ test('owner can author a faction through its complete lifecycle', async ({ page 
   await test.step('warning focus, name blocking, review, and artifact proof use the loaded draft', async () => {
     await loadFactionDraft(page, factionBName);
 
-    await page.getByRole('tab', { name: 'Identity & Appearance', exact: true }).click();
+    await page.getByRole('tab', { name: /^Identity & Appearance/ }).click();
     /* The validation header is open whenever a warning exists, so there is no toolbar count to click through;
        the header's per-source chip is what jumps to and focuses the field. */
     await page.getByRole('button', { name: 'Faction leader: missing name' }).click();
@@ -82,7 +82,7 @@ test('owner can author a faction through its complete lifecycle', async ({ page 
     await expect(factionLeaderName).toBeFocused();
     await factionLeaderName.fill(importedLeaderName);
 
-    await page.getByRole('tab', { name: 'Identity & Appearance', exact: true }).click();
+    await page.getByRole('tab', { name: /^Identity & Appearance/ }).click();
     const factionName = page.getByRole('textbox', { name: 'Faction name' });
     await factionName.fill('');
     await expect(page.getByRole('button', { name: 'Save faction' })).toBeDisabled();
@@ -135,7 +135,7 @@ test('owner can author a faction through its complete lifecycle', async ({ page 
      */
     await page.getByRole('tab', { name: /^Faction leader/ }).click();
     await expect(page.getByRole('textbox', { name: 'Faction leader name' })).toHaveValue(importedLeaderName);
-    await page.getByRole('tab', { name: 'Identity & Appearance', exact: true }).click();
+    await page.getByRole('tab', { name: /^Identity & Appearance/ }).click();
 
     const savedFactionName = page.getByRole('textbox', { name: 'Faction name' });
     await savedFactionName.fill(`${factionAName} local`);

--- a/src/app/db/factions.ts
+++ b/src/app/db/factions.ts
@@ -140,7 +140,7 @@ export async function loadFactionCataloguePage(): Promise<FactionCataloguePageDa
  * Always real args: the caller mounts and unmounts the probe holding this, which is how a domain read stays conditional without a skip.
  */
 export function useFactionSlugTaken(args: { slug: string }) {
-  return useQuery(api.factions.factionSlugTaken, args);
+  return useQuery(api.factions.slugTaken, args);
 }
 
 export function useFaction(

--- a/src/app/db/factions.ts
+++ b/src/app/db/factions.ts
@@ -135,6 +135,14 @@ export async function loadFactionCataloguePage(): Promise<FactionCataloguePageDa
   return toFactionCataloguePageData(raw);
 }
 
+/**
+ * The save guard's slug rule as a live subscription, for the faction editor's name-conflict warning.
+ * Always real args: the caller mounts and unmounts the probe holding this, which is how a domain read stays conditional without a skip.
+ */
+export function useFactionSlugTaken(args: { slug: string }) {
+  return useQuery(api.factions.factionSlugTaken, args);
+}
+
 export function useFaction(
   slug: string,
   options?: {

--- a/src/app/pickers/DeckBackPicker.tsx
+++ b/src/app/pickers/DeckBackPicker.tsx
@@ -1,0 +1,89 @@
+import { Button, Group, Popover, Stack, Text } from '@mantine/core';
+import { CanvasScale } from '@ui/layout/CanvasScale';
+import { useState } from 'react';
+
+import { AssetFace, assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
+
+import { AssetPicker } from './AssetPicker';
+
+/** Enough of the chosen deck to name it and draw its cardback; the id is what reaches storage. */
+export type PickedBackDeck = { id: string; name: string; data: unknown };
+
+/**
+ * Choosing the deck whose cardback this one wears.
+ *
+ * One control for both the create and the edit page, because the choice is the same one: the create page has no id to exclude and nothing saved yet, which changes what is passed in, not what the reader does.
+ * A pick is a draft edit rather than a write;
+ * the reference reaches storage when the deck is saved, which is what lets the create page offer it at all.
+ */
+export function DeckBackPicker({
+  excludeId,
+  picked,
+  onPick,
+}: {
+  /** The deck being edited, so it cannot wear its own back. Absent while creating, which has no id yet. */
+  excludeId?: string;
+  picked: PickedBackDeck | null;
+  onPick: (deck: PickedBackDeck) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Group gap="xs" wrap="nowrap">
+      <Text size="sm" truncate style={{ minWidth: 0, flex: 1 }} title={picked?.name}>
+        {picked ? picked.name : 'No deck chosen yet'}
+      </Text>
+      {/* Gated by the popover: the picker subscribes on mount, so it must not mount until asked for. */}
+      <Popover opened={open} onChange={setOpen} width={340} position="bottom-start" withinPortal>
+        <Popover.Target>
+          <Button variant="light" size="compact-sm" style={{ flexShrink: 0 }} onClick={() => setOpen((was) => !was)}>
+            {picked ? 'Change' : 'Choose'}
+          </Button>
+        </Popover.Target>
+        <Popover.Dropdown>
+          <AssetPicker
+            types={['deck']}
+            excludeIds={excludeId ? [excludeId] : []}
+            /*
+             * Best effort, not the full referenceability rule: listings present a healthy
+             * reference deck wearing its target's composition, so it reads as authored here
+             * and only a dangling presentation (cardback null) can be excluded client-side.
+             * assertReferenceableDeckCardback remains the gate at save.
+             */
+            filter={(entry) => {
+              const cardback = (entry.data as { cardback?: unknown } | null)?.cardback;
+              return typeof cardback === 'object' && cardback !== null;
+            }}
+            copy={{
+              searchLabel: 'Search decks',
+              searchPlaceholder: 'Type a name, slug or owner…',
+              emptyMessage: 'No other deck has a cardback to wear yet.',
+            }}
+            onPick={(entry) => {
+              setOpen(false);
+              onPick({ id: entry.id, name: entry.name, data: entry.data });
+            }}
+            onCancel={() => setOpen(false)}
+          />
+        </Popover.Dropdown>
+      </Popover>
+    </Group>
+  );
+}
+
+/** What the chosen deck's back actually looks like, for the tile that shows the choice. */
+export function DeckBackProof({ picked }: { picked: PickedBackDeck | null }) {
+  if (!picked) {
+    return null;
+  }
+  return (
+    <Stack gap={4} align="center" w="100%">
+      {/* A deck's face is its cardback, so the target's row draws its own proof. */}
+      <CanvasScale canvasWidth={900} canvasHeight={900 * assetFaceAspect('deck')}>
+        <AssetFace type="deck" data={picked.data} name={picked.name} width={900} />
+      </CanvasScale>
+      <Text size="xs" c="dimmed">
+        Cardback, from {picked.name}
+      </Text>
+    </Stack>
+  );
+}

--- a/src/app/pickers/FactionNameInput.tsx
+++ b/src/app/pickers/FactionNameInput.tsx
@@ -1,0 +1,49 @@
+import { useEffect } from 'react';
+
+import { useFactionSlugTaken } from '@app/db/factions';
+
+import { UniqueNameInput } from './UniqueNameInput';
+import type { NameConflict, NameHolder } from './UniqueNameInput';
+
+/** The subscription half, mounted by `UniqueNameInput` only while a settled candidate exists. */
+function FactionSlugProbe({ slug, onAnswer }: { slug: string; onAnswer: (holder: NameHolder | null) => void }) {
+  const holder = useFactionSlugTaken({ slug });
+  useEffect(() => {
+    onAnswer(holder ?? null);
+  }, [holder, onAnswer]);
+  return null;
+}
+
+/**
+ * The faction editor's name field: `UniqueNameInput` bound to the factions table's own slug rule.
+ * The save guard and this probe read one predicate, so the warning and the refusal can never disagree.
+ *
+ * Unlike an asset's, a faction's slug is unique across the whole table rather than per type, so the probe carries no scope.
+ */
+export function FactionNameInput({
+  value,
+  onChange,
+  currentSlug,
+  error,
+  onConflictChange,
+}: {
+  value: string;
+  onChange: (name: string) => void;
+  currentSlug?: string;
+  error?: string;
+  onConflictChange: (conflict: NameConflict | null) => void;
+}) {
+  return (
+    <UniqueNameInput
+      /* The id the validation header's chip focuses, kept from the field this replaces. */
+      id="faction-name"
+      label="Faction name"
+      error={error}
+      value={value}
+      onChange={onChange}
+      currentSlug={currentSlug}
+      onConflictChange={onConflictChange}
+      probe={({ slug, onAnswer }) => <FactionSlugProbe key={slug} slug={slug} onAnswer={onAnswer} />}
+    />
+  );
+}

--- a/src/app/pickers/FactionNameInput.tsx
+++ b/src/app/pickers/FactionNameInput.tsx
@@ -23,12 +23,14 @@ function FactionSlugProbe({ slug, onAnswer }: { slug: string; onAnswer: (holder:
 export function FactionNameInput({
   value,
   onChange,
+  onBlur,
   currentSlug,
   error,
   onConflictChange,
 }: {
   value: string;
   onChange: (name: string) => void;
+  onBlur?: () => void;
   currentSlug?: string;
   error?: string;
   onConflictChange: (conflict: NameConflict | null) => void;
@@ -41,6 +43,7 @@ export function FactionNameInput({
       error={error}
       value={value}
       onChange={onChange}
+      onBlur={onBlur}
       currentSlug={currentSlug}
       onConflictChange={onConflictChange}
       probe={({ slug, onAnswer }) => <FactionSlugProbe key={slug} slug={slug} onAnswer={onAnswer} />}

--- a/src/app/pickers/UniqueNameInput.tsx
+++ b/src/app/pickers/UniqueNameInput.tsx
@@ -107,6 +107,7 @@ export function UniqueNameInput({
   label = 'Name',
   value,
   onChange,
+  onBlur,
   currentSlug,
   error,
   probe,
@@ -117,6 +118,8 @@ export function UniqueNameInput({
   label?: string;
   value: string;
   onChange: (name: string) => void;
+  /** For hosts whose form tracks blur, so the field this replaces loses none of its wiring. */
+  onBlur?: () => void;
   /** The entity's own slug on an edit page, so an unchanged name never warns about its own address. */
   currentSlug?: string;
   /** The caller's own complaint about the name, a blank one for instance. A conflict outranks it, and the two cannot coincide: a blank name has no candidate to conflict with. */
@@ -133,6 +136,7 @@ export function UniqueNameInput({
         aria-label={label}
         value={value}
         onChange={(event) => onChange(event.currentTarget.value)}
+        onBlur={onBlur}
         error={conflict ? nameConflictComplaint(conflict) : error}
       />
     </>

--- a/src/app/pickers/UniqueNameInput.tsx
+++ b/src/app/pickers/UniqueNameInput.tsx
@@ -20,10 +20,11 @@ export type NameAvailabilityProbe = (props: {
 /**
  * The one sentence a name conflict speaks on the client, shared by the field's inline error and the validation header's chip so the two cannot drift.
  * It mirrors the save guard's own distinction: a living holder and a deleted one reserving its address are different answers.
+ * Noun-free on purpose, the way this input is entity-blind: the field sits in an editor that has already told the reader what they are naming, and a noun here would be one more place per entity to keep true.
  */
 export function nameConflictComplaint({ holder, slug }: NameConflict): string {
   return holder === 'deleted'
-    ? `its name is already taken ("${slug}" stays reserved by a deleted asset)`
+    ? `its name is already taken ("${slug}" stays reserved by a deleted one)`
     : `its name is already taken (another one lives at "${slug}")`;
 }
 
@@ -102,18 +103,24 @@ function useSettledConflict({
  * The conflict shows twice on purpose: inline under the field where the author is looking, and through `onConflictChange` so the route can raise it in the validation header, whose chip routes back to this chapter.
  */
 export function UniqueNameInput({
+  id,
   label = 'Name',
   value,
   onChange,
   currentSlug,
+  error,
   probe,
   onConflictChange,
 }: {
+  /** The field's DOM id, so a validation header chip can focus it by id the way the faction editor does. */
+  id?: string;
   label?: string;
   value: string;
   onChange: (name: string) => void;
   /** The entity's own slug on an edit page, so an unchanged name never warns about its own address. */
   currentSlug?: string;
+  /** The caller's own complaint about the name, a blank one for instance. A conflict outranks it, and the two cannot coincide: a blank name has no candidate to conflict with. */
+  error?: string;
   probe: NameAvailabilityProbe;
   onConflictChange: (conflict: NameConflict | null) => void;
 }) {
@@ -122,10 +129,11 @@ export function UniqueNameInput({
     <>
       {settled ? probe({ slug: settled, onAnswer }) : null}
       <TextInput
+        id={id}
         aria-label={label}
         value={value}
         onChange={(event) => onChange(event.currentTarget.value)}
-        error={conflict ? nameConflictComplaint(conflict) : undefined}
+        error={conflict ? nameConflictComplaint(conflict) : error}
       />
     </>
   );

--- a/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
@@ -1,4 +1,4 @@
-import { Alert, Anchor, Button, Group, Popover, Stack, Text } from '@mantine/core';
+import { Alert, Anchor, Popover, Text } from '@mantine/core';
 import { DeckAsset } from '@shared/assets/schema';
 import { ASSET_TYPE_KEYS, ASSET_TYPES } from '@shared/assets/types';
 import { Link, useNavigate } from '@tanstack/react-router';
@@ -6,7 +6,6 @@ import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
 import { AddAction } from '@ui/control/ListLengthActions';
-import { CanvasScale } from '@ui/layout/CanvasScale';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
 import { FilePlus2 } from 'lucide-react';
@@ -16,7 +15,8 @@ import { useAssetPage, useSetMemberCount, useUpdateAsset } from '@app/db/assets'
 import type { AssetPageData } from '@app/db/assets';
 import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetPicker } from '@app/pickers/AssetPicker';
-import { AssetFace, assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
+import { DeckBackPicker, DeckBackProof } from '@app/pickers/DeckBackPicker';
+import type { PickedBackDeck } from '@app/pickers/DeckBackPicker';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
@@ -135,12 +135,11 @@ function DeckEditSession({
   const [chapter, setChapter] = useState<DeckChapter>('identity');
   const [settleTick, setSettleTick] = useState(0);
   const [pickerOpen, setPickerOpen] = useState(false);
-  const [backPickerOpen, setBackPickerOpen] = useState(false);
   /*
    * The deck whose cardback the draft references, for the label and the proof.
    * Server truth seeds it and a pick replaces it; the draft holds only the id.
    */
-  const [pickedBackDeck, setPickedBackDeck] = useState<{ name: string; data: unknown } | null>(backDeck);
+  const [pickedBackDeck, setPickedBackDeck] = useState<PickedBackDeck | null>(backDeck);
   /* Armed by a save attempt while the reference has no target; disarmed the moment the state resolves. */
   const [pickBlocked, setPickBlocked] = useState(false);
   const patch = (update: Partial<DeckDraft>) => setDraft((prev) => ({ ...prev, ...update }));
@@ -316,72 +315,17 @@ function DeckEditSession({
               </Popover>
             }
             backPicker={
-              <Group gap="xs" wrap="nowrap">
-                <Text size="sm" truncate style={{ minWidth: 0, flex: 1 }} title={pickedBackDeck?.name}>
-                  {pickedBackDeck ? pickedBackDeck.name : 'No deck chosen yet'}
-                </Text>
-                {/* Gated by the popover: the picker subscribes on mount, so it must not mount until asked for. */}
-                <Popover
-                  opened={backPickerOpen}
-                  onChange={setBackPickerOpen}
-                  width={340}
-                  position="bottom-start"
-                  withinPortal
-                >
-                  <Popover.Target>
-                    <Button
-                      variant="light"
-                      size="compact-sm"
-                      style={{ flexShrink: 0 }}
-                      onClick={() => setBackPickerOpen((open) => !open)}
-                    >
-                      {pickedBackDeck ? 'Change' : 'Choose'}
-                    </Button>
-                  </Popover.Target>
-                  <Popover.Dropdown>
-                    <AssetPicker
-                      types={['deck']}
-                      excludeIds={[asset.id]}
-                      /*
-                       * Best effort, not the full referenceability rule: listings present a healthy
-                       * reference deck wearing its target's composition, so it reads as authored here
-                       * and only a dangling presentation (cardback null) can be excluded client-side.
-                       * assertReferenceableDeckCardback remains the gate at save.
-                       */
-                      filter={(entry) => {
-                        const cardback = (entry.data as { cardback?: unknown } | null)?.cardback;
-                        return typeof cardback === 'object' && cardback !== null;
-                      }}
-                      copy={{
-                        searchLabel: 'Search decks',
-                        searchPlaceholder: 'Type a name, slug or owner…',
-                        emptyMessage: 'No other deck has a cardback to wear yet.',
-                      }}
-                      onPick={(picked) => {
-                        setBackPickerOpen(false);
-                        /* A pick is a draft edit, not a write; the reference reaches storage when the deck is saved. */
-                        setPickedBackDeck(picked);
-                        patch({ cardback: { mode: 'reference', asset_id: picked.id } });
-                      }}
-                      onCancel={() => setBackPickerOpen(false)}
-                    />
-                  </Popover.Dropdown>
-                </Popover>
-              </Group>
+              <DeckBackPicker
+                excludeId={asset.id}
+                picked={pickedBackDeck}
+                onPick={(deck) => {
+                  /* A pick is a draft edit, not a write; the reference reaches storage when the deck is saved. */
+                  setPickedBackDeck(deck);
+                  patch({ cardback: { mode: 'reference', asset_id: deck.id } });
+                }}
+              />
             }
-            backProof={
-              pickedBackDeck ? (
-                <Stack gap={4} align="center" w="100%">
-                  {/* A deck's face is its cardback, so the target's row draws its own proof. */}
-                  <CanvasScale canvasWidth={900} canvasHeight={900 * assetFaceAspect('deck')}>
-                    <AssetFace type="deck" data={pickedBackDeck.data} name={pickedBackDeck.name} width={900} />
-                  </CanvasScale>
-                  <Text size="xs" c="dimmed">
-                    Cardback, from {pickedBackDeck.name}
-                  </Text>
-                </Stack>
-              ) : null
-            }
+            backProof={<DeckBackProof picked={pickedBackDeck} />}
           />
         </WorkbenchLayout>
       </PageLayout.Content>

--- a/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
@@ -7,6 +7,8 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateAsset } from '@app/db/assets';
+import { DeckBackPicker, DeckBackProof } from '@app/pickers/DeckBackPicker';
+import type { PickedBackDeck } from '@app/pickers/DeckBackPicker';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
@@ -27,6 +29,8 @@ export function DeckCreatePage() {
   const profile = useCurrentProfile();
   const createAsset = useCreateAsset();
   const [draft, setDraft] = useState<DeckDraft>(INITIAL_DECK_DRAFT);
+  /* The chosen deck, kept beside the draft: the draft carries the id that reaches storage, this carries the name and face the tile draws. */
+  const [pickedBackDeck, setPickedBackDeck] = useState<PickedBackDeck | null>(null);
   const [chapter, setChapter] = useState<DeckChapter>('identity');
   const [settleTick, setSettleTick] = useState(0);
   /* Armed by a save attempt while the reference has no target; disarmed the moment the state resolves. */
@@ -131,12 +135,21 @@ export function DeckCreatePage() {
               </Text>
             }
             backPicker={
-              /* The same once-saved line the token creates keep; whether creates should pick is one editorial decision, recorded for Norbert. */
-              <Text size="xs" c="dimmed">
-                A deck can wear another deck's cardback once it has been saved.
-              </Text>
+              /*
+               * Offered before the first save, unlike the members below it: a reference is a value the draft can
+               * already hold, so nothing about it needs an id of our own. Cards, by contrast, are relation rows
+               * written against a deck that does not exist yet, which is why that slot still waits.
+               */
+              <DeckBackPicker
+                picked={pickedBackDeck}
+                onPick={(deck) => {
+                  /* A pick is a draft edit, not a write; the reference reaches storage when the deck is saved. */
+                  setPickedBackDeck(deck);
+                  patch({ cardback: { mode: 'reference', asset_id: deck.id } });
+                }}
+              />
             }
-            backProof={null}
+            backProof={<DeckBackProof picked={pickedBackDeck} />}
           />
         </WorkbenchLayout>
       </PageLayout.Content>

--- a/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
@@ -107,7 +107,11 @@ export function DeckCreatePage() {
           }}
           actions={{
             onSave: save,
-            onReset: () => setDraft(INITIAL_DECK_DRAFT),
+            onReset: () => {
+              setDraft(INITIAL_DECK_DRAFT);
+              /* The pick rides beside the draft, so a reset must drop both or the tile would show a choice the draft no longer holds. */
+              setPickedBackDeck(null);
+            },
             onBack: () => void navigate({ to: '/assets/$type', params: { type: 'deck' } }),
           }}
         />

--- a/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
@@ -71,7 +71,7 @@ export function DeckCreatePage() {
   }
 
   const save = () => {
-    /* The reference tile can be chosen here but not filled (picking waits for the edit page), so the save says so with words rather than a Zod error. */
+    /* Reference mode with nothing picked has no target to store, so the save says so with words rather than a Zod error. */
     if (pickless) {
       setPickBlocked(true);
       return;
@@ -109,8 +109,9 @@ export function DeckCreatePage() {
             onSave: save,
             onReset: () => {
               setDraft(INITIAL_DECK_DRAFT);
-              /* The pick rides beside the draft, so a reset must drop both or the tile would show a choice the draft no longer holds. */
+              /* The pick and the armed alert ride beside the draft, so a reset drops all three, the way the edit page's does. */
               setPickedBackDeck(null);
+              setPickBlocked(false);
             },
             onBack: () => void navigate({ to: '/assets/$type', params: { type: 'deck' } }),
           }}
@@ -121,7 +122,7 @@ export function DeckCreatePage() {
           <SaveErrorAlert error={createAsset.error} />
           {pickBlocked && pickless ? (
             <Alert color="yellow" variant="light" role="alert" title="No deck picked">
-              Picking a deck to wear happens on the edit page; save with another back mode first.
+              Pick a deck whose cardback this one wears, or choose another back mode.
             </Alert>
           ) : null}
           <DeckEditor

--- a/src/app/routes/_app/factions/$factionId/edit.tsx
+++ b/src/app/routes/_app/factions/$factionId/edit.tsx
@@ -23,6 +23,8 @@ import { FactionGroupPopover } from '@app/widgets/faction-editor/FactionGroupPop
 import { FactionLoadPopover } from '@app/widgets/faction-editor/FactionLoadPopover';
 import { useFactionAuthoring } from '@app/widgets/faction-editor/useFactionAuthoring';
 
+import { useFactionNameField } from '../-factionNameField';
+
 export const Route = createFileRoute('/_app/factions/$factionId/edit')({
   validateSearch: (params: Record<string, unknown>): { notice?: RouteNoticeCode } => {
     if (isRouteNoticeCode(params?.notice)) {
@@ -72,7 +74,9 @@ function FactionEditPage() {
       }
     },
   });
-  const validationHeaderOpen = useValidationHeaderOpen(authoring.editing.warnings.length, settleTick);
+  const { nameField, conflictWarnings } = useFactionNameField({ currentSlug: faction.slug });
+  const allWarnings = [...authoring.editing.warnings, ...conflictWarnings];
+  const validationHeaderOpen = useValidationHeaderOpen(allWarnings.length, settleTick);
   const header = (
     <Stack align="center" gap={4}>
       <Anchor
@@ -154,7 +158,7 @@ function FactionEditPage() {
         <PageLayout.Header size="compact">
           <ValidationHeader
             id={VALIDATION_HEADER_ID}
-            warnings={authoring.editing.warnings}
+            warnings={allWarnings}
             onFocusWarning={(warning) => viewRef.current?.focusWarning(warning)}
           />
         </PageLayout.Header>
@@ -254,12 +258,13 @@ function FactionEditPage() {
             </Alert>
           ) : null}
           <FactionEditor
+            nameField={nameField}
             key={faction._id}
             ref={viewRef}
             form={authoring.form}
             errors={authoring.persistence.errors}
             isNameBlank={authoring.editing.isNameBlank}
-            warnings={authoring.editing.warnings}
+            warnings={allWarnings}
             onSettle={() => setSettleTick((tick) => tick + 1)}
           />
         </Stack>

--- a/src/app/routes/_app/factions/-factionNameField.tsx
+++ b/src/app/routes/_app/factions/-factionNameField.tsx
@@ -1,0 +1,38 @@
+import { useCallback, useState } from 'react';
+
+import { FactionNameInput } from '@app/pickers/FactionNameInput';
+import { nameConflictComplaint } from '@app/pickers/UniqueNameInput';
+import type { NameConflict } from '@app/pickers/UniqueNameInput';
+import { factionNameConflictWarning } from '@app/widgets/faction-editor/factionAuthoringContract';
+import type { FactionAuthoringWarning } from '@app/widgets/faction-editor/factionAuthoringContract';
+import type { FactionIdentityNameField } from '@app/widgets/faction-editor/FactionFormSectionIdentity';
+
+/**
+ * The faction editor's name field and the warning it raises, for the two routes that mount the editor.
+ *
+ * The field is a Picker, so it holds the read the widget may not;
+ * the route owns the conflict because the validation header is the route's.
+ * Both routes call this rather than wiring it twice, so the create and edit pages cannot drift on the sentence or on where the chip lands.
+ */
+export function useFactionNameField({ currentSlug }: { currentSlug?: string } = {}): {
+  nameField: FactionIdentityNameField;
+  conflictWarnings: FactionAuthoringWarning[];
+} {
+  const [conflict, setConflict] = useState<NameConflict | null>(null);
+  const nameField = useCallback<FactionIdentityNameField>(
+    ({ value, onChange, error }) => (
+      <FactionNameInput
+        value={value}
+        onChange={onChange}
+        currentSlug={currentSlug}
+        error={error}
+        onConflictChange={setConflict}
+      />
+    ),
+    [currentSlug]
+  );
+  return {
+    nameField,
+    conflictWarnings: conflict ? [factionNameConflictWarning(nameConflictComplaint(conflict))] : [],
+  };
+}

--- a/src/app/routes/_app/factions/-factionNameField.tsx
+++ b/src/app/routes/_app/factions/-factionNameField.tsx
@@ -20,10 +20,11 @@ export function useFactionNameField({ currentSlug }: { currentSlug?: string } = 
 } {
   const [conflict, setConflict] = useState<NameConflict | null>(null);
   const nameField = useCallback<FactionIdentityNameField>(
-    ({ value, onChange, error }) => (
+    ({ value, onChange, onBlur, error }) => (
       <FactionNameInput
         value={value}
         onChange={onChange}
+        onBlur={onBlur}
         currentSlug={currentSlug}
         error={error}
         onConflictChange={setConflict}

--- a/src/app/routes/_app/factions/create.tsx
+++ b/src/app/routes/_app/factions/create.tsx
@@ -18,6 +18,8 @@ import type { FactionAuthoringViewHandle } from '@app/widgets/faction-editor/Fac
 import { FactionLoadPopover } from '@app/widgets/faction-editor/FactionLoadPopover';
 import { useFactionAuthoring } from '@app/widgets/faction-editor/useFactionAuthoring';
 
+import { useFactionNameField } from './-factionNameField';
+
 const VALIDATION_HEADER_ID = 'faction-validation-header';
 
 export const Route = createFileRoute('/_app/factions/create')({
@@ -54,7 +56,9 @@ function CreateFactionPage() {
     },
   });
   const [settleTick, setSettleTick] = useState(0);
-  const validationHeaderOpen = useValidationHeaderOpen(authoring.editing.warnings.length, settleTick);
+  const { nameField, conflictWarnings } = useFactionNameField();
+  const allWarnings = [...authoring.editing.warnings, ...conflictWarnings];
+  const validationHeaderOpen = useValidationHeaderOpen(allWarnings.length, settleTick);
 
   const header = (
     <Stack align="center" gap={4}>
@@ -91,7 +95,7 @@ function CreateFactionPage() {
         {validationHeaderOpen ? (
           <ValidationHeader
             id={VALIDATION_HEADER_ID}
-            warnings={authoring.editing.warnings}
+            warnings={allWarnings}
             onFocusWarning={(warning) => viewRef.current?.focusWarning(warning)}
           />
         ) : (
@@ -129,12 +133,13 @@ function CreateFactionPage() {
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <FactionEditor
+          nameField={nameField}
           key="create"
           ref={viewRef}
           form={authoring.form}
           errors={authoring.persistence.errors}
           isNameBlank={authoring.editing.isNameBlank}
-          warnings={authoring.editing.warnings}
+          warnings={allWarnings}
           onSettle={() => setSettleTick((tick) => tick + 1)}
         />
       </PageLayout.Content>

--- a/src/app/widgets/faction-editor/FactionEditor.tsx
+++ b/src/app/widgets/faction-editor/FactionEditor.tsx
@@ -7,6 +7,7 @@ import type { FactionAuthoringWarning } from './factionAuthoringContract';
 import styles from './FactionEditor.module.css';
 import { FactionFormFields } from './FactionFormFields';
 import type { FactionFormFieldsHandle } from './FactionFormFields';
+import type { FactionIdentityNameField } from './FactionFormSectionIdentity';
 import type { FactionFormApi } from './factionFormTypes';
 import { FactionSheetReview } from './FactionSheetReview';
 import type { FactionSheetReviewHandle } from './FactionSheetReview';
@@ -17,6 +18,7 @@ export interface FactionEditorProps {
   isNameBlank: boolean;
   warnings: FactionAuthoringWarning[];
   /** Fires on field blur and chapter switch — the moments the validation header may settle closed. */
+  nameField?: FactionIdentityNameField;
   onSettle?: () => void;
 }
 
@@ -27,7 +29,7 @@ export interface FactionAuthoringViewHandle {
 }
 
 export const FactionEditor = forwardRef<FactionAuthoringViewHandle, FactionEditorProps>(
-  ({ form, errors, isNameBlank, warnings, onSettle }, ref) => {
+  ({ form, errors, isNameBlank, warnings, nameField, onSettle }, ref) => {
     const reviewRef = useRef<FactionSheetReviewHandle>(null);
     const fieldsRef = useRef<FactionFormFieldsHandle>(null);
 
@@ -61,6 +63,7 @@ export const FactionEditor = forwardRef<FactionAuthoringViewHandle, FactionEdito
                   ref={fieldsRef}
                   form={form}
                   warnings={warnings}
+                  nameField={nameField}
                   onSettle={onSettle}
                   nameError={
                     isNameBlank

--- a/src/app/widgets/faction-editor/FactionEditor.tsx
+++ b/src/app/widgets/faction-editor/FactionEditor.tsx
@@ -17,8 +17,9 @@ export interface FactionEditorProps {
   errors: string[];
   isNameBlank: boolean;
   warnings: FactionAuthoringWarning[];
-  /** Fires on field blur and chapter switch — the moments the validation header may settle closed. */
+  /** A route-bound name input rendered in the Identity section's name slot; see `FactionIdentityNameField`. */
   nameField?: FactionIdentityNameField;
+  /** Fires on field blur and chapter switch — the moments the validation header may settle closed. */
   onSettle?: () => void;
 }
 

--- a/src/app/widgets/faction-editor/FactionFormFields.tsx
+++ b/src/app/widgets/faction-editor/FactionFormFields.tsx
@@ -27,6 +27,7 @@ import { FactionFormSectionBackground } from './FactionFormSectionBackground';
 import { FactionFormSectionComplexity } from './FactionFormSectionComplexity';
 import { FactionFormSectionHero } from './FactionFormSectionHero';
 import { FactionFormSectionIdentity } from './FactionFormSectionIdentity';
+import type { FactionIdentityNameField } from './FactionFormSectionIdentity';
 import { FactionFormSectionLeaders } from './FactionFormSectionLeaders';
 import { FactionFormSectionPlanets } from './FactionFormSectionPlanets';
 import { FactionFormSectionRules } from './FactionFormSectionRules';
@@ -398,10 +399,11 @@ export const FactionFormFields = forwardRef<
     form: FactionFormApi;
     warnings: FactionAuthoringWarning[];
     nameError?: string;
+    nameField?: FactionIdentityNameField;
     /** Fires on field blur and chapter switch so the route's validation header can settle closed. */
     onSettle?: () => void;
   }
->(function FactionFormFields({ form, warnings, nameError, onSettle }, ref) {
+>(function FactionFormFields({ form, warnings, nameError, nameField, onSettle }, ref) {
   const [activeChapter, setActiveChapter] = useState<FactionAuthoringChapterId>('identity');
   const [retainedManualComplexity, setRetainedManualComplexity] = useState<number | null>(null);
   const [selectedItem, setSelectedItem] = useState({
@@ -428,7 +430,7 @@ export const FactionFormFields = forwardRef<
     <>
       {chapter === 'identity' ? (
         <>
-          <FactionFormSectionIdentity form={form} nameError={nameError} showIntro={false} />
+          <FactionFormSectionIdentity form={form} nameError={nameError} nameField={nameField} showIntro={false} />
           <FactionFormSectionBackground form={form} />
         </>
       ) : null}

--- a/src/app/widgets/faction-editor/FactionFormSectionIdentity.tsx
+++ b/src/app/widgets/faction-editor/FactionFormSectionIdentity.tsx
@@ -1,6 +1,7 @@
 import { Box, ColorInput, Stack, Text, TextInput } from '@mantine/core';
 import { AssetSelect } from '@ui/control/AssetSelect';
 import { ControlBlock } from '@ui/control/ControlBlock';
+import type { ReactNode } from 'react';
 
 import type { Faction } from '@db/factions';
 
@@ -14,13 +15,26 @@ const logoSelectOptions = logoOptions.map((value) => ({
   label: logoOptionToLabel(value),
 }));
 
+/**
+ * The control that renders in the name's place, supplied by the route.
+ * A name field that checks its address is free has to fetch, and a widget never does, so the route hands one down the way the asset editors take their pickers.
+ * The form binding stays in the section, so the caller supplies a control rather than learning this form's API.
+ */
+export type FactionIdentityNameField = (props: {
+  value: string;
+  onChange: (name: string) => void;
+  error?: string;
+}) => ReactNode;
+
 export function FactionFormSectionIdentity({
   form,
   nameError,
+  nameField,
   showIntro = true,
 }: {
   form: FactionFormApi;
   nameError?: string;
+  nameField?: FactionIdentityNameField;
   showIntro?: boolean;
 }) {
   return (
@@ -48,14 +62,22 @@ export function FactionFormSectionIdentity({
               title="Faction name"
               description="Used on faction artifacts and to derive the canonical share URL."
               input={
-                <TextInput
-                  id="faction-name"
-                  aria-label="Faction name"
-                  error={nameError}
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(event) => field.handleChange(event.currentTarget.value)}
-                />
+                nameField ? (
+                  nameField({
+                    value: field.state.value,
+                    onChange: (name) => field.handleChange(name),
+                    error: nameError,
+                  })
+                ) : (
+                  <TextInput
+                    id="faction-name"
+                    aria-label="Faction name"
+                    error={nameError}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => field.handleChange(event.currentTarget.value)}
+                  />
+                )
               }
             />
           )}

--- a/src/app/widgets/faction-editor/FactionFormSectionIdentity.tsx
+++ b/src/app/widgets/faction-editor/FactionFormSectionIdentity.tsx
@@ -23,6 +23,8 @@ const logoSelectOptions = logoOptions.map((value) => ({
 export type FactionIdentityNameField = (props: {
   value: string;
   onChange: (name: string) => void;
+  /** The form's blur handler, so the replacement field keeps the plain one's touched tracking. */
+  onBlur: () => void;
   error?: string;
 }) => ReactNode;
 
@@ -66,6 +68,7 @@ export function FactionFormSectionIdentity({
                   nameField({
                     value: field.state.value,
                     onChange: (name) => field.handleChange(name),
+                    onBlur: field.handleBlur,
                     error: nameError,
                   })
                 ) : (

--- a/src/app/widgets/faction-editor/factionAuthoringContract.ts
+++ b/src/app/widgets/faction-editor/factionAuthoringContract.ts
@@ -18,6 +18,9 @@ export const factionAuthoringChapters = [
 
 export type FactionAuthoringChapterId = (typeof factionAuthoringChapters)[number]['id'];
 
+/**
+ * The two shapes `ValidationHeader` already accepts, which is why this union rather than a `missing` string alone: most gaps are an absence ("missing a name"), but a name conflict is a whole complaint about a value that is present.
+ */
 export type FactionAuthoringWarning = {
   path: string;
   chapter: FactionAuthoringChapterId;
@@ -25,9 +28,18 @@ export type FactionAuthoringWarning = {
   targetId: string;
   /** The entity the gap belongs to; the validation header renders one chip per source. */
   source: string;
-  /** What the source is missing, e.g. "name" or "back description". */
-  missing: string;
-};
+} & (
+  | {
+      /** What the source is missing, e.g. "name" or "back description". */
+      missing: string;
+      complaint?: never;
+    }
+  | {
+      /** A whole complaint about the source, e.g. "its name is already taken". */
+      complaint: string;
+      missing?: never;
+    }
+);
 
 function isBlank(value: string | undefined): boolean {
   return value == null || value.trim().length === 0;
@@ -41,6 +53,23 @@ function warning(
   targetId: string
 ): FactionAuthoringWarning {
   return { path, chapter, label: `${source}: missing ${missing}`, targetId, source, missing };
+}
+
+/**
+ * The name-conflict warning, built where the other faction warnings are so its shape cannot drift from theirs.
+ * It carries a complaint rather than a `missing`, because the name is present;
+ * it is the address behind it that is taken.
+ * `targetId` is the name field's own id, so the header's chip focuses the field the author has to change.
+ */
+export function factionNameConflictWarning(complaint: string): FactionAuthoringWarning {
+  return {
+    path: 'name',
+    chapter: 'identity',
+    label: `Faction identity: ${complaint}`,
+    targetId: 'faction-name',
+    source: 'Faction identity',
+    complaint,
+  };
 }
 
 /** Schema-valid blanks that are probably accidental, but never prevent an explicit save. */


### PR DESCRIPTION
Closes #626.

Two changes, both continuations of #623's name-conflict work, built as a blind two-take exercise: two sessions implemented the same brief independently, the takes were compared, and this PR is the stronger take with two grafts from the other.

## A faction's name warns while typing (#626)

- `factionSlugHolder` in `convex/factions.ts` is the one predicate: the save guard refuses on it (now with two sentences, since a soft-deleted faction reserving its address is a different answer than a living one) and the new `factions.slugTaken` query subscribes to it, so the typed warning and the refusal can never disagree.
- `FactionNameInput` binds `UniqueNameInput` to that query, exactly the way `AssetNameInput` does; a faction's slug is table-wide rather than per type, which is the whole difference.
- The faction editor gains a `nameField` render-prop slot on the Identity section. The form binding stays inside the section, so the routes supply a control without learning the form's API; the plain TextInput remains the fallback, so stories render unchanged.
- Both faction routes share `useFactionNameField`, which raises the conflict into the validation header via `factionNameConflictWarning`; the chip focuses the name field by id.
- Two shared-field fixes this exposed (found independently by both takes): `nameConflictComplaint` said "a deleted asset" inside the entity-blind picker (now noun-free), and `UniqueNameInput` had no way to carry a caller's own error, which would have silently swallowed the faction editor's blank-name message (it now takes `error`, and a conflict outranks it).

## A new deck can wear another deck's back from the start

The create page's "Another deck's back" tile was an inert placeholder recorded as an editorial decision; the decision came back the other way. The edit page's fifty lines of Popover-plus-AssetPicker are now `DeckBackPicker`/`DeckBackProof` in `src/app/pickers/`, worn by both pages; the create page differs only in having no id to exclude. A reset on the create page drops the picked deck along with the draft, so the tile can never show a choice the draft no longer holds.

The same inert placeholder still exists on the token and rectangle create pages; deliberately not widened into this PR.

## Verification

- Full local gates: typecheck, oxlint, format:check, css-orphans, 637 unit tests across 106 files (including new pins for all three `slugTaken` answers and both refusal sentences).
- Browser pass on a dev-deployment build: reference tile → Choose → picker lists real decks → pick draws the target's cardback on the tile and the publication preview and clears the "missing a deck to reference" chip; reset drops the pick; re-entering reference mode shows no stale choice.
- The faction warning sits behind login locally, so its live pass is planned as the post-merge prod replay (type a taken faction name, watch the inline error and Identity chip), like #623's Shield replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added faction name availability checks during creation and editing, with clear warnings for active and deleted-name conflicts.
  - Added a reusable deck cardback picker with preview support.
  - Deck creation now allows selecting an existing deck’s cardback before saving.
  - Deck editing uses the same shared cardback selection experience.

- **Bug Fixes**
  - Improved validation messages for names reserved by deleted factions.
  - Resetting a new deck now also clears its selected cardback reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->