### PR TITLE
Headings take the engraved face, and the last eleven titles convert

### DIFF
--- a/src/app/routes/_app/admin/migrations.tsx
+++ b/src/app/routes/_app/admin/migrations.tsx
@@ -1,5 +1,6 @@
 import { Group, Stack } from '@mantine/core';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
@@ -20,6 +21,8 @@ function formatDate(timestamp?: number) {
   return new Date(timestamp).toLocaleString();
 }
 
+const migrationsHeader = <PageTitle title="Migration activity" />;
+
 function AdminMigrationsPage() {
   const loaderData = Route.useLoaderData();
   const profile = useCurrentProfile();
@@ -30,9 +33,7 @@ function AdminMigrationsPage() {
   if (!profile.data?._id) {
     return (
       <PageLayout>
-        <PageLayout.Header>
-          <h1>Migration activity</h1>
-        </PageLayout.Header>
+        <PageLayout.Header>{migrationsHeader}</PageLayout.Header>
         <PageLayout.Content>
           <Surface padding="lg">
             <p>
@@ -46,9 +47,7 @@ function AdminMigrationsPage() {
 
   return (
     <PageLayout>
-      <PageLayout.Header>
-        <h1>Migration activity</h1>
-      </PageLayout.Header>
+      <PageLayout.Header>{migrationsHeader}</PageLayout.Header>
       <PageLayout.Content>
         <Stack gap="sm">
           {dashboardQuery.isPending && <p>Loading migration dashboard…</p>}

--- a/src/app/routes/_app/auth/error.tsx
+++ b/src/app/routes/_app/auth/error.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
 
@@ -18,7 +19,7 @@ function AuthErrorPage() {
   return (
     <PageLayout>
       <PageLayout.Header>
-        <h1>Sign-in error</h1>
+        <PageTitle title="Sign-in error" />
       </PageLayout.Header>
       <PageLayout.Content>
         <Surface padding="lg">

--- a/src/app/routes/_app/auth/login.tsx
+++ b/src/app/routes/_app/auth/login.tsx
@@ -1,6 +1,7 @@
 import { useAuthActions } from '@convex-dev/auth/react';
 import { Stack } from '@mantine/core';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
 import { useState } from 'react';
@@ -177,7 +178,7 @@ function LoginPage() {
   return (
     <PageLayout>
       <PageLayout.Header>
-        <h1>Sign in</h1>
+        <PageTitle title="Sign in" />
       </PageLayout.Header>
       <PageLayout.Content>
         <Surface padding="lg">

--- a/src/app/routes/_app/groups/$groupSlug/edit.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/edit.tsx
@@ -2,6 +2,7 @@ import { Group, Stack, TextInput } from '@mantine/core';
 import { groupInputSchema } from '@shared/groups/validation';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
+import { PageTitle } from '@ui/block/PageTitle';
 import { SlugRenameNotice } from '@ui/content/SlugRenameNotice';
 import { IconAction } from '@ui/control/IconAction';
 import { SubmitAction } from '@ui/control/SubmitAction';
@@ -98,7 +99,7 @@ function GroupEditPage() {
     return (
       <PageLayout>
         <PageLayout.Header>
-          <h1>Edit group</h1>
+          <PageTitle title="Edit group" />
         </PageLayout.Header>
         <PageLayout.Content>
           <Surface padding="lg">
@@ -114,7 +115,7 @@ function GroupEditPage() {
 
   const group = editPage.group;
   const viewerAccess = editPage.viewerAccess;
-  const header = <h1>{`Edit ${group.name}`}</h1>;
+  const header = <PageTitle title={`Edit ${group.name}`} />;
   const toolbar = (
     <Toolbar>
       <Toolbar.Left>

--- a/src/app/routes/_app/groups/create.tsx
+++ b/src/app/routes/_app/groups/create.tsx
@@ -1,5 +1,6 @@
 import { Group, Stack, TextInput } from '@mantine/core';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
@@ -15,7 +16,7 @@ export const Route = createFileRoute('/_app/groups/create')({
 });
 
 const GROUP_CREATE_FORM_ID = 'group-create';
-const groupCreateHeader = <h1>Start group</h1>;
+const groupCreateHeader = <PageTitle title="Start group" />;
 
 function GroupCreatePage() {
   const navigate = useNavigate();

--- a/src/app/routes/_app/index.module.css
+++ b/src/app/routes/_app/index.module.css
@@ -25,9 +25,16 @@
   line-height: 1.45;
 }
 
+/*
+ * The scale is pinned to the engraved face rather than shared with the body face.
+ * Copperplate sets wider than Candara at the same size, so keeping the old numbers here cost two
+ * extra wrapped lines per heading once the theme's heading font changed.
+ * Every value is the old one scaled by 0.815, the ratio that puts the longest of these headings back
+ * on three lines, so the responsive shape is unchanged and only the face's extra width is paid for.
+ */
 .storyTitle {
   max-width: 36rem;
-  font-size: clamp(2rem, 3.5vw, 3.35rem);
+  font-size: clamp(1.63rem, 2.85vw, 2.73rem);
   line-height: 0.98;
   letter-spacing: -0.045em;
 }
@@ -106,7 +113,7 @@
   }
 
   .storyTitle {
-    font-size: clamp(2rem, 10vw, 3rem);
+    font-size: clamp(1.63rem, 8.15vw, 2.45rem);
   }
 
   .storyColumn {

--- a/src/app/routes/_app/profiles/$profileSlug/index.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/index.tsx
@@ -1,6 +1,7 @@
 import { useAuthActions } from '@convex-dev/auth/react';
 import { Group, Stack, Text } from '@mantine/core';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { ProposedContent } from '@ui/block/ProposedContent';
 import { Section } from '@ui/block/Section';
 import { formatRelativeDate } from '@ui/content/dates';
@@ -183,7 +184,7 @@ function ProfileDetailPage() {
     return (
       <PageLayout>
         <PageLayout.Header>
-          <h1>Profile</h1>
+          <PageTitle title="Profile" />
         </PageLayout.Header>
         <PageLayout.Content>
           <Surface padding="lg">

--- a/src/app/routes/_app/profiles/index.tsx
+++ b/src/app/routes/_app/profiles/index.tsx
@@ -1,5 +1,6 @@
 import { Group, Stack, Text } from '@mantine/core';
 import { createFileRoute } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Stats } from '@ui/list/Stats';
@@ -29,7 +30,7 @@ function ProfilesPage() {
   return (
     <PageLayout>
       <PageLayout.Header>
-        <h1>Profiles</h1>
+        <PageTitle title="Profiles" />
       </PageLayout.Header>
       <PageLayout.Content>
         {profiles.data && profiles.data.length > 0 ? (

--- a/src/app/routes/_app/rulesets/create.tsx
+++ b/src/app/routes/_app/rulesets/create.tsx
@@ -2,6 +2,7 @@ import { Button, Group, Stack, Textarea, TextInput } from '@mantine/core';
 import { rulesetDescriptionSchema } from '@shared/rulesets/validation';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
+import { PageTitle } from '@ui/block/PageTitle';
 import { rulesetDescriptionHint } from '@ui/content/rulesetDescriptionHint';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -95,7 +96,7 @@ function CreateRulesetPage() {
   return (
     <PageLayout>
       <PageLayout.Header>
-        <h1>Create ruleset</h1>
+        <PageTitle title="Create ruleset" />
       </PageLayout.Header>
       <PageLayout.Toolbar>
         <Toolbar>

--- a/src/app/shell/AppNotFound.tsx
+++ b/src/app/shell/AppNotFound.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { PageLayout } from '@ui/layout/PageLayout';
 
 import { ApplicationChrome } from './ApplicationChrome';
@@ -10,7 +11,7 @@ export function AppNotFound() {
     <ApplicationChrome pathname={pathname}>
       <PageLayout>
         <PageLayout.Header>
-          <h1>404 - Page Not Found</h1>
+          <PageTitle title="404 - Page Not Found" />
         </PageLayout.Header>
         <PageLayout.Content>
           <p>The page you're looking for doesn't exist.</p>

--- a/src/app/ui/theme.ts
+++ b/src/app/ui/theme.ts
@@ -85,6 +85,13 @@ const twilightNavy: MantineColorsTuple = [
 
 const contentFontFamily = '"C_Candara", Candara, sans-serif';
 
+/**
+ * The engraved face the wordmark uses.
+ * `styles/fonts.css` already sets it on every bare `h1` through `h6`;
+ * naming it here too is what stops a heading's face depending on whether its author reached for `<h2>` or `<Title order={2}>`.
+ */
+const headingFontFamily = '"C_Copperplate_Gothic", sans-serif';
+
 const glassSurface = {
   backgroundColor: 'var(--glass-surface-1)',
   borderColor: 'var(--panel-border)',
@@ -95,7 +102,7 @@ const glassSurface = {
 export const appContentTheme = createTheme({
   fontFamily: contentFontFamily,
   headings: {
-    fontFamily: contentFontFamily,
+    fontFamily: headingFontFamily,
     fontWeight: '700',
   },
   white: 'var(--color-paper)',


### PR DESCRIPTION
Implements the decision on [#662](https://github.com/ndelangen/dunezone/issues/662) and closes out 3b's unblocked work. **Based on `main`, not stacked.**

Norbert decided Copperplate Gothic for non-hero page titles, then chose the mechanism after the enumeration: **align the theme** rather than set the family on `PageTitle`.

## Why the theme rather than the Block

`styles/fonts.css:76` has always set `h1` through `h6` to `C_Copperplate_Gothic`, as an element selector. `theme.ts` set Mantine's headings to the body face. A class beats an element selector, so which face a heading rendered in depended only on whether its author wrote `<h2>` or `<Title order={2}>`.

Setting the family on `PageTitle` would have left that alive one level down. The theme was the accident, so the theme is what changes.

## The radius, measured rather than assumed

I checked what `headings.fontFamily` actually reaches instead of saying "every Mantine component":

- Only `Title.css` and `Typography.css` consume `--mantine-font-family-headings`.
- **`Typography` is used zero times in this repo.**

So this reaches the `Title` component and nothing else: 21 page titles through `PageTitle`, 9 direct `order={1}`, and 36 at order 2 and below.

## The eleven conversions ride along because they became face-neutral

With the theme aligned, converting a bare `<h1>` no longer changes its face: those pages already rendered Copperplate. That is why the sites held back from [#661](https://github.com/ndelangen/dunezone/pull/661) are here now.

`auth/error`, `auth/login`, `admin/migrations` (two spellings hoisted to one), `groups/create`, `groups/$groupSlug/edit` (2), `rulesets/create`, `profiles/index`, `profiles/$profileSlug/index` (placeholder only), `AppNotFound`.

They gain 2px and lose the browser's default 21.44px heading margins, both because the Block owns its spacing.

## Two things to look at rather than take on trust

**The small sizes had no precedent.** Every bare heading in the app is `h1` or `h2`, so nothing showed what Copperplate does at `h3`/`h4`. Checked on the faction detail page: 18px and 16px both read clearly. The concern did not materialise.

**Home's story headings grew, and the last commit pins them back.** Norbert's follow-on decision on #662: the face change was about face, not scale, and the extra wrapped lines were a layout regression riding it. The page already owns this size through `storyTitle`, the same species as future-plans keeping its own mobile `h1` tuning.

Copperplate sets wider than Candara at the same size, so the old numbers bought more wrapping rather than bigger type. Every value in the clamp is scaled by **0.815**, the ratio measured at the wrap point (three lines up to 36.5px, four at 37px), so the responsive shape is unchanged and only the face's extra width is paid for. The mobile override is scaled by the same ratio.

Measured at three widths against what the page rendered before the theme moved:

| width | before the theme change | pinned |
|---|---|---|
| 375px | 110px, 3 lines | 90px, 3 lines |
| 1280px | 132px, 3 lines | 107px, 3 lines |
| 1600px | 210px, 4 lines | 214px, 5 lines |

The 1600px row corrects my own earlier framing: the original was **already** four lines at that width, so the regression was narrower than the 219-against-132 figure suggested. Heights now sit at or below the original everywhere.

**One heading is deliberately left alone.** "Your idea belongs at the table" also gained a line, 35px to 70px, but it carries no `storyTitle` class and sits in a different section, so pinning it would be a second page-local decision rather than the one that was made.

## The page that proves the point

`/privacy` rendered a Copperplate `h1` above nine Candara `h2`, on one page, before this. Two heading voices in one document. It now reads as one. That page is also why the Block-only mechanism was the wrong tool: its `h1` was already Copperplate, so setting the family on `PageTitle` would have left it exactly as split.

## Verified

Browser pass across the hero, `/privacy`, the faction detail body at every heading level, and a converted page. The hero still renders `C_Desdemona` at 85.76px, since `PageTitle`'s own stylesheet owns that and outranks the theme.

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 637 unit tests, 339 storybook tests.

## What is left of 3b

Five class-carrying titles on [#451](https://github.com/ndelangen/dunezone/issues/451), and five small per-page calls (privacy's kicker, rulesets index, both FAQ routes, auth index). `router.tsx` never converts: it is the `defaultErrorComponent` and covers routes that render outside `MantineProvider`.
