### PR TITLE
The asset face fits its own container instead of being told a width

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -49,6 +49,10 @@ export default defineMain({
       titlePrefix: 'Widgets/Card Editor',
     },
     {
+      directory: '../src/app/widgets/asset-face',
+      titlePrefix: 'Widgets/Asset Face',
+    },
+    {
       directory: '../src/app/ui/block',
       titlePrefix: 'Blocks',
     },

--- a/src/app/pickers/AssetPicker.parts.tsx
+++ b/src/app/pickers/AssetPicker.parts.tsx
@@ -30,7 +30,7 @@ export function assetPickerSearchText(entry: AssetListEntry): string {
 function AssetPickerPreview({ entry, side }: { entry: AssetListEntry; side?: AssetFaceSide }) {
   return (
     <Box aria-hidden w={PREVIEW_WIDTH} miw={PREVIEW_WIDTH} style={{ display: 'grid', placeItems: 'center' }}>
-      <AssetFace type={entry.type} data={entry.data} name={entry.name} width={PREVIEW_WIDTH} side={side} />
+      <AssetFace type={entry.type} data={entry.data} name={entry.name} side={side} />
     </Box>
   );
 }

--- a/src/app/pickers/DeckBackPicker.tsx
+++ b/src/app/pickers/DeckBackPicker.tsx
@@ -1,8 +1,7 @@
 import { Button, Group, Popover, Stack, Text } from '@mantine/core';
-import { CanvasScale } from '@ui/layout/CanvasScale';
 import { useState } from 'react';
 
-import { AssetFace, assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
+import { AssetFace } from '@app/widgets/asset-face/AssetFace';
 
 import { AssetPicker } from './AssetPicker';
 
@@ -78,9 +77,7 @@ export function DeckBackProof({ picked }: { picked: PickedBackDeck | null }) {
   return (
     <Stack gap={4} align="center" w="100%">
       {/* A deck's face is its cardback, so the target's row draws its own proof. */}
-      <CanvasScale canvasWidth={900} canvasHeight={900 * assetFaceAspect('deck')}>
-        <AssetFace type="deck" data={picked.data} name={picked.name} width={900} />
-      </CanvasScale>
+      <AssetFace type="deck" data={picked.data} name={picked.name} />
       <Text size="xs" c="dimmed">
         Cardback, from {picked.name}
       </Text>

--- a/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
@@ -3,7 +3,6 @@ import { RectangleTokenAsset } from '@shared/assets/schema';
 import { Link, useNavigate } from '@tanstack/react-router';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
-import { CanvasScale } from '@ui/layout/CanvasScale';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
 import { useState } from 'react';
@@ -11,7 +10,6 @@ import { useState } from 'react';
 import { useAssetPage, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
 import { AssetPicker } from '@app/pickers/AssetPicker';
-import { assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
@@ -308,10 +306,7 @@ function RectangleEditSession({
               pickedBack ? (
                 <Stack gap={4} align="center" w="100%">
                   {referencedBack ? (
-                    /* The picker offers only this token's own type, so the page's type fixes the aspect. */
-                    <CanvasScale canvasWidth={900} canvasHeight={900 * assetFaceAspect(type)}>
-                      <RectangleProof face={referencedBack} width={900} />
-                    </CanvasScale>
+                    <RectangleProof face={referencedBack} />
                   ) : (
                     <Text size="xs" c="dimmed">
                       Its stored back can no longer be read as an authored back, so it cannot be shown here.

--- a/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
@@ -4,7 +4,6 @@ import { ASSET_TYPES, isAssetType } from '@shared/assets/types';
 import { Link, useNavigate } from '@tanstack/react-router';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
-import { CanvasScale } from '@ui/layout/CanvasScale';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
 import { useState } from 'react';
@@ -12,7 +11,6 @@ import { useState } from 'react';
 import { useAssetPage, useUpdateAsset } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
 import { AssetPicker } from '@app/pickers/AssetPicker';
-import { assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
 import { ValidationHeader } from '@app/widgets/authoring/ValidationHeader';
@@ -294,10 +292,7 @@ function TokenEditSession({
               pickedBack ? (
                 <Stack gap={4} align="center" w="100%">
                   {referencedBack ? (
-                    /* The picker offers only this token's own type, so the page's type fixes the aspect. */
-                    <CanvasScale canvasWidth={900} canvasHeight={900 * assetFaceAspect(type)}>
-                      <TokenProof face={referencedBack} type={type} width={900} />
-                    </CanvasScale>
+                    <TokenProof face={referencedBack} type={type} />
                   ) : (
                     <Text size="xs" c="dimmed">
                       Its stored back can no longer be read as an authored back, so it cannot be shown here.

--- a/src/app/routes/_app/assets/$type/$slug/index.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/index.tsx
@@ -24,7 +24,6 @@ import { TopicIcon } from '@ui/content/TopicIcon';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
 import { AsymmetricSplitLayout } from '@ui/layout/AsymmetricSplitLayout';
-import { CanvasScale } from '@ui/layout/CanvasScale';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Links } from '@ui/list/Links';
 import { Stats } from '@ui/list/Stats';
@@ -48,8 +47,7 @@ import type { ReactNode } from 'react';
 
 import { loadAssetPage, useAssetPage } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
-import { AssetFace, assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
-import type { AssetFaceMember } from '@app/widgets/asset-face/AssetFace';
+import { AssetFace } from '@app/widgets/asset-face/AssetFace';
 
 import { useAssetDeletion, useAssetGroupActions } from '../../-assetEditorStates';
 import { compositionTiles, DUPLICATED_TILE_CAP, omissionNote } from './-composition';
@@ -132,27 +130,6 @@ function FaceStage({ children, caption }: { children: ReactNode; caption?: React
         </Text>
       ) : null}
     </Stack>
-  );
-}
-
-function ScaledFace({
-  type,
-  data,
-  name,
-  side,
-  members = [],
-}: {
-  type: string;
-  data: unknown;
-  name: string;
-  side?: 'front' | 'back';
-  members?: AssetFaceMember[];
-}) {
-  return (
-    /* A container's members stand above it and make the drawing taller, so the canvas is asked for the block's height rather than the face's. */
-    <CanvasScale rounded canvasWidth={900} canvasHeight={900 * assetFaceAspect(type, members.length)}>
-      <AssetFace type={type} data={data} name={name} width={900} side={side} members={members} />
-    </CanvasScale>
   );
 }
 
@@ -243,13 +220,13 @@ function AssetFaces({ page }: { page: AssetPage }) {
           }
         >
           {backDeck ? (
-            <ScaledFace type="deck" data={backDeck.data} name={backDeck.name} />
+            <AssetFace type="deck" data={backDeck.data} name={backDeck.name} />
           ) : danglingDeck && page.resolvedBack?.href ? (
             /* The note below carries the words, so the image is decorative to a screen reader. */
             <img src={page.resolvedBack.href} alt="" className={styles.fallbackCardback} />
           ) : (
             /* A deck's cards reach `AssetFace` here too and are ignored, which is that prop's documented contract rather than an accident. */
-            <ScaledFace
+            <AssetFace
               type={asset.type}
               data={asset.data}
               name={asset.name}
@@ -272,7 +249,7 @@ function AssetFaces({ page }: { page: AssetPage }) {
     return (
       <Stack gap="sm" align="center">
         <FaceStage caption="Front & back">
-          <ScaledFace type={asset.type} data={asset.data} name={asset.name} side="front" />
+          <AssetFace type={asset.type} data={asset.data} name={asset.name} side="front" />
         </FaceStage>
         {dangling ? (
           <Text size="sm" c="dimmed">
@@ -285,7 +262,7 @@ function AssetFaces({ page }: { page: AssetPage }) {
   return (
     <Stack gap="lg" align="center">
       <FaceStage caption="Front">
-        <ScaledFace type={asset.type} data={asset.data} name={asset.name} side="front" />
+        <AssetFace type={asset.type} data={asset.data} name={asset.name} side="front" />
       </FaceStage>
       {back?.mode === 'reference' && backToken ? (
         <FaceStage
@@ -307,11 +284,11 @@ function AssetFaces({ page }: { page: AssetPage }) {
             </>
           }
         >
-          <ScaledFace type={backToken.type} data={backToken.data} name={backToken.name} side="back" />
+          <AssetFace type={backToken.type} data={backToken.data} name={backToken.name} side="back" />
         </FaceStage>
       ) : (
         <FaceStage caption="Back">
-          <ScaledFace type={asset.type} data={asset.data} name={asset.name} side="back" />
+          <AssetFace type={asset.type} data={asset.data} name={asset.name} side="back" />
         </FaceStage>
       )}
     </Stack>
@@ -391,9 +368,7 @@ function Composition({
                   <Link {...rootProps} to="/assets/$type/$slug" params={{ type: member.type, slug: member.slug }} />
                 )}
               >
-                <CanvasScale canvasWidth={900} canvasHeight={900 * assetFaceAspect(member.type)}>
-                  <AssetFace type={member.type} data={member.data} name={member.name} width={900} />
-                </CanvasScale>
+                <AssetFace type={member.type} data={member.data} name={member.name} />
               </OpenableTile>
             ))}
           </TileGrid>
@@ -547,7 +522,7 @@ function LoadedAssetDetail({ page }: { page: AssetPage }) {
         {/* The identity pattern the faction and ruleset detail pages use: the media sits in its own column, so the breadcrumb, the title and the meta line share one left edge. */}
         <Group wrap="nowrap" align="center" gap="lg" className={styles.pageHead}>
           <div className={styles.pageHeadMedia} role="img" aria-label={`${asset.name} face`}>
-            <ScaledFace type={asset.type} data={asset.data} name={asset.name} />
+            <AssetFace type={asset.type} data={asset.data} name={asset.name} />
           </div>
           <Stack gap={6} className={styles.pageHeadText}>
             <Group gap="xs" wrap="wrap">

--- a/src/app/routes/_app/assets/$type/index.tsx
+++ b/src/app/routes/_app/assets/$type/index.tsx
@@ -5,7 +5,6 @@ import { OpenableTile } from '@ui/block/OpenableTile';
 import { PageTitle } from '@ui/block/PageTitle';
 import { CallToAction } from '@ui/control/CallToAction';
 import { IconAction } from '@ui/control/IconAction';
-import { CanvasScale } from '@ui/layout/CanvasScale';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { TileGrid } from '@ui/list/TileGrid';
 import { Surface } from '@ui/surface';
@@ -15,7 +14,7 @@ import { useState } from 'react';
 
 import { loadAssetBrowsePage, useAssetBrowsePage } from '@app/db/assets';
 import type { AssetBrowseEntry } from '@app/db/assets';
-import { AssetFace, assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
+import { AssetFace } from '@app/widgets/asset-face/AssetFace';
 
 import { applyAssetBrowseSearch, ASSET_BROWSE_SORTS, parseAssetBrowseSearch } from './-browse';
 import type { AssetBrowseSearch } from './-browse';
@@ -195,10 +194,7 @@ function BrowseTile({ entry }: { entry: AssetBrowseEntry }) {
         <Link {...rootProps} to="/assets/$type/$slug" params={{ type: entry.type, slug: entry.slug }} />
       )}
     >
-      {/* A container's members stand above it and make the drawing taller, so the canvas is asked for the block's height rather than the face's. */}
-      <CanvasScale canvasWidth={900} canvasHeight={900 * assetFaceAspect(entry.type, entry.members.length)}>
-        <AssetFace type={entry.type} data={entry.data} name={entry.name} width={900} members={entry.members} />
-      </CanvasScale>
+      <AssetFace type={entry.type} data={entry.data} name={entry.name} members={entry.members} />
     </OpenableTile>
   );
 }

--- a/src/app/routes/_app/assets/index.tsx
+++ b/src/app/routes/_app/assets/index.tsx
@@ -5,12 +5,11 @@ import { Link, createFileRoute } from '@tanstack/react-router';
 import { Eyebrow } from '@ui/content/Eyebrow';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { SectionedSurface } from '@ui/surface/SectionedSurface';
-import { useEffect, useState } from 'react';
 import type { CSSProperties } from 'react';
 
 import { loadAssetCataloguePage, useAssetCataloguePage } from '@app/db/assets';
 import type { AssetListEntry } from '@app/db/assets';
-import { AssetFace, assetFaceAspect, CARD_ASPECT } from '@app/widgets/asset-face/AssetFace';
+import { AssetFace, assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
 
 import styles from './index.module.css';
 
@@ -30,26 +29,11 @@ const PILE_SLOT = 150;
 const FAN_OVERLAP = 6;
 /** how many cards a pile's fan shows; three reads as a pile without shrinking anyone */
 const FAN_COUNT = 3;
+/** the masthead fan's cards are placed by hand against a fixed 540px band, so they are the one fan drawn at a set size */
+const MASTHEAD_CARD = 138;
 
 /* Handed to the stylesheet so the grid tracks and the art cannot drift apart. */
 const pileGroupStyle = { '--pile-slot': `${PILE_SLOT}px` } as CSSProperties;
-
-/**
- * The width the pile's art actually has: grid tracks flex below their slot ceiling on narrow rows (see index.module.css), so a fixed pixel width would overflow its own track.
- */
-function useSlotWidth() {
-  const [node, setNode] = useState<HTMLDivElement | null>(null);
-  const [width, setWidth] = useState(0);
-  useEffect(() => {
-    if (!node) {
-      return;
-    }
-    const observer = new ResizeObserver(([entry]) => setWidth(entry?.contentRect.width ?? 0));
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, [node]);
-  return { ref: setNode, width };
-}
 
 /**
  * The ledger's three rows, each naming the categories whose piles it holds.
@@ -84,13 +68,14 @@ function MastheadFan({ cards }: { cards: AssetListEntry[] }) {
               key={card.id}
               style={{
                 position: 'absolute',
+                width: MASTHEAD_CARD,
                 left: `calc(50% - 70px + ${off * 90 + (JITTER_LEFT[i] ?? 0)}px)`,
                 top: 28 + Math.abs(off) * 16 + (JITTER_TOP[i] ?? 0),
                 transform: `rotate(${off * 8 + (JITTER_ROT[i] ?? 0)}deg)`,
                 transformOrigin: '50% 130%',
               }}
             >
-              <AssetFace type={card.type} data={card.data} name={card.name} width={138} />
+              <AssetFace type={card.type} data={card.data} name={card.name} />
             </div>
           );
         })}
@@ -99,25 +84,36 @@ function MastheadFan({ cards }: { cards: AssetListEntry[] }) {
   );
 }
 
+/*
+ * The piles below share one shape: every face sits in the same grid cell, so the pile's height is one
+ * face's height and no one computes it. The spread is a `transform`, which takes no part in layout, and
+ * the padding is the room those transforms need to lean into.
+ *
+ * They used to be absolutely positioned inside a box whose height was `faceWidth * ratio`, which is why
+ * the page measured its own grid track: that arithmetic needed a pixel width, and the track's width is a
+ * CSS answer that only a `ResizeObserver` could read back into JavaScript. Nothing needs it now, so the
+ * piles are drawn on first paint rather than after a measurement lands.
+ */
+const PILE_CELL = { gridArea: '1 / 1' } as const;
+
 /** a slightly fanned pile of real faces for card-type piles; every face keeps the placeholder's width */
-function MiniFan({ entries, slot }: { entries: AssetListEntry[]; slot: number }) {
-  /* The grid track may shrink below the spread in the stacked state, so the face width floors at 1px rather than going negative. */
-  const cardWidth = Math.max(1, slot - (entries.length - 1) * FAN_OVERLAP);
+function MiniFan({ entries }: { entries: AssetListEntry[] }) {
+  const spread = (entries.length - 1) * FAN_OVERLAP;
   const mid = (entries.length - 1) / 2;
   return (
-    <div style={{ position: 'relative', width: slot, height: cardWidth * CARD_ASPECT + 16 }}>
+    <div style={{ display: 'grid', width: '100%', padding: '8px 0' }}>
       {entries.map((entry, i) => (
         <div
           key={entry.id}
           style={{
-            position: 'absolute',
-            left: i * FAN_OVERLAP,
-            top: 8 + Math.abs(i - mid) * 3,
-            transform: `rotate(${(i - mid) * 4 + (JITTER_ROT[i % JITTER_ROT.length] ?? 0)}deg)`,
+            ...PILE_CELL,
+            /* The track can shrink below the spread on a stacked row, so the face floors at 1px rather than going negative. */
+            width: `max(1px, calc(100% - ${spread}px))`,
             transformOrigin: '50% 120%',
+            transform: `translate(${i * FAN_OVERLAP}px, ${Math.abs(i - mid) * 3}px) rotate(${(i - mid) * 4 + (JITTER_ROT[i % JITTER_ROT.length] ?? 0)}deg)`,
           }}
         >
-          <AssetFace type={entry.type} data={entry.data} name={entry.name} width={cardWidth} />
+          <AssetFace type={entry.type} data={entry.data} name={entry.name} />
         </div>
       ))}
     </div>
@@ -125,14 +121,16 @@ function MiniFan({ entries, slot }: { entries: AssetListEntry[]; slot: number })
 }
 
 /** a squared-up pile for decks; the newest deck's cardback on top */
-function DeckPile({ entries, slot }: { entries: AssetListEntry[]; slot: number }) {
+function DeckPile({ entries }: { entries: AssetListEntry[] }) {
   const top = entries[0] as AssetListEntry;
-  const cardWidth = Math.max(1, slot - 6);
   return (
-    <div style={{ position: 'relative', width: slot, height: cardWidth * CARD_ASPECT + 10 }}>
+    <div style={{ display: 'grid', width: '100%', paddingBottom: 10 }}>
       {[2, 1, 0].map((n) => (
-        <div key={n} style={{ position: 'absolute', top: n * 4, left: n * 2 }}>
-          <AssetFace type={top.type} data={top.data} name={top.name} width={cardWidth} />
+        <div
+          key={n}
+          style={{ ...PILE_CELL, width: 'max(1px, calc(100% - 6px))', transform: `translate(${n * 2}px, ${n * 4}px)` }}
+        >
+          <AssetFace type={top.type} data={top.data} name={top.name} />
         </div>
       ))}
     </div>
@@ -150,7 +148,7 @@ const STACK_PLACEMENTS = [
   { top: 0, left: 3, rot: 3 },
 ];
 
-function TokenStack({ entries, width }: { entries: AssetListEntry[]; width: number }) {
+function TokenStack({ entries, fill }: { entries: AssetListEntry[]; fill: boolean }) {
   const shown = entries.slice(0, 4);
   const placements = STACK_PLACEMENTS.slice(STACK_PLACEMENTS.length - shown.length);
   const type = shown[0]?.type ?? '';
@@ -167,12 +165,13 @@ function TokenStack({ entries, width }: { entries: AssetListEntry[]; width: numb
    * `TOKEN_PILE_FACE` and an enhance token draws to its grid slot. Bottom-aligned boxes of different
    * heights then put every face on a different line, worst for the widest and shortest one
    * (Norbert, 2026-08-20).
+   *
+   * The centring is the band's own layout now rather than an offset computed from the face's height,
+   * which is the reason this component no longer needs to know how tall its faces are.
    */
-  const faceHeight = width * assetFaceAspect(type);
   const boxHeight = TOKEN_PILE_FACE + (placements[0]?.top ?? 0) + 6;
-  const centring = (TOKEN_PILE_FACE - faceHeight) / 2;
   return (
-    <div style={{ position: 'relative', width: width + 26, height: boxHeight }}>
+    <div style={{ position: 'relative', width: fill ? '100%' : TOKEN_PILE_FACE + 26, height: boxHeight }}>
       {shown.map((entry, i) => {
         const placement = placements[i] ?? { top: 0, left: 0, rot: 0 };
         return (
@@ -180,12 +179,16 @@ function TokenStack({ entries, width }: { entries: AssetListEntry[]; width: numb
             key={entry.id}
             style={{
               position: 'absolute',
-              top: placement.top + centring,
+              top: placement.top,
               left: 6 + placement.left,
+              width: fill ? 'max(1px, calc(100% - 26px))' : TOKEN_PILE_FACE,
+              height: TOKEN_PILE_FACE,
+              display: 'grid',
+              alignContent: 'center',
               transform: straight ? undefined : `rotate(${placement.rot}deg)`,
             }}
           >
-            <AssetFace type={entry.type} data={entry.data} name={entry.name} width={width} />
+            <AssetFace type={entry.type} data={entry.data} name={entry.name} />
           </div>
         );
       })}
@@ -197,20 +200,21 @@ function TokenStack({ entries, width }: { entries: AssetListEntry[]; width: numb
 function emptyOutlineShape(
   type: AssetType
 ): { width: number | string; borderRadius: number | string } & ({ height: number } | { aspectRatio: string }) {
+  /* Every ratio below is read from `assetFaceAspect`, the same function the face itself holds its height from: an outline and the pile that replaces it are the same shape or the row jumps when the first asset of a type lands. The literal here was once 110/68, close to the enhance token's ratio but not equal, and drifting apart was only a matter of time. */
   switch (type) {
     case 'token-disc':
     case 'token-tech':
-      return { width: 96, height: 96, borderRadius: '50%' };
+      return { width: TOKEN_PILE_FACE, height: TOKEN_PILE_FACE * assetFaceAspect(type), borderRadius: '50%' };
     case 'token-plate':
-      return { width: 96, height: 96, borderRadius: 8 };
+      return { width: TOKEN_PILE_FACE, height: TOKEN_PILE_FACE * assetFaceAspect(type), borderRadius: 8 };
     case 'token-enhance':
-      /* `assetFaceAspect` owns this ratio; the literal here was 110/68, which is close to it but not equal, and drifting apart was only a matter of time. */
-      return { width: '100%', aspectRatio: `1 / ${assetFaceAspect('token-enhance')}`, borderRadius: 8 };
+      return { width: '100%', aspectRatio: `1 / ${assetFaceAspect(type)}`, borderRadius: 8 };
     case 'board':
+      /* The one shape with no ratio to read: a board is planned, so nothing renders one and `assetFaceAspect` has no answer of its own for it yet. */
       return { width: '100%', aspectRatio: '3 / 2', borderRadius: 8 };
     default:
       /* cards and decks: the card's own proportions */
-      return { width: '100%', aspectRatio: `1 / ${CARD_ASPECT}`, borderRadius: 6 };
+      return { width: '100%', aspectRatio: `1 / ${assetFaceAspect(type)}`, borderRadius: 6 };
   }
 }
 
@@ -242,25 +246,21 @@ function TypePile({ type, entries }: { type: AssetType; entries: AssetListEntry[
   const definition = ASSET_TYPES[type];
   const planned = definition.status === 'planned';
   const isCardish = type.startsWith('card-') || type === 'deck';
-  const slot = useSlotWidth();
-  /* The track is the ceiling, so the art fills whatever width it was given. */
-  const drawnAt = slot.width;
   const art =
     planned || entries.length === 0 ? (
       <EmptyPileOutline type={type} planned={planned} />
-    ) : drawnAt === 0 ? null : type === 'deck' ? (
-      <DeckPile entries={entries} slot={drawnAt} />
+    ) : type === 'deck' ? (
+      <DeckPile entries={entries} />
     ) : isCardish ? (
-      <MiniFan entries={entries.slice(0, FAN_COUNT)} slot={drawnAt} />
+      <MiniFan entries={entries.slice(0, FAN_COUNT)} />
     ) : (
-      <TokenStack entries={entries} width={type === 'token-enhance' ? Math.max(1, drawnAt - 26) : TOKEN_PILE_FACE} />
+      /* An enhance token is wide and short, so its pile takes the track; the rest draw at the shared pile size. */
+      <TokenStack entries={entries} fill={type === 'token-enhance'} />
     );
 
   const body = (
     <Stack gap={8} align="center">
-      <div ref={slot.ref} className={styles.pileArt}>
-        {art}
-      </div>
+      <div className={styles.pileArt}>{art}</div>
       {/* The pile is its art and its name; the count it once wore said nothing the grid behind the link does not (Norbert, 2026-08-21). */}
       <Text fw={700} c={planned ? 'dimmed' : undefined}>
         {definition.shortLabel}

--- a/src/app/ui/layout/CanvasScale.tsx
+++ b/src/app/ui/layout/CanvasScale.tsx
@@ -7,18 +7,22 @@ import type { CSSProperties, PropsWithChildren } from 'react';
  * The canvas is taken out of flow so the frame's height comes from its aspect ratio alone, never from the unscaled child it clips.
  * Pure placement;
  * the caller decorates the frame (shadow, anything bespoke) through `frameClassName`, and `rounded` is the one shared decoration: the corner treatment every rail proof wears (Norbert, 2026-08-21), kept here so five rails cannot drift apart.
+ * `frameStyle` decorates the same frame for the values a class cannot hold, the ones a caller derives from the canvas it passed;
+ * it may not re-place the frame, since the placement above is the whole point of the component.
  * The browser floor this technique sets is recorded on «Work the kit compliance wave» (#641).
  */
 export function CanvasScale({
   canvasWidth,
   canvasHeight,
   frameClassName,
+  frameStyle,
   rounded = false,
   children,
 }: PropsWithChildren<{
   canvasWidth: number;
   canvasHeight: number;
   frameClassName?: string;
+  frameStyle?: CSSProperties;
   rounded?: boolean;
 }>) {
   return (
@@ -32,6 +36,7 @@ export function CanvasScale({
           position: 'relative',
           overflow: 'hidden',
           borderRadius: rounded ? 'var(--mantine-radius-md)' : undefined,
+          ...frameStyle,
           '--canvas-width': `${canvasWidth}px`,
         } as CSSProperties
       }

--- a/src/app/widgets/asset-face/AssetFace.stories.tsx
+++ b/src/app/widgets/asset-face/AssetFace.stories.tsx
@@ -1,0 +1,119 @@
+import { Box, Group, Stack, Text } from '@mantine/core';
+import preview from '@sb/preview';
+
+import { backgroundPresets } from '@game/data/backgrounds';
+import { treacheryCardFixtures } from '@game/fixtures/treacheryCards';
+
+import { AssetFace } from './AssetFace';
+
+/*
+ * Listing rows, which is what `AssetFace` reads.
+ * Written out here rather than pulled from the editors' stock tables, because a story fixture is the
+ * one place a shape may be stated by hand: these stand in for stored `data`, which arrives untyped.
+ */
+const TREACHERY = { ...treacheryCardFixtures.lasgun, about: '' };
+
+const CARDBACK = {
+  cardback: {
+    name: 'Treachery',
+    background: backgroundPresets.weapon,
+    image: '/vector/icon/projectile.svg',
+    imageScale: 0.55,
+    imageOffset: [0, 10],
+  },
+};
+
+const DISC = {
+  name: 'Spice',
+  about: '',
+  front: {
+    image: '/vector/icon/eye.svg',
+    background: backgroundPresets.special,
+    symbolScale: 1,
+    top: 'SPICE',
+    bottomFirst: '',
+    bottomSecond: '',
+    ring: true,
+  },
+  back: { mode: 'same' },
+};
+
+const ENHANCE = {
+  name: 'Lasgun array',
+  about: '',
+  front: { background: backgroundPresets.weapon, ring: true, decals: [], texts: [] },
+  back: { mode: 'same' },
+};
+
+const BUNDLE = { band: { background: backgroundPresets.weapon, label: 'Weapons' } };
+
+const MEMBERS = [
+  { id: 'a', type: 'token-disc', name: 'Spice', data: DISC },
+  { id: 'b', type: 'token-enhance', name: 'Lasgun array', data: ENHANCE },
+  { id: 'c', type: 'token-plate', name: 'Shield', data: DISC },
+];
+
+const meta = preview.meta({
+  component: AssetFace,
+  parameters: { layout: 'padded' },
+  args: { type: 'card-treachery', data: TREACHERY, name: 'Lasgun' },
+});
+
+/** Four real widths from the app: a picker row, a landing pile, a browse tile, and the detail page's hero. */
+const WIDTHS = [44, 96, 220, 340];
+
+function acrossWidths(args: Parameters<typeof AssetFace>[0]) {
+  return (
+    <Group align="flex-start" gap="xl">
+      {WIDTHS.map((width) => (
+        <Stack key={width} gap={6} align="center">
+          <Box w={width}>
+            <AssetFace {...args} />
+          </Box>
+          <Text size="xs" c="dimmed">{`${width}px parent`}</Text>
+        </Stack>
+      ))}
+    </Group>
+  );
+}
+
+/** A face given the whole canvas takes the whole canvas, because that is the box it was put in. */
+export const Card = meta.story({});
+
+export const Deck = meta.story({ args: { type: 'deck', data: CARDBACK, name: 'Treachery deck' } });
+
+export const DiscToken = meta.story({ args: { type: 'token-disc', data: DISC, name: 'Spice' } });
+
+export const EnhanceToken = meta.story({
+  args: { type: 'token-enhance', data: ENHANCE, name: 'Lasgun array' },
+});
+
+export const Bundle = meta.story({ args: { type: 'bundle', data: BUNDLE, name: 'Weapons' } });
+
+/**
+ * A container's members stand above it, so the block is taller than the container by exactly the headroom the tilted row needs.
+ * The corner of the most-tilted member is the thing to look at: it is what gets clipped when that headroom is wrong.
+ */
+export const BundleWithMembers = meta.story({
+  args: { type: 'bundle', data: BUNDLE, name: 'Weapons', members: MEMBERS },
+});
+
+/** Data that will not read, and an unknown type, both draw the neutral face rather than crashing a page. */
+export const Unreadable = meta.story({
+  args: { type: 'card-treachery', data: { nothing: 'usable' }, name: 'Missing Artwork' },
+});
+
+/**
+ * The property every caller now relies on: one face, four parents, no size passed to any of them.
+ * The face reads its width from the box it is in and its height from its own ratio, so the only thing that changes down the row is the number on the parent.
+ */
+export const AtAnyWidth = meta.story({ render: acrossWidths });
+
+/**
+ * The same run for a container, whose block is the one face taller than its own frame.
+ * The headroom above the container has to grow with the width exactly as the members do, or the most-tilted corner is cut at one size and floats at another.
+ */
+export const BundleAtAnyWidth = meta.story({
+  args: { type: 'bundle', data: BUNDLE, name: 'Weapons', members: MEMBERS },
+  render: acrossWidths,
+});

--- a/src/app/widgets/asset-face/AssetFace.test.tsx
+++ b/src/app/widgets/asset-face/AssetFace.test.tsx
@@ -54,7 +54,6 @@ describe('a token back with mode same', () => {
         type="token-disc"
         data={{ name: 'Spice', about: '', front, back: { mode: 'same' } }}
         name="Spice"
-        width={300}
         side="back"
       />
     );
@@ -67,7 +66,6 @@ describe('a token back with mode same', () => {
         type="token-disc"
         data={{ name: 'Spice', about: '', front, back: { mode: 'reference' } }}
         name="Spice"
-        width={300}
         side="back"
       />
     );

--- a/src/app/widgets/asset-face/AssetFace.tsx
+++ b/src/app/widgets/asset-face/AssetFace.tsx
@@ -404,6 +404,14 @@ function BundleBlock({ members, children }: { members: AssetFaceMember[]; childr
         aspectRatio: `1 / ${BUNDLE_ASPECT + bundleHeadroom(members.length)}`,
         /* The block is what a peeking member measures itself against, and it is the only box here whose width is the one the caller gave. */
         containerType: 'inline-size',
+        /*
+         * The block is the flex item, so it is the only box that can refuse to be squashed: the container
+         * below it is absolutely positioned and cannot resist from in there, whatever it declares.
+         * Measured in a 300x200 column with `min-height: 0`, which any flex layout may carry: without this the
+         * block collapses from 250.6px to 60px while the container keeps drawing 186px, and since the container
+         * is pinned to the block's bottom edge, the 126px it gains goes upward over whatever sits above it.
+         */
+        flexShrink: 0,
       }}
     >
       {/* Pinned to the container's own box rather than the block's, so the two stay aligned whenever the headroom changes. */}

--- a/src/app/widgets/asset-face/AssetFace.tsx
+++ b/src/app/widgets/asset-face/AssetFace.tsx
@@ -6,6 +6,10 @@
  *
  * Listing `data` arrives untyped (the per-type Zod schemas live with the editors), so each adapter safeParses just enough to hand the real game renderer its props, and anything unrenderable falls back to a neutral face rather than crashing a browse page.
  * The scale frames wrap the renderers' intrinsic sizes (cards draw at 900x1263, tokens fill).
+ *
+ * A face fills the width it is given and takes its height from `assetFaceAspect`, so it is placed by sizing its parent (#706).
+ * It was once handed a pixel width instead, which made every caller state a size the face already knew: six of them wrapped it in a `CanvasScale` restating the same 900 and the same ratio, and the landing page ran a `ResizeObserver` whose entire output was that one prop.
+ * A surface needing exact pixels still gets them, by giving the face a fixed-size parent, so there is never a second way to say the same thing.
  */
 import { Text } from '@mantine/core';
 import { NO_DECK_BACK_HREF } from '@shared/asset-publishing/fallbacks';
@@ -16,7 +20,8 @@ import {
   TokenFace,
   TreacheryAsset,
 } from '@shared/assets/schema';
-import type { CSSProperties, ReactNode } from 'react';
+import { CanvasScale } from '@ui/layout/CanvasScale';
+import type { ReactNode } from 'react';
 import { z } from 'zod';
 
 import { CardBack } from '@game/assets/card/Back';
@@ -27,7 +32,7 @@ import { card as CARD_SIZE } from '@game/data/sizes';
 
 import { BUNDLE_ASPECT, BundleContainer } from './BundleContainer';
 
-export const CARD_ASPECT = CARD_SIZE.height / CARD_SIZE.width;
+const CARD_ASPECT = CARD_SIZE.height / CARD_SIZE.width;
 
 /** Enough of a container's member to draw its face. The browse read and the detail page's member list both supply this shape. */
 export type AssetFaceMember = { id: string; type: string; name: string; data: unknown };
@@ -55,7 +60,8 @@ const PEEKING_LIMIT = MEMBER_PEEK.length;
  * How far a tilted member's corner climbs above its own top edge, as a fraction of the member's width.
  *
  * A member is tilted about its centre, so the rise the layout has to reserve is not the rise the transform states.
- * The browse tile draws inside `CanvasScale`, which clips, and without this the corner of the most-tilted member was cut: 10px off a 352px face, and only on the members whose artwork reaches their own corners, which is why a disc token looked fine beside a clipped enhance token.
+ * The browse tile clips, in `OpenableTile`'s art box, and without this the corner of the most-tilted member was cut: 10px off a 352px face, and only on the members whose artwork reaches their own corners, which is why a disc token looked fine beside a clipped enhance token.
+ * Nothing clips it on the detail page, where the same shortfall would put a member's corner over the caption instead, so the reservation is what keeps the block honest about its own height either way.
  * Read off `MEMBER_PEEK` rather than measured once and written down, so changing a tilt cannot leave a stale number behind.
  * `sin` alone slightly over-reserves, because the true growth is offset by a `cos` term that shrinks with the member's height, and over-reserving shows a few transparent pixels where under-reserving shows a cut corner.
  */
@@ -86,75 +92,74 @@ const GEAR_CLIP = (() => {
 })();
 
 /**
- * A card at whatever width it is given, scaled from the renderers' intrinsic 900x1263.
- * Exported for the same reason `TokenFrame` is: an editor drawing its own live draft wants the frame the catalogue surfaces use, and has no business routing a draft through the listing parse to get it.
+ * The card's corner, as a share of its own box rather than a pixel count read off a width.
+ *
+ * `border-radius` in the two-value percentage form takes its horizontal radius from the box's width and its vertical from its height, so dividing the second by `CARD_ASPECT` keeps the corner circular at every size, which is what `width / 18` did arithmetically.
+ * A percentage rather than a container unit because `cqw` inside an element resolves against its *ancestor* container, never against the element declaring the containment, so the frame cannot read its own width that way.
  */
-export function CardFrame({ width, children, style }: { width: number; children: ReactNode; style?: CSSProperties }) {
-  const scale = width / CARD_SIZE.width;
+const CARD_CORNER = `${100 / 18}% / ${100 / (18 * CARD_ASPECT)}%`;
+
+/**
+ * A card filling the width it is given, scaled from the renderers' intrinsic 900x1263.
+ * Exported for the same reason `TokenFrame` is: an editor drawing its own live draft wants the frame the catalogue surfaces use, and has no business routing a draft through the listing parse to get it.
+ *
+ * The fit is `CanvasScale`'s, not a second copy of it: this is exactly the case it was written for, a fixed canvas that has to land inside whatever box it is put in.
+ * All this adds is the catalogue's card decoration, which is why it goes through `frameStyle`.
+ */
+export function CardFrame({ children }: { children: ReactNode }) {
   return (
-    <div
-      style={{
-        width,
-        height: width * CARD_ASPECT,
-        position: 'relative',
-        borderRadius: width / 18,
-        overflow: 'hidden',
+    <CanvasScale
+      canvasWidth={CARD_SIZE.width}
+      canvasHeight={CARD_SIZE.height}
+      frameStyle={{
+        borderRadius: CARD_CORNER,
         boxShadow: '0 2px 10px rgba(0,0,0,0.45)',
+        /* Defends the ratio, not a width: as a flex item in a column a face without this is squashed below its own height. */
         flexShrink: 0,
-        ...style,
       }}
     >
-      <div
-        style={{
-          transform: `scale(${scale})`,
-          transformOrigin: 'top left',
-          width: CARD_SIZE.width,
-          height: CARD_SIZE.height,
-          pointerEvents: 'none',
-        }}
-      >
-        {children}
-      </div>
-    </div>
+      {children}
+    </CanvasScale>
   );
 }
 
 type TokenShape = 'round' | 'gear' | 'square' | 'rectangle';
 
-export function TokenFrame({
-  shape,
-  width,
-  children,
-  style,
-}: {
-  shape: TokenShape;
-  width: number;
-  children: ReactNode;
-  style?: CSSProperties;
-}) {
-  const height = shape === 'rectangle' ? width * RECTANGLE_TOKEN_ASPECT : width;
+/**
+ * The height of a token shape as a multiple of its width.
+ * Read by the frame that draws one and by `assetFaceAspect`, which used to answer the same question from its own copy of this switch.
+ */
+function tokenShapeAspect(shape: TokenShape): number {
+  return shape === 'rectangle' ? RECTANGLE_TOKEN_ASPECT : 1;
+}
+
+/**
+ * One token face filling the width it is given, clipped to its shape.
+ * No scaling: the token renderers fill their box rather than drawing at an intrinsic size, so the shape's own ratio is the whole of the geometry.
+ */
+export function TokenFrame({ shape, children }: { shape: TokenShape; children: ReactNode }) {
   const gear = shape === 'gear';
   return (
     <div
       style={{
-        width,
-        height,
+        width: '100%',
+        aspectRatio: `1 / ${tokenShapeAspect(shape)}`,
         position: 'relative',
         borderRadius: shape === 'round' ? '50%' : gear ? undefined : 8,
         clipPath: gear ? GEAR_CLIP : undefined,
         overflow: 'hidden',
         boxShadow: gear ? undefined : '0 2px 10px rgba(0,0,0,0.45)',
         filter: gear ? 'drop-shadow(0 2px 6px rgba(0,0,0,0.5))' : undefined,
+        /* Defends the ratio, not a width: as a flex item in a column a face without this is squashed below its own height. */
         flexShrink: 0,
-        ...style,
       }}
     >
-      <div style={{ width, height, pointerEvents: 'none' }}>{children}</div>
+      <div style={{ width: '100%', height: '100%', pointerEvents: 'none' }}>{children}</div>
     </div>
   );
 }
 
-function NeutralFace({ name, width, aspect }: { name: string; width: number; aspect: number }) {
+function NeutralFace({ name, aspect }: { name: string; aspect: number }) {
   const initials = name
     .split(/\s+/)
     .map((word) => word[0])
@@ -165,13 +170,14 @@ function NeutralFace({ name, width, aspect }: { name: string; width: number; asp
   return (
     <div
       style={{
-        width,
-        height: width * aspect,
+        width: '100%',
+        aspectRatio: `1 / ${aspect}`,
         borderRadius: 8,
         display: 'grid',
         placeItems: 'center',
         background: 'var(--mantine-color-default)',
         border: '1px solid var(--mantine-color-default-border)',
+        /* Defends the ratio, not a width: as a flex item in a column a face without this is squashed below its own height. */
         flexShrink: 0,
       }}
     >
@@ -317,15 +323,9 @@ export function assetFaceAspect(type: string, memberCount = 0): number {
   if (type === 'bundle') {
     return BUNDLE_ASPECT + bundleHeadroom(memberCount);
   }
+  /* No token shape means no token, and every remaining type draws at card proportions. */
   const shape = tokenShapeOfType(type);
-  switch (shape) {
-    case null:
-      return CARD_ASPECT;
-    case 'rectangle':
-      return RECTANGLE_TOKEN_ASPECT;
-    default:
-      return 1;
-  }
+  return shape === null ? CARD_ASPECT : tokenShapeAspect(shape);
 }
 
 export function tokenShapeOfType(type: string): TokenShape | null {
@@ -362,8 +362,7 @@ function tokenBottom(face: DrawableTokenFace): string | undefined {
  * They are the caller's to supply, since only a caller holding those rows has them, which is why `BundleContainer` draws none.
  * The nested `AssetFace` is passed no members of its own, so a member draws its bare face and the recursion stops one level down whatever it holds.
  */
-function PeekingMembers({ width, members }: { width: number; members: AssetFaceMember[] }) {
-  const memberWidth = width * MEMBER_WIDTH_RATIO;
+function PeekingMembers({ members }: { members: AssetFaceMember[] }) {
   return (
     <div style={{ position: 'absolute', inset: 0, display: 'grid', placeItems: 'start center' }}>
       {members.slice(0, PEEKING_LIMIT).map((member, index) => {
@@ -373,10 +372,17 @@ function PeekingMembers({ width, members }: { width: number; members: AssetFaceM
             key={member.id}
             style={{
               gridArea: '1 / 1',
-              transform: `translate(${placement.left * width}px, ${-memberWidth * MEMBER_RISE_RATIO}px) rotate(${placement.rotation}deg)`,
+              /*
+               * Every one of these was already a fraction of the container's width, so each is now that
+               * same fraction of `100cqw`, which `BundleBlock` declares. The rise reads as a share of the
+               * block rather than of the member because a `translate` percentage resolves against the
+               * element's own box, and a member's height varies with its type while the ratio does not.
+               */
+              width: `calc(100cqw * ${MEMBER_WIDTH_RATIO})`,
+              transform: `translate(calc(100cqw * ${placement.left}), calc(100cqw * ${-MEMBER_WIDTH_RATIO * MEMBER_RISE_RATIO})) rotate(${placement.rotation}deg)`,
             }}
           >
-            <AssetFace type={member.type} data={member.data} name={member.name} width={memberWidth} />
+            <AssetFace type={member.type} data={member.data} name={member.name} />
           </div>
         );
       })}
@@ -389,13 +395,20 @@ function PeekingMembers({ width, members }: { width: number; members: AssetFaceM
  *
  * The block is taller than the container by exactly the headroom the peeking row needs, and `assetFaceAspect` reports that same total from the same function, so a caller reserving space and this drawing it cannot drift apart.
  */
-function BundleBlock({ width, members, children }: { width: number; members: AssetFaceMember[]; children: ReactNode }) {
-  const height = width * BUNDLE_ASPECT;
+function BundleBlock({ members, children }: { members: AssetFaceMember[]; children: ReactNode }) {
   return (
-    <div style={{ position: 'relative', width, height: height + width * bundleHeadroom(members.length) }}>
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        aspectRatio: `1 / ${BUNDLE_ASPECT + bundleHeadroom(members.length)}`,
+        /* The block is what a peeking member measures itself against, and it is the only box here whose width is the one the caller gave. */
+        containerType: 'inline-size',
+      }}
+    >
       {/* Pinned to the container's own box rather than the block's, so the two stay aligned whenever the headroom changes. */}
-      <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height }}>
-        {members.length > 0 ? <PeekingMembers width={width} members={members} /> : null}
+      <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, aspectRatio: `1 / ${BUNDLE_ASPECT}` }}>
+        {members.length > 0 ? <PeekingMembers members={members} /> : null}
         <div style={{ position: 'relative', zIndex: 1 }}>{children}</div>
       </div>
     </div>
@@ -403,9 +416,10 @@ function BundleBlock({ width, members, children }: { width: number; members: Ass
 }
 
 /**
- * Renders one asset's face at the given width, framed and clipped per its type.
+ * Renders one asset's face, framed and clipped per its type.
  * Unknown types and unrenderable data come back as the neutral face, never a crash.
  *
+ * The face fills its parent's width and takes its height from `assetFaceAspect`, so it is placed by sizing that parent.
  * `side` picks which face of a token to draw and is ignored by every other type.
  * A token whose back is a *reference* draws nothing here: that back is another token's front, and only a caller holding that token's own row can supply it.
  */
@@ -413,14 +427,12 @@ export function AssetFace({
   type,
   data,
   name,
-  width,
   side = 'front',
   members = [],
 }: {
   type: string;
   data: unknown;
   name: string;
-  width: number;
   side?: AssetFaceSide;
   /**
    * A container's first few members, drawn peeking above it.
@@ -436,22 +448,22 @@ export function AssetFace({
     const parsed = TreacheryAsset.safeParse(data);
     if (parsed.success) {
       return (
-        <CardFrame width={width}>
+        <CardFrame>
           <TreacheryCard {...parsed.data} />
         </CardFrame>
       );
     }
-    return <NeutralFace name={name} width={width} aspect={CARD_ASPECT} />;
+    return <NeutralFace name={name} aspect={assetFaceAspect(type)} />;
   }
 
   if (type === 'bundle') {
     const parsed = bundleFaceSchema.safeParse(data);
     return (
-      <BundleBlock width={width} members={members}>
+      <BundleBlock members={members}>
         {parsed.success ? (
-          <BundleContainer band={parsed.data.band} name={name} width={width} />
+          <BundleContainer band={parsed.data.band} name={name} />
         ) : (
-          <NeutralFace name={name} width={width} aspect={BUNDLE_ASPECT} />
+          <NeutralFace name={name} aspect={BUNDLE_ASPECT} />
         )}
       </BundleBlock>
     );
@@ -466,7 +478,7 @@ export function AssetFace({
      */
     if (danglingDeckCardback(data)) {
       return (
-        <CardFrame width={width}>
+        <CardFrame>
           {/*
            * Drawn at the frame's internal canvas size, not the caller's width: `CardFrame` lays its
            * children out at `CARD_SIZE` and scales the lot by `width / CARD_SIZE.width`, so a child
@@ -482,7 +494,7 @@ export function AssetFace({
     if (parsed.success) {
       const cardback = parsed.data.cardback;
       return (
-        <CardFrame width={width}>
+        <CardFrame>
           <CardBack
             name={cardback.name}
             background={cardback.background}
@@ -493,7 +505,7 @@ export function AssetFace({
         </CardFrame>
       );
     }
-    return <NeutralFace name={name} width={width} aspect={CARD_ASPECT} />;
+    return <NeutralFace name={name} aspect={assetFaceAspect(type)} />;
   }
 
   const shape = tokenShapeOfType(type);
@@ -506,7 +518,7 @@ export function AssetFace({
     const face = faceForSide(parsed.success ? parsed.data : undefined, side);
     if (face) {
       return (
-        <TokenFrame shape={shape} width={width}>
+        <TokenFrame shape={shape}>
           <RectangleToken
             background={face.background}
             ring={face.ring ?? false}
@@ -517,14 +529,14 @@ export function AssetFace({
         </TokenFrame>
       );
     }
-    return <NeutralFace name={name} width={width} aspect={assetFaceAspect(type)} />;
+    return <NeutralFace name={name} aspect={assetFaceAspect(type)} />;
   }
   if (shape) {
     const parsed = tokenFaceSchema.safeParse(data);
     const face = faceForSide(parsed.success ? parsed.data : undefined, side);
     if (face) {
       return (
-        <TokenFrame shape={shape} width={width}>
+        <TokenFrame shape={shape}>
           <CustomToken
             background={face.background}
             image={face.image}
@@ -537,8 +549,8 @@ export function AssetFace({
         </TokenFrame>
       );
     }
-    return <NeutralFace name={name} width={width} aspect={assetFaceAspect(type)} />;
+    return <NeutralFace name={name} aspect={assetFaceAspect(type)} />;
   }
 
-  return <NeutralFace name={name} width={width} aspect={1} />;
+  return <NeutralFace name={name} aspect={assetFaceAspect(type)} />;
 }

--- a/src/app/widgets/asset-face/BundleContainer.tsx
+++ b/src/app/widgets/asset-face/BundleContainer.tsx
@@ -9,33 +9,57 @@ export type BundleBandData = z.infer<typeof BundleBand>;
 export const BUNDLE_ASPECT = 0.62;
 
 /**
+ * The container's corner, as a share of its own box rather than a pixel count read off a width.
+ *
+ * `border-radius` in the two-value percentage form takes its horizontal radius from the box's width and its vertical from its height, so dividing the second by `BUNDLE_ASPECT` keeps the corner circular at every size, which is what `width / 22` did arithmetically.
+ * The floor stays: below about 90px across, a proportional corner rounds a small box into a lozenge.
+ */
+const CORNER = `max(4px, ${100 / 22}%) / max(4px, ${100 / (22 * BUNDLE_ASPECT)}%)`;
+
+/** The band's share of the container's height, floored so it reads as a band rather than a line on a pile-sized container. */
+const BAND_HEIGHT = 'max(14px, 34%)';
+
+/**
  * A bundle's face: the container it authors.
  *
  * A bundle is the only Asset type with no visual identity of its own to draw from, so «What a bundle looks like» settled that it authors one.
  * The band across the middle is the authored part;
  * everything else is the house box, so two bundles are told apart by the band rather than by whoever happens to be inside them.
  *
+ * It fills the width it is given and takes its height from `BUNDLE_ASPECT`, so a caller places it by sizing its parent rather than by handing it a number.
+ * The label is the one part no percentage can express, since font sizes have no percentage-of-width form, so the container declares itself a query container and the label reads its own width back as `cqw`.
+ *
  * Members are deliberately **not** drawn here.
  * Up to three of them peek above the container from browse-tile size upward, but only a caller holding those rows can supply them, and the landing page draws the container alone on purpose: at pile size the members resolve into a smudge, and putting member data on every catalogue row is a cost only the browse page agrees to pay.
  */
-export function BundleContainer({ band, name, width }: { band: BundleBandData; name: string; width: number }) {
-  const height = width * BUNDLE_ASPECT;
-  const bandHeight = Math.max(14, height * 0.34);
+export function BundleContainer({ band, name }: { band: BundleBandData; name: string }) {
   return (
     <div
       style={{
         position: 'relative',
-        width,
-        height,
-        borderRadius: Math.max(4, width / 22),
+        width: '100%',
+        aspectRatio: `1 / ${BUNDLE_ASPECT}`,
+        containerType: 'inline-size',
+        borderRadius: CORNER,
         overflow: 'hidden',
+        /* Defends the ratio, not a width: as a flex item in a column a face without this is squashed below its own height. */
         flexShrink: 0,
         background: 'linear-gradient(#c8b285, #9d8459)',
         boxShadow: '0 2px 10px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.35)',
         border: '1px solid rgba(60, 44, 20, 0.55)',
       }}
     >
-      <div style={{ position: 'absolute', left: 0, right: 0, top: (height - bandHeight) / 2, height: bandHeight }}>
+      {/* Centred by the layout rather than by an offset anyone computes, so the floor above cannot push it off the middle. */}
+      <div
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          top: '50%',
+          height: BAND_HEIGHT,
+          transform: 'translateY(-50%)',
+        }}
+      >
         <BackgroundRenderer background={band.background} className="" />
       </div>
       <div
@@ -47,7 +71,7 @@ export function BundleContainer({ band, name, width }: { band: BundleBandData; n
           padding: '0 8%',
           textAlign: 'center',
           /* The band's own label when it has one, the Asset's name when it does not, so a container is never blank. */
-          fontSize: Math.max(7, width / 13),
+          fontSize: 'max(7px, calc(100cqw / 13))',
           fontWeight: 700,
           letterSpacing: '0.06em',
           textTransform: 'uppercase',

--- a/src/app/widgets/bundle-editor/BundleEditor.tsx
+++ b/src/app/widgets/bundle-editor/BundleEditor.tsx
@@ -1,10 +1,9 @@
-import { Group, Select, Stack, Text, TextInput } from '@mantine/core';
+import { Box, Group, Select, Stack, Text, TextInput } from '@mantine/core';
 import type { BundleAsset } from '@shared/assets/schema';
 import { TopicIcon } from '@ui/content/TopicIcon';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { ControlBlock } from '@ui/control/ControlBlock';
 import { MemberCountInput } from '@ui/control/MemberCountInput';
-import { CanvasScale } from '@ui/layout/CanvasScale';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
 import { ConnectedTabs } from '@ui/surface/ConnectedTabs';
 import { useState } from 'react';
@@ -12,7 +11,6 @@ import type { ReactNode } from 'react';
 import type { z } from 'zod';
 
 import { aboutChapter } from '@app/widgets/asset-about/AboutChapter';
-import { assetFaceAspect } from '@app/widgets/asset-face/AssetFace';
 import { AssetFace } from '@app/widgets/asset-face/AssetFace';
 import { BundleContainer } from '@app/widgets/asset-face/BundleContainer';
 import type { BundleBandData } from '@app/widgets/asset-face/BundleContainer';
@@ -20,13 +18,6 @@ import { BackgroundPresetControl } from '@app/widgets/background-composer/Backgr
 import { backgroundPresets } from '@game/data/backgrounds';
 
 import { STOCK_BANDS, stockBandKeyFor } from './stockBands';
-
-/**
- * The size the rail's proof is drawn at before `CanvasScale` fits it to the rail.
- * Any number does.
- * This one matches the detail page, so a proof and the page it previews scale off the same canvas.
- */
-const PROOF_CANVAS = 900;
 
 export type BundleDraft = z.infer<typeof BundleAsset>;
 export type BundleChapter = 'identity' | 'tokens' | 'about';
@@ -217,12 +208,14 @@ export function BundleEditor({
                           <Stack gap="xs">
                             {members.map((member) => (
                               <Group key={member.token.id} gap="sm" wrap="nowrap" align="center">
-                                <AssetFace
-                                  type={member.token.type}
-                                  data={member.token.data}
-                                  name={member.token.name}
-                                  width={34}
-                                />
+                                {/* A row thumbnail is a fixed size, which the face reads off this box rather than from a prop. */}
+                                <Box w={34} miw={34}>
+                                  <AssetFace
+                                    type={member.token.type}
+                                    data={member.token.data}
+                                    name={member.token.name}
+                                  />
+                                </Box>
                                 <Text size="sm" style={{ flex: 1, minWidth: 0 }}>
                                   {member.token.name}
                                 </Text>
@@ -261,9 +254,8 @@ export function BundleEditor({
       </WorkbenchLayout.Chapters>
       <WorkbenchLayout.Rail>
         <Stack gap="md" align="center">
-          <CanvasScale rounded canvasWidth={PROOF_CANVAS} canvasHeight={PROOF_CANVAS * assetFaceAspect('bundle')}>
-            <BundleContainer band={draft.band} name={draft.name} width={PROOF_CANVAS} />
-          </CanvasScale>
+          {/* The rail is the container's box now; nothing here restates the size or the ratio the container already holds. */}
+          <BundleContainer band={draft.band} name={draft.name} />
           <Text size="xs" c="dimmed">
             How this bundle is shown
           </Text>

--- a/src/app/widgets/deck-editor/DeckEditor.tsx
+++ b/src/app/widgets/deck-editor/DeckEditor.tsx
@@ -1,4 +1,4 @@
-import { Group, NumberInput, Select, Slider, Stack, Text, TextInput } from '@mantine/core';
+import { Box, Group, NumberInput, Select, Slider, Stack, Text, TextInput } from '@mantine/core';
 import type { DeckAsset } from '@shared/assets/schema';
 import { TopicIcon } from '@ui/content/TopicIcon';
 import { AssetSelect } from '@ui/control/AssetSelect';
@@ -6,7 +6,6 @@ import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { ControlBlock } from '@ui/control/ControlBlock';
 import { MemberCountInput } from '@ui/control/MemberCountInput';
 import { PreviewChoice } from '@ui/control/PreviewChoice';
-import { CanvasScale } from '@ui/layout/CanvasScale';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
 import { ConnectedTabs } from '@ui/surface/ConnectedTabs';
 import { useState } from 'react';
@@ -30,9 +29,10 @@ import { STOCK_CARDBACKS, stockKeyFor } from './stockCardbacks';
 import type { CardbackData } from './stockCardbacks';
 
 /**
- * The size the rail's proof is drawn at before `CanvasScale` fits it to the rail.
+ * The box a backside tile draws its proof inside, which `PreviewChoice` contain-fits to the tile.
  * Any number does.
- * This one matches the detail page, so a proof and the page it previews scale off the same canvas.
+ * This one matches the detail page, so a tile and the page it previews scale off the same canvas.
+ * The rail's own proofs no longer need it: they fill the rail and hold their own ratio.
  */
 const PROOF_CANVAS = 900;
 
@@ -89,9 +89,9 @@ function draftCardbackComposition(cardback: DeckDraftCardback): CardbackData | n
  * A draft is not a stored row: it is transiently invalid on the way to being valid, because `ColorInput` commits raw text per keystroke, so five of the six characters in a hex colour are not yet a colour.
  * `AssetFace` parses what it is given and falls to a neutral face when the parse fails, which is right for a listing reading storage and wrong for a proof watching an author type, where it reads as the preview blanking.
  */
-function CardbackProof({ cardback, width }: { cardback: CardbackData; width: number }) {
+function CardbackProof({ cardback }: { cardback: CardbackData }) {
   return (
-    <CardFrame width={width}>
+    <CardFrame>
       <CardBack {...cardback} />
     </CardFrame>
   );
@@ -350,7 +350,7 @@ export function DeckEditor({
                               value: 'stock',
                               label: 'Stock',
                               /* Always drawable: the stock look this deck wears, or the first standing in. */
-                              preview: <CardbackProof cardback={stockPreview} width={PROOF_CANVAS} />,
+                              preview: <CardbackProof cardback={stockPreview} />,
                               canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('deck') },
                               detail: (
                                 <Select
@@ -375,7 +375,6 @@ export function DeckEditor({
                               preview: (
                                 <CardbackProof
                                   cardback={composition ?? composedCardback.current ?? STOCK_CARDBACKS[0]!.cardback}
-                                  width={PROOF_CANVAS}
                                 />
                               ),
                               canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('deck') },
@@ -419,12 +418,10 @@ export function DeckEditor({
                           <Stack gap="xs">
                             {members.map((member) => (
                               <Group key={member.card.id} gap="sm" wrap="nowrap" align="center">
-                                <AssetFace
-                                  type={member.card.type}
-                                  data={member.card.data}
-                                  name={member.card.name}
-                                  width={34}
-                                />
+                                {/* A row thumbnail is a fixed size, which the face reads off this box rather than from a prop. */}
+                                <Box w={34} miw={34}>
+                                  <AssetFace type={member.card.type} data={member.card.data} name={member.card.name} />
+                                </Box>
                                 <Text size="sm" style={{ flex: 1, minWidth: 0 }}>
                                   {member.card.name}
                                 </Text>
@@ -463,9 +460,7 @@ export function DeckEditor({
       </WorkbenchLayout.Chapters>
       <WorkbenchLayout.Rail>
         <Stack gap="md" align="center">
-          <CanvasScale rounded canvasWidth={PROOF_CANVAS} canvasHeight={PROOF_CANVAS * assetFaceAspect('deck')}>
-            {composition ? <CardbackProof cardback={composition} width={PROOF_CANVAS} /> : backProof}
-          </CanvasScale>
+          {composition ? <CardbackProof cardback={composition} /> : backProof}
           <Text size="xs" c="dimmed">
             The deck's publication
           </Text>

--- a/src/app/widgets/token-editor/RectangleTokenEditor.tsx
+++ b/src/app/widgets/token-editor/RectangleTokenEditor.tsx
@@ -5,7 +5,6 @@ import { TopicIcon } from '@ui/content/TopicIcon';
 import { ControlBlock } from '@ui/control/ControlBlock';
 import { ListLengthActions } from '@ui/control/ListLengthActions';
 import { PreviewChoice } from '@ui/control/PreviewChoice';
-import { CanvasScale } from '@ui/layout/CanvasScale';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
 import { ConnectedTabs } from '@ui/surface/ConnectedTabs';
 import { useRef } from 'react';
@@ -21,9 +20,10 @@ import { RectangleToken } from '@game/assets/token/Rectangle';
 import { backgroundPresets } from '@game/data/backgrounds';
 
 /**
- * The size the rail's proof is drawn at before `CanvasScale` fits it to the rail.
+ * The box a backside tile draws its proof inside, which `PreviewChoice` contain-fits to the tile.
  * Any number does.
- * This one matches the detail page, so a proof and the page it previews scale off the same canvas.
+ * This one matches the detail page, so a tile and the page it previews scale off the same canvas.
+ * The rail's own proofs no longer need it: they fill the rail and hold their own ratio.
  */
 const PROOF_CANVAS = 900;
 
@@ -95,10 +95,10 @@ const newText = (): RectangleFaceDraft['texts'][number] => ({
   opacity: 1,
 });
 
-/** One face at whatever width it is given, clipped by the same frame the catalogue surfaces use. */
-export function RectangleProof({ face, width }: { face: RectangleFaceDraft; width: number }) {
+/** One face filling the box it is put in, clipped by the same frame the catalogue surfaces use. */
+export function RectangleProof({ face }: { face: RectangleFaceDraft }) {
   return (
-    <TokenFrame shape="rectangle" width={width}>
+    <TokenFrame shape="rectangle">
       <RectangleToken {...face} />
     </TokenFrame>
   );
@@ -524,7 +524,6 @@ export function RectangleTokenEditor({
                     preview: (
                       <RectangleProof
                         face={draft.back.mode === 'custom' ? draft.back.face : (composedFace.current ?? INITIAL_FACE)}
-                        width={PROOF_CANVAS}
                       />
                     ),
                     canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('token-enhance') },
@@ -532,7 +531,7 @@ export function RectangleTokenEditor({
                   {
                     value: 'same',
                     label: 'Same as front',
-                    preview: <RectangleProof face={draft.front} width={PROOF_CANVAS} />,
+                    preview: <RectangleProof face={draft.front} />,
                     canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect('token-enhance') },
                   },
                   {
@@ -581,26 +580,14 @@ export function RectangleTokenEditor({
         {/* The face stacks take the full width, or a centred flex child shrinks to its content and `CanvasScale` has nothing to fill. */}
         <Stack gap="md" align="center">
           <Stack gap={4} align="center" w="100%">
-            <CanvasScale
-              rounded
-              canvasWidth={PROOF_CANVAS}
-              canvasHeight={PROOF_CANVAS * assetFaceAspect('token-enhance')}
-            >
-              <RectangleProof face={draft.front} width={PROOF_CANVAS} />
-            </CanvasScale>
+            <RectangleProof face={draft.front} />
             <Text size="xs" c="dimmed">
               Front
             </Text>
           </Stack>
           {draft.back.mode === 'custom' ? (
             <Stack gap={4} align="center" w="100%">
-              <CanvasScale
-                rounded
-                canvasWidth={PROOF_CANVAS}
-                canvasHeight={PROOF_CANVAS * assetFaceAspect('token-enhance')}
-              >
-                <RectangleProof face={draft.back.face} width={PROOF_CANVAS} />
-              </CanvasScale>
+              <RectangleProof face={draft.back.face} />
               <Text size="xs" c="dimmed">
                 Back
               </Text>

--- a/src/app/widgets/token-editor/TokenEditor.stories.tsx
+++ b/src/app/widgets/token-editor/TokenEditor.stories.tsx
@@ -25,7 +25,7 @@ const meta = preview.meta({
     onSettle: fn(),
     patch: fn(),
     backPicker: () => <Text size="xs">Choose a token…</Text>,
-    backProof: <TokenProof face={initialTokenDraft(TYPE).front} type={TYPE} width={900} />,
+    backProof: <TokenProof face={initialTokenDraft(TYPE).front} type={TYPE} />,
     draft: draftWith(composedBack),
   },
 });

--- a/src/app/widgets/token-editor/TokenEditor.tsx
+++ b/src/app/widgets/token-editor/TokenEditor.tsx
@@ -4,7 +4,6 @@ import { TopicIcon } from '@ui/content/TopicIcon';
 import { AssetSelect } from '@ui/control/AssetSelect';
 import { ControlBlock } from '@ui/control/ControlBlock';
 import { PreviewChoice } from '@ui/control/PreviewChoice';
-import { CanvasScale } from '@ui/layout/CanvasScale';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
 import { ConnectedTabs } from '@ui/surface/ConnectedTabs';
 import { Frame } from 'lucide-react';
@@ -25,9 +24,10 @@ import { CustomToken } from '@game/assets/token/Custom';
 import { backgroundPresets } from '@game/data/backgrounds';
 
 /**
- * The size the rail's proof is drawn at before `CanvasScale` fits it to the rail.
+ * The box a backside tile draws its proof inside, which `PreviewChoice` contain-fits to the tile.
  * Any number does.
- * This one matches the detail page, so a proof and the page it previews scale off the same canvas.
+ * This one matches the detail page, so a tile and the page it previews scale off the same canvas.
+ * The rail's own proofs no longer need it: they fill the rail and hold their own ratio.
  */
 const PROOF_CANVAS = 900;
 
@@ -102,11 +102,11 @@ function bottomFor(face: TokenFaceDraft): string {
   return `${face.bottomFirst}\n${face.bottomSecond}`;
 }
 
-/** One face at whatever width it is given, clipped to its shape by the same frame the catalogue surfaces use. */
-export function TokenProof({ face, type, width }: { face: TokenFaceDraft; type: string; width: number }) {
+/** One face filling the box it is put in, clipped to its shape by the same frame the catalogue surfaces use. */
+export function TokenProof({ face, type }: { face: TokenFaceDraft; type: string }) {
   const shape = tokenShapeOfType(type) ?? 'round';
   return (
-    <TokenFrame shape={shape} width={width}>
+    <TokenFrame shape={shape}>
       <CustomToken
         background={face.background}
         image={face.image}
@@ -374,7 +374,6 @@ export function TokenEditor({
                             : (composedFace.current ?? initialTokenFace(type))
                         }
                         type={type}
-                        width={PROOF_CANVAS}
                       />
                     ),
                     canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect(type) },
@@ -382,7 +381,7 @@ export function TokenEditor({
                   {
                     value: 'same',
                     label: 'Same as front',
-                    preview: <TokenProof face={draft.front} type={type} width={PROOF_CANVAS} />,
+                    preview: <TokenProof face={draft.front} type={type} />,
                     canvas: { width: PROOF_CANVAS, height: PROOF_CANVAS * assetFaceAspect(type) },
                   },
                   {
@@ -452,18 +451,14 @@ export function TokenEditor({
       <WorkbenchLayout.Rail>
         <Stack gap="md" align="center">
           <Stack gap={4} align="center" w="100%">
-            <CanvasScale rounded canvasWidth={PROOF_CANVAS} canvasHeight={PROOF_CANVAS * assetFaceAspect(type)}>
-              <TokenProof face={draft.front} type={type} width={PROOF_CANVAS} />
-            </CanvasScale>
+            <TokenProof face={draft.front} type={type} />
             <Text size="xs" c="dimmed">
               Front
             </Text>
           </Stack>
           {draft.back.mode === 'custom' ? (
             <Stack gap={4} align="center" w="100%">
-              <CanvasScale rounded canvasWidth={PROOF_CANVAS} canvasHeight={PROOF_CANVAS * assetFaceAspect(type)}>
-                <TokenProof face={draft.back.face} type={type} width={PROOF_CANVAS} />
-              </CanvasScale>
+              <TokenProof face={draft.back.face} type={type} />
               <Text size="xs" c="dimmed">
                 Back
               </Text>


### PR DESCRIPTION
Closes [#706](https://github.com/ndelangen/dunezone/issues/706), decided by Norbert as option A. **Based on `main`, not stacked.**

## What was wrong

`AssetFace` demanded a pixel width, so every caller had to state a size the face already knew.

Four wrapped it in a `CanvasScale` restating the same `900` and re-deriving the same ratio:

```tsx
<CanvasScale canvasWidth={900} canvasHeight={900 * assetFaceAspect(type, members.length)}>
  <AssetFace ... width={900} />
</CanvasScale>
```

And because the prop was mandatory, a caller that did not know its width had to go and measure one. The assets landing page ran a `ResizeObserver` whose entire output was that single prop, behind a `drawnAt === 0 ? null` gate, so every pile's art was withheld from the first frame and arrived only after a measurement landed.

## What it is now

The face fills the width it is given and takes its height from `assetFaceAspect`. It is placed by sizing its parent, which is why the escape hatch costs nothing: a surface needing exact pixels gives it a fixed-size parent, and that is the same statement rather than a second way to make it.

`side` survives the cut. The issue names four things in the membrane; `side` is a fifth and is the only way to draw a token's back.

## Its frames went with it, because they are how the face draws

`CardFrame` is now a `CanvasScale` carrying the catalogue's card decoration. `TokenFrame` and `BundleContainer` fill and hold their ratio without scaling, because the token renderers already fill their box while the card renderers draw at an intrinsic 900x1263.

That is a consequence rather than a separate decision, and it is what lets **six editor rail proofs** drop the same redundant wrapper. The `CARD_SIZE` users outside the face (the treachery editor, the faction alliance card, the shield) are untouched, as the decision says.

`CanvasScale` gains one prop, `frameStyle`, for the values a class cannot hold because the caller derives them from the canvas it passed. It has one caller and the doc forbids re-placing the frame. Worth naming here rather than letting it read as a general escape hatch.

## Every width-derived number became a share of the box that already knew it

Corners are two-value percentages: `border-radius: X% / Y%` takes its horizontal radius from the box's width and its vertical from its height, so dividing the second by the aspect keeps the corner circular at every size, which is what `width / 18` did arithmetically. A container unit would not work here, because `cqw` inside an element resolves against its **ancestor** container, never against the element declaring the containment.

The bundle's label is the one thing no percentage can express, since font sizes have no percentage-of-width form, so the container declares itself a query container and the label reads its own width back as `cqw`. The peeking members are fractions of the block's `100cqw` for a related reason: their rise is a fraction of the member's *width*, but a `translate` percentage resolves against the element's own *height*, and member heights differ by type.

## Also

`ScaledFace` was left a verbatim pass-through of the whole membrane once its wrapper went, so it is gone and its seven call sites use `AssetFace` directly.

The landing page's empty-pile outlines now read `assetFaceAspect` for every shape that has one, so an outline and the pile that replaces it cannot drift. `board` keeps its hand-written `3 / 2`: it is a planned type, nothing renders one, and there is no ratio source to read.

## Verified

**The widget had no stories at all**, which in a kit compliance wave is its own gap, so it has nine now and its folder is registered in `.storybook/main.ts`.

Gates: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 731 unit tests, 360 storybook tests.

### The claim, at four real widths

One face, four parents, no size passed to any of them. The widths are a picker row, a landing pile, a browse tile, and the detail page's hero.

![the same treachery card in 44, 96, 220 and 340 pixel parents](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-706-card-at-any-width.png)

### The geometry most likely to break

A container's block is taller than its own frame by exactly the headroom the tilted member row needs. Get that wrong and the most-tilted corner is cut at one size and floats at another.

![a bundle with three peeking members at the same four widths](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-706-bundle-at-any-width.png)

Measured at 488px wide: the block's height/width is **0.8354**, against `BUNDLE_ASPECT + bundleHeadroom(3)` = **0.8354**.

An earlier revision of this PR also claimed the worst member overshot the block by 0.44px and called that subpixel. It was 0.95px there and 1.79px at pile size, because the container's border was leaking into the reservation, and it is a fixed 2px rather than a ratio so it hurt most at the smallest sizes. That is the box-sizing defect below. Members now sit **inside** the block at every width.

### The first paint, which is the part that changed behaviour rather than structure

This is the claim the deleted gate was hiding, so it is measured rather than photographed: a screenshot cannot distinguish "the art was there" from "the art arrived a frame later" without racing it.

A `MutationObserver` installed before any page script records, for every pile art box the moment it enters the DOM, whether it already had a child. On this branch, against the real catalogue:

```
pileBoxesSeen: 14
withArtOnArrival: 14
emptyOnArrival: 0
```

Every pile arrives carrying its art, in the same DOM insertion as its own box, so there is no frame in which the box exists empty. That is what the `drawnAt === 0 ? null` gate used to prevent.

To be exact about what did *not* change: the page still constructs four `ResizeObserver`s elsewhere. This removes the one the pile art depended on, not every observer on the page.

### The landing piles, on real rows

![the assets ledger at 1280px, every pile drawn](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-706-landing-wide.png)

The token row shares one centreline, which is the invariant the old `centring` arithmetic existed to hold. Measured from each pile's art box: **48, 48, 48, 47px**.

And the narrow breakpoint, which is where the track shrinks below its slot and the old code needed a measurement most:

![the same ledger at 560px, stacked two abreast](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-706-landing-narrow.png)

And the token row at that breakpoint, which is where both late defects showed and where the first round of proof had no picture at all. The enhance pile draws 174x108 in a 96px band here, the case that broke the shared centreline:

![the token row stacked two abreast, disc, tech, plate, enhance and bundles sharing one centreline](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-706-token-row-narrow.png)

Centreline across that row, measured in the app at a 200px track: **48, 48, 48, 48, 47.99px**, a spread of 0.01px.

The three pile layouts were rewritten from absolutely positioned boxes whose height came from a measured width into single-cell grids with the offsets moved into transforms. I reproduced their DOM in the browser and measured against the old arithmetic:

| pile | slot | old formula | measured |
|---|---|---|---|
| MiniFan face width / fan height | 96 | 84 / 134 | **84 / 134** |
| MiniFan face width / fan height | 150 | 138 / 210 | **138 / 210** |
| MiniFan face width / fan height | 200 | 188 / 280 | **188 / 280** |
| TokenStack face offset, enhance | 150 | 9.56 | **9.56** |
| TokenStack face offset, enhance | 181 | -0.05 | **-0.05** |
| TokenStack face offset, enhance | 192 | -3.46 | **-3.45** |
| TokenStack face offset, enhance | 200 | -5.94 | **-5.94** |
| TokenStack face offset, enhance | 260 | -24.54 | **-24.54** |

The enhance rows are where I got it wrong the first time, so they are worth reading twice.

**An earlier revision of this PR broke the token row's shared centreline, and this table used to say it had not.** `alignContent: center` centres the row inside the box and does nothing when the two are the same size, which is exactly what happens once a face outgrows the 96px band: a token frame carries `overflow: hidden`, which zeroes its automatic minimum size, so the auto grid row stops growing at the box's own height instead of reaching the face's. The face then started at the row's top edge rather than straddling it. Only the enhance token can outgrow the band, and only on the stacked breakpoint past a 181px track, where it sat up to 5.94px below every other pile in its row.

`alignItems: center` centres the face inside its row instead, and restores the old arithmetic to within 0.007px at every track above.

The reason my first check missed it is worth stating: it stood a bare `aspect-ratio` div in for the face rather than cloning the real frame, and the frame's `overflow: hidden` is the whole of the difference. A lookalike measured the wrong thing and reported a clean result. Found by an adversarial review pass, and the numbers above come from the real rendered component.

### The browse tiles and a detail hero

The tile is the one surface that clips, in `OpenableTile`'s art box, so it is where a short headroom reservation shows as a cut corner. The bundle on the right has a member; the one on the left has none, and its block is shorter by exactly the headroom.

![two bundle browse tiles, one with a member peeking above its container](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-706-browse-wide.png)

![a bundle detail page, its member standing above the container](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-706-detail-hero.png)

The detail page is the `rounded` drop: `--mantine-radius-md` is 8px and every branch's own corner already removes at least that much, so it was inert.

## Four things settled after the first push

All four came from review rather than from me, and all four were real. I am listing them in full because two of them contradict claims this PR had already made, and a reviewer deserves to see that rather than a quietly corrected table.

### The block refuses to be squashed, because it is the flex item

CodeRabbit caught a real gap in my reasoning, and it is worth stating plainly: I had put `flex-shrink: 0` on `BundleContainer`, where it does nothing. The container sits inside an absolutely positioned child of the block, so it is not a flex item and cannot resist from in there. The block is the flex item, and it had no such declaration.

Forced rather than reasoned about, on the real rendered component in a 300x200 column carrying `min-height: 0`, which any flex layout may:

| | block height | ratio |
|---|---|---|
| without | 60px | 0.20 |
| with | **250.6px** | **0.8354** |

The container keeps drawing 186px either way, and it is pinned to the block's bottom edge, so the 126px it gains when the block collapses goes upward over whatever sits above it.

### A bordered face kept its border outside the box

The app's baseline is `content-box` (`mantine-shell-compatibility.css` sets it for everything outside Mantine), so a 1px border sat outside the ratio box and made `BundleContainer` and `NeutralFace` 2px wider and taller than the box they were told to fill.

For the container that came straight out of the bundle block's headroom. The block reserves room above itself for the peeking members, and its inner box takes its height from the container it holds, so those two pixels pushed the box up and the members with it. The most-tilted member then overhung the block by up to 1.79px, and the browse tile, which clips, cut its corner. That is the exact regression `MEMBER_TILT_RISE` was written against.

Measured at the browse tile's own 152px track, in the app rather than in a story:

| | container in a 152px block | inner box error | member vs the clipping edge |
|---|---|---|---|
| before | 154px wide, 2px overhang | -2.00px | 1.68px **over** it |
| after | **152px**, no overhang | **0** | 0.83px **clear** of it |

`box-sizing: border-box` on both faces fixes it at the root, on both axes.

### The e2e failure was not this change

`e2e/page-header-transition.spec.ts` failed on the first push, asserting more than 2 distinct band heights sampled inside a `transition: height 0.2s ease-out` and getting 2. The suggested mechanism was that pile art now rendering at first paint crowds that 200ms window.

The uploaded `error-context.md` rules it out. In the e2e fixture the assets landing holds no assets at all, every pile reading "Planned" or "none yet", which is also why the route is headerless: no treachery cards means no masthead. With an empty catalogue every pile takes the `EmptyPileOutline` branch, and it took that branch before this change too, because that branch sits *ahead* of the `drawnAt === 0 ? null` gate in the old ternary. The rendered DOM on that fixture is identical either side of this change.

The one behavioural difference there is that the old page built 14 `ResizeObserver`s, one per pile, and did 14 state updates when they fired. This builds none, which takes work out of the transition window rather than adding it.

Then measured rather than argued: **the same commit was rerun with no code change and passed**, [run 32744300865](https://github.com/ndelangen/dunezone/actions/runs/32744300865). A one-value margin on a frame-count threshold, on a page this change provably does not alter, and non-deterministic on identical bytes.

I could not reproduce it locally either, and that is a dead end rather than evidence: a populated dev catalogue gives `/assets` a masthead, so the route is not headerless and the band never contracts at all. 441px before and after, five runs.

## Not photographed, and why

**No before frame for the first paint.** Getting an honest one means running `main`, which needs either a second checkout with a real install or a branch switch next to a live Convex watcher, and a switch drops this branch's indexes from shared dev. I judged an empty box worth less than that, given the gate itself is right there in the diff and the after is measured above. Say the word and I will pay for it.

**No editor rail screenshot.** The edit pages need a signed-in session, and the editor stories collapse in a bare Storybook canvas. I checked that against the treachery card editor, which this change does not touch and which collapses identically, so it is the story harness rather than the change. The rails are covered by the frame stories, by the 360 storybook tests, and by a measurement on the one caller that relies on a fixed-size parent: in the token editor's backside tiles, the proof measures exactly **900x900 inside `ContainFit`'s 900x900 box**, ratio 1.0.
