### PR TITLE
The shield preview stops measuring itself

### DIFF
--- a/src/app/widgets/faction-editor/FactionSheetReview.module.css
+++ b/src/app/widgets/faction-editor/FactionSheetReview.module.css
@@ -195,22 +195,15 @@
   padding-bottom: 3.5rem;
 }
 
-.shieldFrame {
-  position: relative;
+/* Owns the width, because `CanvasScale` sets its own to 100% inline and an inline style beats a class. */
+.shieldMount {
   flex: 0 0 auto;
   width: min(100%, 22rem);
-  overflow: hidden;
-  filter: drop-shadow(0 0.75rem 1.2rem rgb(0 0 0 / 32%));
 }
 
-.shieldCanvas {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 1608px;
-  height: 805px;
-  transform-origin: top left;
-  pointer-events: none;
+/* Only the decoration: the frame's position and clipping belong to `CanvasScale`. */
+.shieldFrame {
+  filter: drop-shadow(0 0.75rem 1.2rem rgb(0 0 0 / 32%));
 }
 
 .sheetSpread {
@@ -260,7 +253,7 @@
     padding-bottom: 0;
   }
 
-  .shieldFrame {
+  .shieldMount {
     width: min(30%, 17rem);
   }
 

--- a/src/app/widgets/faction-editor/FactionSheetReview.tsx
+++ b/src/app/widgets/faction-editor/FactionSheetReview.tsx
@@ -1,8 +1,9 @@
 import { ActionIcon, Alert, Button, Group, Stack, Text, Title } from '@mantine/core';
 import { FactionRender } from '@shared/factions/schema';
 import { Eyebrow } from '@ui/content/Eyebrow';
+import { CanvasScale } from '@ui/layout/CanvasScale';
 import { ChevronDown, Link2, X } from 'lucide-react';
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 
 import type { Faction } from '@db/factions';
@@ -14,38 +15,19 @@ import styles from './FactionSheetReview.module.css';
 
 const DESKTOP_REVIEW_MEDIA = '(min-width: 48em)';
 
+/**
+ * The shield at whatever width the review pane gives it.
+ * The mount owns the width and names the picture;
+ * `CanvasScale` owns the fit, which is why the shield's own size is read from `@game/data/sizes` here and written down nowhere else.
+ */
 function ScaledFactionShield({ faction }: { faction: Faction }) {
-  const frameRef = useRef<HTMLDivElement>(null);
-  const [frameWidth, setFrameWidth] = useState(352);
   const renderProps = FactionRender.shield.parse(factionDraftForRenderer(faction));
-  const scale = frameWidth / shieldSize.width;
-
-  useLayoutEffect(() => {
-    const frame = frameRef.current;
-    if (!frame) {
-      return;
-    }
-    const update = () => setFrameWidth(frame.clientWidth || 352);
-    update();
-    if (typeof ResizeObserver === 'undefined') {
-      return;
-    }
-    const observer = new ResizeObserver(update);
-    observer.observe(frame);
-    return () => observer.disconnect();
-  }, []);
 
   return (
-    <div
-      ref={frameRef}
-      className={styles.shieldFrame}
-      style={{ height: shieldSize.height * scale }}
-      role="img"
-      aria-label="Faction shield preview"
-    >
-      <div className={styles.shieldCanvas} style={{ transform: `scale(${scale})` }}>
+    <div className={styles.shieldMount} role="img" aria-label="Faction shield preview">
+      <CanvasScale canvasWidth={shieldSize.width} canvasHeight={shieldSize.height} frameClassName={styles.shieldFrame}>
         <Shield {...renderProps} />
-      </div>
+      </CanvasScale>
     </div>
   );
 }


### PR DESCRIPTION
First item of [#707](https://github.com/ndelangen/dunezone/issues/707)'s declarative wave. Net 25 lines removed.

**Now based on `main`.** It was opened stacked on [#705](https://github.com/ndelangen/dunezone/pull/705) and retargeted once that merged; the diff is the shield change alone.

## Why it was stacked, kept as history

The replacement is "use `CanvasScale`", and before #705 that component rendered **nothing** until its `ResizeObserver` reported a width. `ScaledFactionShield` seeded `frameWidth` at 352 precisely so the shield was painted on first render. Landing this against the old `CanvasScale` would therefore have traded one observer for another **and** introduced a blank first paint. That is why it waited rather than raced, and why anyone tempted to reorder this pair should not.

## What it deletes

`ScaledFactionShield` was #705's own precedent, one commit earlier: a fixed 1608x805 canvas, `transform-origin: top left`, an inline `height: shieldSize.height * scale`, and a `useLayoutEffect` + `ResizeObserver` to keep `scale = frameWidth / 1608` current.

Both halves are already CSS:

- `scale = frameWidth / 1608` **is** `calc(100cqw / 1608px)`
- `height = 805 * scale` **is** `aspect-ratio: 1608 / 805`

Nothing branched on the number. It was only ever a style, which is the test [#707](https://github.com/ndelangen/dunezone/issues/707) settled on.

Gone: the layout effect, the observer, the `frameWidth` state, the 352px seed, and the `useLayoutEffect` import.

## The duplicate that came with it

`.shieldCanvas` hard-coded `width: 1608px; height: 805px`. That is a second, hand-written copy of `shield` in [`src/game/data/sizes.ts`](src/game/data/sizes.ts), which the component **already imports** as `shieldSize`. The class is deleted rather than moved, and the two numbers now have one source.

## The trap, handled

`CanvasScale` writes `width: 100%` as an inline style, which beats a class. So `.shieldFrame` could not keep owning the width.

A `.shieldMount` wrapper takes the width (`min(100%, 22rem)`, and `min(30%, 17rem)` under the `faction-review-plane` container query) plus `flex: 0 0 auto`, and carries the `role="img"` and `aria-label` so the picture is still named. `.shieldFrame` keeps only its `drop-shadow`; `position: relative` and `overflow: hidden` come from `CanvasScale` itself.

## Verified in the browser, both width paths

Driving `FactionSheetReview`'s desktop story and measuring:

| state | mount | frame | scale applied | expected |
|---|---|---|---|---|
| base width | 352px | 352x176 | `0.218905` | 352 / 1608 |
| container query fired | 272px | 272x136 | `0.169154` | 272 / 1608 |

The aspect holds in both, the drop-shadow is still on the frame, and the shield draws its 7 SVGs. The second row needed the review plane forced to 1100x700, since the container query wants 56rem x 34rem and the story's plane is smaller than that by default.

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 727 unit tests, 351 storybook tests.
