### PR TITLE
The catalogue ships what it draws, not the whole authored faction

### DIFF
--- a/convex/factions.catalogue.test.ts
+++ b/convex/factions.catalogue.test.ts
@@ -94,6 +94,37 @@ describe('faction catalogue page', () => {
     expect(catalogue.spotlights.freshlyUpdated?.data.name).toBe('Recently updated');
   });
 
+  test('ships what the catalogue draws and leaves the rest of the blob behind', async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      const ownerId = await ctx.db.insert('users', { name: 'Narrowing owner' });
+      await ctx.db.insert('factions', {
+        owner_id: ownerId,
+        data: { ...assetPublishingFaction, name: 'Full blob' },
+        slug: 'full-blob',
+        created_at: '2026-07-20T00:00:00.000Z',
+        updated_at: '2026-07-20T00:00:00.000Z',
+        is_deleted: false,
+        group_id: null,
+      });
+    });
+
+    const catalogue = await t.query(api.factions.cataloguePage, {});
+    const row = catalogue.factions[0];
+
+    expect(Object.keys(row ?? {}).sort()).toEqual(['_id', 'created_at', 'data', 'rulesets', 'slug', 'updated_at']);
+    expect(Object.keys(row?.data ?? {}).sort()).toEqual([
+      'background',
+      'complexity',
+      'hero',
+      'leaders',
+      'logo',
+      'name',
+    ]);
+    /* The stored fixture really does carry the dropped fields, or the assertions above pass for the wrong reason. */
+    expect(Object.keys(assetPublishingFaction)).toEqual(expect.arrayContaining(['rules', 'troops', 'colors']));
+  });
+
   test('rejects malformed faction data at the query boundary', async () => {
     const t = convexTest(schema, modules);
     await t.run(async (ctx) => {

--- a/convex/factions.ts
+++ b/convex/factions.ts
@@ -14,7 +14,7 @@ import {
 import {
   factionDetailPageValidator,
   factionValidator,
-  factionWithRulesetsValidator,
+  catalogueFactionValidator,
   rulesetSummaryValidator,
 } from './lib/collaborativeAccessValidators';
 import { resolveGroupAssignmentForCreation } from './lib/defaultGroupPreference';
@@ -146,11 +146,11 @@ export const list = query({
 export const cataloguePage = query({
   args: {},
   returns: v.object({
-    factions: v.array(factionWithRulesetsValidator),
+    factions: v.array(catalogueFactionValidator),
     rulesets: v.array(rulesetSummaryValidator),
     spotlights: v.object({
-      newArrival: v.union(factionWithRulesetsValidator, v.null()),
-      freshlyUpdated: v.union(factionWithRulesetsValidator, v.null()),
+      newArrival: v.union(catalogueFactionValidator, v.null()),
+      freshlyUpdated: v.union(catalogueFactionValidator, v.null()),
     }),
   }),
   handler: async (ctx) => {

--- a/convex/lib/collaborativeAccessValidators.ts
+++ b/convex/lib/collaborativeAccessValidators.ts
@@ -2,7 +2,7 @@ import { v } from 'convex/values';
 import type { Infer } from 'convex/values';
 
 import schema from '../schema';
-import { factionDataValidator } from './factionData';
+import { catalogueFactionDataValidator, factionDataValidator } from './factionData';
 
 /**
  * Document validators derive from their authority, `convex/schema.ts` (ADR-0002);
@@ -120,14 +120,23 @@ export const factionDetailPageValidator = v.object({
   rulesets: v.array(rulesetSummaryValidator),
 });
 
-/** A faction with the rulesets it belongs to: what both the catalogue and a ruleset's own page put on the wire. */
-export const factionWithRulesetsValidator = factionValidator.extend({
-  rulesets: v.array(rulesetSummaryValidator),
-});
+/**
+ * A catalogue-shaped faction row: what `/factions`, a ruleset's faction rail and a profile's faction list put on the wire.
+ * Deliberately not a whole faction.
+ * It carries what `FactionCard` draws, what links and sorts the row, and the rulesets that caption it;
+ * `factions.getBySlug` remains the contract for anything that needs the authored blob.
+ */
+export const catalogueFactionValidator = schema.tables.factions.validator
+  .pick('slug', 'created_at', 'updated_at')
+  .extend({
+    _id: v.id('factions'),
+    data: catalogueFactionDataValidator,
+    rulesets: v.array(rulesetSummaryValidator),
+  });
 
 export const rulesetPublicBundleValidator = v.object({
   ruleset: rulesetValidator,
-  factions: v.array(factionWithRulesetsValidator),
+  factions: v.array(catalogueFactionValidator),
   viewerAccess: rulesetViewerAccessValidator,
 });
 
@@ -161,7 +170,7 @@ export const profileDetailPageValidator = v.object({
   profile: profileValidator,
   faqAsked: v.array(profileFaqQuestionValidator),
   faqAnswers: v.array(profileFaqAnswerValidator),
-  factions: v.array(factionWithRulesetsValidator),
+  factions: v.array(catalogueFactionValidator),
   groupSummaries: v.array(assignedGroupSummaryValidator),
 });
 

--- a/convex/lib/factionCatalogue.ts
+++ b/convex/lib/factionCatalogue.ts
@@ -1,6 +1,8 @@
-import type { FactionInput } from '../../src/shared/factions/schema';
+import type { Infer } from 'convex/values';
+
 import type { Doc, Id } from '../_generated/dataModel';
 import type { QueryCtx } from '../types';
+import type { catalogueFactionValidator } from './collaborativeAccessValidators';
 import { parseStoredFactionForRead } from './factionInput';
 
 export type FactionRulesetSummary = {
@@ -9,10 +11,25 @@ export type FactionRulesetSummary = {
   name: string;
 };
 
-export type CatalogueFaction = Omit<Doc<'factions'>, 'data'> & {
-  data: FactionInput;
-  rulesets: FactionRulesetSummary[];
-};
+/** Derived from the wire contract, so the projection below cannot quietly ship a field the validator rejects. */
+export type CatalogueFaction = Infer<typeof catalogueFactionValidator>;
+
+/**
+ * The single narrowing site (#642): every catalogue-shaped surface builds its rows here.
+ * Stored data is parsed in full first, because the parse is the read-time correctness check;
+ * only what the surfaces draw survives onto the wire.
+ */
+export function toCatalogueFaction(row: Doc<'factions'>, rulesets: FactionRulesetSummary[]): CatalogueFaction {
+  const { name, logo, background, hero, leaders, complexity } = parseStoredFactionForRead(row.data);
+  return {
+    _id: row._id,
+    slug: row.slug,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    data: { name, logo, background, hero, leaders, complexity },
+    rulesets,
+  };
+}
 
 const FACTION_LIMIT = 500;
 /* Bounded whole-index scan of ruleset_factions for the catalogue path; one read replaces one
@@ -51,14 +68,15 @@ export async function loadFactionCatalogue(
   const linksByFaction = ownerId ? await factionLinksByIndexedReads(ctx, rows) : await factionLinksByScan(ctx);
   const activeRulesetById = new Map(rulesets.map((ruleset) => [ruleset.id, ruleset]));
 
-  const factions = rows.map((row) => ({
-    ...row,
-    data: parseStoredFactionForRead(row.data),
-    rulesets: (linksByFaction.get(row._id) ?? [])
-      .map((rulesetId) => activeRulesetById.get(rulesetId))
-      .filter((ruleset): ruleset is FactionRulesetSummary => ruleset != null)
-      .sort(compareRulesets),
-  }));
+  const factions = rows.map((row) =>
+    toCatalogueFaction(
+      row,
+      (linksByFaction.get(row._id) ?? [])
+        .map((rulesetId) => activeRulesetById.get(rulesetId))
+        .filter((ruleset): ruleset is FactionRulesetSummary => ruleset != null)
+        .sort(compareRulesets)
+    )
+  );
 
   return { factions, rulesets };
 }

--- a/convex/lib/factionData.ts
+++ b/convex/lib/factionData.ts
@@ -1,6 +1,10 @@
 import { zodToConvex } from 'convex-helpers/server/zod4';
 
-import { Background, CanonicalFactionStoredSchema } from '../../src/shared/factions/schema';
+import {
+  Background,
+  CanonicalFactionStoredSchema,
+  CatalogueFactionStoredSchema,
+} from '../../src/shared/factions/schema';
 
 /**
  * Wire validators for faction payloads, derived from their authority, the canonical faction Zod schemas (ADR-0002).
@@ -8,4 +12,7 @@ import { Background, CanonicalFactionStoredSchema } from '../../src/shared/facti
  * these derived validators give the wire the same structural contract instead of `v.any()`.
  */
 export const factionDataValidator = zodToConvex(CanonicalFactionStoredSchema);
+
+/** The catalogue's narrowed `data`, derived from the same authority as the full shape (#642). */
+export const catalogueFactionDataValidator = zodToConvex(CatalogueFactionStoredSchema);
 export const factionBackgroundValidator = zodToConvex(Background);

--- a/convex/lib/rulesetDetailPage.ts
+++ b/convex/lib/rulesetDetailPage.ts
@@ -2,7 +2,7 @@ import type { Id } from '../_generated/dataModel';
 import type { QueryCtx } from '../types';
 import { assetDisplayName } from './assetInput';
 import { loadAssetAccessBundle, loadRulesetAccessForLoadedSubject } from './collaborativeAccess';
-import { parseStoredFactionForRead } from './factionInput';
+import { toCatalogueFaction } from './factionCatalogue';
 import { loadFaqItemsForRuleset } from './faqRulesetList';
 import { profileSummary } from './profileSummary';
 import { withRulesetAbout } from './rulesetAbout';
@@ -41,7 +41,7 @@ async function listPublicRulesetFactions(ctx: QueryCtx, rulesetId: Id<'rulesets'
     if (!faction || faction.is_deleted) {
       return [];
     }
-    return [{ ...faction, data: parseStoredFactionForRead(faction.data), rulesets: [] }];
+    return [toCatalogueFaction(faction, [])];
   });
 }
 

--- a/src/app/db/factions.ts
+++ b/src/app/db/factions.ts
@@ -38,6 +38,11 @@ export type FactionRulesetSummary = {
   name: string;
 };
 
+/* Reaching for a dropped field must fail to compile. It typed as `unknown` until the catalogue data type
+   was inferred from the strict schema instead of the loose one, so this pins which side it comes from. */
+// @ts-expect-error `rules` is not on a catalogue row
+type _CatalogueDataIsExact = FactionCatalogueEntry['data']['rules'];
+
 /**
  * A catalogue-shaped faction: the fields `FactionCard` draws, not a whole faction (#642).
  * Reach for `FactionEntry` when you need the authored blob;

--- a/src/app/db/factions.ts
+++ b/src/app/db/factions.ts
@@ -1,5 +1,10 @@
 import { recalculateFactionComplexity } from '@shared/factions/complexity';
-import { CanonicalFactionClientSchema, FactionInputSchema } from '@shared/factions/schema';
+import {
+  CanonicalFactionClientSchema,
+  CatalogueFactionClientSchema,
+  FactionInputSchema,
+} from '@shared/factions/schema';
+import type { CatalogueFactionData } from '@shared/factions/schema';
 import type { FactionInput } from '@shared/factions/schema';
 import { useQuery } from 'convex/react';
 import type { FunctionReturnType } from 'convex/server';
@@ -33,8 +38,13 @@ export type FactionRulesetSummary = {
   name: string;
 };
 
-export type FactionCatalogueEntry = FactionEntry & {
-  rulesets: FactionRulesetSummary[];
+/**
+ * A catalogue-shaped faction: the fields `FactionCard` draws, not a whole faction (#642).
+ * Reach for `FactionEntry` when you need the authored blob;
+ * it arrives from `factions.getBySlug`, a different contract.
+ */
+export type FactionCatalogueEntry = Omit<FactionCatalogueRow, 'data'> & {
+  data: CatalogueFactionData;
 };
 
 export type FactionCatalogueSpotlightData = {
@@ -42,9 +52,8 @@ export type FactionCatalogueSpotlightData = {
   data: Pick<FactionCatalogueEntry['data'], 'name' | 'logo' | 'background'>;
 };
 
-export type FactionCatalogueRow = FactionRow & {
-  rulesets: FactionRulesetSummary[];
-};
+/** Derived from the query's own return type, so the client never claims a field the server stopped sending. */
+export type FactionCatalogueRow = FunctionReturnType<typeof api.factions.cataloguePage>['factions'][number];
 
 export type FactionCataloguePageData = {
   factions: FactionCatalogueEntry[];
@@ -74,7 +83,7 @@ export type CreatedFactionEntry = ReturnType<typeof toCreatedFactionEntry>;
 function toFactionCatalogueEntry(entry: FactionCatalogueRow): FactionCatalogueEntry {
   return {
     ...entry,
-    data: parseClientBoundary(CanonicalFactionClientSchema, entry.data, 'Faction data'),
+    data: parseClientBoundary(CatalogueFactionClientSchema, entry.data, 'Faction data'),
   };
 }
 

--- a/src/shared/factions/schema.ts
+++ b/src/shared/factions/schema.ts
@@ -170,6 +170,28 @@ export const CanonicalFactionClientSchema = z.looseObject({
   name: z.string(),
 });
 
+/**
+ * The faction fields a catalogue-shaped surface actually draws (#642).
+ * One mask, so the stored schema, the client schema and the Convex wire validator cannot drift apart.
+ * The rest of the blob is 72% of its weight and no catalogue surface reads it;
+ * detail pages and the editor keep the full shape through their own contract.
+ */
+const catalogueFactionMask = {
+  name: true,
+  logo: true,
+  background: true,
+  hero: true,
+  leaders: true,
+  complexity: true,
+} as const;
+
+export const CatalogueFactionStoredSchema = CanonicalFactionStoredSchema.pick(catalogueFactionMask);
+
+/** Loose like its parent, so an additive server change still never breaks a stale tab. */
+export const CatalogueFactionClientSchema = CanonicalFactionClientSchema.pick(catalogueFactionMask);
+
+export type CatalogueFactionData = z.infer<typeof CatalogueFactionClientSchema>;
+
 /** URL slug on the `factions` row, not a field on `FactionInput` / `factions.data`. */
 export const FactionRowSlugSchema = z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
 

--- a/src/shared/factions/schema.ts
+++ b/src/shared/factions/schema.ts
@@ -190,7 +190,11 @@ export const CatalogueFactionStoredSchema = CanonicalFactionStoredSchema.pick(ca
 /** Loose like its parent, so an additive server change still never breaks a stale tab. */
 export const CatalogueFactionClientSchema = CanonicalFactionClientSchema.pick(catalogueFactionMask);
 
-export type CatalogueFactionData = z.infer<typeof CatalogueFactionClientSchema>;
+/**
+ * Inferred from the strict variant on purpose: `.pick()` carries a `looseObject`'s catchall through, so taking this from the client schema would type every dropped field as `unknown` rather than refusing it, and a later read of `data.rules` would compile and then silently render nothing.
+ * Parse loose, declare strict, the same split `toFactionEntry` uses.
+ */
+export type CatalogueFactionData = z.infer<typeof CatalogueFactionStoredSchema>;
 
 /** URL slug on the `factions` row, not a field on `FactionInput` / `factions.data`. */
 export const FactionRowSlugSchema = z.string().regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,12 +4,12 @@
 // sharp version), so this file is reproducible on any machine (wayfinder #269).
 export const rendererManifest = {
   schemaVersion: 2,
-  rendererIdentity: 'faction-sheet/sha256:e02c37c8f405202d445a784b2f641e3a8c86191c4e08ee14b1e9d0dd69122536',
-  digest: 'e02c37c8f405202d445a784b2f641e3a8c86191c4e08ee14b1e9d0dd69122536',
+  rendererIdentity: 'faction-sheet/sha256:d3722b74a33558431cb707102721fbc0faf91bca7551d0b518c1e70682369e46',
+  digest: 'd3722b74a33558431cb707102721fbc0faf91bca7551d0b518c1e70682369e46',
   components: {
     sources: '5289b6254320530ee857ff2912681e9d6a30135dbb3a92239296365f53397813',
     toolchain: 'e7e830225f6973a7d7e43aada3bcbcd5de3c169378aa25849d24d8de97ea517a',
-    code: 'c779a367c707b35b378ebbbc0adbce32b249e8c5ddbbefb1d94b263be28bd76a',
+    code: '8b9214d708db8ce50f4f16db54cfeec485d125ddfeaafd5eaec088dabcd5f51f',
     contract: '2920714c87493d104342355dda2b956202259513c78ce6195670034f31a656a6',
   },
   contract: {


### PR DESCRIPTION
First item of [#698](https://github.com/ndelangen/dunezone/issues/698), decided and measured on [#642](https://github.com/ndelangen/dunezone/issues/642). **Based on `main`, not stacked.** No schema or index change.

Catalogue-shaped faction rows carried the whole authored blob to three surfaces that render six of its thirteen `data` fields.

## One mask, four derivations

The narrowing exists in exactly one place, a field mask in `src/shared/factions/schema.ts`. Everything else follows from it:

| | derived from |
|---|---|
| `CatalogueFactionStoredSchema` | the mask, off the canonical stored schema |
| `CatalogueFactionClientSchema` | the mask, off the canonical client schema (stays loose) |
| `catalogueFactionDataValidator` | `zodToConvex` of the stored variant, the existing ADR-0002 route |
| `CatalogueFaction` (server) | `Infer` of the wire validator |
| `FactionCatalogueRow` (client) | `FunctionReturnType` of `factions.cataloguePage` |

So there is no second list of field names to fall out of step, and the client type cannot claim a field the server stopped sending.

Both build sites, the catalogue loader and the ruleset faction rail, were spreading the row independently. They now go through one `toCatalogueFaction`.

`factions.getBySlug` is untouched: detail pages and the editor keep the full blob through their own contract.

## The stale-tab consequence, stated plainly

Narrowing **is** breaking for a tab running the previous bundle. The client boundary's tolerance is one-directional: `CanonicalFactionClientSchema` is a `looseObject`, so it accepts unknown *extra* fields, but it still requires the ones it declares. I verified this rather than assuming it, and the reverse case fails as expected.

That is already handled by design here. `parseClientBoundary` throws `StaleClientDataError`, documented in that file as "the stale-tab signal", and the router renders it as a refresh prompt instead of a crash. **This is the case that mechanism exists for**, so no two-phase widen-then-narrow deploy is needed.

## Verified

**The wire shape matches the spec exactly**, checked against the validator itself rather than by reading:

- row: `_id, created_at, data, rulesets, slug, updated_at`
- `data` kept: `background, complexity, hero, leaders, logo, name`
- `data` dropped: `colors, decals, extras, planet, rules, themeColor, troops`

Those seven are precisely the ones the measurement identified as dead on all three surfaces.

**The saving, re-measured independently on today's live data** rather than quoted from the ticket. Real `factions.cataloguePage` payload from the dev deployment, projected to the narrowed shape:

| | |
|---|---|
| rows | 35, plus 2 spotlight rows shipped twice |
| full payload | 130.1 KB |
| narrowed payload | 31.0 KB |
| saving | **99.1 KB (76.2%)** |

`rules` alone is 75.1% of blob weight. This lands where #642 predicted (124 KB to 28 KB); the small drift is data added since. The saving recurs on every subscription resend, not just first load.

**Browser pass on all three consuming surfaces**, with the narrowed functions actually deployed:

| surface | result |
|---|---|
| `/factions` | 37 faction cards plus 2 spotlights, no stale-data prompt |
| `/rulesets/dreamrules` | all 11 rail factions render |
| `/profiles/central` | faction list renders |

All six kept fields draw. Bene Gesserit shows hero "Gaius Helen Mohiam" at strength 5, three leaders, the name, background artwork, the complexity glyph, and its "Dreamrules" caption. `FactionCard` destructures exactly the six kept fields and reads nothing else.

**The narrowing is pinned, and the pin is not vacuous.** `factions.catalogue.test.ts` asserts the row and `data` key sets, and asserts the stored fixture really does carry the dropped fields so it cannot pass for the wrong reason. Re-widening the projection fails it, and the Convex return validator rejects the extra fields too.

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 727 tests.

**Shared dev is back on `main`.** The browser pass required deploying these functions to `dev:tame-raccoon-541`. I have since pushed `main`'s functions back and confirmed by querying the deployment that it serves the full blob again, rather than assuming the push landed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved faction catalogue data handling by returning only the fields needed for catalogue views.
  * Standardized faction data across catalogue, ruleset, and profile pages.
  * Added validation to ensure catalogue entries contain the expected information.
  * Preserved additional faction details in stored data while excluding them from catalogue responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->