### PR TITLE
The docs say what the code does, and the practiced rules get written down

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ Convex agent skills for common tasks can be installed by running
 
 - Start with [`docs/README.md`](docs/README.md) for architecture and workflow links.
 - Stack: TanStack Router, Start and Form, Convex, Vite, and Storybook. Reads go through Convex's own
-  `useQuery` inside `src/app/db`, so there is no TanStack Query and no client cache.
+  `useQuery` inside `src/app/db`, so there is no TanStack Query and no client cache to manage; see
+  [`docs/state-management.md`](docs/state-management.md) for what Convex holds instead.
 - Non-obvious workflow: `bun run generate` refreshes generated game data outputs.
 - `bun run app:dev` uses the configured online Convex deployment. Add `--local` for the
   disposable Docker-backed environment with local test auth and a cloned production

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,9 +109,9 @@ goes next, because either one makes it unusable in a story and unusable on a sec
 [`.oxlintrc.json`](.oxlintrc.json) forbids, inside `src/app/ui`:
 
 - the Convex client in any form, including the relative path to `convex/_generated`;
-- **value** imports from a data module by *every* spelling — `@db/**`, `@app/db`, `@app/db/**`,
-  `**/src/app/db/**`, and the relative `../**/db/*` forms. One alias is not one path: `@db/core`
-  and `@app/db/core` are the same file, and it exports a live `ConvexReactClient`.
+- **value** imports from a data module by every spelling the config lists, aliased and relative
+  alike. One alias is not one path: `@db/core` and `@app/db/core` are the same file, and it exports
+  a live `ConvexReactClient`, so a ban that misses a spelling bans nothing.
   `allowTypeImports` keeps `import type` legal, since a type is a statement about what you render,
   not a dependency;
 - the router's data and navigation surface — `useRouter` first of all, since it returns the whole
@@ -144,17 +144,16 @@ Outside the kit:
     one. What used to sit there went to the place that says what it is — `src/app/ui/<category>` when it
     was really vocabulary, the route when it was page composition, `src/app/print/` for the
     document-rendering glue, and `src/app/shell/` for the chrome.
