### PR TITLE
The token pile and the bordered face keep the geometry the face promised

### DIFF
--- a/src/app/routes/_app/assets/index.tsx
+++ b/src/app/routes/_app/assets/index.tsx
@@ -184,7 +184,16 @@ function TokenStack({ entries, fill }: { entries: AssetListEntry[]; fill: boolea
               width: fill ? 'max(1px, calc(100% - 26px))' : TOKEN_PILE_FACE,
               height: TOKEN_PILE_FACE,
               display: 'grid',
-              alignContent: 'center',
+              /*
+               * `alignItems`, which centres the face inside its row, and not `alignContent`, which centres
+               * the row inside this box and does nothing when the two are the same size.
+               * They part company for the one face that outgrows the band: a token frame carries
+               * `overflow: hidden`, which zeroes its automatic minimum size, so the auto row stops growing
+               * at this box's own height instead of reaching the face's. An enhance token past a 181px
+               * track then started at the row's top edge rather than straddling it, 5.94px low at a 200px
+               * track, which is the shared centreline this box exists to hold.
+               */
+              alignItems: 'center',
               transform: straight ? undefined : `rotate(${placement.rot}deg)`,
             }}
           >

--- a/src/app/ui/layout/CanvasScale.tsx
+++ b/src/app/ui/layout/CanvasScale.tsx
@@ -6,7 +6,8 @@ import type { CSSProperties, PropsWithChildren } from 'react';
  * Nothing here re-renders on resize, and the canvas is present on first paint rather than after a measurement lands.
  * The canvas is taken out of flow so the frame's height comes from its aspect ratio alone, never from the unscaled child it clips.
  * Pure placement;
- * the caller decorates the frame (shadow, anything bespoke) through `frameClassName`, and `rounded` is the one shared decoration: the corner treatment every rail proof wears (Norbert, 2026-08-21), kept here so five rails cannot drift apart.
+ * the caller decorates the frame (shadow, anything bespoke) through `frameClassName`, and `rounded` is the corner treatment a rail proof wears (Norbert, 2026-08-21).
+ * It was kept here so five rails could not drift apart, and four of them have since stopped asking for it: their faces fit themselves and carry their own corner, so only the treachery card editor still passes it (#706).
  * `frameStyle` decorates the same frame for the values a class cannot hold, the ones a caller derives from the canvas it passed;
  * it may not re-place the frame, since the placement above is the whole point of the component.
  * The browser floor this technique sets is recorded on «Work the kit compliance wave» (#641).

--- a/src/app/widgets/asset-face/AssetFace.tsx
+++ b/src/app/widgets/asset-face/AssetFace.tsx
@@ -416,8 +416,15 @@ function BundleBlock({ members, children }: { members: AssetFaceMember[]; childr
         flexShrink: 0,
       }}
     >
-      {/* Pinned to the container's own box rather than the block's, so the two stay aligned whenever the headroom changes. */}
-      <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, aspectRatio: `1 / ${BUNDLE_ASPECT}` }}>
+      {/*
+       * Pinned to the container's own box rather than the block's, so the two stay aligned whenever the
+       * headroom changes.
+       * Its height is stated against the block's width rather than left to `aspect-ratio`, because an
+       * absolutely positioned box takes its height from its contents and `aspect-ratio` only offers a
+       * preferred one: anything the container adds outside its ratio box, a border or a padding, would
+       * otherwise push this box up and take that room out of the members' reservation without a word.
+       */}
+      <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, height: `calc(100cqw * ${BUNDLE_ASPECT})` }}>
         {members.length > 0 ? <PeekingMembers members={members} /> : null}
         <div style={{ position: 'relative', zIndex: 1 }}>{children}</div>
       </div>

