### PR TITLE
Not-yet-loaded is not the same as belonging to no Groups

### DIFF
--- a/src/app/routes/_app/profiles/$profileSlug/-edit.test.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/-edit.test.tsx
@@ -208,6 +208,19 @@ describe('profile settings page', () => {
     expect(view.getByRole('img', { name: 'Avatar preview for Owner profile' })).not.toBeNull();
   });
 
+  it('offers no Group choice until the options have actually arrived', async () => {
+    /* The preference query is held by this page, so there is a window where it has not resolved.
+       An enabled control listing only "No default Group" would state that the viewer is in no Groups,
+       and choosing it saves a cleared default they never meant to change. */
+    mocks.useDefaultGroupPreference.mockReturnValue({ data: undefined });
+    const view = await renderPage();
+    await chooseTab(view, 'Creation defaults');
+
+    /* Disabled, so it is no longer exposed as a combobox; find it by its label. */
+    const field = view.container.querySelector('input[aria-label="Default Group"]');
+    expect(field).toHaveProperty('disabled', true);
+  });
+
   it('submits from every tab and includes an explicitly changed default Group', async () => {
     const view = await renderPage();
     fireEvent.change(view.getByRole('textbox', { name: /Display name/ }), { target: { value: 'ChangedOwner' } });

--- a/src/app/routes/_app/profiles/$profileSlug/edit.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/edit.tsx
@@ -305,6 +305,10 @@ function EditableProfilePage({ initial }: { initial: CurrentProfileEntry }) {
               <Select
                 ref={defaultGroupRef}
                 aria-label="Default Group"
+                /* Not yet loaded is not the same as "you are in no Groups", and an enabled control
+                   offering only "No default Group" says the second. The effect above gates on the
+                   same distinction; this is the other half of it. */
+                disabled={defaultGroupOptions === undefined}
                 value={defaultGroupId ?? ''}
                 onChange={(value) => {
                   setDefaultGroupId(value || null);


### PR DESCRIPTION
Follow-up to [#702](https://github.com/ndelangen/dunezone/pull/702), which is already on `main`. Found by an independent review I ran after it merged, because Sourcery and Copilot were quota-blocked on it and only one of the three LLM reviewers actually looked.

## The defect, and it is mine

#702 moved the default-group options onto their own query held by the edit page. That introduced a window where the page is rendered and the options have not arrived.

I gated the reconcile effect on exactly that distinction:

```ts
if (!defaultGroupOptions) {
  return;
}
```

and then left the same conflation in the Select two hundred lines further down:

```ts
...(defaultGroupOptions ?? []).map(...)
```

So during the window the control was **enabled** and offered exactly one entry, "No default Group". That is not a neutral placeholder; it is a statement that the viewer belongs to no Groups. Choosing it calls `setDefaultGroupChanged(true)`, which enables Save, and the reconcile effect then has nothing to correct because the value is already `null`. Submitting sends `default_group_id: null` and clears a default the viewer never meant to touch.

The blank field itself self-heals once options land, so the durable harm is only reachable by interacting inside the window. It is narrow. It is also the exact conflation I had just written a guard for, which is why it is worth closing rather than filing.

## The fix

`disabled={defaultGroupOptions === undefined}`.

Disabled rather than a skeleton or a spinner, deliberately: the control keeps its label, its ref and its `ControlBlock` group, so `e2e/profile-edit.spec.ts` still finds it by role and its help tooltip assertions still hold. A skeleton would have broken them.

## Verified

`-edit.test.tsx` gains one test that renders with the preference query unresolved and asserts the field is disabled. I checked it is not vacuous: removing the guard fails it.

Note for whoever reads that test later: a disabled Mantine `Select` is no longer exposed as a `combobox`, so it is found by label rather than by role. That is why it does not match the query the sibling tests use.

Full gate list: lint, format:check, check:prose, typecheck, knip, 728 tests.

## Not in scope

The same review raised a second, larger point about deleting shell-held public Convex queries and the deploy window that opens between the Convex deploy and the Worker deploy. That is a process concern spanning every future change of its kind, not a bug in this file, and it is filed separately.
