### PR TITLE
Inline-code syntax gets one definition instead of two

### DIFF
--- a/scripts/assert-no-ai-tells.mjs
+++ b/scripts/assert-no-ai-tells.mjs
@@ -13,7 +13,7 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
 
-import { CURLY_QUOTES, EM_DASH, EMOJI, FILLER, HEDGE } from './lib/ai-tells.mjs';
+import { CURLY_QUOTES, EM_DASH, EMOJI, FILLER, HEDGE, stripInlineCode } from './lib/ai-tells.mjs';
 
 const root = join(import.meta.dirname, '..');
 
@@ -124,10 +124,12 @@ function checksFor(rel) {
   return null;
 }
 
-/** Inline code, link targets and emphasis markers are not prose. */
+/**
+ * Inline code, link targets and emphasis markers are not prose.
+ * The backtick step is the shared one, so inline-code syntax is defined in a single place rather than once per gate.
+ */
 function stripInlineMarkup(text) {
-  return text
-    .replace(/`[^`]*`/g, ' ')
+  return stripInlineCode(text)
     .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
     .replace(/[*_]+/g, '');
 }


### PR DESCRIPTION
The two review threads on [#659](https://github.com/ndelangen/dunezone/pull/659) that arrived after it merged. One fix, one decline with the probe attached. **Based on `main`, not stacked.**

## Sourcery was right, and pointedly so

#659 added `stripInlineCode` to the shared module so both gates agree on what counts as a literal rather than prose. It then left `stripInlineMarkup` in `assert-no-ai-tells.mjs` carrying its own copy of the same backtick regex.

Two spellings of one rule is the exact drift that PR existed to remove, reintroduced by the commit that removed it elsewhere. `stripInlineMarkup` now delegates its backtick step and keeps only the parts that are genuinely markdown: link targets and emphasis markers.

Bite-tested both directions:

| probe | result |
|---|---|
| backticked em dash, backticked filler word, a link, emphasis | passes |
| bare em dash | fails |
| `utilized` | fails |
| a title-case heading | fails |

The heading case is the one worth noting: title-case detection calls `stripInlineMarkup` itself, so it exercises the delegated path rather than the shared helper directly.

## Codacy's double-backtick point: declining, with the probe

The claim is accurate about the regex and does not describe a defect here.

```
input                    "The ``—`` character."
stripInlineCode output   "The  —  character."     em dash survives
```

So a `` `` ``-delimited span under-strips: the regex pairs the two opening backticks with each other, leaving the content exposed. It does not corrupt the line, it fails to protect it.

Two reasons not to fix it:

1. **No repo prose uses double-backtick spans.** `grep` for `` `` `` across every markdown file, excluding fences and `node_modules`, returns **zero** lines. The syntax exists in CommonMark for spans that themselves contain a backtick, which nothing here needs.
2. The fix is a materially hairier regex for a case that has never occurred, and the module's own standard is that a guard which cries wolf gets switched off. Complexity should be earned by a real case.

If one ever appears the failure is loud rather than silent: the author sees their em dash flagged, and this thread is the fix. Reopening on a real occurrence is cheap; carrying the regex forever is not.

## Verified

The full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 637 unit tests, 339 storybook tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency when handling inline code in automated content checks.
  * Centralized inline-code syntax handling to ensure formatting is interpreted uniformly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->