### PR TITLE
The assign pane stops holding the choices, so a picker can fetch them lazily

### DIFF
--- a/src/app/pickers/GroupAssignPicker.tsx
+++ b/src/app/pickers/GroupAssignPicker.tsx
@@ -1,0 +1,77 @@
+import { AssignOptions, useAssignPane } from '@ui/control/AssignPopover';
+
+import { useFactionsOwnedForGroupAssign } from '@db/factions';
+import { useRulesetsOwnedForGroupAssign } from '@db/rulesets';
+
+/** Enough of an owned asset to offer it and to say where it currently lives. */
+export type OwnedAssignItem = {
+  id: string;
+  name: string;
+  groupId: string | null;
+  groupName: string | null;
+};
+
+export type GroupAssignPickerProps = {
+  /** The group being added to, so an asset already in it is not offered. */
+  currentGroupId: string;
+  /**
+   * Reports the choice.
+   * The page decides what happens next, including whether to ask first: resolve `false` to leave the pane open, which is how a reader backs out of a move.
+   */
+  onPick: (item: OwnedAssignItem) => Promise<boolean | void>;
+};
+
+/**
+ * The presentation both owned-asset pickers share, once one of them has its rows.
+ * `noun` comes from the pane rather than a prop, so the words the shell chose and the words here cannot disagree.
+ */
+function OwnedAssignOptions({
+  items,
+  loading,
+  currentGroupId,
+  onPick,
+}: GroupAssignPickerProps & { items: OwnedAssignItem[]; loading: boolean }) {
+  const { noun } = useAssignPane();
+  const assignable = items.filter((item) => item.groupId !== currentGroupId);
+  const byId = new Map(assignable.map((item) => [item.id, item]));
+
+  return (
+    <AssignOptions
+      loading={loading}
+      searchLabel={`Search your ${noun}s`}
+      emptyMessage={
+        items.length === 0 ? `You don't own any ${noun}s yet.` : `All your ${noun}s are already in this group.`
+      }
+      options={assignable.map((item) => ({
+        value: item.id,
+        label: item.groupName ? `${item.name} — currently in ${item.groupName}` : `${item.name} — unassigned`,
+      }))}
+      onAssign={async (value) => {
+        const item = byId.get(value);
+        if (!item) {
+          return false;
+        }
+        return await onPick(item);
+      }}
+    />
+  );
+}
+
+/**
+ * The factions this viewer owns, offered for adding to a group.
+ *
+ * Mounted inside an `AssignPopover`, which mounts its content only while open, so the read starts when the reader signals intent and is torn down when they leave.
+ * Its query requires authentication, so only mount it for an active member.
+ * The owned lists are their own queries rather than part of the page bundle, decided on «Group detail's owned-asset lists» (#348/#182);
+ * what changed since is only when they are subscribed to.
+ */
+export function OwnedFactionAssignPicker(props: GroupAssignPickerProps) {
+  const owned = useFactionsOwnedForGroupAssign();
+  return <OwnedAssignOptions items={owned.data ?? []} loading={owned.isLoading} {...props} />;
+}
+
+/** The rulesets this viewer owns. Same rules as the faction picker: active members only. */
+export function OwnedRulesetAssignPicker(props: GroupAssignPickerProps) {
+  const owned = useRulesetsOwnedForGroupAssign();
+  return <OwnedAssignOptions items={owned.data ?? []} loading={owned.isLoading} {...props} />;
+}

--- a/src/app/routes/_app/assets/-assetEditorStates.tsx
+++ b/src/app/routes/_app/assets/-assetEditorStates.tsx
@@ -2,7 +2,7 @@ import { Alert, Anchor, Group, Stack, Text } from '@mantine/core';
 import { ASSET_TYPES, isAssetType } from '@shared/assets/types';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { PageTitle } from '@ui/block/PageTitle';
