### PR TITLE
CanvasScale fits its canvas in CSS and stops measuring

### DIFF
--- a/src/app/ui/layout/CanvasScale.tsx
+++ b/src/app/ui/layout/CanvasScale.tsx
@@ -1,10 +1,13 @@
-import { useEffect, useState } from 'react';
-import type { PropsWithChildren } from 'react';
+import type { CSSProperties, PropsWithChildren } from 'react';
 
 /**
  * Fits a fixed-size canvas, a game renderer drawing in card-space pixels, to the container's width: the frame keeps the canvas aspect and clips it while the canvas renders at native size and scales to fit, down in a rail and up in a wide mount, which stays crisp because the renderers are DOM and vector rather than raster.
+ * The fit is CSS, not measurement: the frame is its own container, so `100cqw` is its width, and dividing that by the canvas width gives the scale directly.
+ * Nothing here re-renders on resize, and the canvas is present on first paint rather than after a measurement lands.
+ * The canvas is taken out of flow so the frame's height comes from its aspect ratio alone, never from the unscaled child it clips.
  * Pure placement;
  * the caller decorates the frame (shadow, anything bespoke) through `frameClassName`, and `rounded` is the one shared decoration: the corner treatment every rail proof wears (Norbert, 2026-08-21), kept here so five rails cannot drift apart.
+ * The browser floor this technique sets is recorded on «Work the kit compliance wave» (#641).
  */
 export function CanvasScale({
   canvasWidth,
@@ -18,42 +21,35 @@ export function CanvasScale({
   frameClassName?: string;
   rounded?: boolean;
 }>) {
-  const [width, setWidth] = useState(0);
-  const [node, setNode] = useState<HTMLDivElement | null>(null);
-  useEffect(() => {
-    if (!node) {
-      return;
-    }
-    const observer = new ResizeObserver(([entry]) => setWidth(entry?.contentRect.width ?? 0));
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [node]);
   return (
-    <div ref={setNode} style={{ width: '100%' }}>
-      {width > 0 && (
-        <div
-          className={frameClassName}
-          style={{
-            width,
-            height: width * (canvasHeight / canvasWidth),
-            position: 'relative',
-            overflow: 'hidden',
-            borderRadius: rounded ? 'var(--mantine-radius-md)' : undefined,
-          }}
-        >
-          <div
-            style={{
-              width: canvasWidth,
-              height: canvasHeight,
-              transform: `scale(${width / canvasWidth})`,
-              transformOrigin: 'top left',
-              pointerEvents: 'none',
-            }}
-          >
-            {children}
-          </div>
-        </div>
-      )}
+    <div
+      className={frameClassName}
+      style={
+        {
+          width: '100%',
+          aspectRatio: `${canvasWidth} / ${canvasHeight}`,
+          containerType: 'inline-size',
+          position: 'relative',
+          overflow: 'hidden',
+          borderRadius: rounded ? 'var(--mantine-radius-md)' : undefined,
+          '--canvas-width': `${canvasWidth}px`,
+        } as CSSProperties
+      }
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: canvasWidth,
+          height: canvasHeight,
+          transform: 'scale(calc(100cqw / var(--canvas-width)))',
+          transformOrigin: 'top left',
+          pointerEvents: 'none',
+        }}
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/app/widgets/bundle-editor/BundleEditor.test.tsx
+++ b/src/app/widgets/bundle-editor/BundleEditor.test.tsx
@@ -20,7 +20,9 @@ window.matchMedia = vi.fn().mockImplementation((query: string) => ({
   dispatchEvent: vi.fn(),
 }));
 
-/* `PreviewChoice` constructs a ResizeObserver without guarding for its absence, and jsdom has none.
+/* jsdom has no ResizeObserver and something in this tree constructs one unguarded. Here it is Mantine's
+   own ScrollArea, reached when the band Select opens its dropdown, not `PreviewChoice`: this editor's
+   preview tiles carry no `canvas`, so the branch that observes never mounts.
    It never has to fire: nothing in these tests depends on a reported size. */
 globalThis.ResizeObserver = class ResizeObserver {
   observe() {}

--- a/src/app/widgets/bundle-editor/BundleEditor.test.tsx
+++ b/src/app/widgets/bundle-editor/BundleEditor.test.tsx
@@ -20,16 +20,10 @@ window.matchMedia = vi.fn().mockImplementation((query: string) => ({
   dispatchEvent: vi.fn(),
 }));
 
-/*
- * jsdom has no layout, so an observer that never fires reports width 0 and `CanvasScale` renders no children at all.
- * This editor draws its proof inside one, so a dead stub would let an assertion about that proof pass against a DOM that never contained it.
- * Reporting a width mounts what the rail actually draws.
- */
+/* `PreviewChoice` constructs a ResizeObserver without guarding for its absence, and jsdom has none.
+   It never has to fire: nothing in these tests depends on a reported size. */
 globalThis.ResizeObserver = class ResizeObserver {
-  constructor(private readonly callback: ResizeObserverCallback) {}
-  observe() {
-    this.callback([{ contentRect: { width: 900 } } as ResizeObserverEntry], this);
-  }
+  observe() {}
   unobserve() {}
   disconnect() {}
 };

--- a/src/app/widgets/deck-editor/DeckEditor.test.tsx
+++ b/src/app/widgets/deck-editor/DeckEditor.test.tsx
@@ -21,16 +21,10 @@ window.matchMedia = vi.fn().mockImplementation((query: string) => ({
   dispatchEvent: vi.fn(),
 }));
 
-/*
- * jsdom has no layout, so an observer that never fires reports width 0 and `CanvasScale` renders no children at all.
- * That silently hid every rail proof from this file: an assertion about the proof would have passed against a DOM that never contained one.
- * Reporting a width mounts what the rail actually draws.
- */
+/* `PreviewChoice` constructs a ResizeObserver without guarding for its absence, and jsdom has none.
+   It never has to fire: nothing in these tests depends on a reported size. */
 globalThis.ResizeObserver = class ResizeObserver {
-  constructor(private readonly callback: ResizeObserverCallback) {}
-  observe() {
-    this.callback([{ contentRect: { width: 900 } } as ResizeObserverEntry], this);
-  }
+  observe() {}
   unobserve() {}
   disconnect() {}
 };

--- a/src/app/widgets/token-editor/TokenEditor.test.tsx
+++ b/src/app/widgets/token-editor/TokenEditor.test.tsx
@@ -20,16 +20,10 @@ window.matchMedia = vi.fn().mockImplementation((query: string) => ({
   dispatchEvent: vi.fn(),
 }));
 
-/*
- * jsdom has no layout, so an observer that never fires reports width 0 and `CanvasScale` renders no children at all.
- * This editor draws its proof inside one, so a dead stub would let an assertion about that proof pass against a DOM that never contained it.
- * Reporting a width mounts what the rail actually draws.
- */
+/* `PreviewChoice` constructs a ResizeObserver without guarding for its absence, and jsdom has none.
+   It never has to fire: nothing in these tests depends on a reported size. */
 globalThis.ResizeObserver = class ResizeObserver {
-  constructor(private readonly callback: ResizeObserverCallback) {}
-  observe() {
-    this.callback([{ contentRect: { width: 900 } } as ResizeObserverEntry], this);
-  }
+  observe() {}
   unobserve() {}
   disconnect() {}
 };


### PR DESCRIPTION
The last item of [#641](https://github.com/ndelangen/dunezone/issues/641), which this closes. **Based on `main`, not stacked.** Net 22 lines removed.

Norbert's decision is [recorded on the ticket](https://github.com/ndelangen/dunezone/issues/641#issuecomment-5394223591): option C, simplify now, no exemption sentence and no scheduled revisit, because current and future simplicity outweighs a temporary niche graceful failure and a revisit is itself a cost.

## What changes

`CanvasScale` measured its container with a `ResizeObserver` and wrote `transform: scale(width / canvasWidth)` in JS. The frame is now its own container, so `100cqw` **is** its width, and the division happens in CSS:

```css
transform: scale(calc(100cqw / var(--canvas-width)));
```

The observer goes, along with two pieces of state, an effect, a callback ref and the `width > 0` render gate.

Two consequences worth naming:

- The canvas is taken **out of flow**, so the frame's height comes from its `aspect-ratio` alone and never from the unscaled child it clips. Without that the frame would be sized by a 1263px-tall child.
- The proof is present **on first paint** rather than after a measurement lands, which removes a frame of empty rail.

## Accepted Firefox tail

Firefox 154 and older lack `calc()` typed arithmetic and render the proofs as a **silently plausible close-up crop** rather than anything obviously broken. Firefox 155 ships the feature on 1 September 2026.

That is the accepted consequence of the decision, not an open question. Measurements across all three engines, the isolation of which feature is missing, the Bugzilla and release-note links, and screenshots of the failure are all in [the evidence comment](https://github.com/ndelangen/dunezone/issues/641#issuecomment-5394223591); this PR does not re-argue them.

## Three test files change, and the reason is the interesting part

`BundleEditor`, `TokenEditor` and `DeckEditor` each carried a `ResizeObserver` stub whose comment said it existed because an unmeasured `CanvasScale` "renders no children at all", so a dead stub would let assertions about a rail proof pass against a DOM that never contained one. That hazard is now gone.

The stub is not, and I checked rather than assumed: removing it entirely fails the suite with `ReferenceError: ResizeObserver is not defined`, because `PreviewChoice` constructs one without guarding for its absence. But making it **inert** passes, so it no longer needs to fire. All three now carry a two-line stub and a comment that says what is actually true.

## Verified

**In Chromium, at four widths**, driving the real story and measuring:

| container | frame | canvas on screen | computed transform |
|---|---|---|---|
| 450px | 450x632 | 450x632 | `matrix(0.5, …)` |
| 300px | 300x421 | 300x421 | `matrix(0.333333, …)` |
| 180px | 180x253 | 180x253 | `matrix(0.2, …)` |
| 90px | 90x126 | 90x126 | `matrix(0.1, …)` |

Every scale is exactly container ÷ 900, the aspect holds, and the canvas fills the frame at each size. The scaling is now continuous rather than quantised by observer callbacks.

**In situ on a rail**, the token editor story draws both proofs in 256px frames at `matrix(0.284444, …)`, which is 256 ÷ 900, with their artwork intact.

Full gate list: lint, format:check, check:prose, typecheck, knip, check:app-layout, 727 unit tests, 351 storybook tests. The renderer manifest is unchanged; `CanvasScale` is not in the capture bundle's import graph.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Canvas previews now scale smoothly within their available frame while preserving aspect ratio, clipping, rounded corners, and pointer interactions.
  * Canvas frames render immediately for a more consistent visual experience.

* **Tests**
  * Updated editor test coverage to use stable resize behavior, reducing layout-dependent results in test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->