-- **The application shell** (`src/app/shell`) — the chrome every page sits in: `AppRoot`
-  (the frame and the document-level effects), `AppHeader` (the artwork band), `AppFooter`, and
-  `SiteNavigation`. The shell is chrome, not a set of organs: it has a
-  doorway — `routes/_app.tsx` mounts `ApplicationChrome` and `AppNotFound`, and nothing else
-  outside the folder imports from it — and its chrome
-  **carries stories**, filed under a `Shell` root, because those states are worth looking at and
-  cannot be reached from any page's story. `SiteNavigation` is chrome for that reason: its four
-  stories cover the overflow and collapsed states no page story can reach. An outside importer or a
-  story alone ends organ-hood, so the shell has no organs. The shell is not a category and never
-  will be: the six are decided at the membrane, and the shell is decided by position. See
-  *The shell is chrome* in
+- **The application shell** (`src/app/shell`) — the chrome every page sits in: `AppRoot` (the frame
+  and the document-level effects), `AppHeader` (the artwork band), `AppFooter`, and
+  `SiteNavigation`. The shell is chrome, not a set of organs: it has a doorway — `routes/_app.tsx`
+  mounts `ApplicationChrome` and `AppNotFound`, and nothing else outside the folder imports from it —
+  and its chrome **carries stories**, filed under a `Shell` root, because those states are worth
+  looking at and cannot be reached from any page's story. `SiteNavigation` is chrome for that
+  reason: its four stories cover the overflow and collapsed states no page story can reach. An
+  outside importer or a story alone ends organ-hood, so the shell has no organs. The shell is not a
+  category and never will be: the six are decided at the membrane, and the shell is decided by
+  position. See *The shell is chrome* in
   [`docs/technical/ui-design-decisions.md`](docs/technical/ui-design-decisions.md#the-shell-is-chrome-decided-by-position)
   for why the header is neither a Surface nor a Layout.
 - **Widgets** (`src/app/widgets/<name>`) — an assembly too domain-specific to be kit and too

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ Convex agent skills for common tasks can be installed by running
 ## Project Quick Context
 
 - Start with [`docs/README.md`](docs/README.md) for architecture and workflow links.
-- Stack: TanStack Router/Query, Convex, Vite, and Storybook.
+- Stack: TanStack Router, Start and Form, Convex, Vite, and Storybook. Reads go through Convex's own
+  `useQuery` inside `src/app/db`, so there is no TanStack Query and no client cache.
 - Non-obvious workflow: `bun run generate` refreshes generated game data outputs.
 - `bun run app:dev` uses the configured online Convex deployment. Add `--local` for the
   disposable Docker-backed environment with local test auth and a cloned production
@@ -108,8 +109,8 @@ goes next, because either one makes it unusable in a story and unusable on a sec
 [`.oxlintrc.json`](.oxlintrc.json) forbids, inside `src/app/ui`:
 
 - the Convex client in any form, including the relative path to `convex/_generated`;
-- **value** imports from a data module by *every* spelling — `@db/**`, `@app/db/**`, `@app/*/db`,
-  and the relative forms with or without a `.ts` extension. One alias is not one path: `@db/core`
+- **value** imports from a data module by *every* spelling — `@db/**`, `@app/db`, `@app/db/**`,
+  `**/src/app/db/**`, and the relative `../**/db/*` forms. One alias is not one path: `@db/core`
   and `@app/db/core` are the same file, and it exports a live `ConvexReactClient`.
   `allowTypeImports` keeps `import type` legal, since a type is a statement about what you render,
   not a dependency;
@@ -144,13 +145,14 @@ Outside the kit:
     was really vocabulary, the route when it was page composition, `src/app/print/` for the
     document-rendering glue, and `src/app/shell/` for the chrome.
 - **The application shell** (`src/app/shell`) — the chrome every page sits in: `AppRoot`
-  (the frame and the document-level effects), `AppHeader` (the artwork band), `AppFooter`, and the
-  organs behind them (`SiteNavigation`). The shell is chrome, not a set of organs: it has a
+  (the frame and the document-level effects), `AppHeader` (the artwork band), `AppFooter`, and
+  `SiteNavigation`. The shell is chrome, not a set of organs: it has a
   doorway — `routes/_app.tsx` mounts `ApplicationChrome` and `AppNotFound`, and nothing else
-  outside the folder imports from it — and its chrome (`AppRoot`, `AppHeader`, `AppFooter`)
+  outside the folder imports from it — and its chrome
   **carries stories**, filed under a `Shell` root, because those states are worth looking at and
-  cannot be reached from any page's story. An outside importer or a story alone ends organ-hood,
-  which is why only `SiteNavigation` qualifies as one here. The shell is not a category and never
+  cannot be reached from any page's story. `SiteNavigation` is chrome for that reason: its four
+  stories cover the overflow and collapsed states no page story can reach. An outside importer or a
+  story alone ends organ-hood, so the shell has no organs. The shell is not a category and never
   will be: the six are decided at the membrane, and the shell is decided by position. See
   *The shell is chrome* in
   [`docs/technical/ui-design-decisions.md`](docs/technical/ui-design-decisions.md#the-shell-is-chrome-decided-by-position)
@@ -168,7 +170,7 @@ Outside the kit:
     widget imports them.
   - **The shelf is a metric.** Every widget is a concession. When `src/app/widgets/` grows,
     something upstream went wrong.
-- **Pickers** (`src/app/pickers/<Name>Picker.tsx`) — the one place a component may fetch, and the
+- **Pickers** (`src/app/pickers`) — the one place a component may fetch, and the
   reason "a widget never fetches" is a rule about *where fetching lives* rather than a blanket ban.
   A Picker is a domain control whose whole job is to let the user choose from a list it loads
   itself — the factions you can load, the users you can assign — and it loads them **lazily and
@@ -277,8 +279,15 @@ data*. Every component in `src/app/ui` has stories; Mantine components used by
 the app get stories too, filed by kind under our theme, indistinguishable from ours. Two kinds of
 file are exempt: organs, and a component whose story lives under a sibling's name because the two
 only make sense together (`SortableItem` and `SortableReorderHandle` share `SortableDnd.stories.tsx`,
-which is why no `SortableDnd.tsx` exists). A rule stated alongside its own violations is not a rule,
-so the three components that were missing stories when this was written now have them.
+which is why no `SortableDnd.tsx` exists).
+
+Three filename conventions carry weight here. A story-only fixture takes the `.stories.fixture.tsx`
+suffix, which the lint overrides key on, so it is a name the tooling reads rather than a preference.
+A Picker's pure view splits into a `.parts.tsx` companion, keeping the fetching shell and the
+rendering apart (`AssetPicker.parts.tsx`, `FactionPicker.parts.tsx`). And a directory whose stories
+should appear needs an explicit `titlePrefix` entry in
+[`.storybook/main.ts`](.storybook/main.ts): the category folder is the Storybook root for the kit,
+but the registration is per directory, so an unregistered folder's stories simply never load.
 
 ## Shared contracts
 
@@ -340,6 +349,17 @@ three callers had already settled statically. The other module imported two stri
 and cost nothing but the second path. `no-restricted-imports` enforces this for all of `src/**`
 except `src/app/db/**`.
 
+Inside `convex/`, mutations come from the trigger-aware builders in
+[`convex/functions.ts`](convex/functions.ts), never from `_generated/server`: the builders run the
+registered triggers, so a mutation that bypasses them writes without them. `no-restricted-imports`
+bans the `mutation` and `internalMutation` names from `_generated/server`, and every override
+restates the ban, because an override replaces the root rule for the files it matches rather than
+adding to it.
+
+Convex seam suites sit beside the module they cover and are named `<domain>.<facet>.test.ts`
+(`factions.catalogue.test.ts`, `groups.softDeletion.test.ts`). One facet per file, so a suite's name
+says what broke before the failure text does.
+
 Moving a file named in `RENDERER_RUNTIME_CLOSURE_PATHS` changes the renderer digest, so
 `publisher:release:verify` will report a `renderer-manifest.generated.ts` diff to commit. That is
 identity, not staleness: regeneration is driven by the checked-in `renderer_revisions`, which a move
@@ -365,6 +385,26 @@ assets, run `bun run publisher:release:verify`. The publisher Worker contains th
 release, while its Renderer identity intentionally excludes application-only shell and chunk
 files. A generated manifest diff must be resolved before push, not discovered by PR CI.
 
+## House conventions
+
+Three practices the whole repo follows, written down because they are enforced or assumed rather
+than obvious.
+
+**Commit subjects are declarative sentences about the behaviour change**, present tense, no
+conventional-commit prefix: "The slotted name field keeps the plain field's blur wiring". The subject
+says what the code now does, so a log reads as a description of the system rather than a list of
+categories.
+
+**Block comments are the house style**, enforced by the local oxlint plugin
+[`scripts/oxlint-prefer-block-comments.mjs`](scripts/oxlint-prefer-block-comments.mjs)
+(`local/prefer-block-comments`, generated files exempt). The rule also normalises the shape, one
+sentence per line, so a comment diff shows the sentence that changed.
+
+**Package scripts follow a taxonomy.** `check:*` are static tree guards backed by
+`scripts/assert-*.mjs`; `verify:*` verify generated artifacts against their sources; `generate:*`
+produce them. The prefix tells you whether a failure means "the code is wrong" or "the artifacts are
+stale".
+
 ## Agent skills
 
 ### Issue tracker
@@ -383,7 +423,8 @@ This is a single-context repository using root `CONTEXT.md` and `docs/adr/`. See
 
 Raster image sources live in `media/**`; everything under `public/image/**` and
 `public/web/**` is generated output (gitignored), apart from the committed files
-named in `COMMITTED_WEB_FILES` (`scripts/verify-images.ts`). Run
+named in `COMMITTED_WEB_FILES` (`src/shared/assetRules.ts`, read by both the generator and
+`scripts/verify-images.ts`). Run
 `bun run generate:images` after changing sources or `src/shared/assetRules.ts`
 (dev and Storybook need the generated files locally; CI produces the deployed
 bytes). `bun run verify:images` checks the output structurally. Renderer

--- a/docs/adr/0001-contracts-over-expressions.md
+++ b/docs/adr/0001-contracts-over-expressions.md
@@ -54,7 +54,7 @@ in for interface tests. The test suite's churn (the architecture test changed
 - The literal-annotation assertion was removed in PR #232, and issue #233 (now
   closed) retired the remaining source-text assertions in favor of validator and
   type-level guarantees, deleting rather than translating where the compiler