--- a/src/app/widgets/asset-face/AssetFace.tsx
+++ b/src/app/widgets/asset-face/AssetFace.tsx
@@ -172,6 +172,8 @@ function NeutralFace({ name, aspect }: { name: string; aspect: number }) {
       style={{
         width: '100%',
         aspectRatio: `1 / ${aspect}`,
+        /* Border inside the ratio box, for the reason `BundleContainer` states: the app's baseline is `content-box`, and a face that overruns its parent by its own border is not the aspect it just promised. */
+        boxSizing: 'border-box',
         borderRadius: 8,
         display: 'grid',
         placeItems: 'center',

--- a/src/app/widgets/asset-face/BundleContainer.tsx
+++ b/src/app/widgets/asset-face/BundleContainer.tsx
@@ -39,6 +39,13 @@ export function BundleContainer({ band, name }: { band: BundleBandData; name: st
         position: 'relative',
         width: '100%',
         aspectRatio: `1 / ${BUNDLE_ASPECT}`,
+        /*
+         * The app's baseline is `content-box` (see `mantine-shell-compatibility.css`), which would put the
+         * border outside the ratio box and make this 2px wider and taller than the box it was told to fill.
+         * A face that overruns its own parent is the one thing this component now promises not to do, and the
+         * block above reserves headroom against this height, so those 2px came straight out of the reservation.
+         */
+        boxSizing: 'border-box',
         containerType: 'inline-size',
         borderRadius: CORNER,
         overflow: 'hidden',

--- a/src/app/widgets/token-editor/RectangleTokenEditor.tsx
+++ b/src/app/widgets/token-editor/RectangleTokenEditor.tsx
@@ -577,7 +577,7 @@ export function RectangleTokenEditor({
         </div>
       </WorkbenchLayout.Chapters>
       <WorkbenchLayout.Rail>
-        {/* The face stacks take the full width, or a centred flex child shrinks to its content and `CanvasScale` has nothing to fill. */}
+        {/* The face stacks take the full width, or a centred flex child shrinks to its content and the proof, which fills the width it is given, is given none. */}
         <Stack gap="md" align="center">
           <Stack gap={4} align="center" w="100%">
             <RectangleProof face={draft.front} />


### PR DESCRIPTION
Finishes [#706](https://github.com/ndelangen/dunezone/issues/706), which [#716](https://github.com/ndelangen/dunezone/pull/716) delivered only in part.

## Why this exists

#716 merged at `9084f59f513`, three commits short of its branch head. The merge caught the branch mid-push, and the ancestry check that cleared it was run against a SHA that was no longer the tip. So the change landed, and the two defects an adversarial review had found in it, along with their fixes, did not.

Verified rather than inferred from a badge, against `real-origin/main`:

```
c00e1052cb2  on main
9084f59f513  on main
1a8f50b66fa  NOT on main    the token row's centring
55dc4668994  NOT on main    the bordered face's box-sizing
015f21de1c8  NOT on main    the container slot's height
```

and by reading the merged files rather than trusting the list: `assets/index.tsx:187` on main still says `alignContent: 'center'`, and `BundleContainer.tsx` on main has no `boxSizing` at all.

Both defects are live on `main` now. Neither breaks a build and neither throws, which is exactly why they would sit there unnoticed.

## The two defects

### The token row loses its shared centreline

Every token pile reserves the same 96px band and centres its face in it, so a row of piles shares one centreline whatever each face's proportions are. That is the whole job of the band.

`alignContent` centres the *row* inside the box, and does nothing when the two are the same size. That is what happens the moment a face outgrows the band: a token frame carries `overflow: hidden`, which zeroes its automatic minimum size, so the auto grid row stops growing at the box's own 96px instead of reaching the face's height. The face then starts at the row's top edge rather than straddling it.

Only the enhance token can outgrow the band, and only on the stacked breakpoint once its track passes 181px.

| track | face | old formula | on `main` | fixed |
|---|---|---|---|---|
| 150 | 124x77 | 9.56 | 9.56 | **9.56** |
| 181 | 155x96 | -0.05 | 0.00 | **-0.05** |
| 192 | 166x103 | -3.46 | 0.00 | **-3.45** |
| 200 | 174x108 | -5.94 | 0.00 | **-5.94** |
| 260 | 234x145 | -24.54 | 0.00 | **-24.54** |

`alignItems` centres the face inside its row instead, which restores the old arithmetic to within 0.007px at every track.

### A bordered face keeps its border outside its box

The app's baseline is `content-box` (`mantine-shell-compatibility.css` sets it for everything outside Mantine), so a 1px border sat outside the ratio box and made `BundleContainer` and `NeutralFace` 2px wider and taller than the box they were told to fill.

For the container that came straight out of the bundle block's headroom. The block reserves room above itself for the peeking members, and its inner box was taking its height from the container it holds, so those two pixels pushed the box up and the members with it. The most-tilted member then overhung the block by up to 1.79px, and the browse tile, which clips in `OpenableTile`'s art box, cut its corner. That is the exact regression `MEMBER_TILT_RISE` exists to prevent.

Measured at the browse tile's own 152px track, in the app rather than in a story:

the container is 154px wide in a 152px block, overhanging by 2px, and the inner box sits 2.00px high at every width. `box-sizing: border-box` fixes it at the root, on both axes. The published pair below carries the numbers.

Then one step further, because the instance is not the class: the container's slot now states its height against the block's own width instead of inheriting it from its contents. An absolutely positioned box takes its height from what it holds, and `aspect-ratio` only offers a preferred one, which is how a border stole from the reservation in the first place. With a container deliberately given 6px of content-box padding, the slot no longer moves at all.

Exact at 96, 152, 220, 340 and 488px wide, worst error 0.006px, every member inside the block.

## Also

Two comments that stopped being true when six rails dropped their `CanvasScale` wrapper: the component claimed five rails share `rounded` when one does, and the rectangle rail justified its width by naming a component no longer in that tree.

## Verified

Gates: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 731 unit tests, 361 storybook tests.

## Proof

Both sides come from real code: the after from this branch, the before from `main`'s own source with the app restarted against it, not from a property toggled in devtools. I re-checked which tree the dev server was serving after each switch, since that trap does not care why you switched.

### The token row at the stacked breakpoint

A 560px viewport stacks the ledger two abreast and puts each track at 200px, where the enhance face draws 174x108 in a 96px band.

| on `main` | this branch |
|---|---|
| ![the enhance pile sitting below the row's centreline](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-717-token-row-before.png) | ![every pile on one centreline](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-717-token-row-after.png) |

Face centres measured from each pile's own art box, in the same render as the pictures:

| pile | face | on `main` | this branch |
|---|---|---|---|
| Disc | 96x96 | 48 | 48 |
| Tech | 96x96 | 48 | 48 |
| Plate | 96x96 | 48 | 48 |
| Enhance | 174x108 | **53.93** | **48** |
| Bundles | 98x62 / 96x60 | **46.99** | **47.99** |
| | | spread **6.94px** | spread **0.01px** |

The bundles row moves too, and its face is 2px smaller after: that pile is where the second defect shows on the same surface, since the container was carrying its border outside its box.

### A bundle browse tile

The tile's art box clips, so a short headroom reservation cuts the member's corner. Look at the gear's top teeth.

| on `main` | this branch |
|---|---|
| ![the member's top teeth cut flat by the tile edge](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-717-browse-tile-before.png) | ![the whole member clear of the tile edge](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-717-browse-tile-after.png) |

| | container in a 152px block | overhang | member vs the clipping edge |
|---|---|---|---|
| on `main` | 154px | 2px | **-1.18px**, past it and cut |
| this branch | **152px** | **0** | **+0.82px**, clear of it |

## How this got past the first review

Worth stating, because the mechanism is more useful than the two fixes.

My original equivalence check for the token piles stood a bare `aspect-ratio` div in for the face rather than cloning the real frame. `overflow: hidden` is the entire difference between the two, so the stand-in measured the wrong thing and reported clean, and #716's body carried a table asserting an equivalence that did not hold. The same body called the member overhang "0.44px, pure subpixel"; it was 0.95px there and 1.79px at pile size, because a fixed 2px of border hurts most at the smallest sizes.

Both were found by an adversarial review pass, and both are measured above against the real rendered component.

The proof gap is the other half of it, and it is the half that let them reach `main`. #716 shipped five screenshots and not one showed the token row at the stacked breakpoint, which is the only place either defect is visible. Everything it photographed was a state where the code was already right. A proof section that pictures only the easy states reads as coverage and is not.
