### PR TITLE
The settle handler moves off the layout and onto the editors that own the idiom

### DIFF
--- a/src/app/ui/layout/WorkbenchLayout.tsx
+++ b/src/app/ui/layout/WorkbenchLayout.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import { Children, isValidElement } from 'react';
-import type { FocusEventHandler, PropsWithChildren, ReactNode } from 'react';
+import type { PropsWithChildren, ReactNode } from 'react';
 
 import styles from './WorkbenchLayout.module.css';
 
@@ -18,12 +18,8 @@ function Rail(_: PropsWithChildren): null {
  * The space at the narrow steps comes from whatever the chapters column holds giving width back, and then from the rail itself becoming a thumbnail.
  * Its desk stretches children to the rail's width, so a proof fills the rail rather than shrinking to content.
  * The desk holds however many artifacts an editor stacks, and the count may change while mounted: a token draws two faces and loses one when its backside becomes a reference.
- * The blur handler rides the grid because settling a draft when focus leaves the form is the editors' shared idiom.
  */
-function Workbench({
-  children,
-  onBlurCapture,
-}: PropsWithChildren<{ onBlurCapture?: FocusEventHandler<HTMLDivElement> }>) {
+function Workbench({ children }: PropsWithChildren) {
   let chapters: ReactNode = null;
   let rail: ReactNode = null;
 
@@ -42,7 +38,7 @@ function Workbench({
 
   return (
     <div className={styles.region}>
-      <div className={styles.workbench} onBlurCapture={onBlurCapture}>
+      <div className={styles.workbench}>
         <div className={styles.chapters}>{chapters}</div>
         <div className={styles.rail}>
           <div className={styles.desk}>{rail}</div>

--- a/src/app/widgets/bundle-editor/BundleEditor.tsx
+++ b/src/app/widgets/bundle-editor/BundleEditor.tsx
@@ -148,113 +148,116 @@ export function BundleEditor({
   const totalTokens = members.reduce((sum, member) => sum + member.count, 0);
 
   return (
-    <WorkbenchLayout.Workbench onBlurCapture={onSettle}>
+    <WorkbenchLayout.Workbench>
       <WorkbenchLayout.Chapters>
-        <ConnectedTabs<BundleChapter>
-          value={chapter}
-          onValueChange={(next) => {
-            onChapterChange(next);
-            onSettle();
-          }}
-          ariaLabel="Bundle chapters"
-          items={[
-            {
-              value: 'identity',
-              label: 'Identity',
-              icon: <TopicIcon topic="identity" size={21} />,
-              panel: panel(
-                <>
-                  <ControlBlock title="Name" description="Determines the bundle's URL." input={nameField} />
-                  <ControlBlock
-                    title="Band"
-                    description="A bundle has no face of its own, so this is what tells it apart. Stock or authored; nothing about the choice is stored either way."
-                    input={
-                      <Select
-                        aria-label="Band"
-                        allowDeselect={false}
-                        data={[
-                          ...STOCK_BANDS.map((stock) => ({ value: stock.key, label: `${stock.label} band` })),
-                          { value: CUSTOM, label: 'Custom…' },
-                        ]}
-                        value={selected}
-                        onChange={(next) => {
-                          if (next === CUSTOM) {
-                            /* Custom keeps the current composition and reveals the fields below. */
-                            setCustomChosen(true);
-                            return;
-                          }
-                          const stock = STOCK_BANDS.find((candidate) => candidate.key === next);
-                          if (stock) {
-                            setCustomChosen(false);
-                            patch({ band: stock.band });
-                          }
-                        }}
-                      />
-                    }
-                  />
-                  {selected === CUSTOM ? <BandFields band={draft.band} onChange={(band) => patch({ band })} /> : null}
-                </>
-              ),
-            },
-            {
-              value: 'tokens',
-              label: 'Tokens',
-              icon: <TopicIcon topic="contents" size={21} />,
-              panel: panel(
-                <>
-                  <ControlBlock
-                    title="Contents"
-                    description="Which tokens this bundle holds, and how many of each, from any community token whoever made it. Shapes may be mixed freely."
-                    tool={tokenPicker}
-                    input={
-                      members.length === 0 ? (
-                        <Text size="sm" c="dimmed">
-                          No tokens yet.
-                        </Text>
-                      ) : (
-                        <Stack gap="xs">
-                          {members.map((member) => (
-                            <Group key={member.token.id} gap="sm" wrap="nowrap" align="center">
-                              <AssetFace
-                                type={member.token.type}
-                                data={member.token.data}
-                                name={member.token.name}
-                                width={34}
-                              />
-                              <Text size="sm" style={{ flex: 1, minWidth: 0 }}>
-                                {member.token.name}
-                              </Text>
-                              <MemberCountInput
-                                label={`How many ${member.token.name}`}
-                                min={1}
-                                max={99}
-                                disabled={onCountChange === null}
-                                value={member.count}
-                                onCommit={(count) => onCountChange?.(member.token.id, count)}
-                              />
-                              {/* Removal is held, not clicked: the row vanishing on a stray click was the last unguarded deletion (Norbert, 2026-08-21). */}
-                              <ConfirmDeleteAction
-                                label={`Remove ${member.token.name}`}
-                                verb="remove"
-                                pending={countPending && removingId === member.token.id}
-                                disabled={onCountChange === null}
-                                onConfirm={() => {
-                                  setRemovingId(member.token.id);
-                                  onCountChange?.(member.token.id, 0);
-                                }}
-                              />
-                            </Group>
-                          ))}
-                        </Stack>
-                      )
-                    }
-                  />
-                </>
-              ),
-            },
-            aboutChapter(draft.about, (about) => patch({ about })),
-          ]}
-        />
+        {/* Settling on focus leaving the fields is the editors' idiom, not the layout's, so it rides an element this widget owns. */}
+        <div onBlurCapture={onSettle}>
+          <ConnectedTabs<BundleChapter>
+            value={chapter}
+            onValueChange={(next) => {
+              onChapterChange(next);
+              onSettle();
+            }}
+            ariaLabel="Bundle chapters"
+            items={[
+              {
+                value: 'identity',
+                label: 'Identity',
+                icon: <TopicIcon topic="identity" size={21} />,
+                panel: panel(
+                  <>
+                    <ControlBlock title="Name" description="Determines the bundle's URL." input={nameField} />
+                    <ControlBlock
+                      title="Band"
+                      description="A bundle has no face of its own, so this is what tells it apart. Stock or authored; nothing about the choice is stored either way."
+                      input={
+                        <Select
+                          aria-label="Band"
+                          allowDeselect={false}
+                          data={[
+                            ...STOCK_BANDS.map((stock) => ({ value: stock.key, label: `${stock.label} band` })),
+                            { value: CUSTOM, label: 'Custom…' },
+                          ]}
+                          value={selected}
+                          onChange={(next) => {
+                            if (next === CUSTOM) {
+                              /* Custom keeps the current composition and reveals the fields below. */
+                              setCustomChosen(true);
+                              return;
+                            }
+                            const stock = STOCK_BANDS.find((candidate) => candidate.key === next);
+                            if (stock) {
+                              setCustomChosen(false);
+                              patch({ band: stock.band });
+                            }
+                          }}
+                        />
+                      }
+                    />
+                    {selected === CUSTOM ? <BandFields band={draft.band} onChange={(band) => patch({ band })} /> : null}
+                  </>
+                ),
+              },
+              {
+                value: 'tokens',
+                label: 'Tokens',
+                icon: <TopicIcon topic="contents" size={21} />,
+                panel: panel(
+                  <>
+                    <ControlBlock
+                      title="Contents"
+                      description="Which tokens this bundle holds, and how many of each, from any community token whoever made it. Shapes may be mixed freely."
+                      tool={tokenPicker}
+                      input={
+                        members.length === 0 ? (
+                          <Text size="sm" c="dimmed">
+                            No tokens yet.
+                          </Text>
+                        ) : (
+                          <Stack gap="xs">
+                            {members.map((member) => (
+                              <Group key={member.token.id} gap="sm" wrap="nowrap" align="center">
+                                <AssetFace
+                                  type={member.token.type}
+                                  data={member.token.data}
+                                  name={member.token.name}
+                                  width={34}
+                                />
+                                <Text size="sm" style={{ flex: 1, minWidth: 0 }}>
+                                  {member.token.name}
+                                </Text>
+                                <MemberCountInput
+                                  label={`How many ${member.token.name}`}
+                                  min={1}
+                                  max={99}
+                                  disabled={onCountChange === null}
+                                  value={member.count}
+                                  onCommit={(count) => onCountChange?.(member.token.id, count)}
+                                />
+                                {/* Removal is held, not clicked: the row vanishing on a stray click was the last unguarded deletion (Norbert, 2026-08-21). */}
+                                <ConfirmDeleteAction
+                                  label={`Remove ${member.token.name}`}
+                                  verb="remove"
+                                  pending={countPending && removingId === member.token.id}
+                                  disabled={onCountChange === null}
+                                  onConfirm={() => {
+                                    setRemovingId(member.token.id);
+                                    onCountChange?.(member.token.id, 0);
+                                  }}
+                                />
+                              </Group>
+                            ))}
+                          </Stack>
+                        )
+                      }
+                    />
+                  </>
+                ),
+              },
+              aboutChapter(draft.about, (about) => patch({ about })),
+            ]}
+          />
+        </div>
       </WorkbenchLayout.Chapters>
       <WorkbenchLayout.Rail>
         <Stack gap="md" align="center">

--- a/src/app/widgets/card-editor/TreacheryCardEditor.tsx
+++ b/src/app/widgets/card-editor/TreacheryCardEditor.tsx
@@ -426,43 +426,46 @@ export function TreacheryCardEditor({
   onSettle: () => void;
 }) {
   return (
-    <WorkbenchLayout.Workbench onBlurCapture={onSettle}>
+    <WorkbenchLayout.Workbench>
       <WorkbenchLayout.Chapters>
-        <ConnectedTabs<TreacheryChapter>
-          value={chapter}
-          onValueChange={(next) => {
-            onChapterChange(next);
-            onSettle();
-          }}
-          ariaLabel="Card chapters"
-          items={[
-            {
-              value: 'head',
-              label: 'Head',
-              icon: <TopicIcon topic="text" size={21} />,
-              panel: panel(<HeadFields draft={draft} patch={patch} nameField={nameField} />),
-            },
-            {
-              value: 'icon',
-              label: 'Symbol',
-              icon: <Stamp size={21} aria-hidden />,
-              panel: panel(<IconFields draft={draft} patch={patch} />),
-            },
-            {
-              value: 'decals',
-              label: 'Decals',
-              icon: <TopicIcon topic="decals" size={21} />,
-              panel: panel(<DecalFields draft={draft} patch={patch} />),
-            },
-            {
-              value: 'body',
-              label: 'Body',
-              icon: <ScrollText size={21} aria-hidden />,
-              panel: panel(<BodyField draft={draft} patch={patch} />),
-            },
-            aboutChapter(draft.about, (about) => patch({ about })),
-          ]}
-        />
+        {/* Settling on focus leaving the fields is the editors' idiom, not the layout's, so it rides an element this widget owns. */}
+        <div onBlurCapture={onSettle}>
+          <ConnectedTabs<TreacheryChapter>
+            value={chapter}
+            onValueChange={(next) => {
+              onChapterChange(next);
+              onSettle();
+            }}
+            ariaLabel="Card chapters"
+            items={[
+              {
+                value: 'head',
+                label: 'Head',
+                icon: <TopicIcon topic="text" size={21} />,
+                panel: panel(<HeadFields draft={draft} patch={patch} nameField={nameField} />),
+              },
+              {
+                value: 'icon',
+                label: 'Symbol',
+                icon: <Stamp size={21} aria-hidden />,
+                panel: panel(<IconFields draft={draft} patch={patch} />),
+              },
+              {
+                value: 'decals',
+                label: 'Decals',
+                icon: <TopicIcon topic="decals" size={21} />,
+                panel: panel(<DecalFields draft={draft} patch={patch} />),
+              },
+              {
+                value: 'body',
+                label: 'Body',
+                icon: <ScrollText size={21} aria-hidden />,
+                panel: panel(<BodyField draft={draft} patch={patch} />),
+              },
+              aboutChapter(draft.about, (about) => patch({ about })),
+            ]}
+          />
+        </div>
       </WorkbenchLayout.Chapters>
       <WorkbenchLayout.Rail>
         <FillCard draft={draft} />

--- a/src/app/widgets/deck-editor/DeckEditor.tsx
+++ b/src/app/widgets/deck-editor/DeckEditor.tsx
@@ -307,156 +307,159 @@ export function DeckEditor({
   const totalCards = members.reduce((sum, member) => sum + member.count, 0);
 
   return (
-    <WorkbenchLayout.Workbench onBlurCapture={onSettle}>
+    <WorkbenchLayout.Workbench>
       <WorkbenchLayout.Chapters>
-        <ConnectedTabs<DeckChapter>
-          value={chapter}
-          onValueChange={(next) => {
-            onChapterChange(next);
-            onSettle();
-          }}
-          ariaLabel="Deck chapters"
-          items={[
-            {
-              value: 'identity',
-              label: 'Identity',
-              icon: <TopicIcon topic="identity" size={21} />,
-              panel: panel(
-                <>
-                  <ControlBlock title="Name" description="Determines the deck's URL." input={nameField} />
-                  <ControlBlock
-                    title="Card back"
-                    description="Every deck wears exactly one. The deck publishes its own image either way, so a stock back only supplies the artwork."
-                    input={
-                      <PreviewChoice
-                        label="Card back"
-                        value={tileFor(draft.cardback, stockKey, customChosen)}
-                        aspectRatio={String(1 / assetFaceAspect('deck'))}
-                        onChange={(tile) => {
-                          setCustomChosen(tile === CUSTOM);
-                          /* Captured on the way out, so returning to Composed finds the composition as it was left. */
-                          if (composition) {
-                            composedCardback.current = composition;
-                          }
-                          const next = cardbackForTile(tile, draft.cardback, stockKey, composedCardback.current);
-                          if (next) {
-                            patch({ cardback: next });
-                          }
-                        }}
-                        options={[
-                          {
-                            value: 'stock',
-                            label: 'Stock',
-                            /* Always drawable: the stock look this deck wears, or the first standing in. */
-                            preview: <CardbackProof cardback={stockPreview} width={PROOF_CANVAS} />,
-                            canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('deck') },
-                            detail: (
-                              <Select
-                                aria-label="Which stock back"
-                                size="xs"
-                                allowDeselect={false}
-                                data={STOCK_CARDBACKS.map((stock) => ({ value: stock.key, label: stock.label }))}
-                                value={stockKey ?? STOCK_CARDBACKS[0]!.key}
-                                onChange={(next) => {
-                                  const stock = STOCK_CARDBACKS.find((candidate) => candidate.key === next);
-                                  if (stock) {
-                                    patch({ cardback: { mode: 'custom', ...stock.cardback } });
-                                  }
-                                }}
-                              />
-                            ),
-                          },
-                          {
-                            value: CUSTOM,
-                            label: 'Composed here',
-                            /* Always drawable, the stock tile's own rule: the live composition, the one the author left behind, or the first stock look standing in. Never a dashed nothing (Norbert, 2026-08-21). */
-                            preview: (
-                              <CardbackProof
-                                cardback={composition ?? composedCardback.current ?? STOCK_CARDBACKS[0]!.cardback}
-                                width={PROOF_CANVAS}
-                              />
-                            ),
-                            canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('deck') },
-                          },
-                          {
-                            value: 'reference',
-                            label: "Another deck's back",
-                            preview: backProof ?? undefined,
-                            emptyHint: <Text size="xs">No deck chosen</Text>,
-                            detail: backPicker,
-                          },
-                        ]}
-                      />
-                    }
-                  />
-                  {composition && customChosen ? (
-                    <CardbackFields
-                      cardback={composition}
-                      onChange={(next) => patch({ cardback: { mode: 'custom', ...next } })}
+        {/* Settling on focus leaving the fields is the editors' idiom, not the layout's, so it rides an element this widget owns. */}
+        <div onBlurCapture={onSettle}>
+          <ConnectedTabs<DeckChapter>
+            value={chapter}
+            onValueChange={(next) => {
+              onChapterChange(next);
+              onSettle();
+            }}
+            ariaLabel="Deck chapters"
+            items={[
+              {
+                value: 'identity',
+                label: 'Identity',
+                icon: <TopicIcon topic="identity" size={21} />,
+                panel: panel(
+                  <>
+                    <ControlBlock title="Name" description="Determines the deck's URL." input={nameField} />
+                    <ControlBlock
+                      title="Card back"
+                      description="Every deck wears exactly one. The deck publishes its own image either way, so a stock back only supplies the artwork."
+                      input={
+                        <PreviewChoice
+                          label="Card back"
+                          value={tileFor(draft.cardback, stockKey, customChosen)}
+                          aspectRatio={String(1 / assetFaceAspect('deck'))}
+                          onChange={(tile) => {
+                            setCustomChosen(tile === CUSTOM);
+                            /* Captured on the way out, so returning to Composed finds the composition as it was left. */
+                            if (composition) {
+                              composedCardback.current = composition;
+                            }
+                            const next = cardbackForTile(tile, draft.cardback, stockKey, composedCardback.current);
+                            if (next) {
+                              patch({ cardback: next });
+                            }
+                          }}
+                          options={[
+                            {
+                              value: 'stock',
+                              label: 'Stock',
+                              /* Always drawable: the stock look this deck wears, or the first standing in. */
+                              preview: <CardbackProof cardback={stockPreview} width={PROOF_CANVAS} />,
+                              canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('deck') },
+                              detail: (
+                                <Select
+                                  aria-label="Which stock back"
+                                  size="xs"
+                                  allowDeselect={false}
+                                  data={STOCK_CARDBACKS.map((stock) => ({ value: stock.key, label: stock.label }))}
+                                  value={stockKey ?? STOCK_CARDBACKS[0]!.key}
+                                  onChange={(next) => {
+                                    const stock = STOCK_CARDBACKS.find((candidate) => candidate.key === next);
+                                    if (stock) {
+                                      patch({ cardback: { mode: 'custom', ...stock.cardback } });
+                                    }
+                                  }}
+                                />
+                              ),
+                            },
+                            {
+                              value: CUSTOM,
+                              label: 'Composed here',
+                              /* Always drawable, the stock tile's own rule: the live composition, the one the author left behind, or the first stock look standing in. Never a dashed nothing (Norbert, 2026-08-21). */
+                              preview: (
+                                <CardbackProof
+                                  cardback={composition ?? composedCardback.current ?? STOCK_CARDBACKS[0]!.cardback}
+                                  width={PROOF_CANVAS}
+                                />
+                              ),
+                              canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('deck') },
+                            },
+                            {
+                              value: 'reference',
+                              label: "Another deck's back",
+                              preview: backProof ?? undefined,
+                              emptyHint: <Text size="xs">No deck chosen</Text>,
+                              detail: backPicker,
+                            },
+                          ]}
+                        />
+                      }
                     />
-                  ) : null}
-                </>
-              ),
-            },
-            {
-              value: 'cards',
-              label: 'Cards',
-              icon: <TopicIcon topic="contents" size={21} />,
-              panel: panel(
-                <>
-                  <ControlBlock
-                    title="Composition"
-                    description="How many of each card this deck holds, from any community card whoever made it. Duplicates are a count, not repeated rows."
-                    tool={cardPicker}
-                    input={
-                      members.length === 0 ? (
-                        <Text size="sm" c="dimmed">
-                          No cards yet.
-                        </Text>
-                      ) : (
-                        <Stack gap="xs">
-                          {members.map((member) => (
-                            <Group key={member.card.id} gap="sm" wrap="nowrap" align="center">
-                              <AssetFace
-                                type={member.card.type}
-                                data={member.card.data}
-                                name={member.card.name}
-                                width={34}
-                              />
-                              <Text size="sm" style={{ flex: 1, minWidth: 0 }}>
-                                {member.card.name}
-                              </Text>
-                              <MemberCountInput
-                                label={`Copies of ${member.card.name}`}
-                                min={1}
-                                max={99}
-                                disabled={onCountChange === null}
-                                value={member.count}
-                                onCommit={(count) => onCountChange?.(member.card.id, count)}
-                              />
-                              {/* Removal is held, not clicked: the row vanishing on a stray click was the last unguarded deletion (Norbert, 2026-08-21). */}
-                              <ConfirmDeleteAction
-                                label={`Remove ${member.card.name}`}
-                                verb="remove"
-                                pending={countPending && removingId === member.card.id}
-                                disabled={onCountChange === null}
-                                onConfirm={() => {
-                                  setRemovingId(member.card.id);
-                                  onCountChange?.(member.card.id, 0);
-                                }}
-                              />
-                            </Group>
-                          ))}
-                        </Stack>
-                      )
-                    }
-                  />
-                </>
-              ),
-            },
-            aboutChapter(draft.about, (about) => patch({ about })),
-          ]}
-        />
+                    {composition && customChosen ? (
+                      <CardbackFields
+                        cardback={composition}
+                        onChange={(next) => patch({ cardback: { mode: 'custom', ...next } })}
+                      />
+                    ) : null}
+                  </>
+                ),
+              },
+              {
+                value: 'cards',
+                label: 'Cards',
+                icon: <TopicIcon topic="contents" size={21} />,
+                panel: panel(
+                  <>
+                    <ControlBlock
+                      title="Composition"
+                      description="How many of each card this deck holds, from any community card whoever made it. Duplicates are a count, not repeated rows."
+                      tool={cardPicker}
+                      input={
+                        members.length === 0 ? (
+                          <Text size="sm" c="dimmed">
+                            No cards yet.
+                          </Text>
+                        ) : (
+                          <Stack gap="xs">
+                            {members.map((member) => (
+                              <Group key={member.card.id} gap="sm" wrap="nowrap" align="center">
+                                <AssetFace
+                                  type={member.card.type}
+                                  data={member.card.data}
+                                  name={member.card.name}
+                                  width={34}
+                                />
+                                <Text size="sm" style={{ flex: 1, minWidth: 0 }}>
+                                  {member.card.name}
+                                </Text>
+                                <MemberCountInput
+                                  label={`Copies of ${member.card.name}`}
+                                  min={1}
+                                  max={99}
+                                  disabled={onCountChange === null}
+                                  value={member.count}
+                                  onCommit={(count) => onCountChange?.(member.card.id, count)}
+                                />
+                                {/* Removal is held, not clicked: the row vanishing on a stray click was the last unguarded deletion (Norbert, 2026-08-21). */}
+                                <ConfirmDeleteAction
+                                  label={`Remove ${member.card.name}`}
+                                  verb="remove"
+                                  pending={countPending && removingId === member.card.id}
+                                  disabled={onCountChange === null}
+                                  onConfirm={() => {
+                                    setRemovingId(member.card.id);
+                                    onCountChange?.(member.card.id, 0);
+                                  }}
+                                />
+                              </Group>
+                            ))}
+                          </Stack>
+                        )
+                      }
+                    />
+                  </>
+                ),
+              },
+              aboutChapter(draft.about, (about) => patch({ about })),
+            ]}
+          />
+        </div>
       </WorkbenchLayout.Chapters>
       <WorkbenchLayout.Rail>
         <Stack gap="md" align="center">

--- a/src/app/widgets/token-editor/RectangleTokenEditor.tsx
+++ b/src/app/widgets/token-editor/RectangleTokenEditor.tsx
@@ -562,17 +562,20 @@ export function RectangleTokenEditor({
   const activeChapter = items.some((item) => item.value === chapter) ? chapter : 'identity';
 
   return (
-    <WorkbenchLayout.Workbench onBlurCapture={onSettle}>
+    <WorkbenchLayout.Workbench>
       <WorkbenchLayout.Chapters>
-        <ConnectedTabs<RectangleChapter>
-          value={activeChapter}
-          onValueChange={(next) => {
-            onChapterChange(next);
-            onSettle();
-          }}
-          ariaLabel="Enhance token chapters"
-          items={items}
-        />
+        {/* Settling on focus leaving the fields is the editors' idiom, not the layout's, so it rides an element this widget owns. */}
+        <div onBlurCapture={onSettle}>
+          <ConnectedTabs<RectangleChapter>
+            value={activeChapter}
+            onValueChange={(next) => {
+              onChapterChange(next);
+              onSettle();
+            }}
+            ariaLabel="Enhance token chapters"
+            items={items}
+          />
+        </div>
       </WorkbenchLayout.Chapters>
       <WorkbenchLayout.Rail>
         {/* The face stacks take the full width, or a centred flex child shrinks to its content and `CanvasScale` has nothing to fill. */}

--- a/src/app/widgets/token-editor/TokenEditor.test.tsx
+++ b/src/app/widgets/token-editor/TokenEditor.test.tsx
@@ -39,7 +39,13 @@ afterEach(cleanup);
 const TYPE = 'token-disc';
 
 /** The draft is real state, because what is guarded here is what survives a re-render. */
-function Harness({ expose }: { expose: (state: { draft: TokenDraft; setDraft: (next: TokenDraft) => void }) => void }) {
+function Harness({
+  expose = () => {},
+  onSettle = () => {},
+}: {
+  expose?: (state: { draft: TokenDraft; setDraft: (next: TokenDraft) => void }) => void;
+  onSettle?: () => void;
+}) {
   const [draft, setDraft] = useState<TokenDraft>(initialTokenDraft(TYPE));
   const [chapter, setChapter] = useState<TokenChapter>('identity');
   expose({ draft, setDraft });
@@ -52,7 +58,7 @@ function Harness({ expose }: { expose: (state: { draft: TokenDraft; setDraft: (n
         type={TYPE}
         chapter={chapter}
         onChapterChange={setChapter}
-        onSettle={() => {}}
+        onSettle={onSettle}
         backPicker={() => null}
         backProof={null}
       />
@@ -95,4 +101,21 @@ it('warns that a chosen reference has no token picked, from the draft alone', ()
   expect(
     tokenDraftWarnings({ ...initialTokenDraft(TYPE), back: { mode: 'reference', asset_id: 'picked' } })
   ).not.toContainEqual({ source: 'Identity', missing: 'a back token', chapter: 'identity' });
+});
+
+/**
+ * `onSettle` is documented as firing on field blur, and the element carrying that is this editor's own, not the layout's: `WorkbenchLayout` arranges chapters beside a rail and knows nothing about drafts.
+ * Pinned because the handler moved here off the layout's grid, and a wrong element fails silently.
+ * Note the event: React implements `onBlur` over `focusout`, so a non-bubbling `blur` never reaches it.
+ */
+it('settles when focus leaves a field', () => {
+  const onSettle = vi.fn();
+  render(<Harness onSettle={onSettle} />);
+  const name = document.querySelector('input[aria-label="Name"]');
+  if (name === null) {
+    throw new Error('the harness renders a name field');
+  }
+  fireEvent.focus(name);
+  fireEvent.focusOut(name);
+  expect(onSettle).toHaveBeenCalled();
 });

--- a/src/app/widgets/token-editor/TokenEditor.tsx
+++ b/src/app/widgets/token-editor/TokenEditor.tsx
@@ -434,17 +434,20 @@ export function TokenEditor({
   const activeChapter = items.some((item) => item.value === chapter) ? chapter : 'identity';
 
   return (
-    <WorkbenchLayout.Workbench onBlurCapture={onSettle}>
+    <WorkbenchLayout.Workbench>
       <WorkbenchLayout.Chapters>
-        <ConnectedTabs<TokenChapter>
-          value={activeChapter}
-          onValueChange={(next) => {
-            onChapterChange(next);
-            onSettle();
-          }}
-          ariaLabel="Token chapters"
-          items={items}
-        />
+        {/* Settling on focus leaving the fields is the editors' idiom, not the layout's, so it rides an element this widget owns. */}
+        <div onBlurCapture={onSettle}>
+          <ConnectedTabs<TokenChapter>
+            value={activeChapter}
+            onValueChange={(next) => {
+              onChapterChange(next);
+              onSettle();
+            }}
+            ariaLabel="Token chapters"
+            items={items}
+          />
+        </div>
       </WorkbenchLayout.Chapters>
       <WorkbenchLayout.Rail>
         <Stack gap="md" align="center">


### PR DESCRIPTION
Closes the `WorkbenchLayout` item on [#629](https://github.com/ndelangen/dunezone/issues/629), the last of K4. **Based on `main`, not stacked.** Read the diff with `-w`: the real change is **23 lines added, 12 removed**, and the rest is the reindent from one new level of nesting.

## The #639 half does not bite, and that is worth stating

The finding was parked on ["State the obligation on widget state that mirrors a caller's draft"](https://github.com/ndelangen/dunezone/issues/639) so the `onSettle` threading could be judged against **derive, don't mirror**. It comes back clean, and the rule is the reason why rather than an excuse:

> A **widget may hold no state** whose correctness depends on the history of the draft its caller owns.

The five editors hold **no state at all**. `draft`, `settleTick` and the open/closed latch all live in the route, in the same component, so nothing is mirrored across a membrane. And what the latch tracks is **focus** history, not draft history: blur is not a draft change, and no draft can express "the author left a field."

So this was never a state-mirroring problem. What survives is the taxonomy half.

## What was actually wrong

`WorkbenchLayout.Workbench` took `onBlurCapture` and hung it on its own grid div. The prop's type is honest DOM (`FocusEventHandler<HTMLDivElement>`) and carries no domain knowledge, which is why this is a close call rather than an obvious break.

The tell is the JSDoc. To justify the prop, the layout's own documentation had to say:

> The blur handler rides the grid because settling a draft when focus leaves the form is the editors' shared idiom.

A layout that cannot document itself without naming its callers' domain knows about its contents. That sentence is gone, and `Workbench` is chapters beside a rail again.

## Where it went

Each editor catches focus leaving its own fields. This is not a new pattern: `FactionFormFields.tsx:499` already does exactly this on its own element, and `WorkbenchLayout` was lifted from that editor's stylesheet in the first place. The five now match the one.

Attaching it to the chapters column rather than the whole grid is also the more precise statement of the intent, "focus left the form."

## Verified, because a wrapper element is exactly the kind of change that passes every gate and still moves the page

**Geometry, measured live.** Rendering the token editor and A/B-ing the same DOM, unwrapping the div and re-measuring, at five widths spanning every container step:

| root width | grid columns | match with/without wrapper |
|---|---|---|
| 1100px | 828px / 272px | identical |
| 700px | 524px / 176px | identical |
| 560px | 384px / 176px | identical |
| 430px | 318px / 112px | identical |
| 320px | 208px / 112px | identical |

Every box byte-identical, including where the rail steps down. `ConnectedTabs` declares its own `container: connected-tabs / inline-size`, so the query boundary does not move, and nothing selects `.chapters > *`.

**The event, in a real browser.** A `focusout` from a real field reaches the wrapper **in the capture phase**, which is what `onBlurCapture` binds to.

**Nothing stopped settling.** All five rails hold only `CanvasScale` proofs and `Text`. Counted in the live DOM: **zero** focusable elements. So no blur that settled before fails to settle now.

**One test, pinned.** `onSettle` is documented as firing on field blur and the element carrying it just moved, so `TokenEditor.test.tsx` asserts it. I checked the test is not vacuous: removing the handler fails it. Note the event, since this cost me a false alarm: React implements `onBlur` over `focusout`, so `fireEvent.blur` dispatches a non-bubbling `blur` that never arrives.

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 721 unit tests, 351 storybook tests.

## Found on the way, not fixed here

[#690](https://github.com/ndelangen/dunezone/issues/690): Reset leaves the validation header open with nothing in it, in all twelve editor routes. Real, reproducible, and not a kit-taxonomy problem, so it is not in this PR.