-  already enforced the intent. What survives is the two tree-level scans above.
+  already enforced the intent. What survives is the three tree-level scans above.
 - Convex boundary suites (e.g. `convex/profiles.detail.test.ts`) are the
   approved testing shape: they cross the public query seam.
 - Future architecture reviews should not propose source-text contracts or

--- a/docs/adr/0001-contracts-over-expressions.md
+++ b/docs/adr/0001-contracts-over-expressions.md
@@ -28,7 +28,7 @@ in for interface tests. The test suite's churn (the architecture test changed
    **Narrow exception — a rule about the tree, not about a module.** A source
    scan is allowed only where the guarantee is a property of the *file tree*
    that no type or lint rule can express, and every such suite must name this
-   ADR and say why. Two exist, and the list is meant to stay short:
+   ADR and say why. Three exist, and the list is meant to stay short:
    - `src/app/ui/layout/PageLayout.architecture.test.ts` — every terminal
      visual route mounts `PageLayout`. "Every file in this directory does X" is
      not something a type can say.
@@ -37,9 +37,13 @@ in for interface tests. The test suite's churn (the architecture test changed
      import spellings deliberately: the guarantee is the *absence* of a
      dependency, and absence has no type to hang off. The lint boundary in
      `.oxlintrc.json` covers `src/app/ui`; it does not cover `src/game`.
