### PR TITLE
Three stray effects, where the census claimed six

### DIFF
--- a/src/app/routes/_app/[_]_icons.tsx
+++ b/src/app/routes/_app/[_]_icons.tsx
@@ -92,9 +92,12 @@ function useInfiniteReveal(total: number, resetKey: string) {
     totalRef.current = total;
   }, [total]);
 
-  useEffect(() => {
+  const [seededKey, setSeededKey] = useState(resetKey);
+  /* Reset during render, the search box's pattern: a new search must not paint the previous batch first. */
+  if (resetKey !== seededKey) {
+    setSeededKey(resetKey);
     setVisibleCount(BATCH_SIZE);
-  }, [resetKey]);
+  }
 
   const sentinelRef = useCallback((node: HTMLDivElement | null) => {
     observerRef.current?.disconnect();
@@ -113,8 +116,6 @@ function useInfiniteReveal(total: number, resetKey: string) {
     observer.observe(node);
     observerRef.current = observer;
   }, []);
-
-  useEffect(() => () => observerRef.current?.disconnect(), []);
 
   return { visibleCount: Math.min(visibleCount, total), sentinelRef };
 }

--- a/src/app/routes/preview/sheet/$factionSlug.tsx
+++ b/src/app/routes/preview/sheet/$factionSlug.tsx
@@ -29,13 +29,6 @@ function FactionSheetDbMode() {
   const factionQuery = useFaction(factionSlug, { initialData: loaderData });
   const faction = factionQuery.data?.faction ?? loaderData?.faction;
 
-  useEffect(() => {
-    document.documentElement.dataset.factionSheet = '';
-    return () => {
-      delete document.documentElement.dataset.factionSheet;
-    };
-  }, []);
-
   if (!faction) {
     return null;
   }
@@ -45,13 +38,6 @@ function FactionSheetDbMode() {
 
 function FactionSheetLiveMode() {
   const factionFromMessage = useFactionSheetPostMessage(true);
-
-  useEffect(() => {
-    document.documentElement.dataset.factionSheet = '';
-    return () => {
-      delete document.documentElement.dataset.factionSheet;
-    };
-  }, []);
 
   if (!factionFromMessage) {
     return (
@@ -66,6 +52,16 @@ function FactionSheetLiveMode() {
 
 function FactionSheetPage() {
   const { mode } = Route.useSearch();
+
+  /* The flag belongs to the route, not to either mode: exactly one of them mounts, and both used to
+     carry an identical copy of this. Writing `<html>` is outside React's tree, so it stays an effect. */
+  useEffect(() => {
+    document.documentElement.dataset.factionSheet = '';
+    return () => {
+      delete document.documentElement.dataset.factionSheet;
+    };
+  }, []);
+
   // The Cmd+P path renders print-grade variants (#254).
   return (
     <AssetRenderModeProvider mode="print">


### PR DESCRIPTION
Items 5 and 6 of [#707](https://github.com/ndelangen/dunezone/issues/707), **as corrected on that ticket rather than as originally written**. The census billed six sites; three of them hold.

## The icons route

**Reset on key change** (`useInfiniteReveal`). `setVisibleCount(BATCH_SIZE)` in an effect keyed on `resetKey` now compares during render, the pattern `useHoldToConfirm.ts:28` already calls "the search box's pattern". A new search no longer paints the previous batch first.

**A cleanup that was already dead.** `useEffect(() => () => observerRef.current?.disconnect(), [])` removed. The sentinel is conditional (`:350`), so React calls `sentinelRef(null)` both when the sentinel unmounts early and when the component does, and that call already disconnects and nulls the ref. Both unmount orderings are safe either way.

**Two the census listed that stay.** `totalRef.current = total` is the standard latest-value-in-a-stable-callback ref, which exists so the `IntersectionObserver` is not rebuilt whenever `total` changes. And the `unmountedRef` effect is not the React 17 guard the census called it: its own comment describes the bug it fixes, where sharing one flag with the `[enabled]` effect meant leaving mid-scan permanently stopped `setVersion` for that page load.

## The preview sheet

The census called these two effects "**racing** to own one global `<html>` attribute". They cannot race: `FactionSheetPage` renders `mode === 'live' ? <FactionSheetLiveMode /> : <FactionSheetDbMode />`, so exactly one is ever mounted.

They were simply the same effect written twice. It is hoisted to the route component that chooses between them.

It stays an effect, deliberately. It writes `document.documentElement.dataset.factionSheet`, which is outside React's tree and which nothing renders, so by [#707](https://github.com/ndelangen/dunezone/issues/707)'s own test it is **earned**. The change is deduplication, not de-effecting.

A small improvement falls out: switching `mode` at runtime used to unmount one child and mount the other, deleting the attribute and re-adding it. Now it never leaves.

## What the flag is for

`html[data-faction-sheet]` drives `src/app/print/sheet/sheet-page.css`, which neutralizes the app's page decoration while a sheet document is on screen. That stylesheet's header names two surfaces that set it: this preview route and `print/capture/PublisherCapture.tsx`. Only the preview route changes here, and it still sets the flag whenever the route is mounted.

## Proof

I stood the app up and looked at both routes, which also closes the gap this PR originally shipped with.

**The preview sheet, db mode.** The flag is set and the print stylesheet takes effect: white page, no background image, no shadow, and the sheet renders.

![Preview sheet in db mode](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-711-preview-sheet-db.png)

**The preview sheet, live mode.** The other branch of the ternary, the one waiting on `postMessage`. Same flag, same neutralized page, which is the point: the flag belongs to the route, not to either mode.

![Preview sheet in live mode](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-711-preview-sheet-live.png)

Measured on both: `data-faction-sheet` present, `background-color: rgb(255, 255, 255)`, `background-image: none`, `box-shadow: none`. On every other route the flag is absent, which is the cleanup not leaking.

**The icons route, and the reset this PR rewrites.** Typing a search changes `resetKey`, which must restart the batch rather than leave the previous one on screen. Searching "spice" shows one match, from the top:

![Icons route after searching spice](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-711-icons-route-after-search.png)

![Icons route unfiltered](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-711-icons-route.png)

## Verified

Full gate list: lint, format:check, check:prose, typecheck, knip, check:app-layout, 729 unit tests.

One thing still argued rather than observed: the cleanup on leaving the route. Its code is unchanged and it moved to a component that unmounts at the same moment the old one did, so the set of moments the attribute exists is the same. What I did confirm is that the flag is present on both sheet modes and absent everywhere else.

