### PR TITLE
ContainFit stops measuring, and stays its own component

### DIFF
--- a/src/app/ui/control/PreviewChoice.tsx
+++ b/src/app/ui/control/PreviewChoice.tsx
@@ -1,6 +1,6 @@
 import { Text } from '@mantine/core';
-import { useEffect, useId, useState } from 'react';
-import type { ReactNode } from 'react';
+import { useId } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 import styles from './PreviewChoice.module.css';
 
@@ -32,41 +32,39 @@ export type PreviewChoiceOption<T extends string> = {
 
 /*
  * Contain-fits a fixed-canvas preview to the tile's art box.
- * `CanvasScale` fits width only, which is right for a rail; a tile also has a height that a control
- * in the detail slot can shrink, so the smaller of the two ratios wins and the render centers.
+ * `CanvasScale` is the other way round and stays separate: there the canvas dictates the box, which is
+ * why it sets an aspect ratio, and here the caller dictates the box and the canvas fits inside it.
+ * The art box is its own container on both axes, so `min()` picks whichever of the two ratios binds,
+ * and the centring is the flex box plus a scale about the centre rather than an offset anyone computes.
  */
 function ContainFit({ width, height, children }: { width: number; height: number; children: ReactNode }) {
-  const [node, setNode] = useState<HTMLDivElement | null>(null);
-  const [box, setBox] = useState<{ w: number; h: number } | null>(null);
-  useEffect(() => {
-    if (!node) {
-      return;
-    }
-    const observer = new ResizeObserver(([entry]) =>
-      setBox({ w: entry?.contentRect.width ?? 0, h: entry?.contentRect.height ?? 0 })
-    );
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [node]);
-  const scale = box ? Math.min(box.w / width, box.h / height) : 0;
   return (
-    <div ref={setNode} style={{ width: '100%', height: '100%', position: 'relative', overflow: 'hidden' }}>
-      {box && scale > 0 && (
-        <div
-          style={{
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        containerType: 'size',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={
+          {
             width,
             height,
-            transform: `scale(${scale})`,
-            transformOrigin: 'top left',
-            position: 'absolute',
-            left: (box.w - width * scale) / 2,
-            top: (box.h - height * scale) / 2,
+            flex: '0 0 auto',
+            '--contain-fit-width': `${width}px`,
+            '--contain-fit-height': `${height}px`,
+            transform: 'scale(min(100cqw / var(--contain-fit-width), 100cqh / var(--contain-fit-height)))',
             pointerEvents: 'none',
-          }}
-        >
-          {children}
-        </div>
-      )}
+          } as CSSProperties
+        }
+      >
+        {children}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Item 3 of [#707](https://github.com/ndelangen/dunezone/issues/707)'s declarative wave. **Based on `main`, not stacked.**

`ContainFit` measured its box on both axes with a `ResizeObserver`, picked `Math.min(box.w / width, box.h / height)`, and centred the result by computing `left` and `top` offsets in JavaScript. All of that is CSS.

## The half the census got right

The art box is now its own container on **both** axes (`container-type: size`, not `inline-size`, because this needs `cqh` as well as `cqw`), so `min()` picks whichever ratio binds:

```css
transform: scale(min(100cqw / var(--contain-fit-width), 100cqh / var(--contain-fit-height)));
```

And the centring is the flex box plus a scale about the default centre origin, rather than two offsets anyone computes. The observer, both pieces of state and the render gate all go.

## The half I am not building, and why

The census proposed folding this into `CanvasScale` behind a `fit?: 'width' | 'contain'` prop, on the grounds that it "removes the reason a second implementation exists". The reason was already written down in `ContainFit`'s own JSDoc, and it is not that `CanvasScale` lacks a mode:

> `CanvasScale` fits width only, which is right for a rail; a tile also has a height that a control in the detail slot can shrink.

The two answer **opposite** questions. Under `CanvasScale` the canvas dictates the box, which is exactly why it sets an `aspect-ratio`. Here the caller dictates the box and the canvas fits inside it, letterboxed. A prop that switches which side decides the shape is two contracts wearing one name, and it would make `canvasWidth` and `canvasHeight` mean different things on either side of it: a ratio source in one mode, a fit target in the other.

So the components stay separate and share the technique rather than the membrane. The JSDoc now says which is which, in those terms, so the next reader does not re-propose the merge.

Worth noting the two were never really duplicates: after this change they share four CSS declarations, not a JavaScript reimplementation of layout.

## Verified in the browser, on the story, at three box shapes

Driving `controls-preview-choice--fixed-canvas-preview` with a 900x1263 canvas and resizing its art box:

| box | binds | drawn | expected | fits | centred |
|---|---|---|---|---|---|
| 300x100 | height | 71x100 | 71x100 | yes | yes |
| 100x400 | width | 100x140 | 100x140 | yes | yes |
| 80x112 | as shipped | 80x112 | 80x112 | yes | yes |

Both binding axes are exercised, which is the whole point of the `min()`.

### Proof

All from the real `PreviewChoice` story in Storybook, not a repro. The art box is outlined in green so the letterboxing is visible, and each image is the box itself rather than the page.

**Said plainly, because it should not read as something I merely observed:** the story renders at one shape, 80x112. The two extreme shapes below are that same live component with its art box resized in the browser, which is the only way to exercise both sides of the `min()`. The component, its data and its styles are untouched; only the container it is asked to fit is. The third image is the shape the story ships.

**Height binds** (box 300x100, canvas 900x1263 drawn at 71x100): the fit is limited by the short axis and the render centres horizontally.

![ContainFit with the height binding](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-710-containfit-height-binds-light.png)

**Width binds** (box 100x400, drawn at 100x140): the other ratio wins and the render centres vertically.

![ContainFit with the width binding](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-710-containfit-width-binds-light.png)

**As shipped** (box 80x112, drawn at 80x112): the tile's own shape, filling it.

![ContainFit at the shipped tile size](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-710-containfit-as-shipped-light.png)

**In situ, unmutated**, the card-shaped story with three tiles:

![PreviewChoice card-shaped story](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-710-preview-choice-in-situ-light.png)

One scheme only, and that is a finding rather than a shortcut: Storybook's preview forces its own colour scheme, so `prefers-color-scheme` emulation is inert inside the iframe. I captured both and the files came back byte-identical (same SHA-256 for each pair), so a dark set would be the same four images under different names.


I also checked the technique across engines before writing it: correct in Chromium 151 and WebKit 26.5 at all three shapes. Firefox 154 and older render unscaled, for the same `calc()` typed-arithmetic gap as `CanvasScale`, which is the accepted tail decided on [#641](https://github.com/ndelangen/dunezone/issues/641) and shipping in Firefox 155 on 1 September.

Full gate list: lint, format:check, check:prose, typecheck, knip, 728 unit tests, 351 storybook tests.

