### PR TITLE
The reorder handle stops hand-building what IconAction already is

### DIFF
--- a/src/app/ui/control/IconAction.tsx
+++ b/src/app/ui/control/IconAction.tsx
@@ -45,6 +45,19 @@ export interface IconActionProps extends Pick<ActionIconProps, 'variant' | 'colo
   /** Placement only. */
   className?: string;
   ref?: Ref<HTMLButtonElement>;
+  /**
+   * The attributes a drag library hangs on its activator: what a screen reader calls the control, where its live instructions live, and whether it is currently grabbed.
+   *
+   * Declared rather than left to the rest spread, because they reach the button either way and a later tightening of this membrane would drop them with no type error and no visible change.
+   * `SortableReorderHandle` is the caller;
+   * nothing else should need these.
+   */
+  role?: string;
+  tabIndex?: number;
+  'aria-describedby'?: string;
+  'aria-roledescription'?: string;
+  'aria-pressed'?: boolean;
+  'aria-disabled'?: boolean;
 }
 
 /**

--- a/src/app/ui/control/SortableReorderHandle.tsx
+++ b/src/app/ui/control/SortableReorderHandle.tsx
@@ -1,8 +1,8 @@
 import type { useSortable } from '@dnd-kit/sortable';
-import { Tooltip } from '@mantine/core';
 import clsx from 'clsx';
 import { GripVertical } from 'lucide-react';
 
+import { IconAction } from './IconAction';
 import styles from './SortableDnd.module.css';
 
 export type SortableHandleProps = Pick<
@@ -33,17 +33,13 @@ export function SortableReorderHandle({
   listeners?: SortableHandleProps['listeners'];
 }) {
   return (
-    <Tooltip label={label} position="left">
-      <button
-        type="button"
-        className={clsx(styles.reorderHandle, className)}
-        aria-label={label}
-        ref={setActivatorNodeRef}
-        {...attributes}
-        {...listeners}
-      >
-        <GripVertical size={16} aria-hidden />
-      </button>
-    </Tooltip>
+    <IconAction
+      label={label}
+      className={clsx(styles.reorderHandle, className)}
+      ref={setActivatorNodeRef}
+      icon={<GripVertical size={16} aria-hidden />}
+      {...attributes}
+      {...listeners}
+    />
   );
 }


### PR DESCRIPTION
The last item from [#629](https://github.com/ndelangen/dunezone/issues/629)'s drift list, held out of [#680](https://github.com/ndelangen/dunezone/pull/680) because it touches a file #678 also touched. **Based on `main`, not stacked.**

`SortableReorderHandle` wrapped a raw `<button>` in a `Tooltip` and set its own `aria-label`. That is the exact assembly `IconAction` exists to replace, and its own doc says so: *"It replaces the hand-assembled `Tooltip` around `ActionIcon` that appeared ~50 times, where the pairing was a convention rather than a guarantee."*

## The swap is not as plain as #629 makes it sound

dnd-kit hands its activator six attributes:

```
role, tabIndex, aria-disabled, aria-pressed, aria-roledescription, aria-describedby
```

The last two are what make a keyboard drag audible: one names the control "sortable", the other points at the live instructions a screen reader reads out.

**`IconAction` declares none of them, and the swap worked anyway.** They fall into its rest parameter and reach the button regardless. Typecheck passes; JSX spread does not do excess-property checking.

That is the **undeclared membrane #680 just removed from `Toolbar`** — except here it would be relied on rather than removed. The type promises five `ActionIcon` props while the component forwards anything, so a later tightening of `IconAction`, exactly the change #680 made next door, would drop a screen reader's only description of this control with **no type error and nothing visible on screen**.

So this PR declares them, as the standard DOM and ARIA attributes they are, with the reason written where someone tightening the membrane will read it. No dnd-kit import, and the doc says nothing else should need them.

## Verified in the DOM, because the types pass either way

| | value |
|---|---|
| `aria-roledescription` | `sortable` |
| `aria-describedby` | `DndDescribedBy-0`, and that element **exists**, holding "To pick up a draggable item, press the space bar" |
| `aria-disabled` | `false` |
| `role` / `tabindex` / `type` | `button` / `0` / `button` |
| `aria-label` | `Reorder Alpha`, so IconAction's own label still wins over the spread |

Three handles render, all identical.

## One thing I could not prove, in either direction

The keyboard pick-up itself. A synthetic space press on the focused handle announces nothing and leaves `aria-pressed` unset.

**It does the same on `main`.** I restored both files to their merged versions, repeated the identical press, and got the identical nothing, so the tool cannot drive dnd-kit's keyboard sensor. That makes this **not a regression**, and it also makes it **not evidence**. Saying so rather than presenting the attribute check as proof of the interaction.

## Verified

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 655 unit tests, 351 storybook tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved drag-and-drop controls with expanded accessibility attributes, including keyboard navigation and screen reader descriptions.
* **UI Improvements**
  * Updated reorder handles to use the shared icon control while preserving tooltips, styling, and drag interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->