### PR TITLE
Six kit components stop accepting more than they mean

### DIFF
--- a/src/app/routes/_app/future-plans/index.module.css
+++ b/src/app/routes/_app/future-plans/index.module.css
@@ -13,10 +13,6 @@
   padding: 3.5rem clamp(0rem, 2vw, 1.5rem) 1rem;
 }
 
-.atlasSidebar {
-  top: 1.5rem;
-}
-
 .indexLink {
   padding: 0.9rem 0;
   color: inherit;

--- a/src/app/routes/_app/future-plans/index.tsx
+++ b/src/app/routes/_app/future-plans/index.tsx
@@ -148,7 +148,7 @@ function FuturePlansPage() {
       </PageLayout.Header>
       <PageLayout.Content>
         <AtlasLayout className={styles.atlasFrame}>
-          <AtlasLayout.Sidebar className={styles.atlasSidebar}>
+          <AtlasLayout.Sidebar>
             <Stack component="aside" gap="md">
               <Badge color="gray" variant="filled" w="fit-content">
                 All planned

--- a/src/app/routes/_app/profiles/$profileSlug/index.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/index.tsx
@@ -70,9 +70,8 @@ function AskerChip({
       username={profile.username}
       avatar_url={profile.avatar_url}
       className={styles.askerLink}
-    >
-      Question by {profile.username ?? 'Unknown'}
-    </ProfileLink>
+      label={`Question by ${profile.username ?? 'Unknown'}`}
+    />
   );
 }
 

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -602,6 +602,8 @@ function RulesetDetailPage() {
                 }
               />
               <FaqList
+                emptyLabel="No FAQ items yet."
+                noMatchesLabel="No questions match your search."
                 items={page.faqItems}
                 rulesetSlug={r.slug}
                 searchQuery={search.q ?? ''}

--- a/src/app/ui/block/OpenableTile.tsx
+++ b/src/app/ui/block/OpenableTile.tsx
@@ -10,7 +10,7 @@ export interface OpenableTileProps {
    * A tile is its render and its name;
    * everything else lives on the page the tile opens (Norbert, 2026-08-21).
    */
-  caption: ReactNode;
+  caption: string;
   /** Makes the whole tile a link, in practice the router's `Link`, so route type-checking stays at the call site. */
   renderRoot: RenderRoot;
   /** The artwork. Decorative to a screen reader, since the caption carries the name. */

--- a/src/app/ui/content/ProfileLink.stories.tsx
+++ b/src/app/ui/content/ProfileLink.stories.tsx
@@ -24,3 +24,11 @@ export const WithAvatar = meta.story({
 export const AvatarOnly = meta.story({
   args: { avatar_url: '/web/logo.svg', showUsername: false, title: 'Central' },
 });
+
+/**
+ * When the citation is naming the person's role in a sentence rather than just citing them.
+ * `label` replaces the plain username, and it is a string: the caller owns the words, not a slot to render into.
+ */
+export const Labelled = meta.story({
+  args: { avatar_url: '/web/logo.svg', label: 'Question by Central' },
+});

--- a/src/app/ui/content/ProfileLink.tsx
+++ b/src/app/ui/content/ProfileLink.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import clsx from 'clsx';
-import type { CSSProperties, ReactNode } from 'react';
+import type { CSSProperties } from 'react';
 
 import type { ProfileEntry } from '@db/profiles';
 
@@ -11,7 +11,11 @@ export type ProfileLinkProps = Pick<ProfileEntry, 'slug' | 'username' | 'avatar_
   style?: CSSProperties;
   title?: string;
   showUsername?: boolean;
-  children?: ReactNode;
+  /**
+   * The words beside the avatar, when the bare username is not what this context should read.
+   * A string rather than a slot: a citation of a person is data, and the one caller that needs this is naming the person's role in a sentence.
+   */
+  label?: string;
 };
 
 /**
@@ -30,10 +34,10 @@ export const ProfileLink = ({
   style,
   title,
   showUsername = true,
-  children,
+  label,
 }: ProfileLinkProps) => {
   const afterAvatar =
-    children !== undefined ? children : showUsername ? <span className={styles.username}>{username}</span> : null;
+    label !== undefined ? label : showUsername ? <span className={styles.username}>{username}</span> : null;
 
   return (
     <Link

--- a/src/app/ui/control/ListLengthActions.tsx
+++ b/src/app/ui/control/ListLengthActions.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Group, Tooltip } from '@mantine/core';
+import { Group } from '@mantine/core';
 import { Minus, Plus } from 'lucide-react';
 import type { Ref } from 'react';
 
@@ -61,19 +61,15 @@ export function ListLengthActions({
 }: ListLengthActionsProps) {
   return (
     <Group gap={6} wrap="nowrap">
-      <Tooltip label={removeLabel}>
-        <ActionIcon
-          type="button"
-          variant="light"
-          color="red"
-          size="sm"
-          aria-label={removeLabel}
-          disabled={removeDisabled}
-          onClick={onRemove}
-        >
-          <Minus size={15} aria-hidden />
-        </ActionIcon>
-      </Tooltip>
+      <IconAction
+        label={removeLabel}
+        variant="light"
+        color="red"
+        size="sm"
+        disabled={removeDisabled}
+        onClick={onRemove}
+        icon={<Minus size={15} aria-hidden />}
+      />
       <AddAction label={addLabel} disabled={addDisabled} onClick={onAdd} />
     </Group>
   );

--- a/src/app/ui/layout/AtlasLayout.module.css
+++ b/src/app/ui/layout/AtlasLayout.module.css
@@ -25,6 +25,7 @@
 
   .sidebar {
     position: sticky;
-    top: 0;
+    /* The offset the one page using this layout had been reaching in to set. */
+    top: 1.5rem;
   }
 }

--- a/src/app/ui/layout/AtlasLayout.tsx
+++ b/src/app/ui/layout/AtlasLayout.tsx
@@ -4,7 +4,7 @@ import type { PropsWithChildren, ReactNode } from 'react';
 
 import styles from './AtlasLayout.module.css';
 
-function Sidebar(_: PropsWithChildren<{ className?: string }>): null {
+function Sidebar(_: PropsWithChildren): null {
   return null;
 }
 
@@ -15,7 +15,6 @@ function Content(_: PropsWithChildren): null {
 /** A fixed sidebar beside flowing content, responsive by container query. */
 function AtlasLayoutBase({ className, children }: PropsWithChildren<{ className?: string }>) {
   let sidebar: ReactNode = null;
-  let sidebarClassName: string | undefined;
   let content: ReactNode = null;
 
   Children.forEach(children, (child) => {
@@ -23,9 +22,7 @@ function AtlasLayoutBase({ className, children }: PropsWithChildren<{ className?
       return;
     }
     if (child.type === Sidebar) {
-      const props = child.props as PropsWithChildren<{ className?: string }>;
-      sidebar = props.children;
-      sidebarClassName = props.className;
+      sidebar = (child.props as PropsWithChildren).children;
       return;
     }
     if (child.type === Content) {
@@ -36,7 +33,7 @@ function AtlasLayoutBase({ className, children }: PropsWithChildren<{ className?
   return (
     <div className={clsx(styles.root, className)}>
       <div className={styles.layout}>
-        <div className={clsx(styles.sidebar, sidebarClassName)}>{sidebar}</div>
+        <div className={styles.sidebar}>{sidebar}</div>
         <div>{content}</div>
       </div>
     </div>

--- a/src/app/ui/list/FaqList.module.css
+++ b/src/app/ui/list/FaqList.module.css
@@ -1,5 +1,5 @@
 .question {
-  color: var(--mantine-color-dark-8);
+  color: var(--color-text);
   line-height: 1.35;
 }
 

--- a/src/app/ui/list/FaqList.stories.tsx
+++ b/src/app/ui/list/FaqList.stories.tsx
@@ -63,17 +63,21 @@ const meta = preview.meta({
     rulesetSlug: 'dreamrules',
     searchQuery: '',
     onOpenQuestion: fn(),
+    emptyLabel: 'No FAQ items yet.',
+    noMatchesLabel: 'No questions match your search.',
   },
 });
 
 export const Populated = meta.story({});
 
+/** Nothing has been asked yet. The words are the page's, so the story passes them like a page would. */
 export const NoItems = meta.story({
   args: {
     items: [],
   },
 });
 
+/** Questions exist, but the reader's search excludes them all, which reads differently from having none. */
 export const NoFilteredMatches = meta.story({
   args: {
     searchQuery: 'ornithopter timing',

--- a/src/app/ui/list/FaqList.tsx
+++ b/src/app/ui/list/FaqList.tsx
@@ -23,6 +23,10 @@ interface FaqListProps {
    * The caller navigates: this list renders the destination as a `Link` too, but where the reader ends up is the page's call.
    */
   onOpenQuestion: (questionSlug: string) => void;
+  /** What to say when the ruleset carries no questions at all. The page owns the words; this owns where they sit. */
+  emptyLabel: string;
+  /** What to say when a search or tag leaves nothing, which is a different situation and reads differently. */
+  noMatchesLabel: string;
 }
 
 /**
@@ -41,13 +45,21 @@ function matchingFaqItems(
   return new Fuse(tagged, { keys: ['question'], threshold: 0.4 }).search(query).map((result) => result.item);
 }
 
-export function FaqList({ items, rulesetSlug, searchQuery, selectedTag, onOpenQuestion }: FaqListProps) {
+export function FaqList({
+  items,
+  rulesetSlug,
+  searchQuery,
+  selectedTag,
+  onOpenQuestion,
+  emptyLabel,
+  noMatchesLabel,
+}: FaqListProps) {
   const filtered = useMemo(() => matchingFaqItems(items, searchQuery, selectedTag), [items, searchQuery, selectedTag]);
 
   if (items.length === 0) {
     return (
       <Text size="sm" c="dimmed">
-        No FAQ items yet.
+        {emptyLabel}
       </Text>
     );
   }
@@ -56,7 +68,7 @@ export function FaqList({ items, rulesetSlug, searchQuery, selectedTag, onOpenQu
     <Stack gap="md">
       {filtered.length === 0 ? (
         <Text size="sm" c="dimmed">
-          No questions match your search.
+          {noMatchesLabel}
         </Text>
       ) : (
         <SectionedSurface>

--- a/src/app/ui/surface/Toolbar.tsx
+++ b/src/app/ui/surface/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { Surface } from '@ui/surface';
 import clsx from 'clsx';
 import { Children, isValidElement } from 'react';
-import type { ComponentPropsWithoutRef, PropsWithChildren, ReactNode } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 
 import styles from './Toolbar.module.css';
 
@@ -33,7 +33,7 @@ function Right({ children }: ToolbarSlotProps) {
 export type ToolbarProps = {
   className?: string;
   children?: ReactNode;
-} & Omit<ComponentPropsWithoutRef<'div'>, 'className' | 'children'>;
+};
 
 type ToolbarComponent = ((props: ToolbarProps) => ReactNode) & {
   Left: typeof Left;
@@ -41,7 +41,7 @@ type ToolbarComponent = ((props: ToolbarProps) => ReactNode) & {
   Right: typeof Right;
 };
 
-const ToolbarBase = ({ className, children, ...rest }: ToolbarProps) => {
+const ToolbarBase = ({ className, children }: ToolbarProps) => {
   let left: ReactNode = null;
   let center: ReactNode = null;
   let right: ReactNode = null;
@@ -68,7 +68,7 @@ const ToolbarBase = ({ className, children, ...rest }: ToolbarProps) => {
 
   return (
     <Surface padding="sm">
-      <div className={clsx(styles.root, className)} {...rest}>
+      <div className={clsx(styles.root, className)}>
         <div className={styles.left}>{left}</div>
         <div className={styles.center}>{center}</div>
         <div className={styles.right}>{right}</div>


### PR DESCRIPTION
Slice K3 of the kit compliance wave (#641), the membrane-drift batch. **Based on `main`, not stacked.**

Every caller was enumerated before each narrowing, so each is provably lossless rather than argued to be. Per item: what the caller loses, and why nothing breaks.

| component | what a caller could hand it | what it can hand now | why nothing breaks |
|---|---|---|---|
| `block/OpenableTile` | `caption: ReactNode` | `caption: string` | both callers already pass a string |
| `content/ProfileLink` | `children: ReactNode` replacing the name | `label?: string` | one caller used it, passing words |
| `surface/Toolbar` | every `div` prop, via an undeclared spread | `className` and `children` | all 14 call sites are a bare `<Toolbar>` |
| `layout/AtlasLayout` | `Sidebar className` landing on the positioned wrapper | nothing | its one use was the sticky offset, now the layout's |
| `list/FaqList` | nothing; **it** owned the page's empty prose | `emptyLabel`, `noMatchesLabel` | its one caller passes the same strings |
| `control/ListLengthActions` | n/a | n/a | remove side deduped onto `IconAction` |

Plus `FaqList.module.css` dropping a pinned palette step.

## Verified by measurement, not by diff

- **AtlasLayout**: sticky at **24px** before and after. The page's `.atlasSidebar { top: 1.5rem }` is gone and the layout's own rule carries it, so the one page that used it renders identically.
- **FaqList colour**: was `--mantine-color-dark-8`, the same value in both schemes, in an app with a real dark mode. Now `--color-text`, measured flipping between `rgb(46, 41, 39)` and `rgb(236, 231, 220)`.
- **FaqList empty prose**: the ruleset page still shows "No FAQ items yet.", now passed by the page.
- **ListLengthActions**: the remove button measures the same **22×22**, same `aria-label`, same `type="button"`, same red light variant, and is now symmetric with the add button beside it.
- **ProfileLink**: new `Labelled` story renders "Question by Central".

## Two items are held rather than done

**The ConnectedTabs story cast is bigger than #629 reads.** I tried it: removing the cast does not typecheck, and the reason is structural. The story's args **cannot** be the component's props, because `items` is required by `ConnectedTabsProps` and is constructed by the story's own `render` from knobs the component does not have. The cast papers over a real mismatch rather than being a stray annotation.

`ConnectedTabs` is already a K4 item wanting a split proposal ("receiver, producer, and control in one component"), and the story's shape follows whatever that split decides. Doing it now would be work thrown away.

**The SortableReorderHandle dedupe** touches a file [#678](https://github.com/ndelangen/dunezone/pull/678) also touches, and 678 is still open. Held to keep a merge conflict off Norbert's desk, not because it is difficult. It lands as a one-item follow-up once 678 merges.

## One inconsistency found and deliberately not fixed

`ProfileLink` renders `label` as bare text, while the plain username goes through `.username`, which carries `font-weight: 600` and `color: var(--color-text)`. So a caller handing it words gets no name treatment.

That predates this change, since the `children` slot rendered bare too, and it is arguably wrong now that `label` is data rather than a slot. I left it because correcting it would restyle the one page that uses it, and this deployment has no FAQ data to render that page, so I could not look at the result. Worth a decision rather than a guess.

## Verified

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 656 unit tests, 340 storybook tests.