+   - `src/app/ui/layout/containerQueries.test.ts`: no layout stylesheet uses a
+     `@media` query, since a Layout lays out by the room it is given. The
+     guarantee is again the absence of a spelling across a directory, and
+     `PageLayout` is the one exemption the suite encodes.
 
    A scan that could have been a validator, a type, or a lint rule is still a
-   defect. Adding a third entry here should feel expensive.
+   defect. Adding a fourth entry here should feel expensive.
 3. **Tests must tolerate additive change.** Prefer asserting the specific
    behavior under test over whole-object equality of page models.
 4. **Testability never dictates API shape.** When a test blocks a better

--- a/docs/adr/0002-confidence-stack.md
+++ b/docs/adr/0002-confidence-stack.md
@@ -54,7 +54,8 @@ infrastructure state that no type system or e2e spec can express.
   cover; "more coverage" is not a reason.
 - #236 (Zod-derived validators), #241 (group-membership and FAQ happy-path e2e)
   and #234 (retiring the client seam tests derived types made redundant) are all
-  closed. The e2e layer is now 6 specs / 450 lines, so the ratio quoted above is
-  historical.
+  closed, so the ratio quoted above is historical. The e2e layer has grown since
+  and will keep growing; its size is a thing to measure when the question comes
+  up, not a number to keep true here.
 - Architecture reviews should flag test accumulation against this stack the
   same way they flag shallow modules.

--- a/docs/data-layer.md
+++ b/docs/data-layer.md
@@ -40,10 +40,8 @@ because both the app and the Convex server parse against them.
 
 ## Basic DB Structure
 
-**Tables**: `users`, `counters`, `profiles`, `groups`, `group_members`, `factions`, `assets`,
-`asset_relations`, `publication_assets`, `publication_jobs`, `admin_settings`, `rulesets`,
-`migration_runs`, `ruleset_asset_slots`, `ruleset_factions`, `faq_items`, `faq_answers`, plus the
-Convex Auth tables.
+**Tables**: [`convex/schema.ts`](../convex/schema.ts) is the list, plus the Convex Auth tables. It is
+not repeated here, because a copy of a registry goes stale without anything failing.
 
 **Pattern**: Domain data is stored in Convex documents, validated with function validators at the
 boundary and shared Zod schemas inside the handler. Factions, rulesets, groups, and community Assets

--- a/docs/technical/ui-design-decisions.md
+++ b/docs/technical/ui-design-decisions.md
@@ -101,8 +101,9 @@ concert with `AppHeader`, genuinely viewport-scoped rather than a container.
 
 *Container-query half enforced by
 [`containerQueries.test.ts`](../../src/app/ui/layout/containerQueries.test.ts) (`PageLayout` excepted
-by name); the rest convention. Canonical in [`AGENTS.md`](../../AGENTS.md). Layouts today:
-`PageLayout`, `TriptychLayout`, `AtlasLayout`, `AsymmetricSplitLayout`.*
+by name); the rest convention. Canonical in [`AGENTS.md`](../../AGENTS.md). The layouts themselves are
+whatever [`src/app/ui/layout`](../../src/app/ui/layout) holds; a roster written here would go stale
+the first time one is added.*
 
 ### Floating UI is small and single-layer
 
