### PR TITLE
A person is cited as a chip, and the sentence stays the page's

### DIFF
--- a/src/app/routes/_app/profiles/$profileSlug/index.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/index.tsx
@@ -65,14 +65,17 @@ function AskerChip({
     return <span className={styles.selfNote}>Your question</span>;
   }
 
+  /* The sentence is the page's and stays unlinked; only the chip navigates. */
   return (
-    <ProfileLink
-      slug={profile.slug}
-      username={profile.username}
-      avatar_url={profile.avatar_url}
-      className={styles.askerLink}
-      label={`Question by ${profile.username ?? 'Unknown'}`}
-    />
+    <span className={styles.askerCitation}>
+      Question by{' '}
+      <ProfileLink
+        slug={profile.slug}
+        username={profile.username}
+        avatar_url={profile.avatar_url}
+        className={styles.askerLink}
+      />
+    </span>
   );
 }
 

--- a/src/app/routes/_app/profiles/ProfileDetail.module.css
+++ b/src/app/routes/_app/profiles/ProfileDetail.module.css
@@ -105,6 +105,15 @@
   gap: 0.5rem;
 }
 
+/* Holds the page's words and the chip on one baseline, so the chip reads as part of the sentence. */
+.askerCitation {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
 .askerLink {
   display: inline-flex;
   align-items: center;

--- a/src/app/ui/content/ProfileLink.stories.tsx
+++ b/src/app/ui/content/ProfileLink.stories.tsx
@@ -24,11 +24,3 @@ export const WithAvatar = meta.story({
 export const AvatarOnly = meta.story({
   args: { avatar_url: '/web/logo.svg', showUsername: false, title: 'Central' },
 });
-
-/**
- * When the citation is naming the person's role in a sentence rather than just citing them.
- * `label` replaces the plain username, and it is a string: the caller owns the words, not a slot to render into.
- */
-export const Labelled = meta.story({
-  args: { avatar_url: '/web/logo.svg', label: 'Question by Central' },
-});

--- a/src/app/ui/content/ProfileLink.tsx
+++ b/src/app/ui/content/ProfileLink.tsx
@@ -11,11 +11,6 @@ export type ProfileLinkProps = Pick<ProfileEntry, 'slug' | 'username' | 'avatar_
   style?: CSSProperties;
   title?: string;
   showUsername?: boolean;
-  /**
-   * The words beside the avatar, when the bare username is not what this context should read.
-   * A string rather than a slot: a citation of a person is data, and the one caller that needs this is naming the person's role in a sentence.
-   */
-  label?: string;
 };
 
 /**
@@ -34,10 +29,8 @@ export const ProfileLink = ({
   style,
   title,
   showUsername = true,
-  label,
 }: ProfileLinkProps) => {
-  const afterAvatar =
-    label !== undefined ? label : showUsername ? <span className={styles.username}>{username}</span> : null;
+  const afterAvatar = showUsername ? <span className={styles.username}>{username}</span> : null;
 
   return (
     <Link


### PR DESCRIPTION
Stage 1 of [#685](https://github.com/ndelangen/dunezone/issues/685). **Based on `main`, not stacked.**

An entity mentioned in prose is a compact link **beside** the words, not the words themselves: "Question by &lt;chip&gt;", never a whole linked sentence.

## This deletes a prop I added two days ago, and that is the right outcome

[#680](https://github.com/ndelangen/dunezone/pull/680) narrowed `ProfileLink`'s `children: ReactNode` slot to a `label: string`. I then flagged that `label` rendered as bare text while the plain username went through a class carrying weight and colour, and asked whether to style it.

The decision skipped both answers, and it is better than either. **The question was never how to style a sentence handed to a link. It was that a sentence should not be handed to a link at all.** So `label` goes, and `ProfileLink`'s membrane returns to exactly a person as a link: the narrowing #680 wanted, completed.

Its story goes with it.

## What the page does instead

The FAQ citation composes its own words and puts a bare chip beside them, so only the person navigates. One new class holds the text and the chip on a shared baseline.

## Not verifiable on a real page, and I checked rather than assumed

This deployment has **no FAQ activity at all**: zero questions asked and zero answers given across all twenty-two profiles, so `AskerChip` never renders. Reaching it would need seeded data.

So I verified against the **built stylesheet** instead, rendering the real markup with the compiled class names beside the shape it replaces:

| | result |
|---|---|
| `askerCitation` computed | `inline-flex`, `align-items: center`, `gap: 5.6px`, `flex-wrap: wrap` |
| composed form | "Question by" unlinked, chip carries the link, one baseline |
| previous form | the whole sentence inside the anchor |

That exercises the CSS the build produced, not a hand-written approximation of it. It does **not** exercise the React composition on a live page, and I would not claim otherwise.

## Verified

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 656 unit tests, 350 storybook tests (351 minus the deleted `Labelled` story).

## Not in scope

Stage 2 of #685 (a mention component per entity kind, then converging the ad hoc inline entity links across at least eight files) is enumerate-first work and explicitly not part of K4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated question citations so “Question by” appears as plain text, while only the asker’s profile name is clickable.
  * Improved citation layout with better alignment, spacing, wrapping, and width handling.
  * Profile links now consistently display the username instead of custom labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->