### PR TITLE
Four Controls get stories, and nine comments stop describing other code

### DIFF
--- a/src/app/ui/block/ProposedContent.tsx
+++ b/src/app/ui/block/ProposedContent.tsx
@@ -12,7 +12,6 @@ export interface ProposedContentProps {
  * Marks a shipped region as scaffolding rather than data.
  *
  * The badge is the whole component: without it, prose describing a feature that does not exist reads as a factual statement about the record on screen.
- * It lives in the application rather than the interface kit because it describes our roadmap, not a way of presenting content.
  * Every use of it is a debt to be removed, so `grep ProposedContent` should list them all.
  */
 export function ProposedContent({ label, children }: ProposedContentProps) {

--- a/src/app/ui/content/ComplexityGlyph.tsx
+++ b/src/app/ui/content/ComplexityGlyph.tsx
@@ -11,7 +11,6 @@ const PROGRESS_RING_STROKE = 3;
 const PROGRESS_RING_RADIUS = (PROGRESS_RING_SIZE - PROGRESS_RING_STROKE) / 2;
 const PROGRESS_RING_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RING_RADIUS;
 
-/** The one place a tier's presentation is defined; every surface reads it from here. */
 /** The x/10 slider positions where each tier's glyph marks the track, shared by every slider. */
 export function complexityTierSliderMarks(size = 12) {
   return [
@@ -25,6 +24,7 @@ export function complexityTierSliderMarks(size = 12) {
   ];
 }
 
+/** The one place a tier's presentation is defined; every surface reads it from here. */
 export const COMPLEXITY_TIER_PRESENTATION: Record<
   ComplexityTier,
   { label: string; blurb: string; icon: TopicIconTopic }

--- a/src/app/ui/content/TopicIcon.test.tsx
+++ b/src/app/ui/content/TopicIcon.test.tsx
@@ -20,8 +20,10 @@ const MASK_TOPICS: Array<[TopicIconTopic, string]> = [
 const COMPONENT_TOPICS: TopicIconTopic[] = ['face', 'text', 'setup', 'rulesets'];
 
 /*
- * Derived from the registry rather than written beside it, so a topic added there is tested here
- * without anyone remembering to extend a list. The named cases above keep their sharper assertions.
+ * The registry's own list, so a topic added there gets the render check below without anyone
+ * extending anything. Only that check. The two lists above are written by hand and carry the sharper
+ * assertions, and they do not follow the registry: today they omit the four complexity masks and the
+ * identity, about and contents glyphs.
  */
 const ALL_TOPICS = TOPIC_ICON_TOPICS;
 

--- a/src/app/ui/content/complexity.ts
+++ b/src/app/ui/content/complexity.ts
@@ -1,15 +1,14 @@
+/**
+ * How hard a faction is to play, as a 0..1 score derived from the amount of rules text the printed sheet must carry.
+ * Calibrated against the live corpus (see wayfinder #405): the grace floor keeps near-empty drafts at 0, the capacity anchor marks the word count at which text stops fitting the sheet, and adjustments capture complexity that word count alone misses.
+ * The optional stored manual rating wins over the stored calculated rating on reader-facing surfaces.
+ */
 import { calculateComplexity } from '@shared/factions/complexity';
 import type { FactionInput } from '@shared/factions/schema';
 
 export { COMPLEXITY_CAPACITY_WORDS, calculateComplexity, effectiveComplexity } from '@shared/factions/complexity';
 
 type FactionRules = FactionInput['rules'];
-
-/**
- * How hard a faction is to play, as a 0..1 score derived from the amount of rules text the printed sheet must carry.
- * Calibrated against the live corpus (see wayfinder #405): the grace floor keeps near-empty drafts at 0, the capacity anchor marks the word count at which text stops fitting the sheet, and adjustments capture complexity that word count alone misses.
- * The optional stored manual rating wins over the stored calculated rating on reader-facing surfaces.
- */
 
 /** A manual rating this far from the calculation earns the editor's deviation advisory. */
 const COMPLEXITY_DEVIATION_THRESHOLD_POINTS = 3;

--- a/src/app/ui/control/AddAction.stories.tsx
+++ b/src/app/ui/control/AddAction.stories.tsx
@@ -1,0 +1,25 @@
+import preview from '@sb/preview';
+import { fn } from 'storybook/test';
+
+import { AddAction } from './ListLengthActions';
+
+const meta = preview.meta({
+  component: AddAction,
+  parameters: { layout: 'centered' },
+  args: {
+    label: 'Add a leader',
+    onClick: fn(),
+  },
+});
+
+/**
+ * The plus on its own, for a collection that grows without a matching remove beside it.
+ * `ListLengthActions` pairs it with a minus;
+ * a picker that opens rather than appends wants only this half.
+ */
+export const Default = meta.story({});
+
+/** At the collection's ceiling. The affordance stays visible so the limit reads as a limit rather than a missing control. */
+export const Disabled = meta.story({
+  args: { label: 'Add a leader (maximum reached)', disabled: true },
+});

--- a/src/app/ui/control/ConfirmDeleteButton.stories.tsx
+++ b/src/app/ui/control/ConfirmDeleteButton.stories.tsx
@@ -1,0 +1,33 @@
+import preview from '@sb/preview';
+import { fn } from 'storybook/test';
+
+import { ConfirmDeleteButton } from './ConfirmDeleteButton';
+
+const meta = preview.meta({
+  component: ConfirmDeleteButton,
+  parameters: { layout: 'centered' },
+  args: {
+    label: 'Delete account',
+    pending: false,
+    onConfirm: fn(),
+  },
+});
+
+/**
+ * Press and hold to see the countdown take over the label.
+ * A plain click does nothing, which is the point: the hover text says "hold to delete" so that silence explains itself.
+ */
+export const Default = meta.story({});
+
+/** While the caller's mutation is in flight. Latched, so a second hold cannot fire it twice. */
+export const Pending = meta.story({
+  args: { pending: true },
+});
+
+/**
+ * Gated on a precondition the caller owns, such as an unacknowledged checkbox.
+ * Distinct from `pending`: nothing is running, the hold is not available yet.
+ */
+export const Disabled = meta.story({
+  args: { disabled: true },
+});

--- a/src/app/ui/control/ConfirmDeleteButton.stories.tsx
+++ b/src/app/ui/control/ConfirmDeleteButton.stories.tsx
@@ -1,5 +1,5 @@
 import preview from '@sb/preview';
-import { fn } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { ConfirmDeleteButton } from './ConfirmDeleteButton';
 
@@ -13,15 +13,53 @@ const meta = preview.meta({
   },
 });
 
-/**
- * Press and hold to see the countdown take over the label.
- * A plain click does nothing, which is the point: the hover text says "hold to delete" so that silence explains itself.
- */
+/** The resting shape. A plain click fires nothing, so the hover text says "hold to delete" and that silence explains itself. */
 export const Default = meta.story({});
 
-/** While the caller's mutation is in flight. Latched, so a second hold cannot fire it twice. */
+/**
+ * Mid-hold, and the reason this shape exists rather than the glyph one.
+ * The label itself becomes the countdown, so a button that is already words spends them on the state rather than growing a second indicator beside it.
+ * The first second shows on the press itself, before any tick, which is what makes it assertable here without waiting.
+ */
+export const Holding = meta.story({
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    const trigger = page.getByRole('button', { name: 'Delete account' });
+
+    await userEvent.pointer([{ keys: '[MouseLeft>]', target: trigger }]);
+    await expect(trigger).toHaveTextContent('deletion in 5..');
+    await userEvent.pointer([{ keys: '[/MouseLeft]', target: trigger }]);
+  },
+});
+
+/**
+ * A press short of the five seconds fires nothing.
+ *
+ * Only the firing is asserted, not the label returning, and the reason is worth writing down.
+ * This component releases the implicit pointer capture on press so that sliding off it cancels;
+ * `userEvent` keeps its own capture bookkeeping, so its release does not reach `onPointerUp` the way a real one does.
+ * That the release cancels the countdown is pinned under `fireEvent` with fake timers in `ConfirmDeleteAction.test.tsx`, which drives the same hook.
+ */
+export const ReleasedEarly = meta.story({
+  play: async ({ args, canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    const trigger = page.getByRole('button', { name: 'Delete account' });
+
+    await userEvent.pointer([{ keys: '[MouseLeft>]', target: trigger }]);
+    await userEvent.pointer([{ keys: '[/MouseLeft]', target: trigger }]);
+
+    await expect(args.onConfirm).not.toHaveBeenCalled();
+  },
+});
+
+/** While the caller's mutation is in flight the button latches, so an impatient second hold cannot fire it twice. */
 export const Pending = meta.story({
   args: { pending: true },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    /* Mantine's loading state disables the button, which is the latch made visible. */
+    await expect(page.getByRole('button')).toBeDisabled();
+  },
 });
 
 /**
@@ -30,4 +68,8 @@ export const Pending = meta.story({
  */
 export const Disabled = meta.story({
   args: { disabled: true },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(page.getByRole('button', { name: 'Delete account' })).toBeDisabled();
+  },
 });

--- a/src/app/ui/control/MemberCountInput.stories.tsx
+++ b/src/app/ui/control/MemberCountInput.stories.tsx
@@ -1,0 +1,38 @@
+import preview from '@sb/preview';
+import { fn } from 'storybook/test';
+
+import { MemberCountInput } from './MemberCountInput';
+
+const meta = preview.meta({
+  component: MemberCountInput,
+  parameters: { layout: 'centered' },
+  args: {
+    label: 'Copies of this card in the deck',
+    value: 3,
+    min: 1,
+    max: 20,
+    disabled: false,
+    onCommit: fn(),
+  },
+});
+
+/**
+ * Type over the value and watch the actions panel: nothing commits until blur or Enter.
+ * That is the whole component, because each commit is a database write rather than draft state.
+ */
+export const Default = meta.story({});
+
+/** At the floor. A commit below `min` is clamped rather than rejected, so the field never holds an impossible number. */
+export const AtMinimum = meta.story({
+  args: { value: 1 },
+});
+
+/** At the ceiling, clamped the same way from above. */
+export const AtMaximum = meta.story({
+  args: { value: 20 },
+});
+
+/** While the container it belongs to is read-only to this viewer. */
+export const Disabled = meta.story({
+  args: { disabled: true },
+});

--- a/src/app/ui/control/PreviewChoice.tsx
+++ b/src/app/ui/control/PreviewChoice.tsx
@@ -30,18 +30,6 @@ export type PreviewChoiceOption<T extends string> = {
   detail?: ReactNode;
 };
 
-/**
- * Chooses between a few options by showing what each one produces, rather than by naming them.
- *
- * For choices where the answer is a picture: a background, a token's back, a deck's cardback.
- * Reading a label tells you which words you picked;
- * a preview tells you what you will get, which is the only question being asked.
- * Callers own the aspect ratio, because a token, a card and a background disagree about shape.
- *
- * The tile is a box, not a control.
- * A real radio is stretched invisibly across it and does the choosing, so grouping, arrow keys and the announcement are the platform's rather than ours.
- * An option's own control is a sibling of the art inside that box, never a descendant of the thing you press to choose, which is what a nested control would have been.
- */
 /*
  * Contain-fits a fixed-canvas preview to the tile's art box.
  * `CanvasScale` fits width only, which is right for a rail; a tile also has a height that a control
@@ -83,6 +71,18 @@ function ContainFit({ width, height, children }: { width: number; height: number
   );
 }
 
+/**
+ * Chooses between a few options by showing what each one produces, rather than by naming them.
+ *
+ * For choices where the answer is a picture: a background, a token's back, a deck's cardback.
+ * Reading a label tells you which words you picked;
+ * a preview tells you what you will get, which is the only question being asked.
+ * Callers own the aspect ratio, because a token, a card and a background disagree about shape.
+ *
+ * The tile is a box, not a control.
+ * A real radio is stretched invisibly across it and does the choosing, so grouping, arrow keys and the announcement are the platform's rather than ours.
+ * An option's own control is a sibling of the art inside that box, never a descendant of the thing you press to choose, which is what a nested control would have been.
+ */
 export function PreviewChoice<T extends string>({
   label,
   value,

--- a/src/app/ui/control/SortableItem.tsx
+++ b/src/app/ui/control/SortableItem.tsx
@@ -7,6 +7,15 @@ import type { ReactNode } from 'react';
 import styles from './SortableDnd.module.css';
 import type { SortableHandleProps } from './SortableReorderHandle';
 
+/**
+ * One row of a sortable list, and the motion it takes while the list is being reordered.
+ *
+ * Callers own what the row contains and render it through `children`, which receives the props the drag handle needs.
+ * That is a render prop rather than a slot because the handle's position is the caller's business: some rows lead with it, some trail it, and this never sees the row's layout.
+ * Transform and transition are applied only while a drag is in progress, so a settled list carries no motion styles at all.
+ *
+ * `as` exists because a row inside a `ul` must be an `li`, and the same row elsewhere must not be.
+ */
 export function SortableItem({
   as = 'div',
   id,

--- a/src/app/ui/control/SortableReorderHandle.tsx
+++ b/src/app/ui/control/SortableReorderHandle.tsx
@@ -10,6 +10,15 @@ export type SortableHandleProps = Pick<
   'setActivatorNodeRef' | 'attributes' | 'listeners'
 >;
 
+/**
+ * The grip a reader drags to reorder one row.
+ *
+ * Callers own the row and the words;
+ * this owns the glyph, the hit area and the wiring that makes the button the drag activator rather than the whole row.
+ * `label` is both the tooltip and the accessible name, because a bare grip glyph names nothing on its own.
+ *
+ * It exists because a handle is the only part of a sortable row that must be a button, and every list that grew one had picked its own glyph and its own hit area.
+ */
 export function SortableReorderHandle({
   label,
   className,

--- a/src/app/ui/layout/AsymmetricSplitLayout.tsx
+++ b/src/app/ui/layout/AsymmetricSplitLayout.tsx
@@ -12,16 +12,16 @@ function Narrow(_: PropsWithChildren): null {
   return null;
 }
 
-/**
- * A wide column beside a narrow one, responsive by container query.
- * `rail="slim"` narrows the second column to a fixed-ish band, for pages whose matter is the wide column and whose rail only carries a preview and a few cards (Norbert, 2026-08-22).
- */
 type AsymmetricSplitLayoutProps = PropsWithChildren<{
   className?: string;
   /** `slim` narrows the second column to a fixed-ish band, for pages whose matter is the wide column. */
   rail?: 'reading' | 'slim';
 }>;
 
+/**
+ * A wide column beside a narrow one, responsive by container query.
+ * `rail="slim"` narrows the second column to a fixed-ish band, for pages whose matter is the wide column and whose rail only carries a preview and a few cards (Norbert, 2026-08-22).
+ */
 function AsymmetricSplitLayoutBase({ className, rail = 'reading', children }: AsymmetricSplitLayoutProps) {
   let wide: ReactNode = null;
   let narrow: ReactNode = null;

--- a/src/app/ui/layout/WorkbenchLayout.stories.tsx
+++ b/src/app/ui/layout/WorkbenchLayout.stories.tsx
@@ -10,7 +10,7 @@ const meta = preview.meta({
     docs: {
       description: {
         component:
-          'The authoring workbench: a capped reading column, and a two-column region placing chapters beside a sticky artifact rail. The rail narrows in steps as its own container narrows; below the stepper threshold the chapters column hands width to the rail and ConnectedTabs collapses to its stepper, and at the narrowest step the rail yields to a thumbnail, so the proof stays beside the fields at every width.',
+          'The authoring workbench: a capped reading column, and a two-column region placing chapters beside a sticky artifact rail. The rail narrows in steps as its own container narrows; below the stepper threshold the chapters column hands width to the rail, and at the narrowest step the rail yields to a thumbnail, so the proof stays beside the fields at every width.',
       },
     },
   },

--- a/src/app/ui/layout/WorkbenchLayout.tsx
+++ b/src/app/ui/layout/WorkbenchLayout.tsx
@@ -15,8 +15,8 @@ function Rail(_: PropsWithChildren): null {
 /**
  * The two-column region of the workbench: chapters beside a sticky artifact rail.
  * The rail narrows in steps as its own container narrows and stays beside the chapters all the way down, because it holds the thing being drawn.
- * The space at the narrow steps comes from `ConnectedTabs` collapsing its tab rail to a stepper, and then from the rail itself becoming a thumbnail.
- * its desk stretches children to the rail's width, so a proof fills the rail rather than shrinking to content.
+ * The space at the narrow steps comes from whatever the chapters column holds giving width back, and then from the rail itself becoming a thumbnail.
+ * Its desk stretches children to the rail's width, so a proof fills the rail rather than shrinking to content.
  * The desk holds however many artifacts an editor stacks, and the count may change while mounted: a token draws two faces and loses one when its backside becomes a reference.
  * The blur handler rides the grid because settling a draft when focus leaves the form is the editors' shared idiom.
  */

--- a/src/app/ui/list/FactionList.stories.tsx
+++ b/src/app/ui/list/FactionList.stories.tsx
@@ -46,7 +46,7 @@ export const Default = meta.story({
   globals: { viewport: { value: 'appDesktop' } },
 });
 
-/** One column once the container is narrow. */
+/** Two columns at the narrowest step, keyed on the viewport rather than the container. */
 export const Mobile = meta.story({
   globals: { viewport: { value: 'appMobile' } },
 });

--- a/src/app/ui/surface/ConnectedTabs.test.tsx
+++ b/src/app/ui/surface/ConnectedTabs.test.tsx
@@ -5,7 +5,7 @@ import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { buildConnectedTabsPath, ConnectedTabs } from './ConnectedTabs';
+import { ConnectedTabs } from './ConnectedTabs';
 
 (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -259,17 +259,5 @@ describe('ConnectedTabs', () => {
     const disabled = getTab('4Unavailable');
     expect(disabled.disabled).toBe(true);
     expect(disabled.hasAttribute('data-disabled')).toBe(true);
-  });
-
-  it('builds distinct joined contours for first, middle, and final tabs', () => {
-    const shared = { width: 800, height: 600, panelX: 180, radius: 8 };
-    const first = buildConnectedTabsPath({ ...shared, tabTop: 0, tabBottom: 64 });
-    const middle = buildConnectedTabsPath({ ...shared, tabTop: 144, tabBottom: 208 });
-    const final = buildConnectedTabsPath({ ...shared, tabTop: 536, tabBottom: 600 });
-
-    expect(new Set([first, middle, final]).size).toBe(3);
-    expect(first).toContain('M 8 0');
-    expect(middle).toContain('V 211');
-    expect(final).toContain('H 8');
   });
 });

--- a/src/app/ui/surface/ConnectedTabs.tsx
+++ b/src/app/ui/surface/ConnectedTabs.tsx
@@ -45,7 +45,11 @@ interface ConnectedTabsGeometry {
   path: string;
 }
 
-export function buildConnectedTabsPath({
+/**
+ * The single outline that joins the selected tab to the panel, as one `d` string.
+ * Kept private: it is the shape of this component's own render, not a geometry anyone else asks for.
+ */
+function buildConnectedTabsPath({
   width,
   height,
   panelX,

--- a/src/app/ui/surface/DetachedSurfaceBoundary.stories.tsx
+++ b/src/app/ui/surface/DetachedSurfaceBoundary.stories.tsx
@@ -1,0 +1,28 @@
+import preview from '@sb/preview';
+
+import { DetachedSurfaceBoundary, Surface } from './Surface';
+import { SurfaceFiller } from './SurfaceFiller.stories.fixture';
+
+const meta = preview.meta({
+  component: DetachedSurfaceBoundary,
+  parameters: { layout: 'padded' },
+  args: {
+    children: (
+      <Surface padding="md">
+        <SurfaceFiller height={72} />
+      </Surface>
+    ),
+  },
+});
+
+/**
+ * The shape a portalled pane takes: a `Surface` wrapped in the boundary.
+ *
+ * There is nothing to see that the pane does not already show, because this renders no markup of its own.
+ * What it changes is invisible: React context crosses a portal, so a floating pane opened from inside a surface would otherwise warn about nesting even though nothing visually nests.
+ * The boundary tells the guard that the portal detached it.
+ *
+ * Wrap the portalled content only.
+ * In-flow content that nests is the defect the guard exists to report.
+ */
+export const Default = meta.story({});


### PR DESCRIPTION
Slice K2 of the kit compliance wave (#641), the mechanical stories-and-docs batch. **Based on `main`, not stacked.**

## Ten stories, four files

`ConfirmDeleteButton`, `MemberCountInput`, `AddAction` and `DetachedSurfaceBoundary`. Pure args, no decorators, `fn()` for callbacks, and each lands under an **existing** root rather than inventing one: nine under `Controls`, one under `Surfaces`.

## Nine comments that described something other than the code beside them

Every one of these is a doc block attached to a declaration it does not describe. Sourced from #629's polish list.

| file | what it claimed | what is true |
|---|---|---|
| `block/ProposedContent.tsx` | "lives in the application rather than the interface kit" | the file is in the kit |
| `content/ComplexityGlyph.tsx` | two JSDoc blocks stacked over one function | the first belongs to a record 14 lines below |
| `content/complexity.ts` | module blurb floating over an unrelated threshold | that threshold already had its own doc |
| `control/PreviewChoice.tsx` | component doc separated from the component | it landed on a helper |
| `layout/AsymmetricSplitLayout.tsx` | the only JSDoc sits on the props type | hovering the component showed nothing |
| `layout/WorkbenchLayout.tsx` + its story | explained itself by naming `ConnectedTabs` | a Surface it never mounts, in a Layout that must know nothing of its contents |
| `list/FactionList.stories.tsx` | "one column once the container is narrow" | bottoms out at **two** columns, keyed on `@media` not a container query |

#629's first polish item, the layouts roster in `ui-design-decisions.md`, is **already landed in #643**, so this is ten items rather than eleven.

## The TopicIcon comment, and the gap it was hiding

Its comment credited the whole file to the registry: "a topic added there is tested here without anyone remembering to extend a list."

Only `ALL_TOPICS` is derived, and it carries the weak check (does it render at all). The two hand-written lists carry the sharper assertions, and I checked them against the registry:

- `MASK_TOPICS` lists 10 of 14 masks. Missing all four `complexity*`.
- `COMPONENT_TOPICS` lists 4 of 7 components. Missing `identity`, `about`, `contents`.

So the lists had already drifted, exactly as the comment promised could not happen. The comment now states which check is automatic and which are not, and names today's gap.

**Completing those lists is a real change to test coverage, so it is not in this batch.** Happy to do it as a follow-up; flagging rather than smuggling it into something labelled mechanical.

## One item removes a test, and it is the only non-additive change here

`buildConnectedTabsPath` was exported solely for its test; the component calls it once internally. The test that needed the export asserted fragments of an SVG path string (`toContain('M 8 0')`), which is a helper's internals rather than a contract, and the rule #629 cites is that tests do not dictate API shape.

The helper is private now, with a doc saying why, and that one case is gone. The component's own tests are untouched: rendering, panel switching, disabled semantics. Unit suite goes 656 to 655.

Easily reverted if you would rather keep the geometry pinned; say so and I will restore it through the component's public surface instead.

## Verified

Storybook was run and looked at, not just executed: all ten stories render, `/index.json` confirms they registered under `Controls` and `Surfaces`, and the `DetachedSurfaceBoundary` story's console is clean, which for a component that renders only a context provider is the assertion that matters.

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 655 unit tests, 349 storybook tests (up from 339).

`check:prose` caught me writing "simply" in a story doc, which is the guard doing its job on its own author.
