### PR TITLE
Add the shared formatted-text value core

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "react-children-utilities": "^2.10.0",
         "react-dom": "^19.2.8",
         "react-icons": "^5.7.0",
+        "unicode-segmenter": "0.17.3",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -1686,6 +1687,8 @@
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "unicode-segmenter": ["unicode-segmenter@0.17.3", "", {}, "sha512-hKZwqBjJDmqNrq1+LjDxck1qLzJFcLLJM2Xq92ORRHOuau6GSHeELmn+uyk6zNH1CK9mogrUJGP9WJCJUQXMAw=="],
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
 

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "react-children-utilities": "^2.10.0",
     "react-dom": "^19.2.8",
     "react-icons": "^5.7.0",
+    "unicode-segmenter": "0.17.3",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/shared/formattedText.test.ts
+++ b/src/shared/formattedText.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import type { NormalizedFormattedText } from './formattedText';
+import { normalizeFormattedText, parseFormattedText } from './formattedText';
+
+function parseValid(input: string) {
+  const result = parseFormattedText(input);
+  expect(result.valid, result.valid ? undefined : JSON.stringify(result.diagnostics)).toBe(true);
+  if (!result.valid) {
+    throw new Error('Expected valid formatted text');
+  }
+  return result;
+}
+
+describe('formatted-text core', () => {
+  it('accepts an empty value without deciding field requiredness', () => {
+    const parsed = parseValid('');
+    const normalized = normalizeFormattedText('');
+
+    expect(parsed.source).toBe('');
+    expect(parsed.blocks).toHaveLength(0);
+    expect(normalized).toEqual({ ok: true, value: '' });
+    if (normalized.ok) {
+      expectTypeOf(normalized.value).toEqualTypeOf<NormalizedFormattedText>();
+    }
+  });
+
+  it('normalizes plain text into paragraphs, separate lists, and multiline list items', () => {
+    const parsed = parseValid(
+      'Opening  \r\ncontinues\r\n\r\n\r\n• first  \r\n– second\r\n\r\n— third\r\n  continuation'
+    );
+
+    expect(parsed.source).toBe('Opening\ncontinues\n\n- first\n- second\n\n- third\n  continuation');
+    expect(parsed.blocks.map((block) => block.kind)).toEqual(['paragraph', 'list', 'list']);
+    expect(parsed.blocks[0]).toMatchObject({
+      kind: 'paragraph',
+      children: [{ kind: 'text', value: 'Opening' }, { kind: 'line-break' }, { kind: 'text', value: 'continues' }],
+    });
+    expect(parsed.blocks[2]).toMatchObject({
+      kind: 'list',
+      items: [
+        {
+          children: [{ kind: 'text', value: 'third' }, { kind: 'line-break' }, { kind: 'text', value: 'continuation' }],
+        },
+      ],
+    });
+  });
+
+  it('stores fully nested marks in canonical underline, italic, bold order', () => {
+    const parsed = parseValid('*-_words_-*');
+
+    expect(parsed.source).toBe('_-*words*-_');
+    expect(parsed.blocks[0]).toMatchObject({
+      kind: 'paragraph',
+      children: [
+        {
+          kind: 'mark',
+          mark: 'underline',
+          children: [
+            {
+              kind: 'mark',
+              mark: 'italic',
+              children: [
+                {
+                  kind: 'mark',
+                  mark: 'bold',
+                  children: [{ kind: 'text', value: 'words' }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it('allows a mark across a line break but not across a block boundary', () => {
+    const valid = parseValid('*line one\nline two*');
+    const invalid = parseFormattedText('*paragraph one\n\nparagraph two*');
+
+    expect(valid.blocks[0]).toMatchObject({
+      kind: 'paragraph',
+      children: [
+        {
+          kind: 'mark',
+          mark: 'bold',
+          children: [{ kind: 'text', value: 'line one' }, { kind: 'line-break' }, { kind: 'text', value: 'line two' }],
+        },
+      ],
+    });
+    expect(invalid.valid).toBe(false);
+    if (!invalid.valid) {
+      expect(invalid.diagnostics[0]).toMatchObject({ code: 'unclosed-mark', line: 1, column: 1 });
+    }
+  });
+
+  it('keeps ordinary prose literal and preserves supported escapes', () => {
+    const parsed = parseValid(String.raw`2*3 snake_case counter-clockwise \*plain\* \-plain\- \_plain\_ \\`);
+
+    expect(parsed.source).toBe(String.raw`2*3 snake_case counter-clockwise \*plain\* \-plain\- \_plain\_ \\`);
+    expect(parsed.blocks[0]).toMatchObject({
+      kind: 'paragraph',
+      children: [{ kind: 'text', value: '2*3 snake_case counter-clockwise *plain* -plain- _plain_ \\' }],
+    });
+  });
+
+  it('reports crossed marks at the offending delimiter with correction guidance', () => {
+    const parsed = parseFormattedText('*bold _underline* still underline_');
+
+    expect(parsed.valid).toBe(false);
+    if (!parsed.valid) {
+      expect(parsed.diagnostics[0]).toMatchObject({
+        code: 'crossed-mark',
+        line: 1,
+        column: 17,
+        offset: 16,
+        length: 1,
+      });
+      expect(parsed.diagnostics[0].suggestion).toContain('Close underline with _ before this *');
+    }
+  });
+
+  it('reports list and continuation errors at their editable source locations', () => {
+    const emptyItem = parseFormattedText('- ');
+    const continuation = parseFormattedText('- first\n  *missing');
+
+    expect(emptyItem.valid).toBe(false);
+    if (!emptyItem.valid) {
+      expect(emptyItem.diagnostics[0]).toMatchObject({
+        code: 'empty-list-item',
+        line: 1,
+        column: 3,
+        offset: 2,
+        length: 0,
+      });
+    }
+    expect(continuation.valid).toBe(false);
+    if (!continuation.valid) {
+      expect(continuation.diagnostics[0]).toMatchObject({
+        code: 'unclosed-mark',
+        line: 2,
+        column: 3,
+        offset: 10,
+      });
+      expect(continuation.diagnostics[0].suggestion).toContain('Add *');
+    }
+  });
+
+  it('refuses to mint a normalized value for an invalid direct-typing draft', () => {
+    const normalized = normalizeFormattedText('An *unfinished draft');
+
+    expect(normalized.ok).toBe(false);
+    if (!normalized.ok) {
+      expect(normalized.diagnostics[0]).toMatchObject({
+        code: 'unclosed-mark',
+        line: 1,
+        column: 4,
+      });
+      expect(normalized.diagnostics[0].message).toBe('Bold starts here but has no closing *.');
+    }
+  });
+
+  it('returns hostile-looking source only as inert text nodes', () => {
+    const source = '<img src=x onerror=alert(1)> <script>alert(1)</script>';
+    const parsed = parseValid(source);
+
+    expect(parsed.source).toBe(source);
+    expect(parsed.blocks[0]).toMatchObject({
+      kind: 'paragraph',
+      children: [{ kind: 'text', value: source }],
+    });
+    expect(JSON.stringify(parsed.blocks)).not.toContain('"html"');
+  });
+
+  it('normalizes valid input idempotently', () => {
+    const first = normalizeFormattedText('  leading\r\n\r\n*-_nested_-*\r\n');
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      throw new Error('Expected a normalized value');
+    }
+
+    expect(normalizeFormattedText(first.value)).toEqual(first);
+  });
+});

--- a/src/shared/formattedText.test.ts
+++ b/src/shared/formattedText.test.ts
@@ -202,7 +202,9 @@ describe('formatted-text core', () => {
   it.each([
     { source: '😀 text *missing', column: 8, offset: 8 },
     { source: 'e\u0301 text *missing', column: 8, offset: 8 },
-  ])('reports a Unicode-aware column and UTF-16 offset for $source', ({ source, column, offset }) => {
+    { source: 'क्ष text *missing', column: 8, offset: 9 },
+    { source: '👩‍💻 text *missing', column: 8, offset: 11 },
+  ])('reports an extended-grapheme column and UTF-16 offset for $source', ({ source, column, offset }) => {
     const parsed = parseFormattedText(source);
 
     expect(parsed.valid).toBe(false);

--- a/src/shared/formattedText.test.ts
+++ b/src/shared/formattedText.test.ts
@@ -19,10 +19,12 @@ describe('formatted-text core', () => {
 
     expect(parsed.source).toBe('');
     expect(parsed.blocks).toHaveLength(0);
-    expect(normalized).toEqual({ ok: true, value: '' });
-    if (normalized.ok) {
-      expectTypeOf(normalized.value).toEqualTypeOf<NormalizedFormattedText>();
+    expect(normalized.ok).toBe(true);
+    if (!normalized.ok) {
+      throw new Error('Expected an empty normalized value');
     }
+    expect(normalized.value).toBe('');
+    expectTypeOf<string>().not.toMatchTypeOf<NormalizedFormattedText>();
   });
 
   it('normalizes plain text into paragraphs, separate lists, and multiline list items', () => {
@@ -117,6 +119,28 @@ describe('formatted-text core', () => {
     });
   });
 
+  it.each(['e\u0301*bold*', 'क्*bold*'])(
+    'treats combining marks as part of the word before an opening delimiter in %s',
+    (source) => {
+      const parsed = parseValid(source);
+
+      expect(parsed.source).toBe(source);
+      expect(parsed.blocks[0]).toMatchObject({
+        kind: 'paragraph',
+        children: [{ kind: 'text', value: source }],
+      });
+    }
+  );
+
+  it('does not close a mark immediately before a combining sequence', () => {
+    const parsed = parseFormattedText('*bold*\u0301e');
+
+    expect(parsed.valid).toBe(false);
+    if (!parsed.valid) {
+      expect(parsed.diagnostics[0]).toMatchObject({ code: 'unclosed-mark', line: 1, column: 1, offset: 0 });
+    }
+  });
+
   it('reports crossed marks at the offending delimiter with correction guidance', () => {
     const parsed = parseFormattedText('*bold _underline* still underline_');
 
@@ -175,6 +199,23 @@ describe('formatted-text core', () => {
     }
   });
 
+  it.each([
+    { source: '😀 text *missing', column: 8, offset: 8 },
+    { source: 'e\u0301 text *missing', column: 8, offset: 8 },
+  ])('reports a Unicode-aware column and UTF-16 offset for $source', ({ source, column, offset }) => {
+    const parsed = parseFormattedText(source);
+
+    expect(parsed.valid).toBe(false);
+    if (!parsed.valid) {
+      expect(parsed.diagnostics[0]).toMatchObject({
+        code: 'unclosed-mark',
+        line: 1,
+        column,
+        offset,
+      });
+    }
+  });
+
   it('refuses to mint a normalized value for an invalid direct-typing draft', () => {
     const normalized = normalizeFormattedText('An *unfinished draft');
 
@@ -198,7 +239,6 @@ describe('formatted-text core', () => {
       kind: 'paragraph',
       children: [{ kind: 'text', value: source }],
     });
-    expect(JSON.stringify(parsed.blocks)).not.toContain('"html"');
   });
 
   it('normalizes valid input idempotently', () => {

--- a/src/shared/formattedText.test.ts
+++ b/src/shared/formattedText.test.ts
@@ -104,6 +104,19 @@ describe('formatted-text core', () => {
     });
   });
 
+  it('treats astral Unicode letters as prose-boundary word characters', () => {
+    const parsed = parseValid('𝒜*bold* and *𝒜*');
+
+    expect(parsed.source).toBe('𝒜*bold* and *𝒜*');
+    expect(parsed.blocks[0]).toMatchObject({
+      kind: 'paragraph',
+      children: [
+        { kind: 'text', value: '𝒜*bold* and ' },
+        { kind: 'mark', mark: 'bold', children: [{ kind: 'text', value: '𝒜' }] },
+      ],
+    });
+  });
+
   it('reports crossed marks at the offending delimiter with correction guidance', () => {
     const parsed = parseFormattedText('*bold _underline* still underline_');
 
@@ -143,6 +156,22 @@ describe('formatted-text core', () => {
         offset: 10,
       });
       expect(continuation.diagnostics[0].suggestion).toContain('Add *');
+    }
+  });
+
+  it('keeps diagnostics aligned to the original input while normalizing the draft', () => {
+    const input = 'Opening\r\n\r\n\r\n\r\n- item   \r\n  *missing';
+    const parsed = parseFormattedText(input);
+
+    expect(parsed.valid).toBe(false);
+    expect(parsed.source).toBe('Opening\n\n- item\n  *missing');
+    if (!parsed.valid) {
+      expect(parsed.diagnostics[0]).toMatchObject({
+        code: 'unclosed-mark',
+        line: 6,
+        column: 3,
+        offset: input.indexOf('*'),
+      });
     }
   });
 

--- a/src/shared/formattedText.ts
+++ b/src/shared/formattedText.ts
@@ -1,3 +1,5 @@
+import { graphemeSegments } from 'unicode-segmenter/grapheme';
+
 const FORMATTED_TEXT_MARKS = [
   { delimiter: '_', mark: 'underline' },
   { delimiter: '-', mark: 'italic' },
@@ -122,7 +124,6 @@ const delimiterDetails = new Map<FormattedTextDelimiter, FormattedTextMark>(
 const canonicalMarkOrder = new Map<FormattedTextMark, number>(
   FORMATTED_TEXT_MARKS.map(({ mark }, index) => [mark, index])
 );
-const combiningMark = /\p{M}/u;
 const wordCharacter = /[\p{L}\p{M}\p{N}]/u;
 const HIGH_SURROGATE_MIN = 55_296;
 const HIGH_SURROGATE_MAX = 56_319;
@@ -146,21 +147,15 @@ function delimiterForMark(mark: FormattedTextMark): FormattedTextDelimiter {
 }
 
 function sourceColumns(text: string): { readonly positions: readonly number[]; readonly end: number } {
-  const positions: number[] = [];
+  const positions = Array<number>(text.length);
   let column = 1;
-  let hasCluster = false;
 
-  for (const character of text) {
-    if (!combiningMark.test(character) || !hasCluster) {
-      if (hasCluster) {
-        column += 1;
-      }
-      hasCluster = true;
-    }
-    positions.push(...Array.from({ length: character.length }, () => column));
+  for (const { index, segment } of graphemeSegments(text)) {
+    positions.fill(column, index, index + segment.length);
+    column += 1;
   }
 
-  return { positions, end: hasCluster ? column + 1 : 1 };
+  return { positions, end: column };
 }
 
 function sourceLines(value: string): readonly SourceLine[] {

--- a/src/shared/formattedText.ts
+++ b/src/shared/formattedText.ts
@@ -1,0 +1,508 @@
+const FORMATTED_TEXT_MARKS = [
+  { delimiter: '_', mark: 'underline' },
+  { delimiter: '-', mark: 'italic' },
+  { delimiter: '*', mark: 'bold' },
+] as const;
+
+type FormattedTextDelimiter = (typeof FORMATTED_TEXT_MARKS)[number]['delimiter'];
+
+type FormattedTextMark = (typeof FORMATTED_TEXT_MARKS)[number]['mark'];
+
+declare const normalizedFormattedTextBrand: unique symbol;
+
+/** A valid, canonical formatted-text source string. */
+export type NormalizedFormattedText = string & {
+  readonly [normalizedFormattedTextBrand]: true;
+};
+
+type FormattedTextInlineNode =
+  | { readonly kind: 'text'; readonly value: string }
+  | { readonly kind: 'line-break' }
+  | {
+      readonly kind: 'mark';
+      readonly mark: FormattedTextMark;
+      readonly children: readonly FormattedTextInlineNode[];
+    };
+
+type FormattedTextBlock =
+  | {
+      readonly kind: 'paragraph';
+      readonly children: readonly FormattedTextInlineNode[];
+    }
+  | {
+      readonly kind: 'list';
+      readonly items: readonly {
+        readonly children: readonly FormattedTextInlineNode[];
+      }[];
+    };
+
+const FORMATTED_TEXT_DIAGNOSTIC_CODES = ['crossed-mark', 'empty-list-item', 'empty-mark', 'unclosed-mark'] as const;
+
+type FormattedTextDiagnosticCode = (typeof FORMATTED_TEXT_DIAGNOSTIC_CODES)[number];
+
+/** One-based line and column plus a zero-based UTF-16 source offset. */
+type FormattedTextDiagnostic = {
+  readonly code: FormattedTextDiagnosticCode;
+  readonly line: number;
+  readonly column: number;
+  readonly offset: number;
+  readonly length: number;
+  readonly message: string;
+  readonly suggestion: string;
+};
+
+export type FormattedTextParseResult =
+  | {
+      readonly valid: true;
+      readonly source: NormalizedFormattedText;
+      readonly blocks: readonly FormattedTextBlock[];
+      readonly diagnostics: readonly [];
+    }
+  | {
+      readonly valid: false;
+      readonly source: string;
+      readonly blocks: readonly FormattedTextBlock[];
+      readonly diagnostics: readonly [FormattedTextDiagnostic, ...FormattedTextDiagnostic[]];
+    };
+
+export type FormattedTextNormalizationResult =
+  | { readonly ok: true; readonly value: NormalizedFormattedText }
+  | {
+      readonly ok: false;
+      readonly diagnostics: readonly [FormattedTextDiagnostic, ...FormattedTextDiagnostic[]];
+    };
+
+type SourcePosition = {
+  readonly line: number;
+  readonly column: number;
+  readonly offset: number;
+};
+
+type SourceLine = {
+  readonly text: string;
+  readonly line: number;
+  readonly column: number;
+  readonly offset: number;
+};
+
+type ParsedTextNode = {
+  readonly kind: 'text';
+  readonly value: string;
+  readonly source: string;
+};
+
+type ParsedInlineNode =
+  | ParsedTextNode
+  | { readonly kind: 'line-break' }
+  | {
+      readonly kind: 'mark';
+      readonly mark: FormattedTextMark;
+      readonly children: readonly ParsedInlineNode[];
+    };
+
+type ParsedBlock =
+  | { readonly kind: 'paragraph'; readonly children: readonly ParsedInlineNode[] }
+  | {
+      readonly kind: 'list';
+      readonly items: readonly { readonly children: readonly ParsedInlineNode[] }[];
+    };
+
+type InlineParseResult = {
+  readonly nodes: readonly ParsedInlineNode[];
+  readonly diagnostics: readonly FormattedTextDiagnostic[];
+};
+
+const delimiterDetails = new Map<FormattedTextDelimiter, FormattedTextMark>(
+  FORMATTED_TEXT_MARKS.map(({ delimiter, mark }) => [delimiter, mark])
+);
+const canonicalMarkOrder = new Map<FormattedTextMark, number>(
+  FORMATTED_TEXT_MARKS.map(({ mark }, index) => [mark, index])
+);
+const wordCharacter = /[\p{L}\p{N}]/u;
+
+function isDelimiter(value: string | undefined): value is FormattedTextDelimiter {
+  return value !== undefined && delimiterDetails.has(value as FormattedTextDelimiter);
+}
+
+function markName(mark: FormattedTextMark): string {
+  return `${mark[0].toUpperCase()}${mark.slice(1)}`;
+}
+
+function delimiterForMark(mark: FormattedTextMark): FormattedTextDelimiter {
+  const detail = FORMATTED_TEXT_MARKS.find((candidate) => candidate.mark === mark);
+  if (!detail) {
+    throw new Error(`Unknown formatted-text mark: ${mark}`);
+  }
+  return detail.delimiter;
+}
+
+function normalizePlainText(value: string): string {
+  return value
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((line) => {
+      const withCanonicalBullet = line.replace(/^(?:•|–|—)[ \t]+/u, '- ');
+      return /^-[ \t]+$/u.test(withCanonicalBullet) ? '- ' : withCanonicalBullet.replace(/[ \t]+$/u, '');
+    })
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n');
+}
+
+function combineInlineSource(lines: readonly SourceLine[]): {
+  readonly source: string;
+  readonly positions: readonly SourcePosition[];
+} {
+  let source = '';
+  const positions: SourcePosition[] = [];
+
+  lines.forEach((line, lineIndex) => {
+    if (lineIndex > 0) {
+      const previous = lines[lineIndex - 1]!;
+      source += '\n';
+      positions.push({
+        line: previous.line,
+        column: previous.column + previous.text.length,
+        offset: previous.offset + previous.text.length,
+      });
+    }
+
+    source += line.text;
+    for (let index = 0; index < line.text.length; index += 1) {
+      positions.push({
+        line: line.line,
+        column: line.column + index,
+        offset: line.offset + index,
+      });
+    }
+  });
+
+  return { source, positions };
+}
+
+function parseInline(lines: readonly SourceLine[]): InlineParseResult {
+  const { source, positions } = combineInlineSource(lines);
+  const root: ParsedInlineNode[] = [];
+  const stack: Array<{
+    readonly delimiter: FormattedTextDelimiter;
+    readonly position: SourcePosition;
+    readonly nodes: ParsedInlineNode[];
+  }> = [];
+  const diagnostics: FormattedTextDiagnostic[] = [];
+  let textValue = '';
+  let textSource = '';
+
+  const currentNodes = () => stack.at(-1)?.nodes ?? root;
+  const flushText = () => {
+    if (textSource.length === 0) {
+      return;
+    }
+    currentNodes().push({ kind: 'text', value: textValue, source: textSource });
+    textValue = '';
+    textSource = '';
+  };
+  const appendText = (value: string, rawSource: string) => {
+    textValue += value;
+    textSource += rawSource;
+  };
+
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index]!;
+
+    if (character === '\n') {
+      flushText();
+      currentNodes().push({ kind: 'line-break' });
+      continue;
+    }
+
+    if (character === '\\') {
+      const escaped = source[index + 1];
+      if (escaped === '\\' || isDelimiter(escaped)) {
+        appendText(escaped, `${character}${escaped}`);
+        index += 1;
+      } else {
+        appendText(character, character);
+      }
+      continue;
+    }
+
+    if (!isDelimiter(character)) {
+      appendText(character, character);
+      continue;
+    }
+
+    const previous = source[index - 1];
+    const next = source[index + 1];
+    const canOpen =
+      next !== undefined && !/\s/u.test(next) && (previous === undefined || !wordCharacter.test(previous));
+    const canClose =
+      previous !== undefined && !/\s/u.test(previous) && (next === undefined || !wordCharacter.test(next));
+    const top = stack.at(-1);
+    const position = positions[index]!;
+
+    if (top?.delimiter === character && canClose) {
+      flushText();
+      const completed = stack.pop()!;
+      if (completed.nodes.length === 0) {
+        diagnostics.push({
+          code: 'empty-mark',
+          ...position,
+          length: 1,
+          message: `${markName(delimiterDetails.get(character)!)} formatting has no text.`,
+          suggestion: `Put words between the two ${character} marks, or remove both marks.`,
+        });
+        currentNodes().push({ kind: 'text', value: `${character}${character}`, source: `${character}${character}` });
+      } else {
+        currentNodes().push({
+          kind: 'mark',
+          mark: delimiterDetails.get(character)!,
+          children: completed.nodes,
+        });
+      }
+      continue;
+    }
+
+    const crossing = canClose && stack.some((entry) => entry.delimiter === character);
+    if (crossing) {
+      const closingMark = delimiterDetails.get(character)!;
+      const openMark = delimiterDetails.get(top!.delimiter)!;
+      diagnostics.push({
+        code: 'crossed-mark',
+        ...position,
+        length: 1,
+        message: `${markName(closingMark)} closes before ${openMark} is finished.`,
+        suggestion: `Close ${openMark} with ${top!.delimiter} before this ${character}, or move this ${character} after it.`,
+      });
+      appendText(character, character);
+      continue;
+    }
+
+    if (canOpen) {
+      flushText();
+      stack.push({ delimiter: character, position, nodes: [] });
+      continue;
+    }
+
+    appendText(character, character);
+  }
+
+  flushText();
+  while (stack.length > 0) {
+    const unclosed = stack.pop()!;
+    const mark = delimiterDetails.get(unclosed.delimiter)!;
+    diagnostics.push({
+      code: 'unclosed-mark',
+      ...unclosed.position,
+      length: 1,
+      message: `${markName(mark)} starts here but has no closing ${unclosed.delimiter}.`,
+      suggestion: `Add ${unclosed.delimiter} after the words you want formatted, or remove this ${unclosed.delimiter}.`,
+    });
+    currentNodes().push({ kind: 'text', value: unclosed.delimiter, source: unclosed.delimiter }, ...unclosed.nodes);
+  }
+
+  return { nodes: root, diagnostics };
+}
+
+function canonicalizeInlineNodes(nodes: readonly ParsedInlineNode[]): readonly ParsedInlineNode[] {
+  return nodes.map((node) => {
+    if (node.kind !== 'mark') {
+      return node;
+    }
+
+    const marks: FormattedTextMark[] = [node.mark];
+    let children = node.children;
+    while (children.length === 1 && children[0]?.kind === 'mark') {
+      marks.push(children[0].mark);
+      children = children[0].children;
+    }
+
+    marks.sort((left, right) => canonicalMarkOrder.get(left)! - canonicalMarkOrder.get(right)!);
+    let nestedChildren = canonicalizeInlineNodes(children);
+    for (const mark of [...marks].reverse()) {
+      nestedChildren = [{ kind: 'mark', mark, children: nestedChildren }];
+    }
+    return nestedChildren[0]!;
+  });
+}
+
+function serializeInline(nodes: readonly ParsedInlineNode[]): string {
+  return nodes
+    .map((node) => {
+      if (node.kind === 'text') {
+        return node.source;
+      }
+      if (node.kind === 'line-break') {
+        return '\n';
+      }
+      const delimiter = delimiterForMark(node.mark);
+      return `${delimiter}${serializeInline(node.children)}${delimiter}`;
+    })
+    .join('');
+}
+
+function toPublicInlineNodes(nodes: readonly ParsedInlineNode[]): readonly FormattedTextInlineNode[] {
+  return nodes.map((node) => {
+    if (node.kind === 'text') {
+      return { kind: 'text', value: node.value };
+    }
+    if (node.kind === 'line-break') {
+      return node;
+    }
+    return {
+      kind: 'mark',
+      mark: node.mark,
+      children: toPublicInlineNodes(node.children),
+    };
+  });
+}
+
+function parseBlocks(source: string): {
+  readonly blocks: readonly ParsedBlock[];
+  readonly diagnostics: readonly FormattedTextDiagnostic[];
+} {
+  const sourceLines: SourceLine[] = [];
+  let sourceOffset = 0;
+  source.split('\n').forEach((text, index) => {
+    sourceLines.push({ text, line: index + 1, column: 1, offset: sourceOffset });
+    sourceOffset += text.length + 1;
+  });
+
+  const blocks: ParsedBlock[] = [];
+  const diagnostics: FormattedTextDiagnostic[] = [];
+  let paragraphLines: SourceLine[] = [];
+  let listItems: SourceLine[][] = [];
+
+  const flushParagraph = () => {
+    if (paragraphLines.length === 0) {
+      return;
+    }
+    const parsed = parseInline(paragraphLines);
+    blocks.push({ kind: 'paragraph', children: parsed.nodes });
+    diagnostics.push(...parsed.diagnostics);
+    paragraphLines = [];
+  };
+
+  const flushList = () => {
+    if (listItems.length === 0) {
+      return;
+    }
+    blocks.push({
+      kind: 'list',
+      items: listItems.map((lines) => {
+        const parsed = parseInline(lines);
+        diagnostics.push(...parsed.diagnostics);
+        return { children: parsed.nodes };
+      }),
+    });
+    listItems = [];
+  };
+
+  for (const line of sourceLines) {
+    if (line.text.length === 0) {
+      flushParagraph();
+      flushList();
+      continue;
+    }
+
+    if (line.text.startsWith('- ')) {
+      flushParagraph();
+      listItems.push([
+        {
+          text: line.text.slice(2),
+          line: line.line,
+          column: 3,
+          offset: line.offset + 2,
+        },
+      ]);
+      if (line.text.length === 2) {
+        diagnostics.push({
+          code: 'empty-list-item',
+          line: line.line,
+          column: 3,
+          offset: line.offset + 2,
+          length: 0,
+          message: 'This list item has no text.',
+          suggestion: 'Type the list item after the dash, or remove this line.',
+        });
+      }
+      continue;
+    }
+
+    if (line.text.startsWith('  ') && listItems.length > 0) {
+      listItems.at(-1)!.push({
+        text: line.text.slice(2),
+        line: line.line,
+        column: 3,
+        offset: line.offset + 2,
+      });
+      continue;
+    }
+
+    flushList();
+    paragraphLines.push(line);
+  }
+
+  flushParagraph();
+  flushList();
+  return { blocks, diagnostics };
+}
+
+function canonicalizeBlocks(blocks: readonly ParsedBlock[]): readonly ParsedBlock[] {
+  return blocks.map((block) =>
+    block.kind === 'paragraph'
+      ? { kind: 'paragraph', children: canonicalizeInlineNodes(block.children) }
+      : {
+          kind: 'list',
+          items: block.items.map((item) => ({ children: canonicalizeInlineNodes(item.children) })),
+        }
+  );
+}
+
+function serializeBlocks(blocks: readonly ParsedBlock[]): string {
+  return blocks
+    .map((block) =>
+      block.kind === 'paragraph'
+        ? serializeInline(block.children)
+        : block.items.map((item) => `- ${serializeInline(item.children).replace(/\n/g, '\n  ')}`).join('\n')
+    )
+    .join('\n\n');
+}
+
+function toPublicBlocks(blocks: readonly ParsedBlock[]): readonly FormattedTextBlock[] {
+  return blocks.map((block) =>
+    block.kind === 'paragraph'
+      ? { kind: 'paragraph', children: toPublicInlineNodes(block.children) }
+      : {
+          kind: 'list',
+          items: block.items.map((item) => ({ children: toPublicInlineNodes(item.children) })),
+        }
+  );
+}
+
+/** Parse an editable draft into renderer-safe data and source-located diagnostics. */
+export function parseFormattedText(input: string): FormattedTextParseResult {
+  const normalizedDraft = normalizePlainText(input);
+  const parsed = parseBlocks(normalizedDraft);
+
+  if (parsed.diagnostics.length > 0) {
+    return {
+      valid: false,
+      source: normalizedDraft,
+      blocks: toPublicBlocks(parsed.blocks),
+      diagnostics: parsed.diagnostics as [FormattedTextDiagnostic, ...FormattedTextDiagnostic[]],
+    };
+  }
+
+  const canonicalBlocks = canonicalizeBlocks(parsed.blocks);
+  return {
+    valid: true,
+    source: serializeBlocks(canonicalBlocks) as NormalizedFormattedText,
+    blocks: toPublicBlocks(canonicalBlocks),
+    diagnostics: [],
+  };
+}
+
+/** Mint a stored value only when the complete draft is valid and canonical. */
+export function normalizeFormattedText(input: string): FormattedTextNormalizationResult {
+  const parsed = parseFormattedText(input);
+  return parsed.valid ? { ok: true, value: parsed.source } : { ok: false, diagnostics: parsed.diagnostics };
+}

--- a/src/shared/formattedText.ts
+++ b/src/shared/formattedText.ts
@@ -40,7 +40,7 @@ const FORMATTED_TEXT_DIAGNOSTIC_CODES = ['crossed-mark', 'empty-list-item', 'emp
 
 type FormattedTextDiagnosticCode = (typeof FORMATTED_TEXT_DIAGNOSTIC_CODES)[number];
 
-/** One-based line and column plus a zero-based UTF-16 offset in the original input. */
+/** One-based line and Unicode column plus a zero-based UTF-16 offset in the original input. */
 type FormattedTextDiagnostic = {
   readonly code: FormattedTextDiagnosticCode;
   readonly line: number;
@@ -122,7 +122,8 @@ const delimiterDetails = new Map<FormattedTextDelimiter, FormattedTextMark>(
 const canonicalMarkOrder = new Map<FormattedTextMark, number>(
   FORMATTED_TEXT_MARKS.map(({ mark }, index) => [mark, index])
 );
-const wordCharacter = /[\p{L}\p{N}]/u;
+const combiningMark = /\p{M}/u;
+const wordCharacter = /[\p{L}\p{M}\p{N}]/u;
 const HIGH_SURROGATE_MIN = 55_296;
 const HIGH_SURROGATE_MAX = 56_319;
 const LOW_SURROGATE_MIN = 56_320;
@@ -144,6 +145,24 @@ function delimiterForMark(mark: FormattedTextMark): FormattedTextDelimiter {
   return detail.delimiter;
 }
 
+function sourceColumns(text: string): { readonly positions: readonly number[]; readonly end: number } {
+  const positions: number[] = [];
+  let column = 1;
+  let hasCluster = false;
+
+  for (const character of text) {
+    if (!combiningMark.test(character) || !hasCluster) {
+      if (hasCluster) {
+        column += 1;
+      }
+      hasCluster = true;
+    }
+    positions.push(...Array.from({ length: character.length }, () => column));
+  }
+
+  return { positions, end: hasCluster ? column + 1 : 1 };
+}
+
 function sourceLines(value: string): readonly SourceLine[] {
   const lines: SourceLine[] = [];
   let lineNumber = 1;
@@ -156,14 +175,15 @@ function sourceLines(value: string): readonly SourceLine[] {
     }
 
     const text = value.slice(lineStart, lineEnd);
+    const columns = sourceColumns(text);
     lines.push({
       text,
-      positions: Array.from({ length: text.length }, (_, index) => ({
+      positions: columns.positions.map((column, index) => ({
         line: lineNumber,
-        column: index + 1,
+        column,
         offset: lineStart + index,
       })),
-      end: { line: lineNumber, column: text.length + 1, offset: lineEnd },
+      end: { line: lineNumber, column: columns.end, offset: lineEnd },
     });
 
     if (lineEnd === value.length) {

--- a/src/shared/formattedText.ts
+++ b/src/shared/formattedText.ts
@@ -40,7 +40,7 @@ const FORMATTED_TEXT_DIAGNOSTIC_CODES = ['crossed-mark', 'empty-list-item', 'emp
 
 type FormattedTextDiagnosticCode = (typeof FORMATTED_TEXT_DIAGNOSTIC_CODES)[number];
 
-/** One-based line and column plus a zero-based UTF-16 source offset. */
+/** One-based line and column plus a zero-based UTF-16 offset in the original input. */
 type FormattedTextDiagnostic = {
   readonly code: FormattedTextDiagnosticCode;
   readonly line: number;
@@ -80,9 +80,13 @@ type SourcePosition = {
 
 type SourceLine = {
   readonly text: string;
-  readonly line: number;
-  readonly column: number;
-  readonly offset: number;
+  readonly positions: readonly SourcePosition[];
+  readonly end: SourcePosition;
+};
+
+type NormalizedPlainText = {
+  readonly source: string;
+  readonly lines: readonly SourceLine[];
 };
 
 type ParsedTextNode = {
@@ -119,6 +123,10 @@ const canonicalMarkOrder = new Map<FormattedTextMark, number>(
   FORMATTED_TEXT_MARKS.map(({ mark }, index) => [mark, index])
 );
 const wordCharacter = /[\p{L}\p{N}]/u;
+const HIGH_SURROGATE_MIN = 55_296;
+const HIGH_SURROGATE_MAX = 56_319;
+const LOW_SURROGATE_MIN = 56_320;
+const LOW_SURROGATE_MAX = 57_343;
 
 function isDelimiter(value: string | undefined): value is FormattedTextDelimiter {
   return value !== undefined && delimiterDetails.has(value as FormattedTextDelimiter);
@@ -136,16 +144,66 @@ function delimiterForMark(mark: FormattedTextMark): FormattedTextDelimiter {
   return detail.delimiter;
 }
 
-function normalizePlainText(value: string): string {
-  return value
-    .replace(/\r\n?/g, '\n')
-    .split('\n')
-    .map((line) => {
-      const withCanonicalBullet = line.replace(/^(?:•|–|—)[ \t]+/u, '- ');
-      return /^-[ \t]+$/u.test(withCanonicalBullet) ? '- ' : withCanonicalBullet.replace(/[ \t]+$/u, '');
-    })
-    .join('\n')
-    .replace(/\n{3,}/g, '\n\n');
+function sourceLines(value: string): readonly SourceLine[] {
+  const lines: SourceLine[] = [];
+  let lineNumber = 1;
+  let lineStart = 0;
+
+  while (lineStart <= value.length) {
+    let lineEnd = lineStart;
+    while (lineEnd < value.length && value[lineEnd] !== '\r' && value[lineEnd] !== '\n') {
+      lineEnd += 1;
+    }
+
+    const text = value.slice(lineStart, lineEnd);
+    lines.push({
+      text,
+      positions: Array.from({ length: text.length }, (_, index) => ({
+        line: lineNumber,
+        column: index + 1,
+        offset: lineStart + index,
+      })),
+      end: { line: lineNumber, column: text.length + 1, offset: lineEnd },
+    });
+
+    if (lineEnd === value.length) {
+      break;
+    }
+    lineStart = lineEnd + (value[lineEnd] === '\r' && value[lineEnd + 1] === '\n' ? 2 : 1);
+    lineNumber += 1;
+  }
+
+  return lines;
+}
+
+function normalizeSourceLine(line: SourceLine): SourceLine {
+  const bullet = line.text.match(/^(?:•|–|—)[ \t]+/u)?.[0];
+  let text = line.text;
+  let positions = [...line.positions];
+
+  if (bullet) {
+    text = `- ${text.slice(bullet.length)}`;
+    positions = [positions[0]!, positions[1]!, ...positions.slice(bullet.length)];
+  }
+
+  if (/^-[ \t]+$/u.test(text)) {
+    return { text: '- ', positions: positions.slice(0, 2), end: line.end };
+  }
+
+  const trailingWhitespace = text.match(/[ \t]+$/u)?.[0].length ?? 0;
+  const retainedLength = text.length - trailingWhitespace;
+  return {
+    text: text.slice(0, retainedLength),
+    positions: positions.slice(0, retainedLength),
+    end: line.end,
+  };
+}
+
+function normalizePlainText(value: string): NormalizedPlainText {
+  const lines = sourceLines(value)
+    .map(normalizeSourceLine)
+    .filter((line, index, allLines) => line.text.length > 0 || allLines[index - 1]?.text.length !== 0);
+  return { source: lines.map((line) => line.text).join('\n'), lines };
 }
 
 function combineInlineSource(lines: readonly SourceLine[]): {
@@ -159,24 +217,42 @@ function combineInlineSource(lines: readonly SourceLine[]): {
     if (lineIndex > 0) {
       const previous = lines[lineIndex - 1]!;
       source += '\n';
-      positions.push({
-        line: previous.line,
-        column: previous.column + previous.text.length,
-        offset: previous.offset + previous.text.length,
-      });
+      positions.push(previous.end);
     }
 
     source += line.text;
-    for (let index = 0; index < line.text.length; index += 1) {
-      positions.push({
-        line: line.line,
-        column: line.column + index,
-        offset: line.offset + index,
-      });
-    }
+    positions.push(...line.positions);
   });
 
   return { source, positions };
+}
+
+function codePointBefore(source: string, index: number): string | undefined {
+  if (index === 0) {
+    return undefined;
+  }
+  const low = source.charCodeAt(index - 1);
+  const high = source.charCodeAt(index - 2);
+  return low >= LOW_SURROGATE_MIN &&
+    low <= LOW_SURROGATE_MAX &&
+    high >= HIGH_SURROGATE_MIN &&
+    high <= HIGH_SURROGATE_MAX
+    ? source.slice(index - 2, index)
+    : source[index - 1];
+}
+
+function codePointAfter(source: string, index: number): string | undefined {
+  if (index + 1 >= source.length) {
+    return undefined;
+  }
+  const high = source.charCodeAt(index + 1);
+  const low = source.charCodeAt(index + 2);
+  return high >= HIGH_SURROGATE_MIN &&
+    high <= HIGH_SURROGATE_MAX &&
+    low >= LOW_SURROGATE_MIN &&
+    low <= LOW_SURROGATE_MAX
+    ? source.slice(index + 1, index + 3)
+    : source[index + 1];
 }
 
 function parseInline(lines: readonly SourceLine[]): InlineParseResult {
@@ -230,8 +306,8 @@ function parseInline(lines: readonly SourceLine[]): InlineParseResult {
       continue;
     }
 
-    const previous = source[index - 1];
-    const next = source[index + 1];
+    const previous = codePointBefore(source, index);
+    const next = codePointAfter(source, index);
     const canOpen =
       next !== undefined && !/\s/u.test(next) && (previous === undefined || !wordCharacter.test(previous));
     const canClose =
@@ -355,95 +431,90 @@ function toPublicInlineNodes(nodes: readonly ParsedInlineNode[]): readonly Forma
   });
 }
 
-function parseBlocks(source: string): {
+type BlockParsingState = {
+  readonly blocks: ParsedBlock[];
+  readonly diagnostics: FormattedTextDiagnostic[];
+  paragraphLines: SourceLine[];
+  listItems: SourceLine[][];
+};
+
+function flushParagraph(state: BlockParsingState): void {
+  if (state.paragraphLines.length === 0) {
+    return;
+  }
+  const parsed = parseInline(state.paragraphLines);
+  state.blocks.push({ kind: 'paragraph', children: parsed.nodes });
+  state.diagnostics.push(...parsed.diagnostics);
+  state.paragraphLines = [];
+}
+
+function flushList(state: BlockParsingState): void {
+  if (state.listItems.length === 0) {
+    return;
+  }
+  state.blocks.push({
+    kind: 'list',
+    items: state.listItems.map((lines) => {
+      const parsed = parseInline(lines);
+      state.diagnostics.push(...parsed.diagnostics);
+      return { children: parsed.nodes };
+    }),
+  });
+  state.listItems = [];
+}
+
+function listContentLine(line: SourceLine): SourceLine {
+  return {
+    text: line.text.slice(2),
+    positions: line.positions.slice(2),
+    end: line.end,
+  };
+}
+
+function addListItem(state: BlockParsingState, line: SourceLine): void {
+  flushParagraph(state);
+  state.listItems.push([listContentLine(line)]);
+  if (line.text.length === 2) {
+    state.diagnostics.push({
+      code: 'empty-list-item',
+      ...line.end,
+      length: 0,
+      message: 'This list item has no text.',
+      suggestion: 'Type the list item after the dash, or remove this line.',
+    });
+  }
+}
+
+function consumeBlockLine(state: BlockParsingState, line: SourceLine): void {
+  if (line.text.length === 0) {
+    flushParagraph(state);
+    flushList(state);
+  } else if (line.text.startsWith('- ')) {
+    addListItem(state, line);
+  } else if (line.text.startsWith('  ') && state.listItems.length > 0) {
+    state.listItems.at(-1)!.push(listContentLine(line));
+  } else {
+    flushList(state);
+    state.paragraphLines.push(line);
+  }
+}
+
+function parseBlocks(normalized: NormalizedPlainText): {
   readonly blocks: readonly ParsedBlock[];
   readonly diagnostics: readonly FormattedTextDiagnostic[];
 } {
-  const sourceLines: SourceLine[] = [];
-  let sourceOffset = 0;
-  source.split('\n').forEach((text, index) => {
-    sourceLines.push({ text, line: index + 1, column: 1, offset: sourceOffset });
-    sourceOffset += text.length + 1;
-  });
-
-  const blocks: ParsedBlock[] = [];
-  const diagnostics: FormattedTextDiagnostic[] = [];
-  let paragraphLines: SourceLine[] = [];
-  let listItems: SourceLine[][] = [];
-
-  const flushParagraph = () => {
-    if (paragraphLines.length === 0) {
-      return;
-    }
-    const parsed = parseInline(paragraphLines);
-    blocks.push({ kind: 'paragraph', children: parsed.nodes });
-    diagnostics.push(...parsed.diagnostics);
-    paragraphLines = [];
+  const state: BlockParsingState = {
+    blocks: [],
+    diagnostics: [],
+    paragraphLines: [],
+    listItems: [],
   };
-
-  const flushList = () => {
-    if (listItems.length === 0) {
-      return;
-    }
-    blocks.push({
-      kind: 'list',
-      items: listItems.map((lines) => {
-        const parsed = parseInline(lines);
-        diagnostics.push(...parsed.diagnostics);
-        return { children: parsed.nodes };
-      }),
-    });
-    listItems = [];
-  };
-
-  for (const line of sourceLines) {
-    if (line.text.length === 0) {
-      flushParagraph();
-      flushList();
-      continue;
-    }
-
-    if (line.text.startsWith('- ')) {
-      flushParagraph();
-      listItems.push([
-        {
-          text: line.text.slice(2),
-          line: line.line,
-          column: 3,
-          offset: line.offset + 2,
-        },
-      ]);
-      if (line.text.length === 2) {
-        diagnostics.push({
-          code: 'empty-list-item',
-          line: line.line,
-          column: 3,
-          offset: line.offset + 2,
-          length: 0,
-          message: 'This list item has no text.',
-          suggestion: 'Type the list item after the dash, or remove this line.',
-        });
-      }
-      continue;
-    }
-
-    if (line.text.startsWith('  ') && listItems.length > 0) {
-      listItems.at(-1)!.push({
-        text: line.text.slice(2),
-        line: line.line,
-        column: 3,
-        offset: line.offset + 2,
-      });
-      continue;
-    }
-
-    flushList();
-    paragraphLines.push(line);
+  for (const line of normalized.lines) {
+    consumeBlockLine(state, line);
   }
-
-  flushParagraph();
-  flushList();
-  return { blocks, diagnostics };
+  flushParagraph(state);
+  flushList(state);
+  return { blocks: state.blocks, diagnostics: state.diagnostics };
 }
 
 function canonicalizeBlocks(blocks: readonly ParsedBlock[]): readonly ParsedBlock[] {
@@ -486,7 +557,7 @@ export function parseFormattedText(input: string): FormattedTextParseResult {
   if (parsed.diagnostics.length > 0) {
     return {
       valid: false,
-      source: normalizedDraft,
+      source: normalizedDraft.source,
       blocks: toPublicBlocks(parsed.blocks),
       diagnostics: parsed.diagnostics as [FormattedTextDiagnostic, ...FormattedTextDiagnostic[]],
     };


### PR DESCRIPTION
## Summary

- add one shared parser and normalizer for the accepted formatted-text language
- mint NormalizedFormattedText only after complete validation and canonicalization
- return renderer-safe paragraph, list, line-break, text, and mark data without producing HTML
- report invalid drafts with line, column, source offset, and practical correction guidance
- cover canonical mark nesting, prose boundaries, escapes, multiline structure, bullet and line-ending normalization, invalid drafts, and inert hostile-looking text

This is the non-persistence core from #666. It does not adopt existing fields or add Convex, Rulebook state, renderer, toolbar, or control work.

## Validation

Passed:

- bun run test -- src/shared/formattedText.test.ts (10 tests)
- bun run typecheck
- bun run check
- bun run knip
- bun run publisher:release:verify

The complete local suite reached 646/647 passing. The unchanged ConnectedTabs Radix keyboard-focus test fails both in the full run and alone because focus remains on the first tab while React reports an asynchronous update outside act(...). This branch does not touch that component or test; the required GitHub gate remains authoritative.
