### PR TITLE
Rulesets retire description from active contracts

### DIFF
--- a/convex/accountDeletion.test.ts
+++ b/convex/accountDeletion.test.ts
@@ -85,7 +85,7 @@ async function seedOwnedRows(t: ReturnType<typeof setup>, ownerId: Id<'users'>, 
     const rulesetId = await ctx.db.insert('rulesets', {
       name: `${prefix} Ruleset`,
       slug: `${prefix}-ruleset`,
-      description: 'A sufficiently long test description for account deletion ownership coverage.',
+      about: 'A sufficiently long test About for account deletion ownership coverage.',
       created_at: now,
       updated_at: now,
       owner_id: ownerId,

--- a/convex/accountLifecycle.widen.test.ts
+++ b/convex/accountLifecycle.widen.test.ts
@@ -139,7 +139,7 @@ describe('account lifecycle widen rollout', () => {
         owner_id: ownerId,
         name: 'Index Ruleset',
         slug: 'index-ruleset',
-        description: '',
+        about: '',
         created_at: now,
         updated_at: now,
         is_deleted: false,

--- a/convex/collaborationPermissions.test.ts
+++ b/convex/collaborationPermissions.test.ts
@@ -49,7 +49,7 @@ async function collaborationFixture() {
   const contributor = t.withIdentity({ subject: ids.contributorId });
   const ruleset = await owner.mutation(api.rulesets.create, {
     name: 'CollaborativeRuleset',
-    description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+    about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
     group_id: ids.groupId,
     image_cover: null,
   });
@@ -64,7 +64,7 @@ describe('group collaboration permissions', () => {
       member.mutation(api.rulesets.update, {
         id: ruleset._id,
         name: ruleset.name,
-        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+        about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
         image_cover: 'https://example.com/collaborative-cover.jpg',
       })
     ).resolves.toMatchObject({
@@ -75,7 +75,7 @@ describe('group collaboration permissions', () => {
       member.mutation(api.rulesets.update, {
         id: ruleset._id,
         name: 'MemberRename',
-        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+        about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       })
     ).rejects.toThrow('Only the ruleset owner can rename this ruleset');
     await expect(member.mutation(api.rulesets.setGroup, { id: ruleset._id, group_id: null })).rejects.toThrow(

--- a/convex/collaborativeAccess.test.ts
+++ b/convex/collaborativeAccess.test.ts
@@ -92,7 +92,7 @@ async function groupAccessFixture() {
     });
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'Collaborative Ruleset',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       slug: 'collaborative-ruleset',
       created_at: now,
       updated_at: now,

--- a/convex/defaultGroupPreference.test.ts
+++ b/convex/defaultGroupPreference.test.ts
@@ -125,7 +125,7 @@ describe('default Group preference', () => {
     await expect(
       member.mutation(api.rulesets.create, {
         name: 'DefaultGroupRuleset',
-        description: DESCRIPTION,
+        about: DESCRIPTION,
         image_cover: null,
       })
     ).resolves.toMatchObject({ group_id: ids.groupId, route_notice: null });
@@ -160,7 +160,7 @@ describe('default Group preference', () => {
     await expect(
       member.mutation(api.rulesets.create, {
         name: 'SoftDeletedDefaultRuleset',
-        description: DESCRIPTION,
+        about: DESCRIPTION,
         image_cover: null,
       })
     ).resolves.toMatchObject({ group_id: null, route_notice: defaultGroupUnavailableRouteNoticeCode });
@@ -172,7 +172,7 @@ describe('default Group preference', () => {
     await expect(
       member.mutation(api.rulesets.create, {
         name: 'ExplicitDeletedGroupRuleset',
-        description: DESCRIPTION,
+        about: DESCRIPTION,
         image_cover: null,
         group_id: ids.groupId,
       })
@@ -219,7 +219,7 @@ describe('default Group preference', () => {
     await expect(
       member.mutation(api.rulesets.create, {
         name: 'LegacyExplicitRuleset',
-        description: DESCRIPTION,
+        about: DESCRIPTION,
         image_cover: null,
         group_id: ids.groupId,
       })

--- a/convex/e2e.ts
+++ b/convex/e2e.ts
@@ -192,8 +192,7 @@ export const seedBaseline = mutation({
 
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'E2EBaselineRuleset',
-      /* The production Ruleset predates About and carries the same empty legacy value, so the route spec exercises that compatibility read. */
-      description: '',
+      about: '',
       slug: 'e2ebaselineruleset',
       created_at: now,
       updated_at: now,

--- a/convex/factions.authoringRoundTrip.test.ts
+++ b/convex/factions.authoringRoundTrip.test.ts
@@ -255,7 +255,7 @@ describe('faction authoring full-field round trip', () => {
     await t.run(async (ctx) => {
       const id = await ctx.db.insert('rulesets', {
         name: 'Canonical transition proof',
-        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+        about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
         slug: 'canonical-transition-proof',
         created_at: '2026-07-23T12:00:00.000Z',
         updated_at: '2026-07-23T12:00:00.000Z',

--- a/convex/factions.catalogue.test.ts
+++ b/convex/factions.catalogue.test.ts
@@ -17,7 +17,7 @@ describe('faction catalogue page', () => {
       const ownerId = await ctx.db.insert('users', { name: 'Catalogue owner' });
       const advancedId = await ctx.db.insert('rulesets', {
         name: 'Advanced',
-        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+        about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
         slug: 'advanced',
         created_at: '2026-07-01T00:00:00.000Z',
         updated_at: '2026-07-01T00:00:00.000Z',
@@ -28,7 +28,7 @@ describe('faction catalogue page', () => {
       });
       await ctx.db.insert('rulesets', {
         name: 'Empty',
-        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+        about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
         slug: 'empty',
         created_at: '2026-07-01T00:00:00.000Z',
         updated_at: '2026-07-01T00:00:00.000Z',
@@ -39,7 +39,7 @@ describe('faction catalogue page', () => {
       });
       await ctx.db.insert('rulesets', {
         name: 'Deleted',
-        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+        about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
         slug: 'deleted',
         created_at: '2026-07-01T00:00:00.000Z',
         updated_at: '2026-07-01T00:00:00.000Z',

--- a/convex/faq.questionPage.test.ts
+++ b/convex/faq.questionPage.test.ts
@@ -45,7 +45,7 @@ async function seedQuestionPage(t: ReturnType<typeof convexTest>): Promise<SeedR
 
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'Advanced',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       slug: 'advanced',
       created_at: at(1),
       updated_at: at(1),

--- a/convex/faq.test.ts
+++ b/convex/faq.test.ts
@@ -37,7 +37,7 @@ async function faqFixture() {
   const outsider = t.withIdentity({ subject: ids.outsiderId });
   const ruleset = await owner.mutation(api.rulesets.create, {
     name: 'FAQBehaviorRuleset',
-    description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+    about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
     group_id: null,
     image_cover: null,
   });
@@ -248,7 +248,7 @@ describe('FAQ lifecycle', () => {
     const outsider = t.withIdentity({ subject: ids.outsiderId });
     const ruleset = await rulesetOwner.mutation(api.rulesets.create, {
       name: 'CollaborativeFAQRuleset',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       group_id: ids.groupId,
       image_cover: null,
     });
@@ -388,7 +388,7 @@ describe('FAQ lifecycle', () => {
     const asUser = t.withIdentity({ subject: userId });
     const ruleset = await asUser.mutation(api.rulesets.create, {
       name: 'LargeFAQRuleset',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       group_id: null,
       image_cover: null,
     });
@@ -446,7 +446,7 @@ describe('FAQ lifecycle', () => {
     const asUser = t.withIdentity({ subject: userId });
     const ruleset = await asUser.mutation(api.rulesets.create, {
       name: 'LargeAnswerRuleset',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       group_id: null,
       image_cover: null,
     });

--- a/convex/groupAssignPicker.test.ts
+++ b/convex/groupAssignPicker.test.ts
@@ -98,7 +98,7 @@ async function seedRulesets(ctx: MutationCtx, seeded: Awaited<ReturnType<typeof 
 
   const unassignedRulesetId = await ctx.db.insert('rulesets', {
     name: 'UnassignedRuleset',
-    description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+    about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
     slug: 'unassigned-ruleset',
     created_at: now,
     updated_at: now,
@@ -109,7 +109,7 @@ async function seedRulesets(ctx: MutationCtx, seeded: Awaited<ReturnType<typeof 
   });
   await ctx.db.insert('rulesets', {
     name: 'DeletedRuleset',
-    description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+    about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
     slug: 'deleted-ruleset',
     created_at: now,
     updated_at: now,
@@ -120,7 +120,7 @@ async function seedRulesets(ctx: MutationCtx, seeded: Awaited<ReturnType<typeof 
   });
   await ctx.db.insert('rulesets', {
     name: 'SomeoneElsesRuleset',
-    description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+    about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
     slug: 'someone-elses-ruleset',
     created_at: now,
     updated_at: now,

--- a/convex/groups.softDeletion.test.ts
+++ b/convex/groups.softDeletion.test.ts
@@ -74,7 +74,7 @@ async function softDeletionFixture() {
     });
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'Collaborative Ruleset',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       slug: 'collaborative-ruleset',
       created_at: now,
       updated_at: now,
@@ -211,7 +211,7 @@ describe('Group soft deletion lifecycle', () => {
     await expect(
       assetOwner.mutation(api.rulesets.create, {
         name: 'OrphanRuleset',
-        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+        about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
         group_id: ids.groupId,
         image_cover: null,
       })

--- a/convex/groups.ts
+++ b/convex/groups.ts
@@ -8,7 +8,7 @@ import { mutation } from './functions';
 import { liveGroupOrNull, loadGroupAccessBundle, requireGroupCapability } from './lib/collaborativeAccess';
 import { groupDetailPageValidator } from './lib/collaborativeAccessValidators';
 import { requireAuthUserId } from './lib/policy';
-import { withRulesetAbout } from './lib/rulesetAbout';
+import { activeRuleset } from './lib/rulesetAbout';
 import { nowIso, slugify } from './lib/utils';
 
 async function resolveUniqueGroupSlug(ctx: QueryCtx | MutationCtx, name: string, excludeId?: Id<'groups'>) {
@@ -69,7 +69,7 @@ export const detailBySlug = query({
     return {
       group: accessBundle.subject,
       factions,
-      rulesets: rulesets.map(withRulesetAbout),
+      rulesets: rulesets.map(activeRuleset),
       owner: accessBundle.owner,
       viewerAccess: accessBundle.viewerAccess,
       roster: accessBundle.roster,

--- a/convex/homepage.test.ts
+++ b/convex/homepage.test.ts
@@ -34,7 +34,7 @@ describe('homepage page data', () => {
     });
     const ruleset = await asUser.mutation(api.rulesets.create, {
       name: 'HomepageRuleset',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       group_id: null,
       image_cover: null,
     });

--- a/convex/lib/collaborativeAccessValidators.ts
+++ b/convex/lib/collaborativeAccessValidators.ts
@@ -29,7 +29,10 @@ const profileValidator = docValidator('profiles');
 
 const factionValidator = docValidator('factions').extend({ data: factionDataValidator });
 
-const rulesetValidator = docValidator('rulesets');
+const rulesetValidator = schema.tables.rulesets.validator.omit('description').extend({
+  _id: v.id('rulesets'),
+  _creationTime: v.number(),
+});
 
 const publicViewerValidator = v.union(
   v.object({ kind: v.literal('anonymous') }),

--- a/convex/lib/rulesetAbout.ts
+++ b/convex/lib/rulesetAbout.ts
@@ -1,11 +1,12 @@
 import type { Doc } from '../_generated/dataModel';
 
 /**
- * A Ruleset row as the widened release puts it on the wire.
- * The stored canonical field stays optional until the backfill finishes, but every read supplies it from the legacy field so the new Worker has one stable contract throughout the rollout.
+ * The active Ruleset contract during storage retirement.
+ * The database may still carry `description` until the retirement migration reaches a row, but no reader receives that field.
  */
-export type RulesetWithAbout = Doc<'rulesets'> & { about: string };
+export type ActiveRuleset = Omit<Doc<'rulesets'>, 'description'>;
 
-export function withRulesetAbout(row: Doc<'rulesets'>): RulesetWithAbout {
-  return { ...row, about: row.about ?? row.description };
+export function activeRuleset(row: Doc<'rulesets'>): ActiveRuleset {
+  const { description: _description, ...active } = row;
+  return active;
 }

--- a/convex/lib/rulesetDetailPage.ts
+++ b/convex/lib/rulesetDetailPage.ts
@@ -5,13 +5,13 @@ import { loadAssetAccessBundle, loadRulesetAccessForLoadedSubject } from './coll
 import { parseStoredFactionForRead } from './factionInput';
 import { loadFaqItemsForRuleset } from './faqRulesetList';
 import { profileSummary } from './profileSummary';
-import { withRulesetAbout } from './rulesetAbout';
-import type { RulesetWithAbout } from './rulesetAbout';
+import { activeRuleset } from './rulesetAbout';
+import type { ActiveRuleset } from './rulesetAbout';
 
 const RULESET_FACTION_LIMIT = 500;
 
 /** A non-deleted ruleset resolved by its public slug, or null. The one soft-delete gate. */
-export async function loadPublicRulesetBySlug(ctx: QueryCtx, slug: string): Promise<RulesetWithAbout | null> {
+export async function loadPublicRulesetBySlug(ctx: QueryCtx, slug: string): Promise<ActiveRuleset | null> {
   const row = await ctx.db
     .query('rulesets')
     .withIndex('by_slug', (q) => q.eq('slug', slug))
@@ -19,7 +19,7 @@ export async function loadPublicRulesetBySlug(ctx: QueryCtx, slug: string): Prom
   if (!row || row.is_deleted) {
     return null;
   }
-  return withRulesetAbout(row);
+  return activeRuleset(row);
 }
 
 /**

--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -26,6 +26,21 @@
       "requires": ["rulesets_about_v1"]
     },
     {
+      "id": "rulesets_about_narrow",
+      "phase": "narrow",
+      "requires": ["rulesets_about_v1", "rulesets_about_verify_v1"]
+    },
+    {
+      "id": "rulesets_description_retire_v1",
+      "phase": "widen",
+      "requires": []
+    },
+    {
+      "id": "rulesets_description_retire_verify_v1",
+      "phase": "widen",
+      "requires": ["rulesets_description_retire_v1"]
+    },
+    {
       "id": "faq_item_slug_v1",
       "phase": "widen",
       "requires": []

--- a/convex/migrations.groupsSoftDelete.test.ts
+++ b/convex/migrations.groupsSoftDelete.test.ts
@@ -50,7 +50,7 @@ describe('Group lifecycle audit', () => {
       });
       const rulesetId = await ctx.db.insert('rulesets', {
         name: 'GroupedRuleset',
-        description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+        about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
         slug: 'groupedruleset',
         created_at: now,
         updated_at: now,

--- a/convex/migrations.rulesetsAbout.test.ts
+++ b/convex/migrations.rulesetsAbout.test.ts
@@ -12,7 +12,8 @@ import schema from './schema';
 const modules = import.meta.glob('./**/*.ts');
 const now = '2026-08-23T00:00:00.000Z';
 const prose = 'A house ruleset that rebalances spice income and shortens the endgame considerably.';
-const required = ['rulesets_about_v1', 'rulesets_about_verify_v1'];
+const completedAboutIds = ['rulesets_about_v1', 'rulesets_about_verify_v1'];
+const retirementIds = ['rulesets_description_retire_v1', 'rulesets_description_retire_verify_v1'];
 
 function rulesetMigrationTest() {
   const t = convexTest(schema, modules);
@@ -23,7 +24,7 @@ function rulesetMigrationTest() {
 
 async function insertRuleset(
   t: ReturnType<typeof convexTest>,
-  fields: { name: string; description: string; about?: string }
+  fields: { name: string; about: string; description?: string }
 ) {
   return await t.run(async (ctx) => {
     const ownerId = await ctx.db.insert('users', { name: `${fields.name} owner` });
@@ -40,32 +41,41 @@ async function insertRuleset(
   });
 }
 
-describe('the Ruleset About widen and verifier', () => {
-  test('copy legacy prose exactly, including the empty production shape', async () => {
+describe('the Ruleset description retirement', () => {
+  test('removes legacy prose while preserving About and accepts already-retired rows', async () => {
     const t = rulesetMigrationTest();
-    const proseId = await insertRuleset(t, { name: 'Prose', description: prose });
-    const emptyId = await insertRuleset(t, { name: 'Empty', description: '' });
-    const currentId = await insertRuleset(t, { name: 'Current', description: prose, about: prose });
+    const proseId = await insertRuleset(t, { name: 'Prose', about: prose, description: prose });
+    const emptyId = await insertRuleset(t, { name: 'Empty', about: '', description: '' });
+    const retiredId = await insertRuleset(t, { name: 'Retired', about: prose });
 
     await t.mutation(internal.migrations.rulesets_about_v1, {});
     await t.mutation(internal.migrations.rulesets_about_verify_v1, {});
+    await t.mutation(internal.migrations.rulesets_description_retire_v1, {});
+    await t.mutation(internal.migrations.rulesets_description_retire_verify_v1, {});
 
-    await expect(t.query(api.migrations.assertReadyForNarrow, { required })).resolves.toMatchObject({ ok: true });
+    await expect(t.query(api.migrations.assertReadyForNarrow, { required: completedAboutIds })).resolves.toMatchObject({
+      ok: true,
+    });
+    await expect(t.query(api.migrations.assertReadyForNarrow, { required: retirementIds })).resolves.toMatchObject({
+      ok: true,
+    });
     await t.run(async (ctx) => {
-      expect(await ctx.db.get('rulesets', proseId)).toMatchObject({ about: prose, description: prose });
-      expect(await ctx.db.get('rulesets', emptyId)).toMatchObject({ about: '', description: '' });
-      expect(await ctx.db.get('rulesets', currentId)).toMatchObject({ about: prose, description: prose });
+      expect(await ctx.db.get('rulesets', proseId)).toMatchObject({ about: prose });
+      expect(await ctx.db.get('rulesets', proseId)).not.toHaveProperty('description');
+      expect(await ctx.db.get('rulesets', emptyId)).toMatchObject({ about: '' });
+      expect(await ctx.db.get('rulesets', emptyId)).not.toHaveProperty('description');
+      expect(await ctx.db.get('rulesets', retiredId)).toMatchObject({ about: prose });
+      expect(await ctx.db.get('rulesets', retiredId)).not.toHaveProperty('description');
     });
   });
 
-  test('block retirement when the two stored values disagree', async () => {
+  test('blocks schema removal while any legacy field remains', async () => {
     const t = rulesetMigrationTest();
-    await insertRuleset(t, { name: 'Drifted', description: prose, about: 'Different stored prose.' });
+    await insertRuleset(t, { name: 'Pending', about: prose, description: prose });
 
-    await t.mutation(internal.migrations.rulesets_about_v1, {});
-    await t.mutation(internal.migrations.rulesets_about_verify_v1, {});
+    await t.mutation(internal.migrations.rulesets_description_retire_verify_v1, {});
 
-    await expect(t.query(api.migrations.assertReadyForNarrow, { required })).rejects.toThrow(
+    await expect(t.query(api.migrations.assertReadyForNarrow, { required: retirementIds })).rejects.toThrow(
       /required migrations are incomplete/
     );
   });

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -37,6 +37,8 @@ const MIGRATION_IDS: Record<string, MigrationRef> = {
   rulesets_description_v1: internal.migrations.rulesets_description_v1,
   rulesets_about_v1: internal.migrations.rulesets_about_v1,
   rulesets_about_verify_v1: internal.migrations.rulesets_about_verify_v1,
+  rulesets_description_retire_v1: internal.migrations.rulesets_description_retire_v1,
+  rulesets_description_retire_verify_v1: internal.migrations.rulesets_description_retire_verify_v1,
   faq_item_slug_v1: internal.migrations.faq_item_slug_v1,
   faq_item_tags_v1: internal.migrations.faq_item_tags_v1,
   profiles_from_users_v1: internal.migrations.profiles_from_users_v1,
@@ -190,28 +192,39 @@ export const rulesets_description_v1 = migrations.define({
   migrateOne: async () => undefined,
 });
 
-/** Copies the legacy Ruleset prose exactly when a row does not carry the canonical About field yet. */
+/** Retains the completed About backfill identity; the required field now enforces what it filled in. */
 export const rulesets_about_v1 = migrations.define({
   table: 'rulesets',
   batchSize: 50,
-  migrateOne: async (_ctx, row) => {
-    if (row.about !== undefined) {
-      return;
-    }
-    return { about: row.description };
-  },
+  migrateOne: async () => undefined,
 });
 
-/** Proves every Ruleset carries one value under both field names before the old field can be retired. */
+/** Retains the completed About verification identity; the required field now enforces its invariant. */
 export const rulesets_about_verify_v1 = migrations.define({
   table: 'rulesets',
   batchSize: 50,
+  migrateOne: async () => undefined,
+});
+
+/** Removes the legacy Ruleset prose after all active contracts have adopted About. */
+export const rulesets_description_retire_v1 = migrations.define({
+  table: 'rulesets',
+  batchSize: 50,
   migrateOne: async (_ctx, row) => {
-    if (row.about === undefined) {
-      throw new Error(`Ruleset ${row._id} still has no About`);
+    if (row.description === undefined) {
+      return;
     }
-    if (row.about !== row.description) {
-      throw new Error(`Ruleset ${row._id} has different About and legacy description values`);
+    return { description: undefined };
+  },
+});
+
+/** Proves every Ruleset has crossed the storage-retirement boundary before the schema drops the old field. */
+export const rulesets_description_retire_verify_v1 = migrations.define({
+  table: 'rulesets',
+  batchSize: 50,
+  migrateOne: async (_ctx, row) => {
+    if (row.description !== undefined) {
+      throw new Error(`Ruleset ${row._id} still has a legacy description`);
     }
   },
 });

--- a/convex/profiles.detail.test.ts
+++ b/convex/profiles.detail.test.ts
@@ -133,7 +133,7 @@ async function seedProfileDetail(t: ReturnType<typeof convexTest>): Promise<Seed
 
     const advancedRulesetId = await ctx.db.insert('rulesets', {
       name: 'Advanced',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       slug: 'advanced',
       created_at: at(1),
       updated_at: at(1),
@@ -144,7 +144,7 @@ async function seedProfileDetail(t: ReturnType<typeof convexTest>): Promise<Seed
     });
     const basicRulesetId = await ctx.db.insert('rulesets', {
       name: 'Basic',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       slug: 'basic',
       created_at: at(1),
       updated_at: at(1),
@@ -155,7 +155,7 @@ async function seedProfileDetail(t: ReturnType<typeof convexTest>): Promise<Seed
     });
     const deletedRulesetId = await ctx.db.insert('rulesets', {
       name: 'Deleted',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       slug: 'deleted',
       created_at: at(1),
       updated_at: at(1),

--- a/convex/profiles.test.ts
+++ b/convex/profiles.test.ts
@@ -62,7 +62,7 @@ test('profile list includes activity counts', async () => {
     });
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'Rules',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       slug: 'rules',
       created_at: '2026-07-19T00:00:00.000Z',
       updated_at: '2026-07-19T00:00:00.000Z',
@@ -119,7 +119,7 @@ test('profile detail returns the newest bounded FAQ activity', async () => {
     });
     const rulesetId = await ctx.db.insert('rulesets', {
       name: 'FAQ activity',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       slug: 'faq-activity',
       created_at: '2026-08-05T00:00:00.000Z',
       updated_at: '2026-08-05T00:00:00.000Z',

--- a/convex/rulesets.about.test.ts
+++ b/convex/rulesets.about.test.ts
@@ -26,8 +26,8 @@ async function rulesetOwner() {
   return { t, owner: t.withIdentity({ subject: ownerId }) };
 }
 
-describe('Ruleset About compatibility', () => {
-  test('canonical creates and updates keep the legacy field synchronized', async () => {
+describe('Ruleset About', () => {
+  test('creates and updates store only the canonical field', async () => {
     const { owner } = await rulesetOwner();
     const ruleset = await owner.mutation(api.rulesets.create, {
       name: 'AboutRuleset',
@@ -36,7 +36,8 @@ describe('Ruleset About compatibility', () => {
       image_cover: null,
     });
 
-    expect(ruleset).toMatchObject({ about: VALID_ABOUT, description: VALID_ABOUT });
+    expect(ruleset).toMatchObject({ about: VALID_ABOUT });
+    expect(ruleset).not.toHaveProperty('description');
 
     await expect(
       owner.mutation(api.rulesets.update, {
@@ -44,34 +45,7 @@ describe('Ruleset About compatibility', () => {
         name: 'AboutRuleset',
         about: UPDATED_ABOUT,
       })
-    ).resolves.toMatchObject({ about: UPDATED_ABOUT, description: UPDATED_ABOUT });
-  });
-
-  test('the old Worker argument remains accepted and dual-written', async () => {
-    const { owner } = await rulesetOwner();
-
-    await expect(
-      owner.mutation(api.rulesets.create, {
-        name: 'LegacyRuleset',
-        description: VALID_ABOUT,
-        group_id: null,
-        image_cover: null,
-      })
-    ).resolves.toMatchObject({ about: VALID_ABOUT, description: VALID_ABOUT });
-  });
-
-  test('conflicting compatibility arguments cannot create drift', async () => {
-    const { owner } = await rulesetOwner();
-
-    await expect(
-      owner.mutation(api.rulesets.create, {
-        name: 'ConflictingRuleset',
-        about: VALID_ABOUT,
-        description: UPDATED_ABOUT,
-        group_id: null,
-        image_cover: null,
-      })
-    ).rejects.toThrow(/must match/);
+    ).resolves.toMatchObject({ about: UPDATED_ABOUT });
   });
 
   test('an About below the floor is rejected in product language', async () => {
@@ -87,14 +61,15 @@ describe('Ruleset About compatibility', () => {
     ).rejects.toThrow(/Ruleset About must be at least 50 characters/);
   });
 
-  test('a legacy empty row reads with an empty About before the backfill reaches it', async () => {
+  test('active reads omit a legacy field that the retirement migration has not reached yet', async () => {
     const t = rulesetTest();
     const rulesetId = await t.run(async (ctx) => {
       const ownerId = await ctx.db.insert('users', { name: 'Ruleset owner' });
       return await ctx.db.insert('rulesets', {
-        name: 'PredatesAbout',
+        name: 'AwaitingRetirement',
+        about: '',
         description: '',
-        slug: 'predates-about',
+        slug: 'awaiting-retirement',
         created_at: '2026-01-01T00:00:00.000Z',
         updated_at: '2026-01-01T00:00:00.000Z',
         owner_id: ownerId,
@@ -104,10 +79,8 @@ describe('Ruleset About compatibility', () => {
       });
     });
 
-    await expect(t.query(api.rulesets.get, { id: rulesetId })).resolves.toMatchObject({
-      name: 'PredatesAbout',
-      about: '',
-      description: '',
-    });
+    const result = await t.query(api.rulesets.get, { id: rulesetId });
+    expect(result).toMatchObject({ name: 'AwaitingRetirement', about: '' });
+    expect(result).not.toHaveProperty('description');
   });
 });

--- a/convex/rulesets.assetSlots.test.ts
+++ b/convex/rulesets.assetSlots.test.ts
@@ -41,7 +41,7 @@ async function slotFixture() {
   const owner = t.withIdentity({ subject: ownerId });
   const ruleset = await owner.mutation(api.rulesets.create, {
     name: 'SlottedRuleset',
-    description: DESCRIPTION,
+    about: DESCRIPTION,
     group_id: null,
     image_cover: null,
   });

--- a/convex/rulesets.factionLinks.test.ts
+++ b/convex/rulesets.factionLinks.test.ts
@@ -63,7 +63,7 @@ async function linkFixture() {
   const owner = t.withIdentity({ subject: ids.ownerId });
   const ruleset = await owner.mutation(api.rulesets.create, {
     name: 'LinkableRuleset',
-    description: DESCRIPTION,
+    about: DESCRIPTION,
     group_id: ids.groupId,
     image_cover: null,
   });
@@ -128,7 +128,7 @@ describe('ruleset faction links', () => {
     const { t, ids, owner, ruleset } = await linkFixture();
     const second = await owner.mutation(api.rulesets.create, {
       name: 'SecondLinkableRuleset',
-      description: DESCRIPTION,
+      about: DESCRIPTION,
       group_id: ids.groupId,
       image_cover: null,
     });

--- a/convex/rulesets.ts
+++ b/convex/rulesets.ts
@@ -19,7 +19,7 @@ import {
   ownedForGroupAssignRowValidator,
 } from './lib/groupAssignPicker';
 import { requireAuthUserId } from './lib/policy';
-import { withRulesetAbout } from './lib/rulesetAbout';
+import { activeRuleset } from './lib/rulesetAbout';
 import { loadRulesetDetailPageBySlug, loadRulesetPublicBundleBySlug } from './lib/rulesetDetailPage';
 import { nowIso, slugify } from './lib/utils';
 import type { MutationCtx, QueryCtx } from './types';
@@ -32,7 +32,6 @@ async function getRulesetById(ctx: QueryCtx | MutationCtx, id: Id<'rulesets'>) {
  * The patch an update writes.
  * `image_cover` keeps the absent-means-untouched rule, since clearing a cover is expressed as `null`;
  * name and About are required of every write, so they are always part of the patch.
- * The two stored fields stay identical until the retirement release removes the legacy one.
  * The shape is inferred rather than restated, so adding a field here cannot drift from the type that describes it.
  */
 function rulesetUpdatePatch(fields: { name: string; slug: string; about: string; image_cover?: string | null }) {
@@ -40,31 +39,13 @@ function rulesetUpdatePatch(fields: { name: string; slug: string; about: string;
     name: fields.name,
     slug: fields.slug,
     about: fields.about,
-    description: fields.about,
     updated_at: nowIso(),
     ...(fields.image_cover === undefined ? {} : { image_cover: fields.image_cover }),
   };
 }
 
-type CompatibleRulesetInput = {
-  name: string;
-  about?: string;
-  description?: string;
-};
-
-/**
- * Accepts the new About argument and the old Worker argument during the compatibility window.
- * Supplying both is allowed only when they name the same trimmed prose, so no caller can make the dual-written columns disagree.
- */
-function parseCompatibleRulesetInput(input: CompatibleRulesetInput) {
-  const suppliedAboutValues = [input.about, input.description].filter((value): value is string => value !== undefined);
-  if (suppliedAboutValues.length === 0) {
-    throw new Error('Ruleset About is required');
-  }
-  if (new Set(suppliedAboutValues.map((value) => value.trim())).size > 1) {
-    throw new Error('Ruleset About and legacy description must match');
-  }
-  const parsed = rulesetInputSchema.safeParse({ name: input.name, about: suppliedAboutValues[0] });
+function parseRulesetInput(input: { name: string; about: string }) {
+  const parsed = rulesetInputSchema.safeParse({ name: input.name, about: input.about });
   if (!parsed.success) {
     const msg = parsed.error.issues.map((issue) => issue.message).join(' ');
     throw new Error(msg || 'Invalid ruleset input');
@@ -96,7 +77,7 @@ export const list = query({
       .query('rulesets')
       .withIndex('by_deleted_name', (q) => q.eq('is_deleted', false))
       .take(500);
-    return rows.map(withRulesetAbout);
+    return rows.map(activeRuleset);
   },
 });
 
@@ -107,7 +88,7 @@ export const get = query({
     if (!row || row.is_deleted) {
       throw new Error(`Ruleset with id ${args.id} not found`);
     }
-    return withRulesetAbout(row);
+    return activeRuleset(row);
   },
 });
 
@@ -147,23 +128,20 @@ export const listByFaction = query({
       .withIndex('by_faction', (q) => q.eq('faction_id', args.faction_id))
       .take(500);
     const rulesets = await Promise.all(links.map((link) => getRulesetById(ctx, link.ruleset_id)));
-    return rulesets
-      .filter((row): row is NonNullable<typeof row> => row != null && !row.is_deleted)
-      .map(withRulesetAbout);
+    return rulesets.filter((row): row is NonNullable<typeof row> => row != null && !row.is_deleted).map(activeRuleset);
   },
 });
 
 export const create = mutation({
   args: {
     name: v.string(),
-    about: v.optional(v.string()),
-    description: v.optional(v.string()),
+    about: v.string(),
     group_id: v.optional(v.union(v.id('groups'), v.null())),
     image_cover: v.union(v.string(), v.null()),
   },
   handler: async (ctx, args) => {
     const userId = await requireAuthUserId(ctx);
-    const input = parseCompatibleRulesetInput(args);
+    const input = parseRulesetInput(args);
     const normalizedName = input.name;
 
     const groupAssignment = await resolveGroupAssignmentForCreation(ctx, userId, args.group_id);
@@ -181,7 +159,6 @@ export const create = mutation({
     const _id = await ctx.db.insert('rulesets', {
       name: normalizedName,
       about: input.about,
-      description: input.about,
       slug,
       owner_id: userId,
       group_id: groupAssignment.group_id,
@@ -194,7 +171,7 @@ export const create = mutation({
     if (!created) {
       throw new Error('Failed to create ruleset');
     }
-    return { ...withRulesetAbout(created), route_notice: groupAssignment.route_notice };
+    return { ...activeRuleset(created), route_notice: groupAssignment.route_notice };
   },
 });
 
@@ -202,12 +179,11 @@ export const update = mutation({
   args: {
     id: v.id('rulesets'),
     name: v.string(),
-    about: v.optional(v.string()),
-    description: v.optional(v.string()),
+    about: v.string(),
     image_cover: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
-    const input = parseCompatibleRulesetInput(args);
+    const input = parseRulesetInput(args);
     const normalizedName = input.name;
     const access = await requireRulesetUpdate(ctx, args.id, { name: normalizedName });
     const ruleset = access.subject;
@@ -233,7 +209,7 @@ export const update = mutation({
     if (!updated) {
       throw new Error('Failed to update ruleset');
     }
-    return withRulesetAbout(updated);
+    return activeRuleset(updated);
   },
 });
 
@@ -263,7 +239,7 @@ export const setGroup = mutation({
     if (!updated) {
       throw new Error('Failed to update ruleset group');
     }
-    return withRulesetAbout(updated);
+    return activeRuleset(updated);
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -154,11 +154,12 @@ export default defineSchema({
     name: v.string(),
     slug: v.string(),
     /**
-     * The first Ruleset About release keeps the legacy field required for the old Worker and adds the canonical field as optional until `rulesets_about_v1` and its verifier finish.
-     * Both mutation generations write the same value to both fields during this compatibility window.
+     * About is authoritative after `rulesets_about_v1` and its verifier completed in production.
+     * The legacy field stays optional only while `rulesets_description_retire_v1` removes it.
+     * The next release removes this branch.
      */
-    description: v.string(),
-    about: v.optional(v.string()),
+    about: v.string(),
+    description: v.optional(v.string()),
     created_at: v.string(),
     updated_at: v.string(),
     owner_id: v.id('users'),

--- a/convex/statistics.test.ts
+++ b/convex/statistics.test.ts
@@ -50,7 +50,7 @@ test('maintains global and per-ruleset totals through wrapped writes', async () 
     });
     const activeRulesetId = await ctx.db.insert('rulesets', {
       name: 'Active ruleset',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       slug: 'active-ruleset',
       created_at: '2026-08-04T10:00:00.000Z',
       updated_at: '2026-08-04T10:00:00.000Z',
@@ -61,7 +61,7 @@ test('maintains global and per-ruleset totals through wrapped writes', async () 
     });
     const deletedRulesetId = await ctx.db.insert('rulesets', {
       name: 'Deleted ruleset',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       slug: 'deleted-ruleset',
       created_at: '2026-08-04T10:00:00.000Z',
       updated_at: '2026-08-04T10:00:00.000Z',
@@ -163,7 +163,7 @@ test('backfills Statistics resumably and rebuilds after later writes bypass trig
     });
     const insertedRulesetId = await ctx.db.insert('rulesets', {
       name: 'Dashboard ruleset',
-      description: 'A test ruleset with a description long enough to satisfy the fifty character floor.',
+      about: 'A test ruleset with an About long enough to satisfy the fifty character floor.',
       slug: 'dashboard-ruleset',
       created_at: '2026-08-04T10:00:00.000Z',
       updated_at: '2026-08-04T10:00:00.000Z',

--- a/src/app/db/rulesets.ts
+++ b/src/app/db/rulesets.ts
@@ -17,8 +17,8 @@ import type { ProfileSummary } from '../../../convex/lib/collaborativeAccessVali
 
 /** What a caller authors, derived from the schema that validates it. Both fields are required, and About sits above its floor. */
 export type Ruleset = RulesetInput;
-export type RulesetRow = Doc<'rulesets'>;
-export type RulesetEntry = Omit<RulesetRow, 'name' | 'about' | 'description'> & {
+export type RulesetRow = Omit<Doc<'rulesets'>, 'description'>;
+export type RulesetEntry = Omit<RulesetRow, 'name' | 'about'> & {
   name: Ruleset['name'];
   about: Ruleset['about'];
   id: RulesetRow['_id'];
@@ -76,12 +76,11 @@ function mapFaqItemsFromConvex(items: FaqItemConvexRow[]): FaqItemWithDetails[] 
 }
 
 function toRulesetEntry(entry: RulesetRow): RulesetEntry {
-  const { description, ...rest } = entry;
   return {
-    ...rest,
+    ...entry,
     id: entry._id,
     name: entry.name,
-    about: entry.about ?? description,
+    about: entry.about,
   };
 }
 
@@ -134,7 +133,7 @@ export function useCreateRuleset() {
     return { ...toRulesetEntry(row), route_notice };
   };
   const mutation = useLiveMutation<
-    { name: string; about?: string; description?: string; group_id?: string | null; image_cover: string | null },
+    { name: string; about: string; group_id?: string | null; image_cover: string | null },
     CreatedRulesetResult
   >(api.rulesets.create);
   return {
@@ -179,7 +178,7 @@ export function useCreateRuleset() {
 
 export function useUpdateRuleset() {
   const mutation = useLiveMutation<
-    { id: string; name: string; about?: string; description?: string; image_cover?: string | null },
+    { id: string; name: string; about: string; image_cover?: string | null },
     RulesetRow
   >(api.rulesets.update);
   return {


### PR DESCRIPTION
Resolves [Retire Ruleset description from production](https://github.com/ndelangen/dunezone/issues/693).

## Summary

- Make Ruleset `about` required while the legacy stored field remains optional for retirement.
- Remove the legacy mutation argument, dual writes, read fallback, and wire exposure.
- Add bounded retirement and verification migrations, preserve completed identities, and guard the About schema narrowing with the production-verified pair.

The deploy runs `rulesets_description_retire_v1` followed by `rulesets_description_retire_verify_v1`. The later schema-removal release adds their narrow checkpoint after production knows both identities. Once this deploy retires the stored fields, this release becomes the rollback floor because the previous schema requires `description`.

## Verification

- `bun run test` (109 files, 724 tests)
- `bun run check`
- `bun run typecheck`
- `bun run publisher:release:verify`
- `PLAYWRIGHT_HEADLESS=true bash scripts/e2e-local.sh all` (13 tests)
- production `bun run migrations:narrow-check`