@@ -113,10 +114,9 @@ no modes, no sub-editors. Anything with modes, a collection to manage, or sub-co
 expands inline and accepts the reflow. One floating layer at a time: a floating pane never opens
 another floating pane inside itself; its innards render inline (a search field with an inline
 options list, not a nested dropdown). Dropdowns portal to the document — never
-`withinPortal: false`, which ties positioning to whatever containment the anchor sits in — with one
-exception: a select that must live inside a popover keeps `withinPortal: false`, because a portalled
-option renders outside the popover's DOM and picking it reads as click-outside, closing the pane
-mid-selection (see `AssignPopover`).
+`withinPortal: false`, which ties positioning to whatever containment the anchor sits in. A select
+that has to live inside a popover renders its options inline instead of as a dropdown, which is the
+same one-layer rule rather than an exception to it (see `AssignPopover`).
 
 *Exemption:* display-only, hover-transient UI — a tooltip, a hover preview — may appear over a
 floating pane; it is glanceable, not operable.
@@ -180,10 +180,11 @@ Enter. A question-and-answer confirm asked for a second decision; the hold asks 
 intent, which is one interaction and cannot be clicked through on autopilot. On success the page
 navigates to the deleted thing's parent, since its own address just died.
 
-*Convention. The kit carries it: `ConfirmDeleteAction` in
-[`src/app/ui/control`](../../src/app/ui/control/ConfirmDeleteAction.tsx). Every delete goes through
-it; `window.confirm` remains only at non-delete confirmations (removing a member, moving an asset
-between groups) pending their own treatment.*
+*Convention. The kit carries it in two shapes, sharing one hold:
+[`ConfirmDeleteAction`](../../src/app/ui/control/ConfirmDeleteAction.tsx) for the icon triggers and
+[`ConfirmDeleteButton`](../../src/app/ui/control/ConfirmDeleteButton.tsx) for the full-width one on
+the account-deletion page. Every delete goes through one of them. One `window.confirm` survives, at
+the asset move on the group page, which is not a delete and is pending its own treatment.*
 
 ### A tab icon is an icon, never a proof
 

