### PR TITLE
Eight page titles that were already Mantine headings become the Block

### DIFF
--- a/src/app/routes/_app/[_]_icons.tsx
+++ b/src/app/routes/_app/[_]_icons.tsx
@@ -1,6 +1,7 @@
 import { Box, Chip, Group, SegmentedControl, SimpleGrid, Stack, Tabs, Text, TextInput, Title } from '@mantine/core';
 import { BACKGROUND, DECAL, GENERIC, ICON, LOGO, TROOP, TROOP_MODIFIER } from '@shared/assetIds';
 import { createFileRoute } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { TOPIC_ICON_TOPICS, TopicIcon } from '@ui/content/TopicIcon';
 import type { TopicIconTopic } from '@ui/content/TopicIcon';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -241,7 +242,7 @@ function IconsPage() {
     <PageLayout>
       <PageLayout.Header size="compact">
         <Stack align="center" gap="xs">
-          <Title order={1}>Icon catalog</Title>
+          <PageTitle title="Icon catalog" />
           <Text ta="center" maw={680}>
             Browse the canonical application topics, Lucide library, and Dune SVG assets available in this project.
           </Text>

--- a/src/app/routes/_app/[_]_jobs.tsx
+++ b/src/app/routes/_app/[_]_jobs.tsx
@@ -11,9 +11,9 @@ import {
   Switch,
   Table,
   Text,
-  Title,
 } from '@mantine/core';
 import { createFileRoute } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
 import { AlertCircle, BriefcaseBusiness } from 'lucide-react';
@@ -46,7 +46,7 @@ function PublicationJobsPage() {
       <PageLayout.Header size="compact">
         <Stack align="center" gap="xs">
           <BriefcaseBusiness size={32} strokeWidth={1.6} aria-hidden />
-          <Title order={1}>Publication jobs</Title>
+          <PageTitle title="Publication jobs" />
           <Text ta="center" maw={680}>
             Inspect the durable work queue and control whether the next scheduled run may pick up pending work.
           </Text>

--- a/src/app/routes/_app/assets/-assetEditorStates.tsx
+++ b/src/app/routes/_app/assets/-assetEditorStates.tsx
@@ -1,6 +1,7 @@
-import { Alert, Anchor, Group, Stack, Text, Title } from '@mantine/core';
+import { Alert, Anchor, Group, Stack, Text } from '@mantine/core';
 import { ASSET_TYPES, isAssetType } from '@shared/assets/types';
 import { Link, useNavigate } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { AssignPopover } from '@ui/control/AssignPopover';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
@@ -34,9 +35,7 @@ export function AssetEditorMessage({
   return (
     <PageLayout>
       <PageLayout.Header size="compact">
-        <Stack gap={2} align="center">
-          <Title order={1}>{title}</Title>
-        </Stack>
+        <PageTitle title={title} />
       </PageLayout.Header>
       <PageLayout.Content>
         <Surface padding="xl">

--- a/src/app/routes/_app/factions/$factionId/edit.tsx
+++ b/src/app/routes/_app/factions/$factionId/edit.tsx
@@ -1,7 +1,8 @@
-import { Alert, Anchor, Stack, Text, Title } from '@mantine/core';
+import { Alert, Anchor, Stack, Text } from '@mantine/core';
 import { isRouteNoticeCode } from '@shared/routeNotices';
 import type { RouteNoticeCode } from '@shared/routeNotices';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { factionAuthoringStatusMessage } from '@ui/content/assetPublishingStatus';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
@@ -85,7 +86,7 @@ function FactionEditPage() {
       >
         View faction
       </Anchor>
-      <Title order={1}>{faction ? `Edit ${faction.data.name}` : 'Edit faction'}</Title>
+      <PageTitle title={faction ? `Edit ${faction.data.name}` : 'Edit faction'} />
       <Text c="dimmed">Changes stay local until you explicitly save them.</Text>
     </Stack>
   );

--- a/src/app/routes/_app/factions/create.tsx
+++ b/src/app/routes/_app/factions/create.tsx
@@ -1,6 +1,7 @@
-import { Anchor, Stack, Text, Title } from '@mantine/core';
+import { Anchor, Stack, Text } from '@mantine/core';
 import type { RouteNoticeCode } from '@shared/routeNotices';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { factionAuthoringStatusMessage } from '@ui/content/assetPublishingStatus';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
@@ -65,7 +66,7 @@ function CreateFactionPage() {
       <Anchor size="sm" renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>
         Factions
       </Anchor>
-      <Title order={1}>Create faction</Title>
+      <PageTitle title="Create faction" />
       <Text c="dimmed">Build one faction document, then save it to schedule publication.</Text>
     </Stack>
   );

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -1,5 +1,6 @@
-import { Alert, Anchor, Avatar, Badge, Box, Button, Divider, Group, Skeleton, Stack, Text, Title } from '@mantine/core';
+import { Alert, Anchor, Avatar, Badge, Box, Button, Divider, Group, Skeleton, Stack, Text } from '@mantine/core';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { formatRelativeDate } from '@ui/content/dates';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { AssignPopover } from '@ui/control/AssignPopover';
@@ -58,7 +59,7 @@ function GroupDetailPage() {
     return (
       <PageLayout>
         <PageLayout.Header>
-          <Title order={1}>Group</Title>
+          <PageTitle title="Group" />
         </PageLayout.Header>
         <PageLayout.Content>
           <Surface padding="xl">
@@ -76,7 +77,7 @@ function GroupDetailPage() {
     return (
       <PageLayout>
         <PageLayout.Header>
-          <Title order={1}>Group</Title>
+          <PageTitle title="Group" />
         </PageLayout.Header>
         <PageLayout.Content>
           <Box className={styles.twoColumnGrid}>
@@ -145,7 +146,7 @@ function GroupDetailPage() {
   return (
     <PageLayout>
       <PageLayout.Header>
-        <Title order={1}>{group.name}</Title>
+        <PageTitle title={group.name} />
       </PageLayout.Header>
       <PageLayout.Toolbar>
         <>


### PR DESCRIPTION
3b's mechanical conversions for the kit compliance wave (#641). **Based on `main`, not stacked.**

Deliberately **half** the slice. Eight of the eighteen sites I set out to convert are here; the other ten are held, and the reason is worth reading before reviewing the diff.

## What is here changes nothing on screen

These eight sites spelled their title `Title order={1}`, which is exactly what `PageTitle` renders. Same face, same size, same margins, same position in the header.

| file | sites |
|---|---|
| `routes/_app/[_]_icons.tsx` | 1 |
| `routes/_app/[_]_jobs.tsx` | 1 |
| `routes/_app/groups/$groupSlug/index.tsx` | 3 |
| `routes/_app/factions/create.tsx` | 1 |
| `routes/_app/factions/$factionId/edit.tsx` | 1 |
| `routes/_app/assets/-assetEditorStates.tsx` | 1 |

`assets/-assetEditorStates.tsx` also drops a `Stack` that wrapped the title alone once the Block took over the grouping, the same tidy-up future-plans got.

## Why the other ten are not here

**A bare `<h1>` and a `Title order={1}` are different typefaces in this app, and I did not know that until I measured.**

- `src/app/styles/fonts.css:76` sets `h1` through `h6` to `C_Copperplate_Gothic`, as an element selector.
- `src/app/ui/theme.ts:97` sets Mantine's `headings.fontFamily` to `C_Candara`.
- A class beats an element selector, so every Mantine `Title` ignores the first rule.

Measured, same viewport, both a sole `h1` in a default header:

| page | spelling | face | size | margins |
|---|---|---|---|---|
| `/rulesets` (unconverted) | bare `<h1>` | **`C_Copperplate_Gothic`** | 32px | 21.44px |
| `/profiles` (converted in a draft) | `PageTitle` | **`C_Candara`** | 34px | 0 |

Copperplate is the engraved face that matches the `DUNE` wordmark in the nav. Candara is the body face. So the app has three page-title faces today (Desdemona on hero pages, Candara wherever `Title` was used, Copperplate wherever a bare `h1` was), and **which one a page gets depends only on which spelling its author reached for.** That is precisely the drift `PageTitle` exists to end, so it is a real question rather than a bug to paper over.

Converting the remaining ten would have changed the face on eight files, silently, inside a PR labelled mechanical. Norbert's call was to split here and settle the face on its own merits. Tracked separately; those ten stay on their bare `h1` until it is decided.

## Verified

Browser pass on every changed page, not a diff review: both dev routes, `/factions/create`, the shared asset editor message frame (reached through a missing slug so the real component renders), and `/groups/dreamers`. Each has exactly one `h1`, still centred by its own header column, `C_Candara` at 34px with zero margins, and unchanged sibling gaps because the parent `Stack` still owns them. The alignment-transparency rule from #657 gets its first mass exposure here and holds: every converted title adopts its container's alignment rather than declaring one.

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 637 unit tests, 339 storybook tests.
