### PR TITLE
The shell stops paying a memberships join for a Select it never renders

### DIFF
--- a/convex/accountLifecycle.widen.test.ts
+++ b/convex/accountLifecycle.widen.test.ts
@@ -83,7 +83,7 @@ describe('account lifecycle widen rollout', () => {
     });
 
     const pending = t.withIdentity({ subject: ids.userId });
-    await expect(pending.query(api.profiles.currentUserId, {})).resolves.toBeNull();
+    await expect(pending.query(api.profiles.session, {})).resolves.toEqual({ userId: null, profile: null });
     await expect(pending.mutation(api.profiles.bootstrapCurrent, {})).rejects.toThrow(/Not authenticated/);
     await expect(t.query(api.profiles.getBySlug, { slug: 'pending-user' })).rejects.toThrow(/not found/);
     await expect(t.query(api.profiles.newestDiscoverable, {})).resolves.toEqual([]);

--- a/convex/defaultGroupPreference.test.ts
+++ b/convex/defaultGroupPreference.test.ts
@@ -94,10 +94,15 @@ describe('default Group preference', () => {
 
     const legacyProfile = await t.run(async (ctx) => await ctx.db.get('profiles', ids.memberProfileId));
     expect(legacyProfile).not.toHaveProperty('default_group_id');
-    await expect(member.query(api.profiles.current, {})).resolves.toMatchObject({
+    await expect(member.query(api.profiles.defaultGroupPreference, {})).resolves.toMatchObject({
       default_group_id: null,
       default_group_options: [{ id: ids.groupId, name: 'Default Group' }],
     });
+
+    /* The point of the split (#698 item 2): every `_app` page holds `session`, so the memberships join
+       must not ride along on it. This member is in a Group, so a regression here would carry a populated list. */
+    const session = await member.query(api.profiles.session, {});
+    expect(session.profile).not.toHaveProperty('default_group_options');
 
     await expect(
       member.mutation(api.profiles.updateCurrent, {
@@ -117,7 +122,7 @@ describe('default Group preference', () => {
       profile: { default_group_id: ids.groupId },
       default_group_unavailable: false,
     });
-    await expect(member.query(api.profiles.current, {})).resolves.toMatchObject({
+    await expect(member.query(api.profiles.defaultGroupPreference, {})).resolves.toMatchObject({
       default_group_id: ids.groupId,
       default_group_options: [{ id: ids.groupId, name: 'Default Group' }],
     });
@@ -144,7 +149,7 @@ describe('default Group preference', () => {
     await expect(t.run(async (ctx) => await ctx.db.get('profiles', ids.memberProfileId))).resolves.toMatchObject({
       default_group_id: ids.groupId,
     });
-    await expect(member.query(api.profiles.current, {})).resolves.toMatchObject({
+    await expect(member.query(api.profiles.defaultGroupPreference, {})).resolves.toMatchObject({
       default_group_id: null,
       default_group_options: [],
     });
@@ -178,7 +183,7 @@ describe('default Group preference', () => {
       })
     ).rejects.toThrow('not found');
     await t.run(async (ctx) => await ctx.db.patch(ids.groupId, { is_deleted: false }));
-    await expect(member.query(api.profiles.current, {})).resolves.toMatchObject({
+    await expect(member.query(api.profiles.defaultGroupPreference, {})).resolves.toMatchObject({
       default_group_id: ids.groupId,
       default_group_options: [{ id: ids.groupId, name: 'Default Group' }],
     });
@@ -191,7 +196,7 @@ describe('default Group preference', () => {
 
     const profile = await t.run(async (ctx) => await ctx.db.get('profiles', ids.memberProfileId));
     expect(profile).toMatchObject({ default_group_id: null });
-    await expect(member.query(api.profiles.current, {})).resolves.toMatchObject({
+    await expect(member.query(api.profiles.defaultGroupPreference, {})).resolves.toMatchObject({
       default_group_id: null,
       default_group_options: [],
     });
@@ -208,7 +213,7 @@ describe('default Group preference', () => {
     await expect(t.run(async (ctx) => await ctx.db.get('profiles', ids.memberProfileId))).resolves.toMatchObject({
       default_group_id: null,
     });
-    await expect(member.query(api.profiles.current, {})).resolves.toMatchObject({
+    await expect(member.query(api.profiles.defaultGroupPreference, {})).resolves.toMatchObject({
       default_group_id: null,
       default_group_options: [{ id: ids.groupId, name: 'Default Group' }],
     });

--- a/convex/profiles.ts
+++ b/convex/profiles.ts
@@ -6,7 +6,11 @@ import { query } from './_generated/server';
 import type { MutationCtx } from './_generated/server';
 import { mutation } from './functions';
 import { isActiveProfile, optionalActiveUserId } from './lib/accountLifecycle';
-import { profileDetailPageValidator, profileValidator } from './lib/collaborativeAccessValidators';
+import {
+  assignedGroupSummaryValidator,
+  profileDetailPageValidator,
+  profileValidator,
+} from './lib/collaborativeAccessValidators';
 import { canSetDefaultGroup, loadDefaultGroupPreferenceProjection } from './lib/defaultGroupPreference';
 import { requireAuthUserId } from './lib/policy';
 import { loadProfileActivityCounts } from './lib/profileActivity';
@@ -45,31 +49,53 @@ async function createProfileIfMissing(ctx: MutationCtx, userId: Id<'users'>) {
   });
 }
 
-export const currentUserId = query({
+/**
+ * The viewer's session in one read: who they are, and their profile row if they have one.
+ * One query rather than two because every `_app` page holds this through the shell, and the pair cost two subscriptions to answer one question.
+ * The envelope is never null: a signed-out viewer and a signed-in viewer with no profile row yet must stay distinguishable, or the client's bootstrap never fires for a new account.
+ */
+export const session = query({
   args: {},
+  returns: v.object({
+    userId: v.union(v.id('users'), v.null()),
+    profile: v.union(profileValidator, v.null()),
+  }),
   handler: async (ctx) => {
-    return await optionalActiveUserId(ctx);
-  },
-});
-
-export const current = query({
-  args: {},
-  handler: async (ctx) => {
-    const authUserId = await optionalActiveUserId(ctx);
-    if (!authUserId) {
-      return null;
+    const userId = await optionalActiveUserId(ctx);
+    if (!userId) {
+      return { userId: null, profile: null };
     }
     const profile = await ctx.db
       .query('profiles')
-      .withIndex('by_user_id', (q) => q.eq('user_id', authUserId))
+      .withIndex('by_user_id', (q) => q.eq('user_id', userId))
       .unique();
+    return { userId, profile: profile && isActiveProfile(profile) ? profile : null };
+  },
+});
+
+/**
+ * The viewer's Groups, for the one Select on the profile edit form that offers them.
+ * Its own query because it is a memberships join plus a group read per membership, and it used to ride on `session` to every page in the app.
+ * `default_group_id` comes back sanitized against that same list, so a default pointing at a group the viewer left reads as none.
+ */
+export const defaultGroupPreference = query({
+  args: {},
+  returns: v.object({
+    default_group_id: v.union(v.id('groups'), v.null()),
+    default_group_options: v.array(assignedGroupSummaryValidator),
+  }),
+  handler: async (ctx) => {
+    const userId = await optionalActiveUserId(ctx);
+    const profile = userId
+      ? await ctx.db
+          .query('profiles')
+          .withIndex('by_user_id', (q) => q.eq('user_id', userId))
+          .unique()
+      : null;
     if (!profile || !isActiveProfile(profile)) {
-      return null;
+      return { default_group_id: null, default_group_options: [] };
     }
-    return {
-      ...profile,
-      ...(await loadDefaultGroupPreferenceProjection(ctx, profile)),
-    };
+    return await loadDefaultGroupPreferenceProjection(ctx, profile);
   },
 });
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -49,9 +49,9 @@ non-visual hand-off sits outside it:
 
 A `profiles` document is created in Convex when an auth user is created or updated: `callbacks.afterUserCreatedOrUpdated` in [`convex/auth.ts`](../convex/auth.ts) calls `ensureProfileForUser` (see [`convex/lib/profileBootstrap.ts`](../convex/lib/profileBootstrap.ts)) using the patched `users` row (`name`, `image`).
 
-If a legacy user has no profile, the client's `useCurrentProfile()` calls `profiles.bootstrapCurrent` once when `currentUserId` is set and `profiles.current` is still `null`. For bulk repair, missing profiles are backfilled by the **`profiles_from_users_v1`** Convex migration (see [`convex/migrations.ts`](../convex/migrations.ts)), which runs with the rest of the widen migrations via `bun run migrations:deploy` / `bun run migrations:dev-strict` and appears on [`/admin/migrations`](../src/app/routes/_app/admin/migrations.tsx).
+If a legacy user has no profile, the client's `useCurrentProfile()` calls `profiles.bootstrapCurrent` once when `profiles.session` returns a `userId` whose `profile` is still `null`. For bulk repair, missing profiles are backfilled by the **`profiles_from_users_v1`** Convex migration (see [`convex/migrations.ts`](../convex/migrations.ts)), which runs with the rest of the widen migrations via `bun run migrations:deploy` / `bun run migrations:dev-strict` and appears on [`/admin/migrations`](../src/app/routes/_app/admin/migrations.tsx).
 
-**Hooks**: `useCurrentProfile()`, `useProfileBySlug(slug)`, `useProfilesAll()`,
-`useUpdateCurrentProfile()`. Profile lookups are slug-based, never by id.
+**Hooks**: `useCurrentProfile()`, `useDefaultGroupPreference()`, `useProfileBySlug(slug)`,
+`useProfilesAll()`, `useUpdateCurrentProfile()`. Profile lookups are slug-based, never by id.
 
 **Example**: [`src/app/db/profiles.ts`](../src/app/db/profiles.ts)

--- a/src/app/db/profiles.ts
+++ b/src/app/db/profiles.ts
@@ -13,7 +13,7 @@ import type { Doc } from '../../../convex/_generated/dataModel';
 
 type ProfileRow = Doc<'profiles'>;
 export type ProfileEntry = ProfileRow;
-export type CurrentProfileEntry = NonNullable<FunctionReturnType<typeof api.profiles.current>>;
+export type CurrentProfileEntry = NonNullable<FunctionReturnType<typeof api.profiles.session>['profile']>;
 export type ProfileUpdateResult = FunctionReturnType<typeof api.profiles.updateCurrent>;
 export type ProfileListEntry = FunctionReturnType<typeof api.profiles.list>[number];
 
@@ -65,20 +65,19 @@ export function useProfilesAll(options?: { initialData?: ProfileListEntry[] }) {
 }
 
 export function useCurrentProfile() {
-  const userId = useQuery(api.profiles.currentUserId, {});
-  const liveData = useQuery(api.profiles.current, {});
+  const session = useQuery(api.profiles.session, {});
   const bootstrap = useMutation(api.profiles.bootstrapCurrent);
   const bootstrapAttemptedRef = useRef(false);
 
   useEffect(() => {
-    if (userId === undefined || liveData === undefined) {
+    if (session === undefined) {
       return;
     }
-    if (userId === null) {
+    if (session.userId === null) {
       bootstrapAttemptedRef.current = false;
       return;
     }
-    if (liveData !== null) {
+    if (session.profile !== null) {
       return;
     }
     if (bootstrapAttemptedRef.current) {
@@ -88,13 +87,21 @@ export function useCurrentProfile() {
     void bootstrap({}).catch(() => {
       bootstrapAttemptedRef.current = false;
     });
-  }, [userId, liveData, bootstrap]);
+  }, [session, bootstrap]);
 
-  const current = toLiveQueryResult(liveData, true);
+  /* Unresolved and signed-out are different states and must stay so: `session.profile` is null for a
+     signed-out viewer, and collapsing that to undefined would leave every page reading as pending. */
+  const current = toLiveQueryResult(session === undefined ? undefined : session.profile, true);
 
   return {
     ...current,
   };
+}
+
+/** The viewer's Groups, held by the page that offers them rather than by the shell. */
+export function useDefaultGroupPreference() {
+  const liveData = useQuery(api.profiles.defaultGroupPreference, {});
+  return toLiveQueryResult(liveData, true);
 }
 
 export function useUpdateCurrentProfile() {

--- a/src/app/routes/_app/profiles/$profileSlug/-edit.test.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/-edit.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
   mutate: vi.fn(),
   useCurrentProfile: vi.fn(),
+  useDefaultGroupPreference: vi.fn(),
   pending: false,
   error: null as Error | null,
 }));
@@ -30,6 +31,7 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
 
 vi.mock('@db/profiles', () => ({
   useCurrentProfile: mocks.useCurrentProfile,
+  useDefaultGroupPreference: mocks.useDefaultGroupPreference,
   useUpdateCurrentProfile: () => ({
     mutate: mocks.mutate,
     isPending: mocks.pending,
@@ -54,7 +56,6 @@ const profile = {
   username: 'Owner profile',
   avatar_url: 'https://avatar.example/original.png',
   default_group_id: null,
-  default_group_options: [{ id: 'group-1', name: 'Spacing Guild', slug: 'spacing-guild' }],
   slug: 'owner-profile',
   created_at: '2026-08-20T00:00:00.000Z',
   updated_at: '2026-08-20T00:00:00.000Z',
@@ -91,6 +92,12 @@ beforeEach(() => {
   mocks.mutate.mockReset();
   mocks.useCurrentProfile.mockReset();
   mocks.useCurrentProfile.mockReturnValue({ data: profile });
+  mocks.useDefaultGroupPreference.mockReturnValue({
+    data: {
+      default_group_id: null,
+      default_group_options: [{ id: 'group-1', name: 'Spacing Guild', slug: 'spacing-guild' }],
+    },
+  });
   mocks.pending = false;
   mocks.error = null;
   localStorage.clear();

--- a/src/app/routes/_app/profiles/$profileSlug/edit.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/edit.tsx
@@ -13,7 +13,7 @@ import { Toolbar } from '@ui/surface/Toolbar';
 import { ArrowLeft, CircleUserRound, Palette, Save, Trash2, User, UsersRound } from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
 
-import { useCurrentProfile, useUpdateCurrentProfile } from '@db/profiles';
+import { useCurrentProfile, useDefaultGroupPreference, useUpdateCurrentProfile } from '@db/profiles';
 import type { CurrentProfileEntry, ProfileUserEditInput } from '@db/profiles';
 import { setSchemePreference, useSchemePreference } from '@app/styles/colorScheme';
 import type { SchemePreference } from '@app/styles/colorScheme';
@@ -135,7 +135,10 @@ function EditableProfilePage({ initial }: { initial: CurrentProfileEntry }) {
   const [activeTab, setActiveTab] = useState<ProfileTab>('profile');
   const [username, setUsername] = useState(initial.username ?? '');
   const [avatarUrl, setAvatarUrl] = useState(initial.avatar_url ?? '');
-  const [defaultGroupId, setDefaultGroupId] = useState<string | null>(initial.default_group_id);
+  /* The raw column now, not the sanitized projection: `session` no longer joins memberships.
+     The effect below corrects a default pointing at a Group the viewer left, once the options land. */
+  const [defaultGroupId, setDefaultGroupId] = useState<string | null>(initial.default_group_id ?? null);
+  const defaultGroupOptions = useDefaultGroupPreference().data?.default_group_options;
   const [defaultGroupChanged, setDefaultGroupChanged] = useState(false);
   const [savedProfile, setSavedProfile] = useState({
     username: initial.username ?? '',
@@ -146,10 +149,13 @@ function EditableProfilePage({ initial }: { initial: CurrentProfileEntry }) {
   const scheme = useSchemePreference();
 
   useEffect(() => {
-    if (defaultGroupId && !initial.default_group_options.some((group) => group.id === defaultGroupId)) {
+    if (!defaultGroupOptions) {
+      return;
+    }
+    if (defaultGroupId && !defaultGroupOptions.some((group) => group.id === defaultGroupId)) {
       setDefaultGroupId(null);
     }
-  }, [defaultGroupId, initial.default_group_options]);
+  }, [defaultGroupId, defaultGroupOptions]);
 
   const mutationError = update.isError && update.error instanceof Error ? update.error.message : null;
   const visibleError = submissionError ?? mutationError;
@@ -306,7 +312,7 @@ function EditableProfilePage({ initial }: { initial: CurrentProfileEntry }) {
                 }}
                 data={[
                   { value: '', label: 'No default Group' },
-                  ...initial.default_group_options.map((group) => ({ value: group.id, label: group.name })),
+                  ...(defaultGroupOptions ?? []).map((group) => ({ value: group.id, label: group.name })),
                 ]}
                 clearable
               />


### PR DESCRIPTION
Item 2 of [#698](https://github.com/ndelangen/dunezone/issues/698), from finding 1 of the subscriptions audit [#632](https://github.com/ndelangen/dunezone/issues/632). **Based on `main`, not stacked.** No schema or index change.

Every `_app` page holds the session read through `SiteNavigation`, and that read computed `default_group_options`: an active-memberships query plus a group read per membership. One Select, on one tab of the profile edit form, consumes it.

## Two changes

**The preference moved to the page that renders it.** New `profiles.defaultGroupPreference`, held by `EditableProfilePage` rather than by `ProfileSettingsPage`. That placement is deliberate: the outer component also renders for signed-out visitors and for people viewing someone else's settings, and neither should subscribe to a memberships join.

**The session pair collapsed.** `profiles.currentUserId` and `profiles.current` were two subscriptions answering one question. They are now `profiles.session`, returning `{ userId, profile }`. Both queries also gained return validators, which neither had.

## Three things worth reviewing rather than skimming

**The envelope is never `null`, on purpose.** A signed-out viewer and a signed-in viewer with no profile row yet have to stay distinguishable, or `useCurrentProfile`'s bootstrap never fires and a new OAuth account never gets a profile. `{ userId: null, profile: null }` and `{ userId, profile: null }` are different states and the shape preserves that.

The client mirror of the same trap: `toLiveQueryResult` derives `isPending` from `liveData === undefined`, so writing `session?.profile` would make a signed-out viewer read as permanently pending. The explicit ternary keeps today's behaviour exactly.

**The reconcile effect gates on loaded, not on non-empty.** The tempting `(options ?? []).some(...)` reads the loading window as "you are in no Groups", clears a valid saved default, and does not set `defaultGroupChanged` — so `isDirty` stays false and nothing on screen says it happened. It gates on `!defaultGroupOptions` instead.

**`session.profile.default_group_id` is now the raw column**, not the sanitized projection, so it can point at a Group the viewer has left. Both write paths (`updateCurrent` and `resolveDefaultGroupForCreation`) already re-check independently, and the form corrects a stale display once options arrive. Flagged because it is a real behaviour change, not because it is unsafe.

## Considered and rejected: the Picker shape

`ConnectedTabs` unmounts inactive panels, so a `DefaultGroupPicker` inside the `defaults` panel would be strictly lazier than a route-held query. It is rejected because the reconcile effect needs the option list *while that panel is unmounted*, and feeding it upward would make a Picker read page state, which is the line AGENTS.md draws. The audit's finding 1 specifies a route-held query; the defer-to-open shape is finding 2, a different item.

## Verified

**The server contract, against the deployment** rather than from the source:

| query | anonymous response |
|---|---|
| `profiles:session` | `{ userId: null, profile: null }` |
| `profiles:defaultGroupPreference` | `{ default_group_id: null, default_group_options: [] }` |
| `profiles:current` | gone — "Could not find public function" |
| `profiles:currentUserId` | gone — same |

The app ran correctly against exactly those functions, which is also the proof the client is not still asking for the old pair: it could not be, they do not exist.

**In the browser, with the change deployed:**

- Visiting `/profiles/central/edit` as a non-owner subscribed to **nothing at all**, and `defaultGroupPreference` in particular was never requested. Recorded off the Convex websocket, not inferred.
- The shell settled to "Login" rather than a pending state, which is the signed-out half of the never-null envelope working end to end.
- `/factions` rendered 39 cards, no console errors.

**The split is pinned and the pin is not vacuous.** A test asserts `session.profile` no longer carries `default_group_options`, using a fixture whose member really is in a Group. Putting the projection back on `session` fails it.

Full gate list: lint, format:check, check:prose, typecheck, knip, check:convex-skip, check:css-orphans, check:app-layout, 727 tests.

## Not verified, and I would rather say so

The signed-in owner path was not exercised in a browser: this deployment's local origin has no session, and I am not going to handle credentials to get one. That path is covered by the unit test (mocked hook, clicks through to a seeded Group) and by `convex/defaultGroupPreference.test.ts`, which exercises the new query with a real member in a real Group.

I also considered adding an e2e assertion that opens the combobox, and did not: the e2e user has no Group seeded, so no assertion there can tell "options loaded, user has none" apart from "options never loaded". It would look like coverage without being any.

## What this does not fix

The per-membership fan-out is unchanged — one `db.get` per active membership, under the existing `take(500)` cap. This is a subscription-scope change, not a read-count change: the join now runs on one page instead of every page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved profile loading to clearly distinguish signed-out users, authenticated users without a profile, and active profiles.
  * Profile setup now proceeds automatically for authenticated users who do not yet have a profile.
  * Default Group settings now use current membership information, preventing unavailable Groups from being selected.
  * Profile editing provides refreshed Group options and safely handles loading or outdated selections.

* **Documentation**
  * Updated authentication guidance for the revised profile loading and default Group preference experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->