### PR TITLE
The sheet preview stops scrolling itself, and stops offering a page that is not there

### DIFF
--- a/src/app/widgets/faction-editor/FactionSheetPagePreview.module.css
+++ b/src/app/widgets/faction-editor/FactionSheetPagePreview.module.css
@@ -1,3 +1,10 @@
+/* Steps the sheet up by one page, so the second tile shows the second page.
+   The distance is the page's own aspect box plus the rule between pages, both declared by the sheet
+   stylesheet that defines a page; nothing here measures anything. */
+.steppedToPage2 {
+  margin-block-start: calc(-1 * (var(--faction-sheet-page-aspect) + var(--faction-sheet-page-rule)));
+}
+
 .frame {
   display: block;
   width: 100%;

--- a/src/app/widgets/faction-editor/FactionSheetPagePreview.tsx
+++ b/src/app/widgets/faction-editor/FactionSheetPagePreview.tsx
@@ -1,5 +1,4 @@
-import { CAPTURE_PROTOCOL } from '@shared/asset-publishing/capture-protocol';
-import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import type { Faction } from '@db/factions';
@@ -32,35 +31,10 @@ function preparePreviewDocument(document: Document) {
   document.body.style.overflow = 'hidden';
 }
 
-function alignIframePage(iframe: HTMLIFrameElement | null, pageNumber: 1 | 2) {
-  const document = iframe?.contentDocument;
-  if (!document) {
-    return;
-  }
-  const target = document.querySelector<HTMLElement>(`[${CAPTURE_PROTOCOL.pageMarker.attribute}="${pageNumber}"]`);
-  if (!target) {
-    return;
-  }
-  const top = target.offsetTop;
-  document.documentElement.scrollTop = top;
-  document.body.scrollTop = top;
-}
-
 export function FactionSheetPagePreview({ faction, pageNumber }: { faction: Faction; pageNumber: 1 | 2 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [portalRoot, setPortalRoot] = useState<HTMLElement | null>(null);
   const renderFaction = useMemo(() => factionDraftForRenderer(faction), [faction]);
-
-  useLayoutEffect(() => {
-    if (!portalRoot) {
-      return;
-    }
-    const firstFrame = window.requestAnimationFrame(() => {
-      alignIframePage(iframeRef.current, pageNumber);
-      window.requestAnimationFrame(() => alignIframePage(iframeRef.current, pageNumber));
-    });
-    return () => window.cancelAnimationFrame(firstFrame);
-  }, [pageNumber, portalRoot]);
 
   return (
     <>
@@ -80,7 +54,14 @@ export function FactionSheetPagePreview({ faction, pageNumber }: { faction: Fact
           setPortalRoot(document.body);
         }}
       />
-      {portalRoot ? createPortal(<FactionSheetView faction={renderFaction} />, portalRoot) : null}
+      {portalRoot
+        ? createPortal(
+            <div className={pageNumber === 2 ? styles.steppedToPage2 : undefined}>
+              <FactionSheetView faction={renderFaction} />
+            </div>,
+            portalRoot
+          )
+        : null}
     </>
   );
 }

--- a/src/app/widgets/faction-editor/FactionSheetReview.stories.tsx
+++ b/src/app/widgets/faction-editor/FactionSheetReview.stories.tsx
@@ -97,6 +97,29 @@ export const ConstrainedStacked = meta.story({
   play: async ({ canvasElement }) => openReview(canvasElement),
 });
 
+/**
+ * A faction with no karama rules, no troops and no leaders has no second sheet page.
+ * The review offers one tile rather than a second one showing the first page again under a page-2 label.
+ */
+const singlePageFaction: Faction = {
+  ...storyFaction,
+  leaders: [],
+  troops: [],
+  rules: { ...storyFaction.rules, advantages: [] },
+};
+
+export const WithoutASecondPage = meta.story({
+  args: {
+    faction: singlePageFaction,
+  },
+  globals: {
+    viewport: {
+      value: 'appLarge',
+    },
+  },
+  play: async ({ canvasElement }) => openReview(canvasElement),
+});
+
 export const LongContent = meta.story({
   args: {
     faction: storyFaction,

--- a/src/app/widgets/faction-editor/FactionSheetReview.tsx
+++ b/src/app/widgets/faction-editor/FactionSheetReview.tsx
@@ -7,6 +7,7 @@ import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useSta
 import type { CSSProperties, ReactNode } from 'react';
 
 import type { Faction } from '@db/factions';
+import { hasSheetPage2 } from '@game/assets/faction/sheet/Sheet';
 import { Shield } from '@game/assets/faction/shield/Shield';
 import { shield as shieldSize } from '@game/data/sizes';
 
@@ -93,13 +94,19 @@ function ReviewProofDesk({ faction }: { faction: Faction }) {
               <div className={styles.sheetPage} data-review-sheet-page="1">
                 <FactionSheetPagePreview faction={faction} pageNumber={1} />
               </div>
-              <div className={styles.sheetPage} data-review-sheet-page="2">
-                <FactionSheetPagePreview faction={faction} pageNumber={2} />
-              </div>
+              {/* A faction with no karama rules, troops or leaders has no second page, and a tile for it
+                  used to show the first page again under a "page 2" label. */}
+              {hasSheetPage2(faction) ? (
+                <div className={styles.sheetPage} data-review-sheet-page="2">
+                  <FactionSheetPagePreview faction={faction} pageNumber={2} />
+                </div>
+              ) : null}
             </div>
           </div>
         </div>
-        {showScrollCue ? (
+        {/* The cue names page 2 by hand, so it must not appear for a faction that has none: with the
+            tile gone there would be nothing below to scroll to. */}
+        {showScrollCue && hasSheetPage2(faction) ? (
           <div className={styles.scrollCue} role="status">
             <Text size="xs" fw={700}>
               Scroll for page 2

--- a/src/game/assets/faction/sheet/Sheet.module.css
+++ b/src/game/assets/faction/sheet/Sheet.module.css
@@ -22,14 +22,22 @@
   }
 }
 
+/* The page's own geometry, named because a surface showing one page of a stack has to step past
+   exactly this much, and a second copy of the numbers would be free to drift from these.
+   Custom properties are not scoped by CSS modules, so a document that clones this sheet gets them too. */
+:root {
+  /* A4 portrait aspect ratio (297 / 210). */
+  --faction-sheet-page-aspect: 141.428571%;
+  --faction-sheet-page-rule: 0.3vw;
+}
+
 .page {
   position: relative;
   background-color: #fffdf1;
-  /* A4 portrait aspect ratio (297 / 210). */
-  padding-top: 141.428571%;
+  padding-top: var(--faction-sheet-page-aspect);
 
   font-size: 3vw;
-  border-bottom: 0.3vw dashed #dedede;
+  border-bottom: var(--faction-sheet-page-rule) dashed #dedede;
 
   & * {
     box-sizing: border-box;

--- a/src/game/assets/faction/sheet/Sheet.tsx
+++ b/src/game/assets/faction/sheet/Sheet.tsx
@@ -97,12 +97,20 @@ export function FactionSheetPage1(props: SheetProps) {
   );
 }
 
+/**
+ * Whether a faction has a second sheet page at all.
+ * Exported because a surface that offers page 2 has to ask before offering it, and asking a different question than the renderer answers is how a preview ends up showing page 1 twice.
+ */
+export function hasSheetPage2(faction: Pick<SheetProps, 'rules' | 'troops' | 'leaders'>): boolean {
+  return (
+    faction.rules.advantages.some((rule) => !!rule.karama) || faction.troops.length > 0 || faction.leaders.length > 0
+  );
+}
+
 export function FactionSheetPage2(props: SheetProps) {
   return (
     <>
-      {props.rules.advantages.filter((r) => !!r.karama).length > 0 ||
-      props.troops.length > 0 ||
-      props.leaders.length > 0 ? (
+      {hasSheetPage2(props) ? (
         <div className={styles.page} {...{ [CAPTURE_PROTOCOL.pageMarker.attribute]: '2' }}>
           <div className={`${styles.page_subtitle} ${styles.subtitle}`}>Karama effects</div>
           <div className={styles.details}>

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,12 +4,12 @@
 // sharp version), so this file is reproducible on any machine (wayfinder #269).
 export const rendererManifest = {
   schemaVersion: 2,
-  rendererIdentity: 'faction-sheet/sha256:d3722b74a33558431cb707102721fbc0faf91bca7551d0b518c1e70682369e46',
-  digest: 'd3722b74a33558431cb707102721fbc0faf91bca7551d0b518c1e70682369e46',
+  rendererIdentity: 'faction-sheet/sha256:6f1efe244d7d4359ca8981088ed0fb815272f0b34178d4f569c653d6c0e120aa',
+  digest: '6f1efe244d7d4359ca8981088ed0fb815272f0b34178d4f569c653d6c0e120aa',
   components: {
     sources: '5289b6254320530ee857ff2912681e9d6a30135dbb3a92239296365f53397813',
     toolchain: 'e7e830225f6973a7d7e43aada3bcbcd5de3c169378aa25849d24d8de97ea517a',
-    code: '8b9214d708db8ce50f4f16db54cfeec485d125ddfeaafd5eaec088dabcd5f51f',
+    code: '94415425c0bca550fe1129935fc81ad2722370bf0fc0376d36dc923db5b28987',
     contract: '2920714c87493d104342355dda2b956202259513c78ce6195670034f31a656a6',
   },
   contract: {


### PR DESCRIPTION
Settles the one **unclear** item of [#707](https://github.com/ndelangen/dunezone/issues/707), whose investigation is [on that ticket](https://github.com/ndelangen/dunezone/issues/707#issuecomment-5395375475). **Based on `main`, not stacked.**

## What the effect did, and why CSS can do it

`alignIframePage` queried the iframe for `[data-faction-sheet-page="N"]`, read its `offsetTop`, and scrolled the document there, behind a `useLayoutEffect` and two nested `requestAnimationFrame`s.

Measured on seven real factions with deliberately varied content, that offset is always the page's own aspect box plus the rule between pages, and never varies with content, because `.page` reserves its height with `padding-top` and every child is out of flow.

So the page's geometry is now **named once, beside the page it describes**:

```css
:root {
  --faction-sheet-page-aspect: 141.428571%;
  --faction-sheet-page-rule: 0.3vw;
}
```

`.page` consumes both, and the preview steps past exactly that much with a margin. No second copy of the numbers, and nothing measures anything. Custom properties are not scoped by CSS modules, so the cloned document inside the iframe gets them too.

## The half that made the CSS alone wrong

The caller rendered a page-2 tile **unconditionally**. A faction with no karama rules, no troops and no leaders has no page 2, so that tile showed page 1 again under a page-2 label. The effect's early return hid it by no-oping; a fixed offset would have scrolled it to blank instead.

`Sheet.tsx` now exports the three-way test it was already applying inline, and the caller asks before offering a tile. One predicate, so the question the caller asks cannot drift from the one the renderer answers.

## What photographing it caught

The scroll cue is hand-written text, "Scroll for page 2", gated only on the scroller overflowing. With the tile gone it kept promising a page that no longer existed anywhere on screen.

The measurements could not show that: every number was correct. It took looking. The cue is now gated on the same predicate.

## Proof

From Storybook, on `FactionSheetReview`'s own stories.

**Two tiles**, the ordinary case, `defaultFaction` which ships a leader and a troop:

![Review pane with two sheet tiles](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-712-review-two-tiles.png)

**One tile**, a faction with no karama rules, troops or leaders. No second tile, and no cue offering one:

![Review pane with a single sheet tile](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-712-review-one-tile.png)

**Captioned as staged:** the single-page faction is a new story fixture, `WithoutASecondPage`, not a faction on the deployment. It has to be, because all 35 live factions have at least one leader; reaching this state means a person deleting every leader and every troop in the editor. The fixture is `defaultFaction` with those three fields emptied, so it is the real component and the real shape, with content removed rather than invented.

Measured alongside the pixels, in the iframes:

| tile | pages in its document | wrapper `margin-block-start` | topmost visible page | iframe `scrollTop` |
|---|---|---|---|---|
| two-tile, tile 1 | 1, 2 | `0px` | 1 | 0 |
| two-tile, tile 2 | 1, 2 | `-816.344px` | **2** | 0 |
| one-tile, tile 1 | 1 | `0px` | 1 | 0 |

The `scrollTop: 0` on the second tile is the point: it shows page 2 without anything having scrolled. And the one-tile document contains only page 1, which is the renderer's own condition agreeing with the caller's.

## Verified

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 729 unit tests, 352 storybook tests. The new story runs its play function, so the single-page path is exercised by the suite rather than only by the screenshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Faction sheet reviews now hide the second page when it contains no content.
  - The page-two scroll indicator appears only when a second page is available.
  - Page-two previews are aligned consistently with the full faction sheet.

- **Tests**
  - Added coverage for reviewing factions that contain only a single sheet page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
