### PR TITLE
The headings rule gains its depth-zero rung

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,7 +237,9 @@ Rules between categories:
   controls, no sub-editors; a floating pane never opens another floating pane (display-only
   tooltips/hover previews exempt); dropdowns portal to the document. Complex editors expand inline.
 - **Only Blocks, and a Surface naming itself, render headings.** Loudness comes from depth, never
-  from a prop.
+  from a prop. The page title is the depth-zero case, and it is a Block like the rest: one
+  page-title Block, mounted once by the route, taking its words as data. `BlockHeading` keeps its
+  `h2` floor, because depth governs loudness inside a page's content, below the page's own voice.
 - **Receivers vs producers.** Layouts and Surfaces *receive* built content through slots. Blocks,
   Lists and Content *produce* content from data. Controls *change* data. A component doing two of
   these is two components.


### PR DESCRIPTION
Executes the amendment decided on #638. One sentence pair in AGENTS.md, nothing else, so the rulebook change is reviewed on its own rather than inside the compliance diff that will carry it out (#641).

## The gap

The rule said only Blocks and a self-naming Surface render headings, and that loudness comes from depth. It never said what the **page title** is. Three mechanisms grew in that gap:

- `HeroTitle`, a Content component, on 2 routes
- `Title order={1}`, on the icons and jobs dev pages, both assets indexes, and the asset detail page twice
- a raw `<h1>`, on the admin pages and the router fallback

## The amendment

The page title is the depth-zero case, and it is a Block like the rest: one page-title Block, mounted once by the route, taking its words as data.

This reduces the mechanism count rather than licensing a fourth, and it is the test the rulebook already states two sections down: *a string prop becoming a heading → Block*. The page title was always going to be a Block; the rule just never said so out loud.

`BlockHeading` keeps its `h2` floor. Depth governs loudness *inside* a page's content, which sits below the page's own voice, so the existing floor is untouched and no block three deep starts claiming to be louder.

## What this PR is not

It does not build the Block, migrate `HeroTitle`, or convert the `Title order={1}` and raw `h1` sites. That is #641, and it will cite this sentence rather than restate it.

It also does not design the identity-band capture from #451, which builds on this Block when the composition wave reaches it. The resolution on #638 is explicit that this ticket stays out of that.

## Verified

check:prose, lint, format:check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that page titles are top-level blocks with configurable wording.
  * Documented that `BlockHeading` maintains an `h2` minimum heading level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->