### PR TITLE
Painting goes back to being Surface's alone

### DIFF
--- a/.agents/skills/ui-create-standards/SKILL.md
+++ b/.agents/skills/ui-create-standards/SKILL.md
@@ -39,7 +39,7 @@ Classify every UI concern before implementation:
 3. Adapt the composition in the route or owning component, keeping `PageLayout` ownership at the terminal route.
 4. Extract a shared composition only after repeated product semantics or repeated composition are demonstrated.
 
-Prefer direct `Button`, `ActionIcon`, `Card`/`Paper`, `Stack`, `Group`, `Grid`, `Text`, `Title`, `Tooltip`, field, and overlay composition. Do not create wrappers whose only purpose is renaming or lightly forwarding Mantine APIs. For navigation controls, use Mantine's router integration at the call site; extract an adapter only when repeated use proves it can preserve TanStack Router's typed contract.
+Prefer direct `Button`, `ActionIcon`, `Stack`, `Group`, `Grid`, `Text`, `Title`, `Tooltip`, field, and overlay composition. A pane comes from the kit's `Surface`, never from a Mantine `Paper`. Do not create wrappers whose only purpose is renaming or lightly forwarding Mantine APIs. For navigation controls, use Mantine's router integration at the call site; extract an adapter only when repeated use proves it can preserve TanStack Router's typed contract.
 
 ### Domain UI
 

--- a/src/app/routes/_app/[_]_icons.tsx
+++ b/src/app/routes/_app/[_]_icons.tsx
@@ -1,4 +1,4 @@
-import { Chip, Group, Paper, SegmentedControl, SimpleGrid, Stack, Tabs, Text, TextInput, Title } from '@mantine/core';
+import { Box, Chip, Group, SegmentedControl, SimpleGrid, Stack, Tabs, Text, TextInput, Title } from '@mantine/core';
 import { BACKGROUND, DECAL, GENERIC, ICON, LOGO, TROOP, TROOP_MODIFIER } from '@shared/assetIds';
 import { createFileRoute } from '@tanstack/react-router';
 import { TOPIC_ICON_TOPICS, TopicIcon } from '@ui/content/TopicIcon';
@@ -248,7 +248,7 @@ function IconsPage() {
         </Stack>
       </PageLayout.Header>
       <PageLayout.Toolbar>
-        <Paper withBorder p="md" radius="md" mb="xl">
+        <Box p="md" mb="xl">
           <Stack gap="md">
             <TextInput
               aria-label="Search icons"
@@ -312,7 +312,7 @@ function IconsPage() {
               </Group>
             ) : null}
           </Stack>
-        </Paper>
+        </Box>
       </PageLayout.Toolbar>
       <PageLayout.Content>
         <Stack gap="lg">

--- a/src/app/routes/_app/future-plans/index.module.css
+++ b/src/app/routes/_app/future-plans/index.module.css
@@ -52,6 +52,7 @@
 
 .contribution {
   margin: 2rem 0 1rem;
+  border-radius: var(--mantine-radius-lg);
   background: radial-gradient(circle at 95% 10%, rgb(211 146 46 / 20%), transparent 36%), var(--mantine-color-body);
   border: 1px solid rgb(123 52 25 / 20%);
 }

--- a/src/app/routes/_app/future-plans/index.tsx
+++ b/src/app/routes/_app/future-plans/index.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Badge, Box, Button, Grid, Paper, SimpleGrid, Stack, Text, ThemeIcon, Title } from '@mantine/core';
+import { Anchor, Badge, Box, Button, Grid, SimpleGrid, Stack, Text, ThemeIcon, Title } from '@mantine/core';
 import { createFileRoute } from '@tanstack/react-router';
 import { Eyebrow } from '@ui/content/Eyebrow';
 import { HeroTitle } from '@ui/content/HeroTitle';
@@ -215,7 +215,7 @@ function FuturePlansPage() {
                 </Stack>
               ))}
 
