### PR TITLE
A page can declare that its title is the display treatment

### DIFF
--- a/src/app/routes/_app/future-plans/index.tsx
+++ b/src/app/routes/_app/future-plans/index.tsx
@@ -137,7 +137,7 @@ const FUTURE_PLANS: FuturePlan[] = [
 function FuturePlansPage() {
   return (
     <PageLayout>
-      <PageLayout.Header>
+      <PageLayout.Header size="hero">
         <SimpleGrid className={styles.hero} cols={{ base: 1, md: 2 }} spacing="xl">
           <Stack gap="xs">
             <Eyebrow tone="inverse">Our ambitions</Eyebrow>

--- a/src/app/routes/_app/index.tsx
+++ b/src/app/routes/_app/index.tsx
@@ -86,7 +86,7 @@ function IndexPage() {
 
   return (
     <PageLayout>
-      <PageLayout.Header>
+      <PageLayout.Header size="hero">
         <Stack className={styles.hero} align="center" justify="center" gap="sm">
           <Eyebrow tone="inverse">A game of conquest, diplomacy &amp; betrayal</Eyebrow>
           <HeroTitle>Make Dune your own</HeroTitle>
@@ -302,7 +302,7 @@ function IndexPage() {
 function HomepagePending() {
   return (
     <PageLayout>
-      <PageLayout.Header>
+      <PageLayout.Header size="hero">
         <HeroTitle>Make Dune your own</HeroTitle>
       </PageLayout.Header>
       <PageLayout.Content>
@@ -321,7 +321,7 @@ function HomepagePending() {
 function HomepageError({ error }: ErrorComponentProps) {
   return (
     <PageLayout>
-      <PageLayout.Header>
+      <PageLayout.Header size="hero">
         <HeroTitle>Make Dune your own</HeroTitle>
       </PageLayout.Header>
       <PageLayout.Content>

--- a/src/app/ui/layout/PageLayout.tsx
+++ b/src/app/ui/layout/PageLayout.tsx
@@ -3,7 +3,14 @@ import type { PropsWithChildren, ReactNode } from 'react';
 
 import styles from './PageLayout.module.css';
 
-function Header(_: PropsWithChildren<{ size?: 'default' | 'compact' }>): null {
+/**
+ * What kind of header a page declares.
+ * `compact` shrinks the band;
+ * `hero` marks a page whose title is the display treatment, which the title Block reads back the way `AppHeader` reads the band size.
+ */
+type PageHeaderSize = 'default' | 'compact' | 'hero';
+
+function Header(_: PropsWithChildren<{ size?: PageHeaderSize }>): null {
   return null;
 }
 
@@ -22,13 +29,13 @@ function Content(_: PropsWithChildren): null {
  * That is why it is the documented exemption from the container-query rule: it is the page frame, sized against the viewport in concert with the shell, not a container.
  *
  * Slots: `Header` (omit it to mark the page intentionally compact;
- * `size="compact"` shrinks the band), `Toolbar`, and
+ * `size="compact"` shrinks the band, and `size="hero"` declares a page whose title takes the display treatment), `Toolbar`, and
  * `Content`.
  */
 function PageLayoutBase({ children }: PropsWithChildren) {
   let hasHeader = false;
   let header: ReactNode = null;
-  let headerSize: 'default' | 'compact' = 'default';
+  let headerSize: PageHeaderSize = 'default';
   let toolbar: ReactNode = null;
   let content: ReactNode = null;
 
@@ -38,7 +45,7 @@ function PageLayoutBase({ children }: PropsWithChildren) {
     }
     if (child.type === Header) {
       hasHeader = true;
-      const props = child.props as PropsWithChildren<{ size?: 'default' | 'compact' }>;
+      const props = child.props as PropsWithChildren<{ size?: PageHeaderSize }>;
       header = props.children;
       headerSize = props.size ?? 'default';
       return;


### PR DESCRIPTION
First of the page-title work in the kit compliance wave (#641), split out of 3a so the Layout change is reviewed on its own. Executes the mechanism Norbert picked on #638.

**Nothing renders differently.** This adds vocabulary the title Block will read; the Block itself comes next.

## The problem it unblocks

The amendment in [#650](https://github.com/ndelangen/dunezone/pull/650) says the page title is one Block, words as data, one fixed arrangement. Building it surfaced a collision: **there are two live page-title treatments.**

- `HeroTitle` renders `C_Desdemona`, uppercase, `clamp(2.8rem, 6.7vw, 5.8rem)`, white with a heavy shadow. **2 pages.**
- Every other page title renders `C_Copperplate_Gothic` at Mantine's h1 size, because `src/app/styles/fonts.css:76` sets that face for `h1`–`h6` globally. **45 sites.**

One Block cannot render both, and the rule it executes says loudness never comes from a prop.

## Why position, and not a prop

Position already decides things in this codebase. The shell is decided by position rather than at the membrane. A block's heading level follows its depth. And `PageLayout` already declares its state through `data-page-layout-header-size`, which `AppHeader.module.css` reads back with `:has()` to size the artwork band.

The header size simply had no value for this case: home, future-plans, factions and privacy all rendered a bare `<PageLayout.Header>`, so nothing distinguished a display title from a standard one.

Now `size="hero"` exists, the two display pages declare it, and the title Block will read it back exactly as `AppHeader` reads `compact`. **No treatment prop anywhere.**

Two alternatives were rejected on #638: a treatment prop on the Block, which would contradict the sentence directly above the one this wave just added; and converging the visuals, which is a redesign rather than a compliance fix.

## Also, a small registry fix

The size union was written out three times in one file: the `Header` signature, the `headerSize` local, and the props cast. It is named once as `PageHeaderSize`. A fourth size can no longer land in two of the three places.

## Same pixels, verified rather than claimed

Only `"compact"` is keyed in CSS today, so `"hero"` is inert until the Block reads it. Rather than assert that, I flipped the attribute between `hero` and `default` in the live DOM on both pages and compared computed styles:

| | home | future-plans |
|---|---|---|
| font | `C_Desdemona` | `C_Desdemona` |
| size | 45px | 39.2px |
| transform | uppercase | uppercase |
| band height | 319px | 319px |
| h1 position | unchanged | unchanged |

`identical: true` on both, covering colour and text-shadow as well. Rendered against the hosted dev deployment from a server verified to be running in this worktree, not the repo root.

## The guards the widening could have tripped

`PageLayout.architecture.test.ts` and `containerQueries.test.ts` are **untouched and both pass.** The change adds a value to an attribute the Layout already declares and alters no geometry, so the container-query exemption is unaffected: `PageLayout` remains the one Layout sized against the viewport in concert with the shell.

## Next

3a builds the Block, migrates `HeroTitle` into it with its stories and a `titlePrefix` entry, and reads this attribute. Then 3b converges the single-title routes and 3c the multi-state ones. The #451 identity band stays out of all of them.

## Verified

lint, format:check, check:prose, typecheck, 637 tests, plus the two named guards run individually.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a hero-sized page header option.
  - Updated the homepage and Future Plans page to use the larger hero header layout consistently, including loading and error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->