### PR TITLE
Apply the accepted Rulebook editor workspace

### DIFF
--- a/e2e/rulebook-editor-route.spec.ts
+++ b/e2e/rulebook-editor-route.spec.ts
@@ -163,6 +163,23 @@ test('only the narrow editor workspace scrolls horizontally', async ({ page }) =
 
   const workspace = page.getByRole('region', { name: 'Rulebook editor and preview' });
   await expect(workspace).toBeVisible();
+  const editingSection = page.getByRole('region', { name: 'Rulebook editing workspace' });
+  const controls = page.getByRole('region', { name: 'Rulebook controls' });
+  const preview = page.getByRole('region', { name: 'Rulebook page preview' });
+  const [editingSectionBox, controlsBox, previewBox] = await Promise.all([
+    editingSection.boundingBox(),
+    controls.boundingBox(),
+    preview.boundingBox(),
+  ]);
+  expect(editingSectionBox).not.toBeNull();
+  expect(controlsBox).not.toBeNull();
+  expect(previewBox).not.toBeNull();
+  if (!editingSectionBox || !controlsBox || !previewBox) {
+    throw new Error('The narrow Rulebook workspace has no rendered bounds.');
+  }
+  const contentBottom = Math.max(controlsBox.y + controlsBox.height, previewBox.y + previewBox.height);
+  const sectionBottom = editingSectionBox.y + editingSectionBox.height;
+  expect(sectionBottom - contentBottom).toBeLessThan(350);
   await expect.poll(() => workspace.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true);
   await expect
     .poll(() =>

--- a/e2e/rulebook-editor-route.spec.ts
+++ b/e2e/rulebook-editor-route.spec.ts
@@ -3,63 +3,71 @@ import { expect, test } from './coverage';
 /* The browser-local fixture editor must not rotate an authenticated spec's refresh token. */
 test.use({ storageState: { cookies: [], origins: [] } });
 
-test('the local Rulebook editor keeps its A4 preview synchronized', async ({ page }) => {
-  await page.goto('/rulesets/local-rules/rulebooks/starter/edit');
+const editorPath = '/rulesets/local-rules/rulebooks/starter/edit';
 
-  await expect(page.getByRole('heading', { name: 'Edit starter' })).toBeVisible();
-  await expect(page.getByText('It does not load from or save to the database.')).toBeVisible();
+test('the local Rulebook editor keeps its preview synchronized', async ({ page }) => {
+  await page.goto(editorPath);
 
   const preview = page.getByRole('region', { name: 'Rulebook page preview' });
   await expect(preview).toBeVisible();
 
-  await page.getByText('Edit page', { exact: true }).click();
+  await page.getByRole('button', { name: /Edit Page 1/ }).click();
   await page.getByRole('textbox', { name: 'Text block' }).fill('A browser-local Rulebook revision.');
 
   await expect(preview).toContainText('A browser-local Rulebook revision.');
-});
-
-test('invalid formatted text stays literal in the preview', async ({ page }) => {
-  await page.goto('/rulesets/local-rules/rulebooks/starter/edit');
-  await page.getByText('Edit page', { exact: true }).click();
 
   const invalidText = '*bold _underline* still underline_';
   await page.getByRole('textbox', { name: 'Text block' }).fill(invalidText);
-
-  const preview = page.getByRole('region', { name: 'Rulebook page preview' });
   await expect(preview.getByText(invalidText, { exact: true })).toBeVisible();
   await expect(preview.locator('strong')).toHaveCount(0);
 });
 
-test('selecting a Page enters Edit mode', async ({ page }) => {
-  await page.goto('/rulesets/local-rules/rulebooks/starter/edit');
-
-  await page.getByRole('button', { name: /Page 2/ }).click();
-
-  await expect(page.getByRole('radio', { name: 'Edit page' })).toBeChecked();
-  await expect(page.getByRole('heading', { name: 'Edit Page 2' })).toBeVisible();
-});
-
-test('fit height shows the full Page while fit width provides a materially larger scrolling preview', async ({
-  page,
-}) => {
+test('the fit toggle changes Page size while the document owns vertical scrolling', async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
-  await page.goto('/rulesets/local-rules/rulebooks/starter/edit');
-  await page.getByRole('button', { name: /Page 2/ }).click();
+  await page.goto(editorPath);
 
-  const previewScroller = page.getByRole('region', { name: 'Rulebook page preview' });
-  const previewPage = page.getByRole('article', { name: 'Preview of Page 2' });
+  const controlsRegion = page.getByRole('region', { name: 'Rulebook controls' });
+  const previewRegion = page.getByRole('region', { name: 'Rulebook page preview' });
+  const previewPage = page.getByRole('article', { name: 'Preview of Page 1' });
   await expect(previewPage).toBeVisible();
+
   const fitHeightBox = await previewPage.boundingBox();
   expect(fitHeightBox).not.toBeNull();
   if (!fitHeightBox) {
     throw new Error('The fit-height preview has no rendered bounds.');
   }
   expect(fitHeightBox.width).toBeGreaterThan(0);
-  await expect
-    .poll(() => previewScroller.evaluate((element) => element.scrollHeight - element.clientHeight))
-    .toBeLessThanOrEqual(1);
+  expect(fitHeightBox.width / fitHeightBox.height).toBeCloseTo(210 / 297, 2);
 
-  await page.getByText('Fit width', { exact: true }).click();
+  for (const region of [controlsRegion, previewRegion]) {
+    await expect
+      .poll(() => region.evaluate((element) => element.scrollHeight - element.clientHeight))
+      .toBeLessThanOrEqual(1);
+  }
+
+  await controlsRegion.hover();
+  await page.mouse.wheel(0, 250);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
+  const afterControlsWheel = await page.evaluate(() => window.scrollY);
+  expect(await controlsRegion.evaluate((element) => element.scrollTop)).toBe(0);
+  expect(await previewRegion.evaluate((element) => element.scrollTop)).toBe(0);
+
+  const stickyFitHeightBox = await previewPage.boundingBox();
+  expect(stickyFitHeightBox).not.toBeNull();
+  if (!stickyFitHeightBox) {
+    throw new Error('The sticky fit-height preview has no rendered bounds.');
+  }
+  expect(stickyFitHeightBox.y).toBeGreaterThanOrEqual(-1);
+  expect(stickyFitHeightBox.y + stickyFitHeightBox.height).toBeLessThanOrEqual(901);
+
+  await previewRegion.hover();
+  await page.mouse.wheel(0, 250);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(afterControlsWheel);
+  expect(await controlsRegion.evaluate((element) => element.scrollTop)).toBe(0);
+  expect(await previewRegion.evaluate((element) => element.scrollTop)).toBe(0);
+
+  await page.getByRole('button', { name: 'Switch preview to fit width' }).click();
+  await expect(page.getByRole('button', { name: 'Switch preview to fit height' })).toBeVisible();
 
   const fitWidthBox = await previewPage.boundingBox();
   expect(fitWidthBox).not.toBeNull();
@@ -68,17 +76,18 @@ test('fit height shows the full Page while fit width provides a materially large
   }
   expect(fitWidthBox.width).toBeGreaterThan(0);
   expect(fitWidthBox.width / fitHeightBox.width).toBeGreaterThanOrEqual(1.3);
-  await expect
-    .poll(() => previewScroller.evaluate((element) => element.scrollHeight > element.clientHeight))
-    .toBe(true);
 });
 
 test('a repeated text item can be added, edited, previewed, and removed', async ({ page }) => {
-  await page.goto('/rulesets/local-rules/rulebooks/starter/edit');
+  await page.goto(editorPath);
   await page.getByRole('button', { name: /Page 2/ }).click();
+
+  await expect(page.getByRole('article', { name: 'Preview of Page 2' })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Edit Page 2/ })).toHaveAttribute('aria-expanded', 'true');
 
   const preview = page.getByRole('region', { name: 'Rulebook page preview' });
   const items = page.getByRole('textbox', { name: /^repeated text block, item \d+$/ });
+  await expect(items.first()).toBeVisible();
   const originalCount = await items.count();
   await page.getByRole('button', { name: 'Add item to repeated text block' }).click();
 
@@ -100,41 +109,46 @@ test('a repeated text item can be added, edited, previewed, and removed', async 
   await expect(preview).not.toContainText('A newly repeated browser-local rule.');
 });
 
-test('the narrow workspace scrolls beside a fixed two-column Page and changes fit', async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 700 });
-  await page.goto('/rulesets/local-rules/rulebooks/starter/edit');
-  await page.getByRole('button', { name: /Page 2/ }).click();
+test('only the narrow editor workspace scrolls horizontally', async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 700 });
+  await page.goto(editorPath);
 
-  const workspace = page.getByRole('region', { name: 'Rulebook editing workspace' });
-  const scroller = workspace.getByRole('region', { name: 'Editor and preview' });
-  await expect.poll(() => scroller.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true);
-  await scroller.focus();
-  await expect(scroller).toBeFocused();
+  const workspace = page.getByRole('region', { name: 'Rulebook editor and preview' });
+  await expect(workspace).toBeVisible();
+  await expect.poll(() => workspace.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true);
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          document.documentElement.scrollWidth === document.documentElement.clientWidth &&
+          document.body.scrollWidth === document.body.clientWidth
+      )
+    )
+    .toBe(true);
+
+  const viewportWidth = page.viewportSize()?.width ?? 0;
+  for (const landmark of [page.getByRole('banner'), page.getByRole('contentinfo')]) {
+    const box = await landmark.boundingBox();
+    expect(box).not.toBeNull();
+    if (box) {
+      expect(box.x).toBeGreaterThanOrEqual(0);
+      expect(box.x + box.width).toBeLessThanOrEqual(viewportWidth);
+    }
+  }
+  await expect(page.getByText('Starter state', { exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Switch preview to fit width' })).toBeVisible();
+
+  await workspace.focus();
+  await expect(workspace).toBeFocused();
   await page.keyboard.press('ArrowRight');
-  await expect.poll(() => scroller.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0);
+  await expect.poll(() => workspace.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0);
 
-  const leftColumn = page.getByRole('group', { name: 'Left page column' });
-  const rightColumn = page.getByRole('group', { name: 'Right page column' });
-  const leftBox = await leftColumn.boundingBox();
-  const rightBox = await rightColumn.boundingBox();
-  expect(leftBox).not.toBeNull();
-  expect(rightBox).not.toBeNull();
-  expect(Math.round(rightBox?.y ?? 0)).toBe(Math.round(leftBox?.y ?? 0));
-  expect(rightBox?.x ?? 0).toBeGreaterThan(leftBox?.x ?? 0);
-
-  const previewPage = page.getByRole('article', { name: 'Preview of Page 2' });
-  const fitHeightWidth = (await previewPage.boundingBox())?.width ?? 0;
-  await page.getByText('Fit width', { exact: true }).click();
-
-  await expect(page.getByRole('radio', { name: 'Fit width' })).toBeChecked();
-  await expect(workspace).toHaveAttribute('data-fit', 'width');
+  const previewPage = page.getByRole('article', { name: 'Preview of Page 1' });
+  const fitHeightBox = await previewPage.boundingBox();
+  expect(fitHeightBox).not.toBeNull();
+  await page.getByRole('button', { name: 'Switch preview to fit width' }).click();
+  await expect(page.getByRole('button', { name: 'Switch preview to fit height' })).toBeVisible();
   await expect
     .poll(async () => Math.round((await previewPage.boundingBox())?.width ?? 0))
-    .not.toBe(Math.round(fitHeightWidth));
-
-  const previewScroller = page.getByRole('region', { name: 'Rulebook page preview' });
-  await previewScroller.focus();
-  await expect(previewScroller).toBeFocused();
-  await page.keyboard.press('PageDown');
-  await expect.poll(() => previewScroller.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+    .not.toBe(Math.round(fitHeightBox?.width ?? 0));
 });

--- a/e2e/rulebook-editor-route.spec.ts
+++ b/e2e/rulebook-editor-route.spec.ts
@@ -15,11 +15,6 @@ test('the local Rulebook editor keeps its preview synchronized', async ({ page }
   await page.getByRole('textbox', { name: 'Text block' }).fill('A browser-local Rulebook revision.');
 
   await expect(preview).toContainText('A browser-local Rulebook revision.');
-
-  const invalidText = '*bold _underline* still underline_';
-  await page.getByRole('textbox', { name: 'Text block' }).fill(invalidText);
-  await expect(preview.getByText(invalidText, { exact: true })).toBeVisible();
-  await expect(preview.locator('strong')).toHaveCount(0);
 });
 
 test('the fit toggle changes Page size while the document owns vertical scrolling', async ({ page }) => {
@@ -46,7 +41,14 @@ test('the fit toggle changes Page size while the document owns vertical scrollin
   }
 
   await controlsRegion.hover();
-  await page.mouse.wheel(0, 250);
+  const hoveredFitHeightBox = await previewPage.boundingBox();
+  expect(hoveredFitHeightBox).not.toBeNull();
+  if (!hoveredFitHeightBox) {
+    throw new Error('The fit-height preview has no rendered bounds after focusing the controls.');
+  }
+  const stickyOffset = 16;
+  const engageStickyDelta = Math.max(1, Math.floor(hoveredFitHeightBox.y - stickyOffset));
+  await page.mouse.wheel(0, engageStickyDelta);
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
   const afterControlsWheel = await page.evaluate(() => window.scrollY);
   expect(await controlsRegion.evaluate((element) => element.scrollTop)).toBe(0);
@@ -61,7 +63,7 @@ test('the fit toggle changes Page size while the document owns vertical scrollin
   expect(stickyFitHeightBox.y + stickyFitHeightBox.height).toBeLessThanOrEqual(901);
 
   await previewRegion.hover();
-  await page.mouse.wheel(0, 250);
+  await page.mouse.wheel(0, 40);
   await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(afterControlsWheel);
   expect(await controlsRegion.evaluate((element) => element.scrollTop)).toBe(0);
   expect(await previewRegion.evaluate((element) => element.scrollTop)).toBe(0);

--- a/e2e/rulebook-editor-route.spec.ts
+++ b/e2e/rulebook-editor-route.spec.ts
@@ -40,17 +40,32 @@ test('the fit toggle changes Page size while the document owns vertical scrollin
       .toBeLessThanOrEqual(1);
   }
 
-  await controlsRegion.hover();
-  const hoveredFitHeightBox = await previewPage.boundingBox();
-  expect(hoveredFitHeightBox).not.toBeNull();
-  if (!hoveredFitHeightBox) {
-    throw new Error('The fit-height preview has no rendered bounds after focusing the controls.');
+  const controlsBox = await controlsRegion.boundingBox();
+  expect(controlsBox).not.toBeNull();
+  if (!controlsBox) {
+    throw new Error('The Rulebook controls have no rendered bounds.');
   }
-  const stickyOffset = 16;
-  const engageStickyDelta = Math.max(1, Math.floor(hoveredFitHeightBox.y - stickyOffset));
-  await page.mouse.wheel(0, engageStickyDelta);
-  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0);
-  const afterControlsWheel = await page.evaluate(() => window.scrollY);
+  await page.mouse.move(controlsBox.x + 20, controlsBox.y + 20);
+
+  let previousPageY = fitHeightBox.y;
+  let previousWindowY = await page.evaluate(() => window.scrollY);
+  let stickyPageY: number | undefined;
+  for (let step = 0; step < 30; step += 1) {
+    await page.mouse.wheel(0, 20);
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(previousWindowY);
+    const candidateBox = await previewPage.boundingBox();
+    expect(candidateBox).not.toBeNull();
+    if (!candidateBox) {
+      throw new Error('The fit-height preview lost its rendered bounds while scrolling.');
+    }
+    if (Math.abs(candidateBox.y - previousPageY) <= 1) {
+      stickyPageY = candidateBox.y;
+      break;
+    }
+    previousPageY = candidateBox.y;
+    previousWindowY = await page.evaluate(() => window.scrollY);
+  }
+  expect(stickyPageY).toBeDefined();
   expect(await controlsRegion.evaluate((element) => element.scrollTop)).toBe(0);
   expect(await previewRegion.evaluate((element) => element.scrollTop)).toBe(0);
 
@@ -59,17 +74,27 @@ test('the fit toggle changes Page size while the document owns vertical scrollin
   if (!stickyFitHeightBox) {
     throw new Error('The sticky fit-height preview has no rendered bounds.');
   }
+  expect(stickyFitHeightBox.y).toBeCloseTo(stickyPageY ?? Number.NaN, 0);
   expect(stickyFitHeightBox.y).toBeGreaterThanOrEqual(-1);
   expect(stickyFitHeightBox.y + stickyFitHeightBox.height).toBeLessThanOrEqual(901);
 
-  await previewRegion.hover();
-  await page.mouse.wheel(0, 40);
-  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(afterControlsWheel);
+  await page.mouse.move(stickyFitHeightBox.x + stickyFitHeightBox.width / 2, stickyFitHeightBox.y + 20);
+  const beforePinnedWheel = await page.evaluate(() => window.scrollY);
+  await page.mouse.wheel(0, 20);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(beforePinnedWheel);
+  const pinnedFitHeightBox = await previewPage.boundingBox();
+  expect(pinnedFitHeightBox).not.toBeNull();
+  if (!pinnedFitHeightBox) {
+    throw new Error('The pinned fit-height preview has no rendered bounds.');
+  }
+  expect(Math.abs(pinnedFitHeightBox.y - stickyFitHeightBox.y)).toBeLessThanOrEqual(1);
   expect(await controlsRegion.evaluate((element) => element.scrollTop)).toBe(0);
   expect(await previewRegion.evaluate((element) => element.scrollTop)).toBe(0);
 
   await page.getByRole('button', { name: 'Switch preview to fit width' }).click();
   await expect(page.getByRole('button', { name: 'Switch preview to fit height' })).toBeVisible();
+  await page.evaluate(() => window.scrollTo(0, 0));
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
 
   const fitWidthBox = await previewPage.boundingBox();
   expect(fitWidthBox).not.toBeNull();
@@ -78,6 +103,27 @@ test('the fit toggle changes Page size while the document owns vertical scrollin
   }
   expect(fitWidthBox.width).toBeGreaterThan(0);
   expect(fitWidthBox.width / fitHeightBox.width).toBeGreaterThanOrEqual(1.3);
+
+  const fitWidthRegionBox = await previewRegion.boundingBox();
+  expect(fitWidthRegionBox).not.toBeNull();
+  if (!fitWidthRegionBox) {
+    throw new Error('The fit-width preview region has no rendered bounds.');
+  }
+  await page.mouse.move(fitWidthRegionBox.x + fitWidthRegionBox.width / 2, fitWidthRegionBox.y + 20);
+  const beforeFitWidthWheel = await page.evaluate(() => window.scrollY);
+  await page.mouse.wheel(0, 40);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(beforeFitWidthWheel);
+  const afterFitWidthWheel = await page.evaluate(() => window.scrollY);
+  const scrolledFitWidthBox = await previewPage.boundingBox();
+  expect(scrolledFitWidthBox).not.toBeNull();
+  if (!scrolledFitWidthBox) {
+    throw new Error('The scrolled fit-width preview has no rendered bounds.');
+  }
+  expect(
+    Math.abs(fitWidthBox.y - scrolledFitWidthBox.y - (afterFitWidthWheel - beforeFitWidthWheel))
+  ).toBeLessThanOrEqual(1);
+  expect(await controlsRegion.evaluate((element) => element.scrollTop)).toBe(0);
+  expect(await previewRegion.evaluate((element) => element.scrollTop)).toBe(0);
 });
 
 test('a repeated text item can be added, edited, previewed, and removed', async ({ page }) => {

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
@@ -1,58 +1,125 @@
+.prototypeRoot {
+  --prototype-side-space: clamp(1rem, calc((100vw - 64rem) * 1.25 + 1rem), 2.5rem);
+  container: rulebook-editor-prototype / inline-size;
+  width: min(116rem, calc(100vw - var(--prototype-side-space) - var(--prototype-side-space)));
+  margin-inline-start: max(calc(50% - 58rem), calc(50% - 50vw + var(--prototype-side-space)));
+  padding-bottom: 5rem;
+}
+
+.mobileStatus {
+  display: none;
+}
+
 .workspaceSticky {
-  --workspace-top: calc(var(--app-shell-header-offset, 0px) + 5.5rem);
-  --workspace-height: clamp(28rem, calc(100dvh - var(--app-shell-header-offset, 0px) - 7rem), 52rem);
-  --preview-caption-space: 2.5rem;
-  --fit-height-page-height: calc(var(--workspace-height) - var(--preview-caption-space));
-  --fit-height-page-width: calc(var(--fit-height-page-height) * 210 / 297);
-  --fit-width-page-width: calc(var(--fit-height-page-width) * 1.35);
-  container: rulebook-editor-workspace / inline-size;
-  position: sticky;
-  z-index: 1;
-  top: var(--workspace-top);
+  --workspace-top: calc(var(--app-shell-header-offset, 0px) + 0.75rem);
+  --preview-caption-space: 2rem;
+  --available-page-height: min(52rem, calc(100dvh - var(--app-shell-header-offset, 0px) - 2rem));
+  --height-page-width: calc((var(--available-page-height) - var(--preview-caption-space)) * 210 / 297);
+  --workspace-gap: var(--mantine-spacing-xl);
   min-width: 0;
 }
 
-.workspaceScroller {
+.workspaceSticky[data-fit="height"][data-mode="navigate"] {
+  position: sticky;
+  z-index: 1;
+  top: var(--workspace-top);
+}
+
+.workspaceViewport {
+  width: 100%;
+  max-width: 100%;
   min-width: 0;
-  overscroll-behavior-inline: contain;
+  overflow: visible;
 }
 
 .workspace {
   display: grid;
-  gap: var(--mantine-spacing-md);
+  gap: var(--workspace-gap);
   align-items: stretch;
-  height: var(--workspace-height);
 }
 
-.workspaceSticky[data-fit="height"] .workspace {
-  grid-template-columns: minmax(30rem, 1fr) var(--fit-height-page-width);
-  min-width: calc(30rem + var(--fit-height-page-width) + var(--mantine-spacing-md));
+.workspace[data-fit="height"] {
+  grid-template-columns: minmax(0, 1fr) min(var(--height-page-width), 50cqi);
 }
 
-.workspaceSticky[data-fit="width"] .workspace {
-  grid-template-columns: minmax(30rem, 1fr) var(--fit-width-page-width);
-  min-width: calc(30rem + var(--fit-width-page-width) + var(--mantine-spacing-md));
+.workspace[data-fit="width"] {
+  align-items: start;
+  grid-template-columns:
+    minmax(0, 1fr)
+    min(calc(var(--height-page-width) * 1.45), calc(100cqi - 18rem - var(--workspace-gap)));
 }
 
-.controlsScroll,
+.outlineRail,
 .previewRail {
   min-width: 0;
-  max-height: var(--workspace-height);
-  overflow-y: auto;
-  overscroll-behavior-block: contain;
 }
 
-.controlsScroll {
-  scrollbar-gutter: stable;
+.outlineRail {
+  min-height: 100%;
+}
+
+.outlineAccordion {
+  background: transparent;
+}
+
+.outlineAccordion :global(.mantine-Accordion-item),
+.outlineAccordion :global(.mantine-Accordion-control),
+.outlineAccordion :global(.mantine-Accordion-panel),
+.outlineAccordion :global(.mantine-Accordion-content) {
+  background: transparent;
+  box-shadow: none;
+}
+
+.outlineAccordion :global(.mantine-Accordion-item) {
+  border-color: var(--mantine-color-default-border);
+}
+
+.outlineAccordion :global(.mantine-Accordion-content) {
+  padding-inline: 0;
+  padding-block-end: var(--mantine-spacing-xl);
+}
+
+.sectionLabel {
+  letter-spacing: 0.12em;
+}
+
+.pageChoice {
+  width: 100%;
+  min-height: 3rem;
+  padding-inline: var(--mantine-spacing-sm);
+  color: var(--mantine-color-text);
+  border-inline-start: 3px solid transparent;
+  border-radius: 0;
+}
+
+.pageChoice :global(.mantine-Button-label) {
+  display: grid;
+  grid-template-columns: 2.25rem minmax(7rem, 1fr) auto;
+  width: 100%;
+}
+
+.pageChoice[aria-current="page"] {
+  border-inline-start-color: var(--mantine-primary-color-filled);
+}
+
+.pageChoiceNumber {
+  color: var(--mantine-color-dimmed);
+  font-variant-numeric: tabular-nums;
+  text-align: start;
+}
+
+.pageChoiceName {
+  text-align: start;
 }
 
 .previewRail {
-  height: var(--workspace-height);
+  width: 100%;
 }
 
 .previewFigure {
   display: grid;
   gap: var(--mantine-spacing-xs);
+  width: 100%;
   margin: 0;
 }
 
@@ -60,33 +127,36 @@
   container: rulebook-page-preview / inline-size;
   display: grid;
   place-items: start center;
+  width: 100%;
   min-width: 0;
 }
 
 .pagePreview {
+  box-sizing: border-box;
   container-type: inline-size;
   position: relative;
+  width: 100%;
   aspect-ratio: 210 / 297;
   overflow: hidden;
   contain: paint;
   color: #282218;
-  background: linear-gradient(105deg, transparent 0 54%, rgb(125 91 40 / 5%) 55%, transparent 56%), #f4ecd9;
+  background: linear-gradient(90deg, rgb(66 45 16 / 4%), transparent 12%, transparent 88%, rgb(66 45 16 / 4%)), #f4ecd9;
   border: 1px solid rgb(75 56 29 / 32%);
   box-shadow: 0 0.7rem 1.8rem rgb(41 27 8 / 22%);
 }
 
+.pagePreview::before {
+  position: absolute;
+  z-index: 1;
+  inset: 3cqi;
+  border: 1px solid rgb(117 88 43 / 20%);
+  content: "";
+  pointer-events: none;
+}
+
+.previewViewport[data-fit="height"] .pagePreview,
 .previewViewport[data-fit="width"] .pagePreview {
   width: 100%;
-}
-
-.previewViewport[data-fit="height"] {
-  width: var(--fit-height-page-width);
-  height: var(--fit-height-page-height);
-}
-
-.previewViewport[data-fit="height"] .pagePreview {
-  width: 100%;
-  height: 100%;
 }
 
 .pageFolio {
@@ -111,7 +181,7 @@
 }
 
 .previewColumns .previewSlot:first-child {
-  border-right: 1px solid rgb(75 56 29 / 20%);
+  border-inline-end: 1px solid rgb(75 56 29 / 20%);
 }
 
 .previewBlock,
@@ -135,12 +205,12 @@
 .previewBlock ul,
 .repeatedText ul {
   margin: 0 0 2.5cqi;
-  padding-left: 5cqi;
+  padding-inline-start: 5cqi;
 }
 
 .repeatedText {
   margin: 0;
-  padding-left: 6cqi;
+  padding-inline-start: 6cqi;
 }
 
 .repeatedText > li + li {
@@ -162,8 +232,83 @@
   white-space: pre-wrap;
 }
 
-@container rulebook-editor-workspace (max-width: 44rem) {
-  .workspace {
-    gap: var(--mantine-spacing-sm);
+@container rulebook-editor-prototype (max-width: 72rem) {
+  .workspaceSticky {
+    --workspace-gap: var(--mantine-spacing-lg);
+  }
+
+  .outlineRail {
+    padding: var(--mantine-spacing-md);
+  }
+
+  .outlineAccordion :global(.mantine-Accordion-content) {
+    padding-block-end: var(--mantine-spacing-md);
+  }
+
+  .pageChoiceAnchor {
+    display: none;
+  }
+}
+
+@container rulebook-editor-prototype (max-width: 45rem) {
+  .workspaceSticky {
+    --workspace-gap: var(--mantine-spacing-sm);
+  }
+
+  .workspaceSticky[data-fit="height"][data-mode="navigate"] {
+    position: relative;
+    top: auto;
+  }
+
+  .workspaceViewport {
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+  }
+
+  .workspace[data-fit="height"] {
+    grid-template-columns: 17rem 25rem;
+    min-width: calc(42rem + var(--workspace-gap));
+  }
+
+  .workspace[data-fit="width"] {
+    grid-template-columns: 17rem 34.5rem;
+    min-width: calc(51.5rem + var(--workspace-gap));
+  }
+
+  .outlineRail {
+    padding: var(--mantine-spacing-sm);
+  }
+
+  .outlineAccordion :global(.mantine-Accordion-control) {
+    padding-inline: var(--mantine-spacing-xs);
+  }
+
+  .outlineAccordion :global(.mantine-Accordion-content) {
+    padding-block-end: var(--mantine-spacing-sm);
+  }
+
+  .pageChoice {
+    min-height: 2.5rem;
+    padding-inline: var(--mantine-spacing-xs);
+  }
+
+  .pageChoice :global(.mantine-Button-label) {
+    grid-template-columns: 1.75rem minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 48rem) {
+  .desktopStatus {
+    display: none;
+  }
+
+  .mobileStatus {
+    display: block;
+  }
+}
+
+@media (max-width: 24rem) {
+  .mobileStatus {
+    display: none;
   }
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
@@ -6,8 +6,13 @@
   padding-bottom: 5rem;
 }
 
-.prototypeRoot:has(> .workspaceSticky[data-fit="height"][data-mode="navigate"]) {
-  min-height: 200dvh;
+.stickyRunway {
+  display: none;
+}
+
+.workspaceSticky[data-fit="height"][data-mode="navigate"] + .stickyRunway {
+  display: block;
+  height: 100dvh;
 }
 
 .mobileStatus {
@@ -259,6 +264,10 @@
 }
 
 @container rulebook-editor-prototype (max-width: 45rem) {
+  .workspaceSticky[data-fit="height"][data-mode="navigate"] + .stickyRunway {
+    display: none;
+  }
+
   .workspaceSticky {
     --workspace-gap: var(--mantine-spacing-sm);
   }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
@@ -6,6 +6,10 @@
   padding-bottom: 5rem;
 }
 
+.prototypeRoot:has(> .workspaceSticky[data-fit="height"][data-mode="navigate"]) {
+  min-height: 200dvh;
+}
+
 .mobileStatus {
   display: none;
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
@@ -58,6 +58,10 @@
   min-height: 100%;
 }
 
+.outlineContent {
+  padding: var(--mantine-spacing-lg);
+}
+
 .outlineAccordion {
   background: transparent;
 }
@@ -237,7 +241,7 @@
     --workspace-gap: var(--mantine-spacing-lg);
   }
 
-  .outlineRail {
+  .outlineContent {
     padding: var(--mantine-spacing-md);
   }
 
@@ -275,7 +279,7 @@
     min-width: calc(51.5rem + var(--workspace-gap));
   }
 
-  .outlineRail {
+  .outlineContent {
     padding: var(--mantine-spacing-sm);
   }
 

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
@@ -457,6 +457,7 @@ function RulebookEditorPage() {
                 />
               </Box>
             </div>
+            <div className={styles.stickyRunway} aria-hidden="true" />
           </section>
         ) : (
           <Alert color="yellow" role="status" title="No page selected">

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
@@ -1,26 +1,13 @@
-import {
-  Alert,
-  Badge,
-  Box,
-  Button,
-  Group,
-  ScrollArea,
-  SegmentedControl,
-  Stack,
-  Text,
-  Textarea,
-  Title,
-} from '@mantine/core';
+import { Accordion, Alert, Badge, Box, Button, Group, Stack, Text, Textarea, Title } from '@mantine/core';
 import { parseFormattedText } from '@shared/formattedText';
 import type { FormattedTextParseResult } from '@shared/formattedText';
 import type { RulebookBlockDraft, RulebookContentsDraftV1, RulebookPageDraft } from '@shared/rulebooks/contents';
 import { createFileRoute } from '@tanstack/react-router';
-import { PageTitle } from '@ui/block/PageTitle';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { AddAction } from '@ui/control/ListLengthActions';
 import { PageLayout } from '@ui/layout/PageLayout';
-import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
 import { Surface } from '@ui/surface';
+import { Toolbar } from '@ui/surface/Toolbar';
 import { BookOpenText, Minus } from 'lucide-react';
 import { Fragment, useState } from 'react';
 import type { ReactNode } from 'react';
@@ -35,7 +22,6 @@ type PreviewFit = 'height' | 'width';
 type ReadyResult = Extract<RulebookEditorResult, { status: 'ready' }>;
 type FormattedBlock = FormattedTextParseResult['blocks'][number];
 type FormattedInline = Extract<FormattedBlock, { kind: 'paragraph' }>['children'][number];
-
 export const Route = createFileRoute('/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit')({
   component: RulebookEditorPage,
 });
@@ -275,6 +261,94 @@ function PageTextEditors({
   );
 }
 
+type ConceptProps = {
+  page: RulebookPageDraft;
+  pageId: string;
+  pageNumber: number;
+  result: ReadyResult;
+  dispatch: RulebookEditorStateManager['dispatch'];
+  mode: EditorMode;
+  fit: PreviewFit;
+  setMode: (mode: EditorMode) => void;
+  selectPage: (pageId: string) => void;
+};
+
+function PageOutline({ result, pageId, selectPage }: Pick<ConceptProps, 'result' | 'pageId' | 'selectPage'>) {
+  return (
+    <Stack component="nav" aria-label="Rulebook pages" gap="xs">
+      <Text size="xs" fw={700} tt="uppercase" c="dimmed" className={styles.sectionLabel}>
+        Contents
+      </Text>
+      {result.draft.pageOrder.map((candidateId, index) => {
+        const candidate = result.draft.pagesById[candidateId];
+        return candidate ? (
+          <Button
+            key={candidateId}
+            className={styles.pageChoice}
+            variant={candidateId === pageId ? 'light' : 'subtle'}
+            color="gray"
+            justify="space-between"
+            aria-current={candidateId === pageId ? 'page' : undefined}
+            onClick={() => selectPage(candidateId)}
+          >
+            <span className={styles.pageChoiceNumber}>{String(index + 1).padStart(2, '0')}</span>
+            <span className={styles.pageChoiceName}>Page {index + 1}</span>
+            <Text component="span" size="xs" inherit opacity={0.62}>
+              <span className={styles.pageChoiceAnchor}>{candidate.anchor}</span>
+            </Text>
+          </Button>
+        ) : null;
+      })}
+    </Stack>
+  );
+}
+
+function PreviewRail({ page, pageNumber, result, fit }: ConceptProps) {
+  return (
+    <section className={styles.previewRail} aria-label="Rulebook page preview">
+      <RulebookPagePreview page={page} pageNumber={pageNumber} draft={result.draft} fit={fit} />
+    </section>
+  );
+}
+
+function OutlineConcept(props: ConceptProps) {
+  return (
+    <div className={styles.workspace} data-fit={props.fit}>
+      <Surface className={styles.outlineRail} padding="lg" as="section" aria-label="Rulebook controls">
+        <Accordion
+          value={props.mode}
+          onChange={(value) => value && props.setMode(value as EditorMode)}
+          className={styles.outlineAccordion}
+        >
+          <Accordion.Item value="navigate">
+            <Accordion.Control>
+              <Text fw={700}>Navigate</Text>
+              <Text size="xs" c="dimmed">
+                Page {props.pageNumber} of {props.result.draft.pageOrder.length}
+              </Text>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <PageOutline result={props.result} pageId={props.pageId} selectPage={props.selectPage} />
+            </Accordion.Panel>
+          </Accordion.Item>
+          <Accordion.Item value="edit">
+            <Accordion.Control>
+              <Text fw={700}>Edit Page {props.pageNumber}</Text>
+              <Text size="xs" c="dimmed">
+                Text and repeated text
+              </Text>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <PageTextEditors page={props.page} result={props.result} dispatch={props.dispatch} />
+            </Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>
+      </Surface>
+      <PreviewRail {...props} />
+    </div>
+  );
+}
+
 function RulebookEditorPage() {
   const { rulesetSlug, rulebookSlug } = Route.useParams();
   const [manager] = useState(() => createRulebookEditorStateManager(createCleanRulebookEditorInput()));
@@ -284,12 +358,13 @@ function RulebookEditorPage() {
   );
   const [mode, setMode] = useState<EditorMode>('navigate');
   const [fit, setFit] = useState<PreviewFit>('height');
-
   if (result.status !== 'ready') {
     return (
       <PageLayout>
-        <PageLayout.Header>
-          <PageTitle eyebrow="Local Rulebook session" title="Rulebook editor unavailable" />
+        <PageLayout.Header size="compact">
+          <Title order={1} size="h3">
+            Rulebook editor unavailable
+          </Title>
         </PageLayout.Header>
         <PageLayout.Content>
           <Alert color="red" role="alert" title="This starter session could not open">
@@ -317,120 +392,78 @@ function RulebookEditorPage() {
 
   return (
     <PageLayout>
-      <PageLayout.Header>
-        <PageTitle eyebrow={`${rulesetSlug} / ${rulebookSlug}`} title={`Edit ${rulebookSlug}`} />
+      <PageLayout.Header size="compact">
+        <Group gap="sm" wrap="nowrap">
+          <BookOpenText size={24} aria-hidden />
+          <div>
+            <Title order={1} size="h3">
+              Rulebook workspace
+            </Title>
+            <Text size="xs" c="dimmed">
+              {rulesetSlug} / {rulebookSlug}
+            </Text>
+          </div>
+        </Group>
       </PageLayout.Header>
       <PageLayout.Toolbar>
-        <Surface padding="sm">
-          <Group justify="space-between" align="center" wrap="wrap">
-            <Group gap="xs">
+        <Toolbar>
+          <Toolbar.Left>
+            <Group gap="xs" wrap="nowrap">
               <Badge variant="light" color={hasLocalChanges ? 'yellow' : 'gray'}>
                 {hasLocalChanges ? 'Local changes' : 'Starter state'}
               </Badge>
-              <Text size="sm" c="dimmed">
-                Preview scale
+              <Text className={styles.desktopStatus} size="xs" c="dimmed">
+                Browser-only starter state. Nothing is loaded from or saved to the database.
+              </Text>
+              <Text className={styles.mobileStatus} size="xs" c="dimmed">
+                Local only.
               </Text>
             </Group>
-            <SegmentedControl
-              aria-label="Preview scale"
-              value={fit}
-              onChange={(value) => setFit(value as PreviewFit)}
-              data={[
-                { value: 'height', label: 'Fit height' },
-                { value: 'width', label: 'Fit width' },
-              ]}
-            />
-          </Group>
-        </Surface>
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Button
+              size="xs"
+              variant="default"
+              aria-label={`Switch preview to fit ${fit === 'height' ? 'width' : 'height'}`}
+              onClick={() => setFit((current) => (current === 'height' ? 'width' : 'height'))}
+            >
+              Fit {fit === 'height' ? 'width' : 'height'}
+            </Button>
+          </Toolbar.Right>
+        </Toolbar>
       </PageLayout.Toolbar>
       <PageLayout.Content>
-        <WorkbenchLayout gap="sm">
-          <Alert
-            icon={<BookOpenText size={18} aria-hidden />}
-            color="blue"
-            variant="light"
-            title="Local editing session"
-          >
-            This page uses the starter Rulebook in this browser tab. It does not load from or save to the database.
-          </Alert>
-          {page ? (
-            <section className={styles.workspaceSticky} data-fit={fit} aria-label="Rulebook editing workspace">
-              <ScrollArea
-                className={styles.workspaceScroller}
-                type="auto"
-                scrollbars="x"
-                viewportProps={{ tabIndex: 0, role: 'region', 'aria-label': 'Editor and preview' }}
+        {page ? (
+          <section className={styles.prototypeRoot} aria-label="Rulebook editing workspace">
+            <div className={styles.workspaceSticky} data-fit={fit} data-mode={mode}>
+              <Box
+                className={styles.workspaceViewport}
+                role="region"
+                aria-label="Rulebook editor and preview"
+                tabIndex={0}
               >
-                <div className={styles.workspace}>
-                  <div className={styles.controlsScroll}>
-                    <Surface padding="lg" as="section" aria-labelledby="rulebook-editor-controls-title">
-                      <Stack gap="lg">
-                        <Group justify="space-between" align="flex-start" wrap="wrap">
-                          <Stack gap={2}>
-                            <Title id="rulebook-editor-controls-title" order={2} size="h4">
-                              {mode === 'navigate' ? 'Choose a page' : `Edit Page ${pageNumber}`}
-                            </Title>
-                            <Text size="sm" c="dimmed">
-                              Page navigation and text editing use separate modes.
-                            </Text>
-                          </Stack>
-                          <SegmentedControl
-                            aria-label="Editor mode"
-                            value={mode}
-                            onChange={(value) => setMode(value as EditorMode)}
-                            data={[
-                              { value: 'navigate', label: 'Choose page' },
-                              { value: 'edit', label: 'Edit page' },
-                            ]}
-                          />
-                        </Group>
-
-                        {mode === 'navigate' ? (
-                          <Stack component="nav" aria-label="Rulebook pages" gap="xs">
-                            {result.draft.pageOrder.map((candidateId, index) => {
-                              const candidate = result.draft.pagesById[candidateId];
-                              return candidate ? (
-                                <Button
-                                  key={candidateId}
-                                  variant={candidateId === pageId ? 'filled' : 'light'}
-                                  justify="space-between"
-                                  aria-current={candidateId === pageId ? 'page' : undefined}
-                                  onClick={() => {
-                                    setActivePageId(candidateId);
-                                    setMode('edit');
-                                  }}
-                                >
-                                  <span>Page {index + 1}</span>
-                                  <Text component="span" size="xs" inherit opacity={0.7}>
-                                    {candidate.anchor}
-                                  </Text>
-                                </Button>
-                              ) : null;
-                            })}
-                          </Stack>
-                        ) : (
-                          <PageTextEditors page={page} result={result} dispatch={dispatch} />
-                        )}
-                      </Stack>
-                    </Surface>
-                  </div>
-                  <ScrollArea
-                    className={styles.previewRail}
-                    type="auto"
-                    scrollbars="y"
-                    viewportProps={{ tabIndex: 0, role: 'region', 'aria-label': 'Rulebook page preview' }}
-                  >
-                    <RulebookPagePreview page={page} pageNumber={pageNumber} draft={result.draft} fit={fit} />
-                  </ScrollArea>
-                </div>
-              </ScrollArea>
-            </section>
-          ) : (
-            <Alert color="yellow" role="status" title="No page selected">
-              The local starter session has no Page to edit.
-            </Alert>
-          )}
-        </WorkbenchLayout>
+                <OutlineConcept
+                  page={page}
+                  pageId={pageId}
+                  pageNumber={pageNumber}
+                  result={result}
+                  dispatch={dispatch}
+                  mode={mode}
+                  fit={fit}
+                  setMode={setMode}
+                  selectPage={(candidateId) => {
+                    setActivePageId(candidateId);
+                    setMode('edit');
+                  }}
+                />
+              </Box>
+            </div>
+          </section>
+        ) : (
+          <Alert color="yellow" role="status" title="No page selected">
+            The local starter session has no Page to edit.
+          </Alert>
+        )}
       </PageLayout.Content>
     </PageLayout>
   );

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
@@ -1,8 +1,9 @@
-import { Accordion, Alert, Badge, Box, Button, Group, Stack, Text, Textarea, Title } from '@mantine/core';
+import { Accordion, Alert, Badge, Box, Button, Group, Stack, Text, Textarea } from '@mantine/core';
 import { parseFormattedText } from '@shared/formattedText';
 import type { FormattedTextParseResult } from '@shared/formattedText';
 import type { RulebookBlockDraft, RulebookContentsDraftV1, RulebookPageDraft } from '@shared/rulebooks/contents';
 import { createFileRoute } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { AddAction } from '@ui/control/ListLengthActions';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -261,7 +262,7 @@ function PageTextEditors({
   );
 }
 
-type ConceptProps = {
+type RulebookWorkspaceProps = {
   page: RulebookPageDraft;
   pageId: string;
   pageNumber: number;
@@ -273,7 +274,7 @@ type ConceptProps = {
   selectPage: (pageId: string) => void;
 };
 
-function PageOutline({ result, pageId, selectPage }: Pick<ConceptProps, 'result' | 'pageId' | 'selectPage'>) {
+function PageOutline({ result, pageId, selectPage }: Pick<RulebookWorkspaceProps, 'result' | 'pageId' | 'selectPage'>) {
   return (
     <Stack component="nav" aria-label="Rulebook pages" gap="xs">
       <Text size="xs" fw={700} tt="uppercase" c="dimmed" className={styles.sectionLabel}>
@@ -303,7 +304,7 @@ function PageOutline({ result, pageId, selectPage }: Pick<ConceptProps, 'result'
   );
 }
 
-function PreviewRail({ page, pageNumber, result, fit }: ConceptProps) {
+function PreviewRail({ page, pageNumber, result, fit }: RulebookWorkspaceProps) {
   return (
     <section className={styles.previewRail} aria-label="Rulebook page preview">
       <RulebookPagePreview page={page} pageNumber={pageNumber} draft={result.draft} fit={fit} />
@@ -311,38 +312,40 @@ function PreviewRail({ page, pageNumber, result, fit }: ConceptProps) {
   );
 }
 
-function OutlineConcept(props: ConceptProps) {
+function RulebookWorkspace(props: RulebookWorkspaceProps) {
   return (
     <div className={styles.workspace} data-fit={props.fit}>
-      <Surface className={styles.outlineRail} padding="lg" as="section" aria-label="Rulebook controls">
-        <Accordion
-          value={props.mode}
-          onChange={(value) => value && props.setMode(value as EditorMode)}
-          className={styles.outlineAccordion}
-        >
-          <Accordion.Item value="navigate">
-            <Accordion.Control>
-              <Text fw={700}>Navigate</Text>
-              <Text size="xs" c="dimmed">
-                Page {props.pageNumber} of {props.result.draft.pageOrder.length}
-              </Text>
-            </Accordion.Control>
-            <Accordion.Panel>
-              <PageOutline result={props.result} pageId={props.pageId} selectPage={props.selectPage} />
-            </Accordion.Panel>
-          </Accordion.Item>
-          <Accordion.Item value="edit">
-            <Accordion.Control>
-              <Text fw={700}>Edit Page {props.pageNumber}</Text>
-              <Text size="xs" c="dimmed">
-                Text and repeated text
-              </Text>
-            </Accordion.Control>
-            <Accordion.Panel>
-              <PageTextEditors page={props.page} result={props.result} dispatch={props.dispatch} />
-            </Accordion.Panel>
-          </Accordion.Item>
-        </Accordion>
+      <Surface className={styles.outlineRail} padding="none" as="section" aria-label="Rulebook controls">
+        <div className={styles.outlineContent}>
+          <Accordion
+            value={props.mode}
+            onChange={(value) => value && props.setMode(value as EditorMode)}
+            className={styles.outlineAccordion}
+          >
+            <Accordion.Item value="navigate">
+              <Accordion.Control>
+                <Text fw={700}>Navigate</Text>
+                <Text size="xs" c="dimmed">
+                  Page {props.pageNumber} of {props.result.draft.pageOrder.length}
+                </Text>
+              </Accordion.Control>
+              <Accordion.Panel>
+                <PageOutline result={props.result} pageId={props.pageId} selectPage={props.selectPage} />
+              </Accordion.Panel>
+            </Accordion.Item>
+            <Accordion.Item value="edit">
+              <Accordion.Control>
+                <Text fw={700}>Edit Page {props.pageNumber}</Text>
+                <Text size="xs" c="dimmed">
+                  Text and repeated text
+                </Text>
+              </Accordion.Control>
+              <Accordion.Panel>
+                <PageTextEditors page={props.page} result={props.result} dispatch={props.dispatch} />
+              </Accordion.Panel>
+            </Accordion.Item>
+          </Accordion>
+        </div>
       </Surface>
       <PreviewRail {...props} />
     </div>
@@ -362,9 +365,7 @@ function RulebookEditorPage() {
     return (
       <PageLayout>
         <PageLayout.Header size="compact">
-          <Title order={1} size="h3">
-            Rulebook editor unavailable
-          </Title>
+          <PageTitle title="Rulebook editor unavailable" />
         </PageLayout.Header>
         <PageLayout.Content>
           <Alert color="red" role="alert" title="This starter session could not open">
@@ -396,9 +397,7 @@ function RulebookEditorPage() {
         <Group gap="sm" wrap="nowrap">
           <BookOpenText size={24} aria-hidden />
           <div>
-            <Title order={1} size="h3">
-              Rulebook workspace
-            </Title>
+            <PageTitle title="Rulebook workspace" />
             <Text size="xs" c="dimmed">
               {rulesetSlug} / {rulebookSlug}
             </Text>
@@ -442,7 +441,7 @@ function RulebookEditorPage() {
                 aria-label="Rulebook editor and preview"
                 tabIndex={0}
               >
-                <OutlineConcept
+                <RulebookWorkspace
                   page={page}
                   pageId={pageId}
                   pageNumber={pageNumber}

--- a/src/app/ui/control/Accordion.stories.tsx
+++ b/src/app/ui/control/Accordion.stories.tsx
@@ -1,0 +1,22 @@
+import { Accordion } from '@mantine/core';
+import preview from '@sb/preview';
+
+const meta = preview.meta({
+  component: Accordion,
+  parameters: { layout: 'centered' },
+});
+
+export const Default = meta.story({
+  render: () => (
+    <Accordion defaultValue="first" w={320}>
+      <Accordion.Item value="first">
+        <Accordion.Control>First section</Accordion.Control>
+        <Accordion.Panel>Content for the first section.</Accordion.Panel>
+      </Accordion.Item>
+      <Accordion.Item value="second">
+        <Accordion.Control>Second section</Accordion.Control>
+        <Accordion.Panel>Content for the second section.</Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>
+  ),
+});


### PR DESCRIPTION
Closes #687.

## What changed

- applies the accepted Outline dock workspace from prototype `2b2671519ecbef46a7560a7177097c2e3939df8e`
- keeps fixed A4 rendering, body-owned vertical scrolling, mobile-only workspace overflow, and the compact fit toggle
- preserves hold-to-remove repeated items, literal invalid formatted text, current Contents/editor-state behavior, and anonymous browser-test storage
- aligns the focused Rulebook browser confidence anchor with the accepted workspace

## Validation

- focused editor-state tests: 64 passed
- full unit suite: 720 passed
- focused Docker-backed Rulebook E2E: 5 passed, including the required animation dependency
- full Docker-backed E2E: 13 passed
- typecheck, lint, format, Knip, app-layout, CSS-orphan, prose, app build, and publisher release verification passed
