### PR TITLE
The last two popovers point their arrow at the control that opened them

### DIFF
--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -82,6 +82,8 @@ function AddFactionPopover({
       width={440}
       shadow="md"
       withArrow
+      /* A 440px pane over a 40px trigger is slid by `shift` to fit, and a side-anchored arrow goes with the pane rather than staying on the control that opened it (#715). */
+      arrowPosition="center"
       trapFocus
       returnFocus
     >

--- a/src/app/widgets/faction-editor/FactionLoadPopover.tsx
+++ b/src/app/widgets/faction-editor/FactionLoadPopover.tsx
@@ -31,6 +31,8 @@ export function FactionLoadPopover({ disabled, currentPublicSlug, onLoaded }: Fa
       width={440}
       shadow="md"
       withArrow
+      /* A 440px pane over a 40px trigger is slid by `shift` to fit, and a side-anchored arrow goes with the pane rather than staying on the control that opened it (#715). */
+      arrowPosition="center"
       trapFocus
       returnFocus
     >


### PR DESCRIPTION
Closes [#715](https://github.com/ndelangen/dunezone/issues/715). One word each, on the two popovers [#714](https://github.com/ndelangen/dunezone/issues/714) left behind.

## The mechanism

A `Popover` with `withArrow` and no `arrowPosition` anchors the arrow to the pane's own corner. A 440px pane over a 40px trigger gets slid by `shift` to fit the viewport, and the arrow goes with the pane rather than staying on the control that opened it.

| file | position | width |
|---|---|---|
| `widgets/faction-editor/FactionLoadPopover.tsx` | `bottom-start` | 440 |
| `routes/_app/rulesets/$rulesetSlug/index.tsx` | `bottom-end` | 440 |

`ControlBlock`'s help affordance also carries `withArrow`, but it is a `Tooltip`: narrow and following its target, so not this defect class. These two are the last of it.

## Measured, because the filing had not been

The ticket asked for this explicitly: it inspected these two components' configuration rather than measuring them, and said `bottom-end` in particular had never been exercised. That caution was worth having, because the placement turns out to matter more than the position does.

The variable is where the trigger sits, since that is what decides how far `shift` has to slide the pane. A toolbar can put its control anywhere, so this sweeps it rather than picking one:

| position | trigger | viewport | default | `arrowPosition="center"` |
|---|---|---|---|---|
| bottom-start | start | 560 / 900 / 1440 | -7 | **0** |
| bottom-start | middle | 560 | **-155** | **0** |
| bottom-start | middle | 900 / 1440 | -7 | **0** |
| bottom-start | end | 560 / 900 / 1440 | 8 | **0** |
| bottom-end | start | 560 / 900 / 1440 | -7 | **0** |
| bottom-end | middle | 560 | **156** | **0** |
| bottom-end | middle | 900 / 1440 | 8 | **0** |
| bottom-end | end | 560 / 900 / 1440 | 8 | **0** |

Arrow centre against trigger centre, in pixels. Across all eighteen combinations the default is off by up to **156px** and never better than 7px; `arrowPosition="center"` is **0px off in every one**.

The worst case is exactly the one that had gone unexercised. `bottom-end` is well behaved when its trigger sits at the right of a toolbar, which is what end-alignment is for, and falls apart when the trigger moves inward and the pane has to be shifted.

## Proof

`bottom-end`, trigger mid-toolbar, 560px viewport. The pane has been slid 156px away from the control that opened it.

| before | after |
|---|---|
| ![the arrow parked at the pane's far corner, pointing at background](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-715-arrow-before.png) | ![the arrow directly beneath its trigger](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-715-arrow-after.png) |

## How this was measured, and what that does not cover

Both popovers live behind a session. The faction loader is on the create and edit routes; the ruleset one renders only for a viewer with `capabilities.edit`. I will not handle credentials to reach them, so I did not photograph the pages themselves.

What I measured instead is the real Mantine `Popover` and the real `IconAction`, mounted in a scratch harness with the exact props each page passes, so the floating computation under measurement is the one those pages run. The harness is not committed; it existed to produce the table above.

That leaves one honest gap: the numbers are the floating behaviour these two components will get, not an observation of the two pages. What would close it is opening either control while signed in and reading the arrow's offset, which is a minute's work for anyone with a session.

I also got the harness wrong once and it is worth saying so, because the wrong version looked convincing. My first attempt put the trigger at the container's leading edge for both positions, which made `bottom-end` and `bottom-start` produce identical numbers: at that placement `shift` clamps them to the same box, so the harness reported the two positions as indistinguishable and the `bottom-end` case as barely affected. Placing the trigger where a toolbar actually puts it is what surfaced the 156px.

## Also worth noting, not done here

Three popovers now spell out the same floating configuration by hand, and a fourth would spell it out again. The ticket flags this and says whether the shared shape earns a wrapper is a separate question; it still is, and this PR does not answer it.

## Verified

Gates: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 731 unit tests, 361 storybook tests.