-              <Paper component="section" className={styles.contribution} radius="lg" p={{ base: 'xl', md: 48 }}>
+              <Box component="section" className={styles.contribution} p={{ base: 'xl', md: 48 }}>
                 <SimpleGrid cols={{ base: 1, md: 3 }} spacing="xl" verticalSpacing="xl">
                   <ThemeIcon size={72} radius="50%" variant="light" color="dune" aria-hidden>
                     <Lightbulb />
@@ -249,7 +249,7 @@ function FuturePlansPage() {
                     </Button>
                   </Stack>
                 </SimpleGrid>
-              </Paper>
+              </Box>
             </Stack>
           </AtlasLayout.Content>
         </AtlasLayout>

--- a/src/app/routes/_app/privacy/index.tsx
+++ b/src/app/routes/_app/privacy/index.tsx
@@ -1,4 +1,4 @@
-import { List, Paper, SimpleGrid, Stack, Text, Title } from '@mantine/core';
+import { List, SimpleGrid, Stack, Text, Title } from '@mantine/core';
 import { createFileRoute } from '@tanstack/react-router';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
@@ -21,7 +21,7 @@ function PrivacyPage() {
               Signing in creates a public profile. Anything you publish can be seen and shared by anyone.
             </Text>
           </Stack>
-          <Paper bg="rgba(255, 255, 255, 0.82)" p="lg" radius="md" shadow="sm">
+          <Surface padding="lg">
             <Stack gap="sm">
               <Title order={2} size="h3">
                 Two firm promises
@@ -34,7 +34,7 @@ function PrivacyPage() {
                 There is no private-profile setting.
               </Text>
             </Stack>
-          </Paper>
+          </Surface>
         </SimpleGrid>
       </PageLayout.Header>
       <PageLayout.Content>

--- a/src/app/ui/theme.ts
+++ b/src/app/ui/theme.ts
@@ -125,11 +125,6 @@ export const appContentTheme = createTheme({
     xl: '0 18px 48px rgba(38, 24, 11, 0.3)',
   },
   components: {
-    Paper: {
-      styles: {
-        root: glassSurface,
-      },
-    },
     Popover: {
       styles: {
         dropdown: {
@@ -142,6 +137,21 @@ export const appContentTheme = createTheme({
     Menu: {
       styles: {
         dropdown: {
+          ...glassSurface,
+          backgroundColor: 'var(--glass-overlay)',
+        },
+      },
+    },
+    /*
+     * A drawer is a floating pane like the two above, and it used to get this treatment by accident:
+     * Mantine renders a drawer's content as a `Paper`, so the Paper mapping painted it second-hand.
+     * That mapping is gone, so the drawer asks for the pane by name.
+     * Verified by render: a `Drawer.content` entry and the old `Paper.root` entry reach the same
+     * `<section class="mantine-Drawer-content">`.
+     */
+    Drawer: {
+      styles: {
+        content: {
           ...glassSurface,
           backgroundColor: 'var(--glass-overlay)',
         },

--- a/src/app/widgets/faction-editor/useFactionSortableItem.ts
+++ b/src/app/widgets/faction-editor/useFactionSortableItem.ts
@@ -4,9 +4,8 @@ import { CSS } from '@dnd-kit/utilities';
 import type { CSSProperties } from 'react';
 
 /**
- * Editor-domain drag behavior without owning the surrounding Mantine presentation.
- * Each collection composes its own
- * Paper, actions, and accessible handle directly.
+ * Editor-domain drag behavior without owning the surrounding presentation.
+ * Each collection composes its own box, actions, and accessible handle directly.
  */
 export function useFactionSortableItem(id: string) {
   const { attributes, listeners, setActivatorNodeRef, setNodeRef, transform, transition, isDragging, isOver } =


### PR DESCRIPTION
Executes the decision on #637. Part of the kit compliance wave (#641); resolves the `theme.ts:128` breaks-taxonomy finding on #629.

Visually verified against the hosted dev deployment with real data, in both colour schemes and at both widths. See the browser pass below.

## Why the mapping had to go

`Surface`'s own JSDoc names it. The pane treatment "had been written out three separate times, once against the `--panel-*` tokens, once as a `color-mix` of white, and once inside the Mantine theme". The first two were removed when `Surface` was built. **This is the third**, and it survived because it never looked like a copy: it lived in the theme rather than in a component.

The enforcement inverts with the removal. A stray Paper used to render correct-looking, which is the worst kind of violation. Now it does not.

One correction to the resolution's wording, since it changes what a reviewer should look for: a stray Paper does **not** render "visibly unpainted". It renders as an *opaque* cream or navy box (`var(--mantine-color-body)`), keeping its radius and losing the blur. On the desert artwork that is conspicuous, so the intent holds, but the tell is "wrong pane", not "no pane".

## The inventory, as required before removal

**Mechanism.** The entry is `styles`, not `defaultProps` or `classNames`. Mantine resolves `theme.components.Paper.styles` into the **inline `style` attribute**, so it outranks every stylesheet on that element, including our own CSS modules, and it reaches Papers rendered *inside* other components, because those inner Papers call `useStyles({ name: 'Paper' })` themselves.

**What it set:** `--glass-surface-1` infill, `--panel-border` colour, `--panel-shadow`, `blur(8px)`. Not the border shorthand, not the radius, no padding. So it was never a second `Surface`; it was a second copy of the *paint*.

**Which Mantine components render a Paper internally.** Exactly six outputs: `Card`, `Dialog`, `Drawer`, `Modal`, `FloatingWindow`, `Paper` (Modal and Drawer via `ModalBaseContent`). Established two ways: statically, by grepping the whole installed package; and empirically, by SSR-rendering **all 141 exported members** of `@mantine/core` under a provider carrying a marked `Paper` entry and diffing the markup. `Popover`, `Menu`, `Tooltip`, `Select`, `Accordion`, `Alert`, `Notification` and the rest are byte-identical with and without the entry.

**Blast radius in this repo: one component nobody would have thought to check.** Of those six, only `Drawer` is used — the filter drawer at `src/app/routes/_app/factions/index.tsx:464`. Every `<Card>` in the tree resolves to the kit's own `@ui/surface/Card`, and there is no Mantine `Modal`, `Dialog` or `FloatingWindow` anywhere.

**`Popover` and `Menu` do not render a Paper at all**, so their theme entries are the only thing painting them and are untouched, exactly as the resolution requires.

Each of the four inventory lanes was then handed to an agent instructed to refute it. All four survived; the refuters re-derived the results with different methods and corrected three details, including one in this PR's favour (the drawer has no border today, because Mantine only paints one under `[data-with-border]`, so removal takes one *fewer* thing away than first reported).

## The drawer, which the resolution did not know about

This is what the inventory existed to catch. Mantine renders a drawer's content as a Paper, so the factions filter drawer was getting its glass second-hand from a mapping written for something else. Removing the mapping alone would have turned it opaque **in production, in a file nobody touched**.

A drawer is a floating pane, like the popover and the menu the resolution deliberately keeps. So it now asks for the pane by name, beside them, with the same `--glass-overlay` infill a floating pane needs. Its appearance is now deliberate rather than inherited.

Verified by render rather than by reading: a `Drawer.content` entry and the old `Paper.root` entry reach the same `<section class="mantine-Drawer-content">`.

## The four direct users

The resolution named four, one of which is not a Paper user:

| site | resolution | what shipped | why |
|---|---|---|---|
| `privacy/index.tsx:24` | move to Surface | `Surface padding="lg"` | it had pinned `rgba(255,255,255,0.82)`, which never flipped for dark mode; Surface's infill does |
| `future-plans/index.tsx:218` | move to Surface | **`Box`**, see below | its own stylesheet already paints it |
| `FactionFormFields.tsx` | composes the kit | **no change** | it renders no Paper; line 309 is a comment about *physical* paper on a `<Box>` |
| `[_]_icons.tsx:251` | stays plain | unchanged | dev page, now renders unpainted |

The real fourth Paper user is `FactionSheetReview.stories.tsx`, which the resolution does not mention. It is story scaffolding standing in for editor chapters, so it keeps its Paper and renders as a plain box, which is honest for filler.

**One departure worth arguing about.** The resolution says future-plans moves to `Surface`. Its `.contribution` class supplies a radial gradient over `--mantine-color-body` and a `1px solid rgb(123 52 25 / 20%)` border, and the theme's inline styles were overriding both. Making it a `Surface` would replace a bespoke warm panel with the glass treatment: a visual redesign, not a compliance fix. It is a `Box` instead, so it renders what its author wrote, for the first time since the mapping landed. Say the word and I will make it a Surface, but that wants a look rather than a rule.

It does leave `.contribution` painting outside a Surface, which is the rule this PR is about. #629 did not flag it and I have not widened the scope to it; it is worth its own decision.

## Also corrected

Two references that this PR makes wrong: `useFactionSortableItem.ts` told the next author that each collection composes its own Paper (they compose a `Box`), and `.agents/skills/ui-create-standards/SKILL.md` recommended `Paper` as a composition primitive.

## Browser pass

Done against the hosted dev deployment with real data (35 factions), at mobile and desktop widths, in both colour schemes.

**Proven to be the right tree first**, because the preview tooling starts its server in the repo root, not the worktree, and the root was 74 commits behind main on a feature branch. The listener was verified before any pixel was trusted:

```
node /Users/me/Projects/Dune/dunezone/.claude/worktrees/kit-compliance-wave/node_modules/.bin/vite dev --port 3200
bun  /Users/me/Projects/Dune/dunezone/.claude/worktrees/kit-compliance-wave/scripts/app-dev.ts
```

The DOM confirmed it independently: `/privacy` rendered `_surface_…` module classes rather than `mantine-Paper-root`.

### The drawer keeps its pane, and here is what it would have lost

The `Drawer.content` entry was A/B tested by removing it and reloading, so the regression is measured rather than argued.

| | with the entry | without it |
|---|---|---|
| background (dark) | `rgba(13, 22, 37, 0.96)` | `rgb(20, 28, 43)`, opaque |
| background (light) | `rgba(255, 253, 248, 0.95)` | `rgb(255, 253, 248)`, opaque cream |
| backdrop filter | `blur(8px)` | `none` |
| shadow | `--panel-shadow` | Mantine's `shadow-xl` |

In dark mode the loss is subtle; in light mode the drawer becomes a flat cream slab. This is the regression the inventory existed to catch, and it would have shipped silently in a file nobody edited.

The drawer only exists at narrow widths (desktop uses a Popover), so it was reached at 375px.

### The privacy panel: this PR fixes a live legibility defect

Not a regression, a cure, and I nearly missed which one it was.

The panel sits inside the hero band, which sets light text for legibility over artwork. On main it is a `Paper` pinned to `rgba(255,255,255,0.82)`, so that light text lands on near-white. The heading is ghostly and "There is no private-profile setting." is invisible.

Verified as an A/B on the same tree, swapping only that one file between main's version and this branch's, so nothing else could account for the difference. As a `Surface`, the translucent infill lets the dark artwork through and the text reads.

A caution on numbers: an early contrast ratio I quoted was computed against the pane's own translucent colour rather than the composited backdrop, which is meaningless for glass over artwork. The evidence here is the A/B render, not that figure.

**This defect is live on main and older than this PR.** It is cured incidentally here, and worth tracking separately so the fix is not invisible.

### future-plans

Renders as `<section>` with no Paper. Its own stylesheet paints it again: the radial gradient is present, the border is the author's `rgba(123, 52, 25, 0.2)` rather than the theme's override, radius is 12px matching the removed `radius="lg"`, and padding still resolves responsively to 48px at desktop.

### Screenshot note

`/future-plans` captures black whenever the page is scrolled, which is an artifact of its scroll-linked background pan in the capture path, not a page defect. That panel is evidenced by computed styles instead.

## Verified

lint, format:check, check:prose, typecheck, knip, check:css-orphans, 637 tests, plus the browser pass above.