-import { AssignPopover } from '@ui/control/AssignPopover';
+import { AssignOptions, AssignPopover } from '@ui/control/AssignPopover';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -172,11 +172,17 @@ export function useAssetGroupActions({
       icon={<UsersRound size={17} aria-hidden />}
       title="Assign Group"
       disabled={setAssetGroup.isPending}
-      options={access.assignableGroups.map((group) => ({ value: group.id, label: `${group.name} (${group.slug})` }))}
-      onAssign={async (nextGroupId) => {
-        await setAssetGroup.mutateAsync({ id: asset.id, group_id: nextGroupId });
-      }}
-    />
+    >
+      <AssignOptions
+        options={access.assignableGroups.map((group) => ({
+          value: group.id,
+          label: `${group.name} (${group.slug})`,
+        }))}
+        onAssign={async (nextGroupId) => {
+          await setAssetGroup.mutateAsync({ id: asset.id, group_id: nextGroupId });
+        }}
+      />
+    </AssignPopover>
   );
 
   return {

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -12,14 +12,17 @@ import { Card } from '@ui/surface/Card';
 import { Toolbar } from '@ui/surface/Toolbar';
 import { ArrowLeft, BookOpen, Check, Crown, Pencil, Plus, UserPlus, UserRoundMinus, UsersRound, X } from 'lucide-react';
 import { useState } from 'react';
+import type { ReactNode } from 'react';
 
-import { useFactionsOwnedForGroupAssign, useSetFactionGroup } from '@db/factions';
+import { useSetFactionGroup } from '@db/factions';
 import type { FactionEntry } from '@db/factions';
 import { loadGroupDetailBySlug, useDeleteGroup, useGroupDetailBySlug } from '@db/groups';
 import type { GroupDetailPageData, MembershipState } from '@db/groups';
 import { useGroupMembershipWorkflow } from '@db/members';
-import { useRulesetsOwnedForGroupAssign, useSetRulesetGroup } from '@db/rulesets';
+import { useSetRulesetGroup } from '@db/rulesets';
 import type { RulesetEntry } from '@db/rulesets';
+import { OwnedFactionAssignPicker, OwnedRulesetAssignPicker } from '@app/pickers/GroupAssignPicker';
+import type { OwnedAssignItem } from '@app/pickers/GroupAssignPicker';
 
 import styles from './index.module.css';
 
@@ -28,13 +31,6 @@ import styles from './index.module.css';
  * Their validator-derived row types remain the authority for the shape;
  * this names only the part the picker reads.
  */
-type AssetAssignOption = {
-  id: string;
-  name: string;
-  groupId: string | null;
-  groupName: string | null;
-};
-
 type RosterEntry = GroupDetailPageData['roster'][number];
 
 export const Route = createFileRoute('/_app/groups/$groupSlug/')({
@@ -135,11 +131,11 @@ function GroupDetailPage() {
     });
   };
 
-  const handleAssignFaction = async (item: AssetAssignOption) => {
+  const handleAssignFaction = async (item: OwnedAssignItem) => {
     await setFactionGroup.mutateAsync({ id: item.id, groupId });
   };
 
-  const handleAssignRuleset = async (item: AssetAssignOption) => {
+  const handleAssignRuleset = async (item: OwnedAssignItem) => {
     await setRulesetGroup.mutateAsync({ id: item.id, groupId });
   };
 
@@ -286,29 +282,31 @@ type AssignPickerProps = {
   disabled: boolean;
   currentGroupId: string;
   currentGroupName: string;
-  onAssign: (item: AssetAssignOption) => Promise<void>;
+  onAssign: (item: OwnedAssignItem) => Promise<void>;
 };
 
 /**
- * Labels this viewer's own factions or rulesets for `AssignPopover`, and owns the one thing the kit control must not: asking before a move.
- * An asset already maintained by another group leaves that group when it is added here, which is a consequence only this page knows about, so the confirmation lives here, and backing out resolves `false` to leave the popover open.
+ * The one thing neither the kit nor the picker may own: asking before a move.
+ * An asset already maintained by another group leaves that group when it is added here, which is a consequence only this page knows about, so the question lives here, and backing out resolves `false` to leave the pane open.
  */
-function OwnedAssetPicker({
-  noun,
-  items,
-  loading,
-  disabled,
-  currentGroupId,
-  currentGroupName,
-  onAssign,
-}: AssignPickerProps & {
-  noun: string;
-  items: AssetAssignOption[];
-  loading: boolean;
-}) {
-  const assignable = items.filter((item) => item.groupId !== currentGroupId);
-  const byId = new Map(assignable.map((item) => [item.id, item]));
+async function confirmThenAssign(
+  item: OwnedAssignItem,
+  currentGroupName: string,
+  onAssign: (item: OwnedAssignItem) => Promise<void>
+): Promise<boolean | void> {
+  if (item.groupId !== null) {
+    const confirmed = window.confirm(
+      `Move "${item.name}" from "${item.groupName}" to "${currentGroupName}"? It will no longer be maintained by "${item.groupName}".`
+    );
+    if (!confirmed) {
+      return false;
+    }
+  }
+  await onAssign(item);
+}
 
+/** The shell both add-buttons wear, so the two directions cannot drift apart in their words. */
+function AddOwnedPopover({ noun, disabled, children }: { noun: string; disabled: boolean; children: ReactNode }) {
   return (
     <AssignPopover
       noun={noun}
@@ -316,63 +314,38 @@ function OwnedAssetPicker({
       icon={<Plus size={14} aria-hidden />}
       title={`Add a ${noun}`}
       triggerLabel={`Add a ${noun} you own`}
-      searchLabel={`Search your ${noun}s`}
       disabled={disabled}
-      loading={loading}
-      options={assignable.map((item) => ({
-        value: item.id,
-        label: item.groupName ? `${item.name} — currently in ${item.groupName}` : `${item.name} — unassigned`,
-      }))}
-      emptyMessage={
-        items.length === 0 ? `You don't own any ${noun}s yet.` : `All your ${noun}s are already in this group.`
-      }
-      onAssign={async (value) => {
-        const item = byId.get(value);
-        if (!item) {
-          return false;
-        }
-        if (item.groupId !== null) {
-          const confirmed = window.confirm(
-            `Move "${item.name}" from "${item.groupName}" to "${currentGroupName}"? It will no longer be maintained by "${item.groupName}".`
-          );
-          if (!confirmed) {
-            return false;
-          }
-        }
-        await onAssign(item);
-      }}
-    />
+    >
+      {children}
+    </AssignPopover>
   );
 }
 
 /**
  * Only mounted for active members (see call sites): the owned-factions query requires authentication, so it must not be called for anonymous, pending, or non-member viewers.
- * Subscribing to a second query beyond the page query deviates from the one-query-per-route default;
- * that was decided explicitly for this picker (issues #348/#182: keep
- * `detailBySlug` unchanged, expose the viewer-scoped owned lists as their own queries).
+ * The query itself now starts when the pane opens rather than when the page does, because the picker is mounted by the shell's own gate;
+ * the lists staying separate from `detailBySlug` is still #348/#182's decision.
  */
-function FactionAssignPicker(props: AssignPickerProps) {
-  const ownedFactionsQuery = useFactionsOwnedForGroupAssign();
+function FactionAssignPicker({ disabled, currentGroupId, currentGroupName, onAssign }: AssignPickerProps) {
   return (
-    <OwnedAssetPicker
-      noun="faction"
-      items={ownedFactionsQuery.data ?? []}
-      loading={ownedFactionsQuery.isLoading}
-      {...props}
-    />
+    <AddOwnedPopover noun="faction" disabled={disabled}>
+      <OwnedFactionAssignPicker
+        currentGroupId={currentGroupId}
+        onPick={(item) => confirmThenAssign(item, currentGroupName, onAssign)}
+      />
+    </AddOwnedPopover>
   );
 }
 
 /** Same rules as `FactionAssignPicker`: only mount this for active members. */
-function RulesetAssignPicker(props: AssignPickerProps) {
-  const ownedRulesetsQuery = useRulesetsOwnedForGroupAssign();
+function RulesetAssignPicker({ disabled, currentGroupId, currentGroupName, onAssign }: AssignPickerProps) {
   return (
-    <OwnedAssetPicker
-      noun="ruleset"
-      items={ownedRulesetsQuery.data ?? []}
-      loading={ownedRulesetsQuery.isLoading}
-      {...props}
-    />
+    <AddOwnedPopover noun="ruleset" disabled={disabled}>
+      <OwnedRulesetAssignPicker
+        currentGroupId={currentGroupId}
+        onPick={(item) => confirmThenAssign(item, currentGroupName, onAssign)}
+      />
+    </AddOwnedPopover>
   );
 }
 

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -26,11 +26,6 @@ import type { OwnedAssignItem } from '@app/pickers/GroupAssignPicker';
 
 import styles from './index.module.css';
 
-/**
- * The structural minimum both owned-asset queries satisfy.
- * Their validator-derived row types remain the authority for the shape;
- * this names only the part the picker reads.
- */
 type RosterEntry = GroupDetailPageData['roster'][number];
 
 export const Route = createFileRoute('/_app/groups/$groupSlug/')({

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -13,7 +13,7 @@ import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { StatusBadge } from '@ui/content/StatusBadge';
 import { TopicIcon } from '@ui/content/TopicIcon';
-import { AssignPopover } from '@ui/control/AssignPopover';
+import { AssignOptions, AssignPopover } from '@ui/control/AssignPopover';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
 import { ColumnsWithRailLayout } from '@ui/layout/ColumnsWithRailLayout';
@@ -477,15 +477,18 @@ function RulesetDetailPage() {
                     triggerLabel="Assign group"
                     icon={<UsersRound size={17} aria-hidden />}
                     disabled={setRulesetGroup.isPending}
-                    options={page.assignableGroups.map((group) => ({
-                      value: group.id,
-                      label: `${group.name} (${group.slug})`,
-                    }))}
-                    onAssign={async (nextGroupId) => {
-                      await setRulesetGroup.mutateAsync({ id: r._id, groupId: nextGroupId });
-                    }}
                     title="Assign Group"
-                  />
+                  >
+                    <AssignOptions
+                      options={page.assignableGroups.map((group) => ({
+                        value: group.id,
+                        label: `${group.name} (${group.slug})`,
+                      }))}
+                      onAssign={async (nextGroupId) => {
+                        await setRulesetGroup.mutateAsync({ id: r._id, groupId: nextGroupId });
+                      }}
+                    />
+                  </AssignPopover>
                 ) : null}
                 {actionVisibility.removeGroup ? (
                   <IconAction

--- a/src/app/ui/control/AssignPopover.stories.tsx
+++ b/src/app/ui/control/AssignPopover.stories.tsx
@@ -2,12 +2,16 @@ import preview from '@sb/preview';
 import { Plus, Users } from 'lucide-react';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 
-import { AssignPopover } from './AssignPopover';
+import { AssignOptions, AssignPopover } from './AssignPopover';
 
 const groups = [
   { value: 'group-1', label: 'Arrakeen Rules Council (arrakeen-rules-council)' },
   { value: 'group-2', label: 'Spice Cartel (spice-cartel)' },
 ];
+
+/* The commit a story asserts on. Declared here rather than through `args` because the callback now
+   belongs to the pane's contents, and the contents are what a story passes as `children`. */
+const onAssign = fn(async () => undefined);
 
 const meta = preview.meta({
   component: AssignPopover,
@@ -16,14 +20,13 @@ const meta = preview.meta({
     noun: 'group',
     disabled: false,
     icon: <Users size={17} aria-hidden />,
-    options: groups,
-    onAssign: fn(async () => undefined),
+    children: <AssignOptions options={groups} onAssign={onAssign} />,
   },
-  argTypes: { icon: { control: false } },
+  argTypes: { icon: { control: false }, children: { control: false } },
 });
 
 export const Default = meta.story({
-  play: async ({ args, canvasElement }) => {
+  play: async ({ canvasElement }) => {
     const page = within(canvasElement.ownerDocument.body);
     const trigger = page.getByRole('button', { name: 'Assign group' });
 
@@ -35,7 +38,7 @@ export const Default = meta.story({
     /* The suggestions are already in the pane, which keeps it to one floating layer, and choosing one commits it. */
     await expect(page.getByRole('option', { name: /Spice Cartel/ })).toBeVisible();
     await userEvent.click(page.getByRole('option', { name: /Spice Cartel/ }));
-    await waitFor(() => expect(args.onAssign).toHaveBeenCalledWith('group-2'));
+    await waitFor(() => expect(onAssign).toHaveBeenCalledWith('group-2'));
   },
 });
 
@@ -46,7 +49,9 @@ export const DifferentNoun = meta.story({
     title: 'Add a faction',
     size: 'sm',
     icon: <Plus size={14} aria-hidden />,
-    options: [{ value: 'faction-1', label: 'House Atreides — unassigned' }],
+    children: (
+      <AssignOptions options={[{ value: 'faction-1', label: 'House Atreides — unassigned' }]} onAssign={fn()} />
+    ),
   },
   play: async ({ canvasElement }) => {
     const page = within(canvasElement.ownerDocument.body);
@@ -66,8 +71,13 @@ export const CallerSuppliedCopy = meta.story({
     icon: <Plus size={14} aria-hidden />,
     title: 'Add a faction',
     triggerLabel: 'Add a faction you own',
-    searchLabel: 'Search your factions',
-    options: [{ value: 'faction-1', label: 'House Atreides — unassigned' }],
+    children: (
+      <AssignOptions
+        options={[{ value: 'faction-1', label: 'House Atreides — unassigned' }]}
+        searchLabel="Search your factions"
+        onAssign={fn()}
+      />
+    ),
   },
   play: async ({ canvasElement }) => {
     const page = within(canvasElement.ownerDocument.body);
@@ -78,7 +88,7 @@ export const CallerSuppliedCopy = meta.story({
 });
 
 export const NothingToAssign = meta.story({
-  args: { options: [] },
+  args: { children: <AssignOptions options={[]} onAssign={fn()} /> },
   play: async ({ canvasElement }) => {
     const page = within(canvasElement.ownerDocument.body);
     await userEvent.click(page.getByRole('button', { name: 'Assign group' }));
@@ -90,8 +100,9 @@ export const NothingToAssign = meta.story({
 export const CallerSuppliedEmptyMessage = meta.story({
   args: {
     noun: 'faction',
-    options: [],
-    emptyMessage: 'All your factions are already in this group.',
+    children: (
+      <AssignOptions options={[]} emptyMessage="All your factions are already in this group." onAssign={fn()} />
+    ),
   },
   play: async ({ canvasElement }) => {
     const page = within(canvasElement.ownerDocument.body);
@@ -100,9 +111,12 @@ export const CallerSuppliedEmptyMessage = meta.story({
   },
 });
 
-/** Still fetching the choices. */
+/**
+ * Still fetching the choices.
+ * A pane whose contents fetch their own choices reaches this state on its own, because the read starts when the pane opens.
+ */
 export const Loading = meta.story({
-  args: { loading: true, options: [] },
+  args: { children: <AssignOptions options={[]} loading onAssign={fn()} /> },
   play: async ({ canvasElement }) => {
     const page = within(canvasElement.ownerDocument.body);
     await userEvent.click(page.getByRole('button', { name: 'Assign group' }));

--- a/src/app/ui/control/AssignPopover.test.tsx
+++ b/src/app/ui/control/AssignPopover.test.tsx
@@ -9,7 +9,7 @@ import { createRoot } from 'react-dom/client';
 import type { Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { AssignPopover } from './AssignPopover';
+import { AssignOptions, AssignPopover } from './AssignPopover';
 
 const groupOption = { value: 'group-1', label: 'Arrakeen Rules Council (arrakeen-rules-council)' };
 
@@ -48,6 +48,58 @@ afterEach(async () => {
 });
 
 describe('AssignPopover', () => {
+  it('mounts its content only while open, which is what makes a Picker inside it lazy', async () => {
+    /* A Picker mounted here starts its read on mount. If the shell rendered its children eagerly and
+       merely hid them, every such read would fire on page load, which is the whole defect this shape
+       exists to prevent. A story cannot show this: it can only show what appears after the click. */
+    const mounted = vi.fn();
+    function Probe() {
+      mounted();
+      return <span>pane content</span>;
+    }
+
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(
+        <MantineProvider theme={appContentTheme} forceColorScheme="light">
+          <AssignPopover noun="group" icon={<Users size={17} aria-hidden />} disabled={false}>
+            <Probe />
+          </AssignPopover>
+        </MantineProvider>
+      );
+    });
+
+    expect(mounted).not.toHaveBeenCalled();
+
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-label="Assign group"]');
+    expect(trigger).not.toBeNull();
+    if (!trigger) {
+      return;
+    }
+    await act(async () => trigger.click());
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 200)));
+
+    expect(mounted).toHaveBeenCalled();
+
+    await act(async () => trigger.click());
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 200)));
+
+    expect(document.body.textContent).not.toContain('pane content');
+
+    /* And each opening is a fresh mount: a read starts again rather than resuming, and a cancelled pick
+       cannot reappear. Both halves currently hold whether or not the shell gates on `opened` itself,
+       because Mantine's dropdown declines to render its children while closed. This asserts the
+       property rather than the mechanism, so it still catches the change that matters: a dropdown kept
+       mounted, or content moved outside it. */
+    await act(async () => trigger.click());
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 200)));
+
+    expect(mounted).toHaveBeenCalledTimes(2);
+  });
+
   it('places popover semantics on the focusable trigger and returns focus when closed', async () => {
     container = document.createElement('div');
     document.body.append(container);
@@ -56,13 +108,9 @@ describe('AssignPopover', () => {
     await act(async () => {
       root?.render(
         <MantineProvider theme={appContentTheme} forceColorScheme="light">
-          <AssignPopover
-            noun="group"
-            icon={<Users size={17} aria-hidden />}
-            disabled={false}
-            onAssign={vi.fn(async () => undefined)}
-            options={[groupOption]}
-          />
+          <AssignPopover noun="group" icon={<Users size={17} aria-hidden />} disabled={false}>
+            <AssignOptions options={[groupOption]} onAssign={vi.fn(async () => undefined)} />
+          </AssignPopover>
         </MantineProvider>
       );
     });
@@ -109,13 +157,9 @@ describe('AssignPopover', () => {
     await act(async () => {
       root?.render(
         <MantineProvider theme={appContentTheme} forceColorScheme="light">
-          <AssignPopover
-            noun="group"
-            icon={<Users size={17} aria-hidden />}
-            disabled={false}
-            onAssign={onAssign}
-            options={[groupOption]}
-          />
+          <AssignPopover noun="group" icon={<Users size={17} aria-hidden />} disabled={false}>
+            <AssignOptions options={[groupOption]} onAssign={onAssign} />
+          </AssignPopover>
         </MantineProvider>
       );
     });
@@ -149,15 +193,14 @@ describe('AssignPopover', () => {
     await act(async () => {
       root?.render(
         <MantineProvider theme={appContentTheme} forceColorScheme="light">
-          <AssignPopover
-            noun="group"
-            icon={<Users size={17} aria-hidden />}
-            disabled={false}
-            onAssign={vi.fn(async () => {
-              throw 'transport failure';
-            })}
-            options={[groupOption]}
-          />
+          <AssignPopover noun="group" icon={<Users size={17} aria-hidden />} disabled={false}>
+            <AssignOptions
+              options={[groupOption]}
+              onAssign={vi.fn(async () => {
+                throw 'transport failure';
+              })}
+            />
+          </AssignPopover>
         </MantineProvider>
       );
     });
@@ -191,13 +234,12 @@ describe('AssignPopover', () => {
     await act(async () => {
       root?.render(
         <MantineProvider theme={appContentTheme} forceColorScheme="light">
-          <AssignPopover
-            noun="group"
-            icon={<Users size={17} aria-hidden />}
-            disabled={false}
-            onAssign={onAssign}
-            options={[groupOption, { value: 'group-2', label: 'Spice Cartel (spice-cartel)' }]}
-          />
+          <AssignPopover noun="group" icon={<Users size={17} aria-hidden />} disabled={false}>
+            <AssignOptions
+              options={[groupOption, { value: 'group-2', label: 'Spice Cartel (spice-cartel)' }]}
+              onAssign={onAssign}
+            />
+          </AssignPopover>
         </MantineProvider>
       );
     });

--- a/src/app/ui/control/AssignPopover.test.tsx
+++ b/src/app/ui/control/AssignPopover.test.tsx
@@ -148,6 +148,38 @@ describe('AssignPopover', () => {
     expect(document.activeElement).toBe(trigger);
   });
 
+  it('offers the search field while the choices are still arriving, so the focus trap has something to hold', async () => {
+    /* Mantine's focus trap runs once when the dropdown attaches and never re-runs. A pane that opens
+       with only text in it leaves the caret on the dropdown container, and a field appearing a moment
+       later never receives it, so the reader types into nothing. Any pane whose contents fetch their
+       own choices reaches this frame on every open. */
+    container = document.createElement('div');
+    document.body.append(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root?.render(
+        <MantineProvider theme={appContentTheme} forceColorScheme="light">
+          <AssignPopover noun="group" icon={<Users size={17} aria-hidden />} disabled={false}>
+            <AssignOptions options={[]} loading onAssign={vi.fn(async () => undefined)} />
+          </AssignPopover>
+        </MantineProvider>
+      );
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>('button[aria-label="Assign group"]');
+    expect(trigger).not.toBeNull();
+    if (!trigger) {
+      return;
+    }
+    await act(async () => trigger.click());
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 200)));
+
+    expect(document.body.textContent).toContain('Loading groups…');
+    const field = document.body.querySelector('input[aria-label="Search groups"]');
+    expect(field).not.toBeNull();
+  });
+
   it('commits the chosen option and closes after success', async () => {
     container = document.createElement('div');
     document.body.append(container);

--- a/src/app/ui/control/AssignPopover.tsx
+++ b/src/app/ui/control/AssignPopover.tsx
@@ -144,7 +144,11 @@ export function AssignOptions({ options, onAssign, loading = false, searchLabel,
   }, [combobox, search]);
   const needle = search.trim().toLowerCase();
   const matching = needle ? options.filter((option) => option.label.toLowerCase().includes(needle)) : options;
-  const hasOptions = !loading && options.length > 0;
+  /* The field and the list are present from the first frame, including while the choices are still
+     arriving. Mantine's focus trap runs once when the dropdown attaches and does not re-run: a pane
+     that opens with nothing focusable in it leaves the caret on the dropdown itself, and the reader
+     types into nothing when the field appears a moment later. */
+  const hasPicker = loading || options.length > 0;
   const isEmpty = !loading && options.length === 0;
 
   return (
@@ -163,13 +167,11 @@ export function AssignOptions({ options, onAssign, loading = false, searchLabel,
         </Alert>
       ) : null}
 
-      {loading ? <AssignPopoverPlaceholder>{`Loading ${noun}s…`}</AssignPopoverPlaceholder> : null}
-
       {isEmpty ? (
         <AssignPopoverPlaceholder>{emptyMessage ?? `No ${noun}s are available yet.`}</AssignPopoverPlaceholder>
       ) : null}
 
-      {hasOptions ? (
+      {hasPicker ? (
         /* One floating layer only, the pickers' rule: the options render inline in the pane
            (Combobox without dropdown), never as a second popover. Choosing one IS the commit,
            because the pick is the whole reason the reader opened this (Norbert, 2026-08-21). */
@@ -197,7 +199,9 @@ export function AssignOptions({ options, onAssign, loading = false, searchLabel,
           </Combobox.EventsTarget>
           <ScrollArea.Autosize mah={260} type="auto">
             <Combobox.Options>
-              {matching.length === 0 ? (
+              {loading ? (
+                <Combobox.Empty>{`Loading ${noun}s…`}</Combobox.Empty>
+              ) : matching.length === 0 ? (
                 <Combobox.Empty>{`No matching ${noun}s`}</Combobox.Empty>
               ) : (
                 matching.map((option) => (
@@ -248,6 +252,11 @@ export function AssignPopover({
       withArrow
       trapFocus
       returnFocus
+      /* Mantine locks the placement once it has measured a visible dropdown, and drops `flip` when it
+         does. That is right for a pane whose size is settled on open, and wrong here: contents that
+         fetch their own choices grow after opening, and a placement chosen for the short version puts
+         the grown one off the bottom of the screen. */
+      preventPositionChangeWhenVisible={false}
     >
       <Popover.Target>
         <IconAction

--- a/src/app/ui/control/AssignPopover.tsx
+++ b/src/app/ui/control/AssignPopover.tsx
@@ -250,6 +250,12 @@ export function AssignPopover({
       width={340}
       shadow="md"
       withArrow
+      /* Centred on the trigger rather than parked at the pane's corner. The pane is far wider than
+         its icon trigger, so `shift` slides it to fit and the default side-anchored arrow is left
+         pointing at empty background: measured 75px off the trigger at a 520px viewport, and it
+         grows as the pane is pushed further. Centred, it tracks the trigger exactly whether the pane
+         is shifted or not. */
+      arrowPosition="center"
       trapFocus
       returnFocus
       /* Mantine locks the placement once it has measured a visible dropdown, and drops `flip` when it

--- a/src/app/ui/control/AssignPopover.tsx
+++ b/src/app/ui/control/AssignPopover.tsx
@@ -1,6 +1,6 @@
 import { Alert, Combobox, Popover, ScrollArea, Stack, Text, TextInput, useCombobox } from '@mantine/core';
 import { IconAction } from '@ui/control/IconAction';
-import { useEffect, useId, useMemo, useState } from 'react';
+import { createContext, useContext, useEffect, useId, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 
 interface AssignPopoverOption {
@@ -9,24 +9,37 @@ interface AssignPopoverOption {
   label: string;
 }
 
+/**
+ * What the pane owns and its content has to be told: the words every label derives from, the id the dropdown is named by, whether the caller has the control disabled, and how to close after a commit.
+ * Through context rather than props because the content is whatever the caller mounts, which may be a
+ * Picker that fetches its own choices and knows none of this.
+ */
+type AssignPaneValue = {
+  noun: string;
+  title: string;
+  labelId: string;
+  disabled: boolean;
+  close: () => void;
+};
+
+const AssignPaneContext = createContext<AssignPaneValue | null>(null);
+
+/** What the pane can tell its content. Exported so a Picker mounted inside names things the same way. */
+export function useAssignPane(): AssignPaneValue {
+  const pane = useContext(AssignPaneContext);
+  if (!pane) {
+    throw new Error('AssignOptions renders inside an AssignPopover, which owns the pane it names and closes.');
+  }
+  return pane;
+}
+
 export interface AssignPopoverProps {
   /**
    * What is being picked, singular and lowercase: `group`, `faction`.
    * Every label in the popover is derived from it, so a caller supplies one word instead of eight strings.
    */
   noun: string;
-  /** The choices, already labelled: how a thing reads is the caller's knowledge, not this one's. */
-  options: AssignPopoverOption[];
-  /**
-   * Commits the pick.
-   * Rejecting shows the error's message inside the popover and leaves it open so the reader can try another choice;
-   * resolving closes it.
-   * Anything the commit should ask first (a confirmation, a consequence the reader must accept) belongs here, in the caller: resolve `false` when the reader backs out, and the popover stays open.
-   */
-  onAssign: (value: string) => Promise<boolean | void>;
   disabled: boolean;
-  /** True while the caller is still fetching the choices. */
-  loading?: boolean;
   /** The trigger's glyph. */
   icon: ReactNode;
   /** Names the dropdown. Defaults to `Assign <noun>`. */
@@ -37,11 +50,31 @@ export interface AssignPopoverProps {
    * the dropdown says where they now are.
    */
   triggerLabel?: string;
+  size?: 'sm' | 'lg';
+  /**
+   * What fills the pane, mounted only while it is open and torn down when it closes.
+   * Usually `AssignOptions` with choices the caller already holds;
+   * a caller whose choices have to be fetched mounts a Picker here instead, whose read then lives no longer than the opening.
+   */
+  children: ReactNode;
+}
+
+export interface AssignOptionsProps {
+  /** The choices, already labelled: how a thing reads is the caller's knowledge, not this one's. */
+  options: AssignPopoverOption[];
+  /**
+   * Commits the pick.
+   * Rejecting shows the error's message inside the popover and leaves it open so the reader can try another choice;
+   * resolving closes it.
+   * Anything the commit should ask first (a confirmation, a consequence the reader must accept) belongs here, in the caller: resolve `false` when the reader backs out, and the popover stays open.
+   */
+  onAssign: (value: string) => Promise<boolean | void>;
+  /** True while the caller is still fetching the choices. */
+  loading?: boolean;
   /** Overrides `Search <noun>s` on the field, where the product says it differently. */
   searchLabel?: string;
   /** Replaces `No <noun>s are available yet.` when the caller knows a better reason. */
   emptyMessage?: string;
-  size?: 'sm' | 'lg';
 }
 
 /** One line standing in for the picker while there is nothing to pick, or nothing yet loaded. */
@@ -63,7 +96,7 @@ function useAssignCommit({
   options,
   onAssign,
   onAssigned,
-}: Pick<AssignPopoverProps, 'noun' | 'options' | 'onAssign'> & { onAssigned: () => void }) {
+}: Pick<AssignOptionsProps, 'options' | 'onAssign'> & { noun: string; onAssigned: () => void }) {
   const [error, setError] = useState<string | null>(null);
   const [isAssigning, setIsAssigning] = useState(false);
   const available = useMemo(() => new Set(options.map((option) => option.value)), [options]);
@@ -94,22 +127,14 @@ function useAssignCommit({
   return { error, isAssigning, commit };
 }
 
-function AssignPopoverBody({
-  noun,
-  options,
-  onAssign,
-  disabled,
-  loading = false,
-  title,
-  searchLabel,
-  emptyMessage,
-  labelId,
-  onAssigned,
-}: Omit<AssignPopoverProps, 'icon' | 'size' | 'triggerLabel'> & {
-  labelId: string;
-  onAssigned: () => void;
-}) {
-  const { error, isAssigning, commit } = useAssignCommit({ noun, options, onAssign, onAssigned });
+/**
+ * The pane's contents for a caller that already holds the choices: the title, the search, the inline suggestions, the in-flight latch, and the failure shown in place rather than swallowed.
+ *
+ * Its own component rather than the popover's insides, so that a Picker fetching its own choices renders exactly this and the two directions cannot drift apart in their labels, their empty states, or whether a failure is announced at all, which is what happened to the two components `AssignPopover` replaced.
+ */
+export function AssignOptions({ options, onAssign, loading = false, searchLabel, emptyMessage }: AssignOptionsProps) {
+  const { noun, title, labelId, disabled, close } = useAssignPane();
+  const { error, isAssigning, commit } = useAssignCommit({ noun, options, onAssign, onAssigned: close });
   const [search, setSearch] = useState('');
   /* No Dropdown is mounted, so "opened" changes nothing visually; it is what lets Enter submit the highlighted option, which Mantine gates on the dropdown state. */
   const combobox = useCombobox({ defaultOpened: true });
@@ -129,7 +154,7 @@ function AssignPopoverBody({
           `aria-labelledby` instead. The title is all the prose there is; the pick explains itself
           by being pickable (Norbert, 2026-08-21). */}
       <Text id={labelId} fw={700} fz="h4">
-        {title ?? `Assign ${noun}`}
+        {title}
       </Text>
 
       {error ? (
@@ -190,21 +215,28 @@ function AssignPopoverBody({
 }
 
 /**
- * Picks one of a set and commits it, in a popover hung off an icon.
+ * The pane a pick happens in, hung off an icon: the trigger, the dropdown that names itself for assistive tech, and nothing about the choices.
  *
- * Callers own the choices and their labels, what committing means, and anything the reader must agree to first.
- * This owns the machine around that pick: the trigger, the dropdown that names itself for assistive tech, the inline suggestions, the in-flight latch, and the failure message shown in place rather than swallowed.
- *
- * The suggestions render inline in the pane rather than in a nested Select dropdown, keeping to the pickers' one-floating-layer rule, and choosing one commits it: the interstitial select-then-confirm step asked the reader to say the same thing twice (Norbert, 2026-08-21).
- * A caller that must ask first still can, in `onAssign`, where the question was always meant to live.
+ * It mounts its content only while open, which is what makes a Picker inside it lazy: the read starts when the reader signals intent and is torn down when they leave.
+ * Callers who already hold their choices mount `AssignOptions`;
+ * callers whose choices must be fetched mount a Picker, which renders `AssignOptions` in turn.
  *
  * It replaced two components that asked the same question from opposite ends (one picked a group for an asset, one picked an asset for a group) and had drifted apart in their labels, their empty states, and whether a failure was announced at all.
  * Every label defaults from `noun`, so the two directions cannot drift apart by accident;
  * a page overrides the words only where it means something different by them.
  */
-export function AssignPopover({ icon, size = 'lg', ...body }: AssignPopoverProps) {
+export function AssignPopover({
+  noun,
+  disabled,
+  icon,
+  title,
+  triggerLabel,
+  size = 'lg',
+  children,
+}: AssignPopoverProps) {
   const [opened, setOpened] = useState(false);
   const labelId = useId();
+  const paneTitle = title ?? `Assign ${noun}`;
 
   return (
     <Popover
@@ -219,19 +251,28 @@ export function AssignPopover({ icon, size = 'lg', ...body }: AssignPopoverProps
     >
       <Popover.Target>
         <IconAction
-          label={body.triggerLabel ?? body.title ?? `Assign ${body.noun}`}
+          label={triggerLabel ?? paneTitle}
           variant="light"
           /* Neutral, not the primary colour: red on a toolbar means destructive and nothing else, and this sits beside a delete. */
           color="gray"
           size={size}
-          disabled={body.disabled}
+          disabled={disabled}
           onClick={() => setOpened((current) => !current)}
           icon={icon}
         />
       </Popover.Target>
       <Popover.Dropdown aria-labelledby={labelId}>
-        {/* Remounted per opening, so a cancelled pick never reappears the next time. */}
-        {opened ? <AssignPopoverBody {...body} labelId={labelId} onAssigned={() => setOpened(false)} /> : null}
+        {/* Remounted per opening, so a cancelled pick never reappears the next time, and a read inside
+            lives exactly as long as the opening. Mantine's dropdown happens to do this too, but a
+            Picker's read now depends on it, and that is worth one explicit line rather than an
+            undocumented behaviour of a dependency. */}
+        {opened ? (
+          <AssignPaneContext.Provider
+            value={{ noun, title: paneTitle, labelId, disabled, close: () => setOpened(false) }}
+          >
+            {children}
+          </AssignPaneContext.Provider>
+        ) : null}
       </Popover.Dropdown>
     </Popover>
   );

--- a/src/app/widgets/faction-editor/FactionGroupPopover.tsx
+++ b/src/app/widgets/faction-editor/FactionGroupPopover.tsx
@@ -1,4 +1,4 @@
-import { AssignPopover } from '@ui/control/AssignPopover';
+import { AssignOptions, AssignPopover } from '@ui/control/AssignPopover';
 import { Users } from 'lucide-react';
 
 import type { AssignedGroupSummary } from '@db/groups';
@@ -18,11 +18,14 @@ export function FactionGroupPopover({ onAssignGroup, disabled, assignableGroups 
       icon={<Users size={17} aria-hidden />}
       title="Assign Group"
       disabled={disabled}
-      options={assignableGroups.map((group) => ({
-        value: group.id,
-        label: `${group.name} (${group.slug})`,
-      }))}
-      onAssign={onAssignGroup}
-    />
+    >
+      <AssignOptions
+        options={assignableGroups.map((group) => ({
+          value: group.id,
+          label: `${group.name} (${group.slug})`,
+        }))}
+        onAssign={onAssignGroup}
+      />
+    </AssignPopover>
   );
 }


### PR DESCRIPTION
Closes item 3 of [#698](https://github.com/ndelangen/dunezone/issues/698), [decided by Norbert](https://github.com/ndelangen/dunezone/issues/698#issuecomment-5395144442) as shape 2, the shell-and-picker split. **Based on `main`, not stacked.**

## What was wrong

`factions.listOwnedForGroupAssign` and `rulesets.listOwnedForGroupAssign` subscribed when the group page mounted, for every active member, to fill a popover most visits never open.

## The split

**`AssignPopover` becomes the shell.** The trigger, the pane that names itself for assistive tech, and content mounted only while open. It holds no choices and no commit.

**`AssignOptions` is that content** for a caller who already holds its choices: the title, the search, the inline suggestions, the in-flight latch, the failure shown in place. It stays in the kit deliberately, because the four assign surfaces must not drift apart in their labels, their empty states, or whether a failure is announced at all, which is exactly what happened to the two components `AssignPopover` originally replaced.

**`GroupAssignPicker` owns the two queries.** It is lazy because the shell gates mounting, which is the `FactionPicker`-inside-`FactionLoadPopover` shape, and AGENTS.md already names this exact case: a Picker "renders *through* the kit (a `Select`, an `AssignPopover`)".

**The group page keeps the one thing neither may own:** asking before a move. An asset already maintained by another group leaves it when added here, and that consequence is the page's knowledge. `onPick` resolving `false` leaves the pane open, which is how a reader backs out.

## The shell tells its content what it knows

`noun`, `title`, `disabled`, the label id and the close travel by context rather than props. A Picker mounted inside knows none of that and should not have to be told twice, so the words the shell chose and the words the contents use cannot disagree.

## Also removed

The group page's own `AssetAssignOption`, a second copy of the picker's item type.

## Verified

**The property the whole split rests on is now pinned.** A new kit test asserts the pane's content does not mount until it opens, and mounts fresh on each opening. Nothing asserted it before, and a story cannot: a story can only show what appears after a click, not that nothing existed before it.

Worth stating precisely, because I checked rather than assumed: **that test passes whether or not the shell gates on `opened` itself**, because Mantine's dropdown already declines to render its children while closed. So the assertion pins the *property*, not my line. I kept the explicit gate anyway and said why in the code: a Picker's read now depends on this, and one explicit line is better than an undocumented behaviour of a dependency. The test still catches what matters, a dropdown kept mounted or content moved outside it.

Full gate list: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 730 unit tests, 352 storybook tests.

## A rider: the arrow now points at its trigger

**Norbert caught this in the proof images below**, which is why it is here rather than parked. Pre-existing rather than introduced by this PR, folded in because this PR already rewrites the component, and filed as [#714](https://github.com/ndelangen/dunezone/issues/714).

The pane is 340px wide over a 40px icon trigger, so `shift` slides it to fit and the default side-anchored arrow stays pinned to the pane's corner, pointing at empty background.

Settled by measuring rather than reading, since the ticket asked for that. Arrow centre against trigger centre on the real story:

| viewport | before | after (`arrowPosition="center"`) |
|---|---|---|
| 400px | shifted hard | **0px off** |
| 520px | **75px off** | **0px off** |
| 1200px (unshifted) | side-anchored | **0px off** |

So the arrow stays rather than being dropped: it tracks the trigger exactly whether the pane is shifted or not, which is a better answer than the removal the ticket floated. **All four images below were recaptured with this fix in**, and that correction is why they moved.

## Proof

From `AssignPopover`'s own stories. All four assign surfaces render these same states.

| closed | open, with choices |
|---|---|
| ![trigger only, pane closed](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-713-assign-closed.png) | ![pane open showing a faction to add](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-713-assign-open-with-options.png) |

| open, still fetching | open, nothing to offer |
|---|---|
| ![pane open showing Loading groups](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-713-assign-open-loading.png) | ![pane open showing no groups available yet](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-713-assign-open-empty.png) |

The loading state matters more after this change than before: a caller holding its choices was never loading, but a Picker inside the pane starts its read when the pane opens, so this is the first frame a reader now sees.

## Not verified, and I would rather say so

**The group detail page's signed-in path was not exercised in a browser.** The add-a-faction control only renders for an active member, and the local origin has no session; I will not handle credentials to get one.

So the deferral is argued structurally rather than observed on that page: the queries now live only inside `GroupAssignPicker`, the picker is only reachable as the shell's content, and the shell mounts content only while open, which the new test pins. A websocket-level check on the real page, the way [#702](https://github.com/ndelangen/dunezone/pull/702) was verified, is the thing that would close it, and it needs a signed-in member.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared pickers for assigning owned factions and rulesets to groups.
  * Assignment pickers now show ownership locations, exclude items already in the group, and support search, loading, and empty states.
  * Assignment content loads when the picker opens, improving page responsiveness.

* **Improvements**
  * Standardized assignment popovers with reusable option panels, clearer error handling, and improved repositioning as content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->