### PR TITLE
Detail-page placeholder titles become the Block

### DIFF
--- a/src/app/routes/_app/assets/$type/$slug/index.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/index.tsx
@@ -16,6 +16,7 @@ import type { RulesetAssetSlot } from '@shared/rulesets/assetSlots';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { OpenableTile } from '@ui/block/OpenableTile';
+import { PageTitle } from '@ui/block/PageTitle';
 import { Section } from '@ui/block/Section';
 import { formatRelativeDate } from '@ui/content/dates';
 import { ProfileLink } from '@ui/content/ProfileLink';
@@ -86,7 +87,7 @@ function AssetDetailMessage({ children }: { children: ReactNode }) {
     <PageLayout>
       <PageLayout.Header>
         <Stack align="center" gap="xs">
-          <Title order={1}>{label}</Title>
+          <PageTitle title={label} />
           <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/assets/$type" params={{ type }} />}>
             Back to {label.toLowerCase()}
           </Anchor>

--- a/src/app/routes/_app/factions/$factionId/index.tsx
+++ b/src/app/routes/_app/factions/$factionId/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mantine/core';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { Section } from '@ui/block/Section';
 import { factionAssetPublishingCopy } from '@ui/content/assetPublishingStatus';
 import { complexityOutOfTen, complexityTier, effectiveComplexity } from '@ui/content/complexity';
@@ -56,7 +57,7 @@ function FactionDetailPending() {
     <PageLayout>
       <PageLayout.Header>
         <Stack align="center" gap="xs">
-          <Title order={1}>Faction</Title>
+          <PageTitle title="Faction" />
           <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>Back to factions</Anchor>
         </Stack>
       </PageLayout.Header>
@@ -109,7 +110,7 @@ function FactionDetailError({ error }: ErrorComponentProps) {
     <PageLayout>
       <PageLayout.Header>
         <Stack align="center" gap="xs">
-          <Title order={1}>Faction</Title>
+          <PageTitle title="Faction" />
           <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>Back to factions</Anchor>
         </Stack>
       </PageLayout.Header>
@@ -138,7 +139,7 @@ function FactionDetailPage() {
       <PageLayout>
         <PageLayout.Header>
           <Stack align="center" gap="xs">
-            <Title order={1}>Faction</Title>
+            <PageTitle title="Faction" />
             <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>Back to factions</Anchor>
           </Stack>
         </PageLayout.Header>

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -6,6 +6,7 @@ import type { RouteNoticeCode } from '@shared/routeNotices';
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { FactionCard } from '@ui/block/FactionCard';
+import { PageTitle } from '@ui/block/PageTitle';
 import { ProposedContent } from '@ui/block/ProposedContent';
 import { Section } from '@ui/block/Section';
 import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
@@ -189,7 +190,7 @@ function RulesetDetailPending() {
     <PageLayout>
       <PageLayout.Header>
         <Stack align="center" gap="xs">
-          <Title order={1}>Ruleset</Title>
+          <PageTitle title="Ruleset" />
           <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>Back to rulesets</Anchor>
         </Stack>
       </PageLayout.Header>
@@ -210,7 +211,7 @@ function RulesetDetailError({ error }: ErrorComponentProps) {
     <PageLayout>
       <PageLayout.Header>
         <Stack align="center" gap="xs">
-          <Title order={1}>Ruleset</Title>
+          <PageTitle title="Ruleset" />
           <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>Back to rulesets</Anchor>
         </Stack>
       </PageLayout.Header>
@@ -243,7 +244,7 @@ function RulesetDetailPage() {
       <PageLayout>
         <PageLayout.Header>
           <Stack align="center" gap="xs">
-            <Title order={1}>Ruleset</Title>
+            <PageTitle title="Ruleset" />
             <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>Back to rulesets</Anchor>
           </Stack>
         </PageLayout.Header>


### PR DESCRIPTION
3b's second slice for the kit compliance wave (#641). **Based on `main`, not stacked.** Independent of [#661](https://github.com/ndelangen/dunezone/pull/661): no overlapping files, so they can land in either order.

Seven sites, all of them the title a detail page shows while it is loading, erroring, or reporting the thing does not exist.

| file | sites | states |
|---|---|---|
| `routes/_app/factions/$factionId/index.tsx` | 3 | pending, error, no-page |
| `routes/_app/rulesets/$rulesetSlug/index.tsx` | 3 | pending, error, not-found |
| `routes/_app/assets/$type/$slug/index.tsx` | 1 | `AssetDetailMessage`, which serves all three |

All seven were already `Title order={1}`, so **none of them changes typeface.** The bare-`<h1>` sites are held on [#662](https://github.com/ndelangen/dunezone/issues/662).

## These files are half converted on purpose

Each of the three keeps its loaded-state title, because each carries a page-specific class that is blocked on [#451](https://github.com/ndelangen/dunezone/issues/451). `PageTitle` takes only `title` and `eyebrow`, and those classes supply `overflow-wrap: anywhere` and a colour override with nowhere to go.

So a reviewer will see `PageTitle` and `Title order={1}` in the same file. That is the state of the work, not an oversight.

## `rulesets/$rulesetSlug/edit.tsx` is left out entirely

Its falsy arm (`<Title order={1}>Edit ruleset</Title>`) qualifies on every criterion and I still skipped it. Its header is a ternary whose *other* arm is exactly the hand-rolled `.pageHead` markup #451 covers. Converting one arm leaves two spellings inside one expression, and #451 has to rewrite that whole expression anyway, so doing it now saves nobody a visit. It goes with #451.

## Verified by reaching the states, not by reading the diff

Each state was reached deliberately, through slugs that do not exist, so the real components rendered:

| page | title | face | size | centred | back link |
|---|---|---|---|---|---|
| `/factions/no-such-faction` | Faction | `C_Candara` | 34px | yes | 10px below |
| `/rulesets/no-such-ruleset` | Ruleset | `C_Candara` | 34px | yes | 10px below |
| `/assets/card-treachery/no-such-card` | Treachery cards | `C_Candara` | 34px | yes | 10px below |

One `h1` each. The 10px gap is the parent `Stack`'s own `xs`, unchanged, because the Block only owns the space between an eyebrow and the title and these have no eyebrow.

I also checked the loaded states these files keep, to confirm the half conversion left them alone: `/factions/spacing-guild` still renders `.factionTitle` with `overflow-wrap: anywhere`.

## Verified

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 637 unit tests, 339 storybook tests.