--- a/src/app/ui/layout/containerQueries.test.ts
+++ b/src/app/ui/layout/containerQueries.test.ts
@@ -5,6 +5,10 @@ import { describe, expect, it } from 'vitest';
 const layoutDir = new URL('.', import.meta.url);
 
 /*
+ * A source scan under ADR-0001's narrow exception: the guarantee is the absence of a spelling across
+ * a whole directory, which no type and no lint rule covers, since `.oxlintrc.json` has no rule that
+ * reads stylesheet contents.
+ *
  * A Layout is responsive by container query, so it lays out by the room it is given, not the size
  * of the window (the "Layouts own spacing" rule in docs/technical/ui-design-decisions.md).
  * `PageLayout` is the one exemption: it is the shell's page frame, sized against the viewport in

--- a/src/game/rendererIsolation.test.ts
+++ b/src/game/rendererIsolation.test.ts
@@ -5,6 +5,10 @@ import { describe, expect, it } from 'vitest';
 const rendererDirectory = new URL('.', import.meta.url);
 
 /**
+ * A source scan under ADR-0001's narrow exception: the guarantee is the absence of a dependency, and absence has no type to hang off.
+ * The lint boundary covers `src/app/ui`;
+ * it does not cover `src/game`.
+ *
  * Any spelling that resolves a module: `import x from`, `export … from`, a bare side-effect `import`, and
  * `import(...)`, in either quote style.
  *

--- a/src/game/rendererIsolation.test.ts
+++ b/src/game/rendererIsolation.test.ts
@@ -5,9 +5,9 @@ import { describe, expect, it } from 'vitest';
 const rendererDirectory = new URL('.', import.meta.url);
 
 /**
- * A source scan under ADR-0001's narrow exception: the guarantee is the absence of a dependency, and absence has no type to hang off.
- * The lint boundary covers `src/app/ui`;
- * it does not cover `src/game`.
+ * A source scan under ADR-0001's narrow exception.
+ * The guarantee is the absence of a dependency, and absence has no type to hang off.
+ * The lint boundary covers `src/app/ui` and not `src/game`.
  *
  * Any spelling that resolves a module: `import x from`, `export … from`, a bare side-effect `import`, and
  * `import(...)`, in either quote style.


### PR DESCRIPTION
First of two for #636. This is the docs half: make the claims true and give the practiced rules a written home. The tells sweep and the guard follow in a second PR, so this one stays reviewable as prose.

Works the findings of #633.

## Wrong claims

**The stack line named TanStack Query.** There is no such dependency anywhere. Reads go through Convex's own `useQuery` inside `src/app/db`, which is also why there is no client cache. The line was sending a newcomer to look for a library the app does not have.

**SiteNavigation.** The organ definition stands, so the classification gave rather than the story. Its four stories cover overflow and collapsed states that no page story can reach, which is the same justification the doc already gives for `AppRoot`, `AppHeader` and `AppFooter` carrying stories. So `SiteNavigation` is chrome, and the shell has no organs. That reads better against the doc's own sentence, "the shell is chrome, not a set of organs", than the exception did.

One correction to the finding while I was in there: #633 says `docs/technical/ui-component-hierarchy.md` also classifies `SiteNavigation` as an organ. It does not. Grepping that file for both the name and "organ" turns up only a generic mention. The contradiction lived in AGENTS.md alone.

**ADR-0001's tree-scan registry.** It listed two suites and there are three: `containerQueries.test.ts` reads every layout stylesheet off disk to assert no `@media`. The ADR also requires every such suite to name the ADR and say why, and two of the three did not, so both now carry that sentence. The closing line moves from "a third entry" to "a fourth".

**Three stale lists stop being lists.** The layouts roster, the data-layer table list and ADR-0002's e2e ratio were each a copy of a registry that goes stale without anything failing, which #633 itself calls the hand-written-list-beside-a-registry trap. Rather than correct three copies, each now points at the registry: the layout folder, `convex/schema.ts`, and for the ratio no number at all.

**The remaining stale claims.** `window.confirm` is down to the one that survives, the asset move on the group page, and `ConfirmDeleteButton`, the second hold-to-delete shape, is named. The `withinPortal: false` exception described retired code; `AssignPopover` now renders its options inline, which is the one-layer rule rather than an exception to it. The banned data-module spellings now match `.oxlintrc.json`, which never contained `@app/*/db`. `COMMITTED_WEB_FILES` is defined in `src/shared/assetRules.ts`. The Pickers path pattern names the folder, since it no longer describes its own contents.

## Practiced but undocumented

The eight from #633, recorded where they belong rather than in one pile.

Convex doorway: mutations come from the trigger-aware builders in `convex/functions.ts`, with the note that every override restates the ban because an override replaces the root rule rather than adding to it; seam suites are `<domain>.<facet>.test.ts` beside the module they cover.

Stories: `.stories.fixture.tsx` is a name the lint overrides read rather than a preference, a Picker's pure view splits into a `.parts.tsx` companion, and a storied directory needs its own `titlePrefix` entry or its stories never load.

A new House conventions section carries the three repo-wide ones: declarative commit subjects, block comments enforced by the local oxlint plugin, and the `check:` / `verify:` / `generate:` script taxonomy.

## Deliberately left out

**The widget ladder** has no rung for widget-to-widget sharing (#633 finding 5, and #630 reached it independently). That is a rule change rather than a doc fix, and #630 filed it as an amendment candidate, so it belongs with the triage rather than here.

**CONTEXT.md's ten-leader cap** exists only client-side; the shared schema the server parses has no maximum (#633 finding 14). Correcting the doc would paper over a real server-side gap against data-layer.md's own "server parsing is authoritative" rule. It wants a code decision, not a sentence.

**The two kit components missing stories** are the kit wave's, per the ticket. I did trim the sentence that claimed the story rule had no live violations, since it was asserting a completeness that is not true today, but I did not touch the components.

## Verified

typecheck, lint, format:check, knip, 637 unit tests. The two test files I touched still pass.

Three em dashes appear in the added lines. All three are pre-existing punctuation on lines whose content changed; the sweep in the second PR removes them repo-wide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contributor guidance to reflect current development conventions and UI organization.
  - Clarified database documentation so the schema remains the authoritative source for available tables.
  - Refined architecture guidance for source scanning, confidence metrics, layout implementation, popover selects, and destructive actions.
  - Expanded documentation around image-generation ownership, Convex mutation practices, Storybook conventions, and test naming.
  - Added context explaining approved stylesheet and renderer-isolation checks, including their scope and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->