### PR TITLE
ConnectedTabs drops two dead props and its story stops inventing a type

### DIFF
--- a/src/app/ui/surface/ConnectedTabs.stories.tsx
+++ b/src/app/ui/surface/ConnectedTabs.stories.tsx
@@ -2,7 +2,6 @@ import { Box } from '@mantine/core';
 import preview from '@sb/preview';
 import { BookOpen, CircleUserRound, Settings } from 'lucide-react';
 import { useState } from 'react';
-import type { ComponentType, CSSProperties } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { ConnectedTabs } from './ConnectedTabs';
@@ -12,14 +11,11 @@ import { SurfaceFiller } from './SurfaceFiller.stories.fixture';
 
 type ExampleTab = 'overview' | 'people' | 'settings';
 
-interface ConnectedTabsStoryArgs {
-  value?: ExampleTab;
-  onValueChange?: (value: ExampleTab) => void;
-  items?: ConnectedTabsProps<ExampleTab>['items'];
-  ariaLabel?: string;
-  className?: string;
-  panelClassName?: string;
-  style?: CSSProperties;
+/**
+ * What the example panels are made of.
+ * These are the story's own knobs, not props: the component takes finished panels, so a story that wants taller ones builds taller ones rather than asking the component for them.
+ */
+interface ExamplePanels {
   contentHeight?: number;
   animateDimensions?: boolean;
   showPanelTitle?: boolean;
@@ -51,14 +47,11 @@ function Panel({
   );
 }
 
-function createItems({
+function examplePanels({
   contentHeight,
   animateDimensions,
   showPanelTitle,
-}: Pick<
-  ConnectedTabsStoryArgs,
-  'contentHeight' | 'animateDimensions' | 'showPanelTitle'
->): ConnectedTabsProps<ExampleTab>['items'] {
+}: ExamplePanels = {}): ConnectedTabsProps<ExampleTab>['items'] {
   const resolvedContentHeight = contentHeight ?? 180;
   const resolvedAnimateDimensions = animateDimensions ?? false;
   const resolvedShowPanelTitle = showPanelTitle ?? true;
@@ -105,51 +98,20 @@ function createItems({
   ];
 }
 
-function renderConnectedTabs({
-  contentHeight,
-  animateDimensions,
-  showPanelTitle,
-  value = 'overview',
-  onValueChange = () => {},
-  items: _storyItems,
-  ariaLabel = 'Workbench sections',
-  ...optionalTabsProps
-}: ConnectedTabsStoryArgs) {
-  return (
-    <ConnectedTabs
-      {...optionalTabsProps}
-      value={value}
-      onValueChange={onValueChange}
-      ariaLabel={ariaLabel}
-      items={createItems({ contentHeight, animateDimensions, showPanelTitle })}
-    />
-  );
-}
-
 const meta = preview.meta({
   title: 'Connected Tabs',
-  component: ConnectedTabs as ComponentType<ConnectedTabsStoryArgs>,
-  render: renderConnectedTabs,
+  component: ConnectedTabs,
   args: {
     value: 'overview',
     onValueChange: () => {},
     ariaLabel: 'Workbench sections',
-    contentHeight: 180,
-    animateDimensions: false,
-    showPanelTitle: true,
+    items: examplePanels(),
   },
   argTypes: {
     value: { control: false, table: { disable: true } },
     onValueChange: { control: false, table: { disable: true } },
     items: { control: false, table: { disable: true } },
     ariaLabel: { control: false, table: { disable: true } },
-    contentHeight: {
-      name: 'Content height',
-      description: 'Selected-panel content height in pixels.',
-      control: { type: 'range', min: 40, max: 800, step: 20 },
-    },
-    animateDimensions: { control: false, table: { disable: true } },
-    showPanelTitle: { control: false, table: { disable: true } },
   },
   parameters: {
     layout: 'fullscreen',
@@ -200,7 +162,7 @@ export const FinalActive = meta.story({
 export const ContentDrivenHeight = meta.story({
   args: {
     value: 'overview',
-    contentHeight: 720,
+    items: examplePanels({ contentHeight: 720 }),
   },
   parameters: {
     docs: {
@@ -214,14 +176,13 @@ export const ContentDrivenHeight = meta.story({
 export const ResizeDrivenGeometry = meta.story({
   args: {
     value: 'people',
-    contentHeight: 320,
-    animateDimensions: true,
+    items: examplePanels({ contentHeight: 320, animateDimensions: true }),
   },
   parameters: {
     docs: {
       description: {
         story:
-          'Resize the Storybook canvas with the Viewport toolbar, browser window, or sidebar; use the Content height control for the other axis. Width always follows the canvas, while height is the greater of the left tab rail and selected-panel content. The SVG contour and clipped glass surface follow every intermediate size.',
+          'Resize the Storybook canvas with the Viewport toolbar, browser window, or sidebar. Width always follows the canvas, while height is the greater of the left tab rail and selected-panel content. The SVG contour and clipped glass surface follow every intermediate size.',
       },
     },
   },
@@ -230,8 +191,7 @@ export const ResizeDrivenGeometry = meta.story({
 export const MobileViewport = meta.story({
   args: {
     value: 'overview',
-    contentHeight: 180,
-    showPanelTitle: false,
+    items: examplePanels({ showPanelTitle: false }),
   },
   globals: {
     viewport: {
@@ -292,7 +252,7 @@ export const OverflowPreserved = meta.story({
   args: { value: 'people' },
   render: (args) => (
     <Box p="xl">
-      {renderConnectedTabs(args)}
+      <ConnectedTabs {...args} />
       <Box data-testid="overflow-marker" w={48} h={48} ml={540} mt={-80} bg="dune.7" />
     </Box>
   ),

--- a/src/app/ui/surface/ConnectedTabs.tsx
+++ b/src/app/ui/surface/ConnectedTabs.tsx
@@ -3,7 +3,7 @@ import * as Tabs from '@radix-ui/react-tabs';
 import clsx from 'clsx';
 import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useId, useLayoutEffect, useRef, useState } from 'react';
-import type { CSSProperties, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 import styles from './ConnectedTabs.module.css';
 import { PaintedSurfaceBoundary } from './Surface';
@@ -35,8 +35,6 @@ export interface ConnectedTabsProps<Value extends string> {
   items: readonly ConnectedTabsItem<Value>[];
   ariaLabel: string;
   className?: string;
-  panelClassName?: string;
-  style?: CSSProperties;
 }
 
 interface ConnectedTabsGeometry {
@@ -289,8 +287,6 @@ export function ConnectedTabs<Value extends string>({
   items,
   ariaLabel,
   className,
-  panelClassName,
-  style,
 }: ConnectedTabsProps<Value>) {
   const rootRef = useRef<HTMLDivElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -300,7 +296,7 @@ export function ConnectedTabs<Value extends string>({
   const selectAdjacent = (direction: -1 | 1) => onValueChange(findAdjacentEnabledValue({ value, items, direction }));
 
   return (
-    <div className={clsx(styles.host, className)} style={style}>
+    <div className={clsx(styles.host, className)}>
       <Tabs.Root
         ref={rootRef}
         className={styles.root}
@@ -381,7 +377,7 @@ export function ConnectedTabs<Value extends string>({
             </Tabs.Trigger>
           ))}
         </Tabs.List>
-        <div ref={panelRef} className={clsx(styles.panelShell, panelClassName)}>
+        <div ref={panelRef} className={styles.panelShell}>
           {items.map((item) => (
             <Tabs.Content className={styles.panel} key={item.value} value={item.value}>
               {/* The SVG glass paints this panel as a pane, so the nesting guard


### PR DESCRIPTION
Closes the `ConnectedTabs` item on [#629](https://github.com/ndelangen/dunezone/issues/629). **Based on `main`, not stacked.** Net **44 lines removed**.

#629 wanted this split three ways: receiver, producer and control. I proposed against it after reading the component, its 395-line stylesheet, all seven call sites, and its story and test. Norbert's call was **no split, repair in place**.

## Why the three-way claim does not hold

**The producer leg is wrong.** It rests on `label: string` being rendered as text (`ConnectedTabs.tsx:13`, rendered `:329`, `:348`, `:379`). By that test half of `ui/control` is misfiled: `PreviewChoice` takes per-option captions, renders them, and is filed as a Control. So is `Select`. An option's name is not produced content.

**Receiver and control are both real, and a split does not remove the overlap.** Radix forces a compound shape (`Tabs.List` and `Tabs.Content` both read `Tabs.Root` context), and a compound root still takes `value`/`onValueChange` and still receives panels. Both tells fire on the composite exactly as they do today.

**It would also make a rule *more* false.** The geometry finds the active trigger through a private DOM handshake: `root.querySelector('[data-connected-tab][data-state="active"]')` at `:157`, against a stamp at `:371`. Split across components, that has to become published API — slotted rail content must carry those attributes so the pane can find its notch. "Layouts and Surfaces know nothing about their contents" goes from private-to-one-file to false-by-declaration.

The full analysis, including the one clean seam (the compact mobile picker) and why it is a move rather than a fix, is in the proposal I sent Norbert.

## What this PR does

**Deletes two dead props.** `panelClassName` and `style`. Verified by grep across every call site: `panelClassName` appears nowhere in `src` except the component and the story's invented args type, and **zero** callers pass `style`. The membrane drops from seven props to five, three of which are the ordinary tab contract.

**The story stops describing a component that does not exist.** It cast `ConnectedTabs` to an invented args type because `items` is required while the story built items from three knobs (`contentHeight`, `animateDimensions`, `showPanelTitle`) that are not props at all.

Those knobs were never props. They are what the example panels are *made of*. So a helper builds panels and `args` pass them, which is exactly what the sibling `SectionedSurface.stories.tsx` already does. The cast then becomes unnecessary rather than merely unwanted, and the generic types itself by inference from args, the way `PreviewChoice.stories.tsx` already does with the repo's only other generic component.

**No cast, no `render`, no invented type.**

## What is lost, said plainly

The **Content height** range control. A knob that rebuilds panels per keystroke needs a render function, which is what the invented args type existed to serve. The width axis, which is the one that redraws the contour continuously, still works from the viewport toolbar, and `ResizeDrivenGeometry`'s description no longer points at a control that is gone.

If the live height demo is worth keeping, the shape is a per-story `render` over a `.stories.fixture.tsx` component owning the slider. `OverflowPreserved` already has a per-story render and needs no cast, so that route stays open.

## Verified

Every story rendered, not just executed: `ContentDrivenHeight` builds its 720px panels from args and measures a 760px panel with the contour and glass surface intact.

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 720 unit tests, 351 storybook tests. The storybook suite runs every play function, including the mobile picker's stepper interaction.
