### PR TITLE
Three drafts re-seed during render instead of through an effect

### DIFF
--- a/src/app/routes/_app/factions/-catalogue.ts
+++ b/src/app/routes/_app/factions/-catalogue.ts
@@ -149,8 +149,13 @@ export function useFactionCatalogueSession(data: Pick<FactionCataloguePageData, 
   const search = parseFactionCatalogueSearch(location.search ?? {});
   const rawSearch = location.searchStr;
   const [draftQuery, setDraftQuery] = useState(search.q ?? '');
-
-  useEffect(() => setDraftQuery(search.q ?? ''), [search.q]);
+  const [seededQuery, setSeededQuery] = useState(search.q ?? '');
+  /* Reset during render, the search box's pattern: the URL is the committed value, and a back button
+     that restores an older query must not paint the previous one first. */
+  if ((search.q ?? '') !== seededQuery) {
+    setSeededQuery(search.q ?? '');
+    setDraftQuery(search.q ?? '');
+  }
 
   useEffect(() => {
     if (!data) {

--- a/src/app/routes/_app/factions/index.tsx
+++ b/src/app/routes/_app/factions/index.tsx
@@ -27,7 +27,7 @@ import { FactionList } from '@ui/list/FactionList';
 import { Surface } from '@ui/surface';
 import { Toolbar } from '@ui/surface/Toolbar';
 import { ArrowDownAZ, ChevronsDown, Filter, Plus, Search, SlidersHorizontal } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { KeyboardEvent } from 'react';
 
 import { loadFactionCataloguePage, useFactionCataloguePage } from '@db/factions';
@@ -186,10 +186,13 @@ function ComplexityRangeSlider({
   onCommit: (value: FactionComplexityRange) => void;
 }) {
   const [draft, setDraft] = useState<FactionComplexityRange>(() => parseComplexityRange(value));
-
-  useEffect(() => {
+  const [seeded, setSeeded] = useState(value);
+  /* Reset during render, the search box's pattern. Compared on the raw prop rather than on the parsed
+     range, because parsing allocates a new object every call and would reset on every render. */
+  if (value !== seeded) {
+    setSeeded(value);
     setDraft(parseComplexityRange(value));
-  }, [value]);
+  }
 
   return (
     <RangeSlider

--- a/src/app/ui/control/MemberCountInput.test.tsx
+++ b/src/app/ui/control/MemberCountInput.test.tsx
@@ -28,6 +28,26 @@ function renderInput(onCommit: (count: number) => void, value = 7) {
   );
 }
 
+it('re-seeds the field when the committed count changes underneath an untouched edit', () => {
+  /* The reset happens during render rather than in an effect, so a value arriving from elsewhere is
+     never shown stale for a paint first. Nothing else covered this branch. */
+  const onCommit = vi.fn();
+  const view = renderInput(onCommit, 7);
+  const field = () => screen.getByRole('textbox', { name: 'Copies of Lasgun' });
+  expect(field()).toHaveProperty('value', '7');
+
+  fireEvent.change(field(), { target: { value: '12' } });
+  expect(field()).toHaveProperty('value', '12');
+
+  view.rerender(
+    <MantineProvider theme={appContentTheme} forceColorScheme="light">
+      <MemberCountInput label="Copies of Lasgun" value={3} min={1} max={99} disabled={false} onCommit={onCommit} />
+    </MantineProvider>
+  );
+  expect(field()).toHaveProperty('value', '3');
+  expect(onCommit).not.toHaveBeenCalled();
+});
+
 it('commits a typed count once, not once per keystroke', () => {
   const onCommit = vi.fn();
   renderInput(onCommit);

--- a/src/app/ui/control/MemberCountInput.tsx
+++ b/src/app/ui/control/MemberCountInput.tsx
@@ -1,5 +1,5 @@
 import { NumberInput } from '@mantine/core';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 /**
  * A membership count the author types freely and commits once, because each commit is a database write.
@@ -24,7 +24,13 @@ export function MemberCountInput({
   onCommit: (count: number) => void;
 }) {
   const [typed, setTyped] = useState<string | number>(value);
-  useEffect(() => setTyped(value), [value]);
+  const [seeded, setSeeded] = useState(value);
+  /* Reset during render, the search box's pattern: a committed change arriving from elsewhere must not
+     show the stale draft for a paint first. */
+  if (value !== seeded) {
+    setSeeded(value);
+    setTyped(value);
+  }
 
   const commit = () => {
     const next = Math.min(max, Math.max(min, Math.round(Number(typed) || min)));


### PR DESCRIPTION
Item 7 of [#707](https://github.com/ndelangen/dunezone/issues/707)'s declarative wave. **Based on `main`, not stacked.**

Three controls keep a draft the reader edits, and re-seed it when the committed value changes underneath: `MemberCountInput`, the catalogue's search box, and the complexity range slider. All three did the re-seed in an effect, which means a commit and a paint showing the **stale** draft before the correction lands.

## The repo already had the fix, and a name for it

`useHoldToConfirm.ts:28` calls it "the search box's pattern": compare during render, and React re-runs the component before painting.

```tsx
const [seeded, setSeeded] = useState(value);
if (value !== seeded) {
  setSeeded(value);
  setTyped(value);
}
```

All three now do that. Two `useEffect` imports become unused and go.

## One that is not mechanical

The complexity range compares the **raw prop**, not the parsed range:

```tsx
if (value !== seeded) {
  setSeeded(value);
  setDraft(parseComplexityRange(value));
}
```

`parseComplexityRange` allocates a new object every call, so comparing parsed values would be true on every render and reset the draft forever. The effect version was safe from this only because its dependency array held the raw `value`.

## The branch had no test, so it has one now

`MemberCountInput.test.tsx` gains a case where the committed count changes while an untouched edit is in the field. Both existing tests drive the field and never change `value` from outside, so the re-seed, the exact behaviour this PR rewrites, was uncovered.

I checked it is not vacuous: removing the render-phase reset fails it.

The other two are covered indirectly. The catalogue's re-seed rides the URL and is exercised by `-catalogue.test.ts`; the range slider is a story-only control.

## Proof, and what it does not prove

`MemberCountInput` is the one of the three with stories; the catalogue search box and the complexity range are route-level. All four of its stories, after the change:

| default | at minimum | at maximum | disabled |
|---|---|---|---|
| ![default](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-709-membercount-default.png) | ![at minimum](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-709-membercount-at-minimum.png) | ![at maximum](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-709-membercount-at-maximum.png) | ![disabled](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-709-membercount-disabled.png) |

And the draft holding an edit, which is the state a re-seed has to override:

![mid-edit, field showing 42](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-709-membercount-mid-edit.png)

**Being straight about these:** they show the control still renders correctly, which is the parity half of the claim. They cannot show the fix. What this PR removes is a single paint where the field showed the stale draft before the effect corrected it, and a still image cannot show a frame that no longer happens. That half is carried by the test, which fails when the render-phase reset is removed.

The other two are unscreenshotted: the search box's re-seed rides the URL and the range slider is route-level. Their change is the same three lines and the same reasoning.

## Verified

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 729 unit tests, 351 storybook tests.

## A note on the census this came from

While working the items around this one I checked [#707](https://github.com/ndelangen/dunezone/issues/707)'s other claims and two of them do not hold. Details are on that ticket rather than here, but in short: the preview-sheet effects are duplicated, not racing, and the effect itself is earned; and of the icons route's four effects, one is a documented fix for a real bug rather than a React 17 guard. The census is directionally right and its per-item reasoning still needs checking, which is what it asked for.

