### PR TITLE
A route's load failure offers the way forward it was already entitled to

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -376,6 +376,25 @@ Convex seam suites sit beside the module they cover and are named `<domain>.<fac
 (`factions.catalogue.test.ts`, `groups.softDeletion.test.ts`). One facet per file, so a suite's name
 says what broke before the failure text does.
 
+**Deleting a public query the shell holds is an expand/contract change, not an edit.** Production ships
+the Convex functions first and the browser bundle last
+([`deploy-main.yml`](.github/workflows/deploy-main.yml)), so between those two steps every visitor
+downloads the *previous* bundle against the *new* functions. That order is right for adding a
+function and wrong for removing one: an old bundle subscribing to a deleted query gets "Could not
+find public function", `useQuery` rethrows during render, and a query held by an always-mounted
+component takes every page in `_app` down with it. Neither `routes/_app.tsx` nor `routes/__root.tsx`
+defines an `errorComponent`, and refreshing does not help, because the Worker is still serving the
+bundle that asks for the missing function. So:
+
+1. Add the new query, move the client to it, ship.
+2. Delete the old one in a **later** release, once no deployed bundle asks for it.
+
+The window is not as narrow as it looks. It measured 58 seconds on
+[the #702 deploy](https://github.com/ndelangen/dunezone/actions/runs/32717958994), which ran no
+migrations, and `migrations:deploy` sits inside it carrying a 45-minute guard budget. A deletion that
+also carries a migration can hold the site on an error page for as long as the migration takes. This
+is harsher than the stale-tab case, which at least ends in a refresh prompt.
+
 Moving a file named in `RENDERER_RUNTIME_CLOSURE_PATHS` changes the renderer digest, so
 `publisher:release:verify` will report a `renderer-manifest.generated.ts` diff to commit. That is
 identity, not staleness: regeneration is driven by the checked-in `renderer_revisions`, which a move

--- a/src/app/db/core/clientBoundary.ts
+++ b/src/app/db/core/clientBoundary.ts
@@ -2,13 +2,25 @@ import type { z } from 'zod';
 
 /**
  * Incoming data no longer matches this bundle's compiled expectations, the stale-tab signal.
- * Rendered by the router's error component as a refresh prompt instead of a crash.
+ * Rendered as a refresh prompt instead of a crash.
+ *
+ * Not exported: the throw is this module's and so is the question about it, so callers ask `isStaleClientData` rather than matching the class themselves.
  */
-export class StaleClientDataError extends Error {
+class StaleClientDataError extends Error {
   constructor(context: string, options?: { cause?: unknown }) {
     super(`${context} does not match this version of the app`, options);
     this.name = 'StaleClientDataError';
   }
+}
+
+/**
+ * Whether a caught error is the stale-tab signal, and so wants a refresh rather than a red alert.
+ *
+ * One owner for the question, because it is asked from two places that cannot share an answer's presentation: the router's error component renders outside `MantineProvider` and styles itself inline, while a route's own error component renders inside it.
+ * Five route error components used to skip the question entirely and show the message with no way forward (#700).
+ */
+export function isStaleClientData(error: unknown): boolean {
+  return error instanceof StaleClientDataError;
 }
 
 /** Validate data entering the client runtime against this bundle's schema. */

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -1,11 +1,11 @@
 import { ErrorComponent, createRouter as createTanStackRouter } from '@tanstack/react-router';
 
-import { StaleClientDataError } from '@app/db/core/clientBoundary';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
 
 import { routeTree } from './routeTree.gen';
 
 function AppErrorComponent({ error }: { error: Error }) {
-  if (error instanceof StaleClientDataError) {
+  if (isStaleClientData(error)) {
     return (
       <div role="alert" style={{ maxWidth: '28rem', margin: '4rem auto', textAlign: 'center' }}>
         <h1>This page changed</h1>

--- a/src/app/routes/_app/assets/$type/$slug/index.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/index.tsx
@@ -15,6 +15,7 @@ import { RULESET_ASSET_SLOTS } from '@shared/rulesets/assetSlots';
 import type { RulesetAssetSlot } from '@shared/rulesets/assetSlots';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
+import { LoadError } from '@ui/block/LoadError';
 import { OpenableTile } from '@ui/block/OpenableTile';
 import { PageTitle } from '@ui/block/PageTitle';
 import { Section } from '@ui/block/Section';
@@ -47,6 +48,7 @@ import type { ReactNode } from 'react';
 
 import { loadAssetPage, useAssetPage } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
 import { AssetFace } from '@app/widgets/asset-face/AssetFace';
 
 import { useAssetDeletion, useAssetGroupActions } from '../../-assetEditorStates';
@@ -112,9 +114,9 @@ function AssetDetailPending() {
 function AssetDetailError({ error }: ErrorComponentProps) {
   return (
     <AssetDetailMessage>
-      <Alert color="red" title="This asset could not be loaded" role="alert">
-        <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
-      </Alert>
+      <LoadError title="This asset could not be loaded" stale={isStaleClientData(error)}>
+        {error.message}
+      </LoadError>
     </AssetDetailMessage>
   );
 }

--- a/src/app/routes/_app/factions/$factionId/index.tsx
+++ b/src/app/routes/_app/factions/$factionId/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '@mantine/core';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
+import { LoadError } from '@ui/block/LoadError';
 import { PageTitle } from '@ui/block/PageTitle';
 import { Section } from '@ui/block/Section';
 import { factionAssetPublishingCopy } from '@ui/content/assetPublishingStatus';
@@ -37,6 +38,7 @@ import { ArrowLeft, Download, Eye, FileText, MapPin, Pencil, UserPlus, UsersRoun
 import { loadFaction, useFaction } from '@db/factions';
 import type { FactionData } from '@db/factions';
 import { useGroupMembershipWorkflow } from '@db/members';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
 import { LeaderToken } from '@game/assets/faction/leader/Leader';
 import { Token as FactionToken } from '@game/assets/faction/token/Token';
 import { TroopToken } from '@game/assets/faction/troop/Troop';
@@ -115,9 +117,9 @@ function FactionDetailError({ error }: ErrorComponentProps) {
         </Stack>
       </PageLayout.Header>
       <PageLayout.Content>
-        <Alert color="red" title="Faction could not be loaded" role="alert">
-          <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
-        </Alert>
+        <LoadError title="Faction could not be loaded" stale={isStaleClientData(error)}>
+          {error.message}
+        </LoadError>
       </PageLayout.Content>
     </PageLayout>
   );

--- a/src/app/routes/_app/factions/index.tsx
+++ b/src/app/routes/_app/factions/index.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   Badge,
   Button,
   Drawer,
@@ -17,6 +16,7 @@ import {
 import { Link, createFileRoute } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { FactionCatalogueSpotlight } from '@ui/block/FactionCatalogueSpotlight';
+import { LoadError } from '@ui/block/LoadError';
 import { PageTitle } from '@ui/block/PageTitle';
 import { complexityTierSliderMarks } from '@ui/content/ComplexityGlyph';
 import { formatFactionCatalogueDate } from '@ui/content/dates';
@@ -32,6 +32,7 @@ import type { KeyboardEvent } from 'react';
 
 import { loadFactionCataloguePage, useFactionCataloguePage } from '@db/factions';
 import type { FactionCatalogueEntry, FactionCataloguePageData, FactionRulesetSummary } from '@db/factions';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
 
 import {
   complexityRangeSearchValue,
@@ -128,9 +129,9 @@ function FactionCatalogueError({ error }: ErrorComponentProps) {
         <CatalogueHeader />
       </PageLayout.Header>
       <PageLayout.Content>
-        <Alert color="red" title="Faction catalogue could not be loaded" role="alert">
-          <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
-        </Alert>
+        <LoadError title="Faction catalogue could not be loaded" stale={isStaleClientData(error)}>
+          {error.message}
+        </LoadError>
       </PageLayout.Content>
     </PageLayout>
   );

--- a/src/app/routes/_app/index.tsx
+++ b/src/app/routes/_app/index.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   Anchor,
   Avatar,
   Badge,
@@ -17,6 +16,7 @@ import { useReducedMotion } from '@mantine/hooks';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { FactionCatalogueSpotlight } from '@ui/block/FactionCatalogueSpotlight';
+import { LoadError } from '@ui/block/LoadError';
 import { PageTitle } from '@ui/block/PageTitle';
 import { Section } from '@ui/block/Section';
 import { formatFactionCatalogueDate } from '@ui/content/dates';
@@ -33,6 +33,7 @@ import { FaRedditAlien } from 'react-icons/fa6';
 import { SiBoardgamegeek, SiDiscord } from 'react-icons/si';
 
 import { loadHomepage, useHomepage } from '@db/homepage';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
 import { LeaderToken } from '@game/assets/faction/leader/Leader';
 import { factionTokenFixtures } from '@game/fixtures/factionTokens';
 
@@ -423,9 +424,9 @@ function HomepageError({ error }: ErrorComponentProps) {
         <PageTitle title="Make Dune your own" />
       </PageLayout.Header>
       <PageLayout.Content>
-        <Alert color="red" title="The homepage could not be loaded" role="alert">
-          <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
-        </Alert>
+        <LoadError title="The homepage could not be loaded" stale={isStaleClientData(error)}>
+          {error.message}
+        </LoadError>
       </PageLayout.Content>
     </PageLayout>
   );

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -6,6 +6,7 @@ import type { RouteNoticeCode } from '@shared/routeNotices';
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { FactionCard } from '@ui/block/FactionCard';
+import { LoadError } from '@ui/block/LoadError';
 import { PageTitle } from '@ui/block/PageTitle';
 import { ProposedContent } from '@ui/block/ProposedContent';
 import { Section } from '@ui/block/Section';
@@ -49,6 +50,7 @@ import {
   useRulesetDetailPage,
   useSetRulesetGroup,
 } from '@db/rulesets';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
 import { FactionPicker } from '@app/pickers/FactionPicker';
 import { resolveRouteNotice } from '@app/routes/-routeNotices';
 
@@ -216,9 +218,9 @@ function RulesetDetailError({ error }: ErrorComponentProps) {
         </Stack>
       </PageLayout.Header>
       <PageLayout.Content>
-        <Alert color="red" title="Ruleset could not be loaded" role="alert">
-          <Text size="sm">{error.message || 'An unexpected error occurred.'}</Text>
-        </Alert>
+        <LoadError title="Ruleset could not be loaded" stale={isStaleClientData(error)}>
+          {error.message}
+        </LoadError>
       </PageLayout.Content>
     </PageLayout>
   );

--- a/src/app/ui/block/LoadError.stories.tsx
+++ b/src/app/ui/block/LoadError.stories.tsx
@@ -1,0 +1,21 @@
+import preview from '@sb/preview';
+
+import { LoadError } from './LoadError';
+
+const meta = preview.meta({
+  component: LoadError,
+  parameters: { layout: 'padded' },
+  args: { title: 'Faction could not be loaded', children: 'Faction data could not be read.' },
+});
+
+/** A page that failed for its own reasons: the caller's sentence, then the error's. */
+export const Failed = meta.story({});
+
+/** An error carrying no message of its own still says something rather than showing an empty alert. */
+export const FailedWithoutAMessage = meta.story({ args: { children: '' } });
+
+/**
+ * The stale-tab case, which is the one the five routes used to swallow.
+ * The reason is beside the point here: this tab is running an older bundle than the data it was sent, so the only thing worth offering is the reload.
+ */
+export const Stale = meta.story({ args: { stale: true } });

--- a/src/app/ui/block/LoadError.tsx
+++ b/src/app/ui/block/LoadError.tsx
@@ -1,0 +1,35 @@
+import { Button, Stack, Text, Title } from '@mantine/core';
+
+import { FormError } from './FormError';
+
+export interface LoadErrorProps {
+  /** What failed, as the reader would say it, "Faction could not be loaded". Ignored on the stale path, which has its own sentence. */
+  title: string;
+  /** The reason, off the caught error. Empty is expected and handled, since an error reaching a route need not carry a message. */
+  children: string;
+  /** The stale-tab signal: this tab is running an older bundle than the data it was sent, so the way forward is a reload rather than the reason. */
+  stale?: boolean;
+}
+
+/**
+ * Says that a page did not load, and either why or what to do about it.
+ *
+ * `FormError`'s sibling, and it composes it: an action that did not happen and a page that did not load are the same sentence with the same treatment, so the colour and the live region are stated once.
+ * What this adds is the second case, because a page has a failure mode a form does not: the reader's tab can be running an older bundle than the data it was sent, and then the message is not the point and the reload is.
+ *
+ * Whether that is the case is the caller's to decide, not this component's: answering it needs `isStaleClientData` from the data layer, which the kit may not import, and a page has it to hand anyway.
+ *
+ * It exists because five routes overrode `errorComponent` and each rendered the failure as a red alert, so on those five the stale case arrived with its message and no way forward, telling the reader the data did not match this version of the app and leaving them to work out that reloading fixes it (#700).
+ */
+export function LoadError({ title, children, stale = false }: LoadErrorProps) {
+  if (stale) {
+    return (
+      <Stack gap="sm" align="center" role="alert">
+        <Title order={2}>This page changed</Title>
+        <Text size="sm">The data no longer matches this version of the app.</Text>
+        <Button onClick={() => window.location.reload()}>Refresh</Button>
+      </Stack>
+    );
+  }
+  return <FormError title={title}>{children || 'An unexpected error occurred.'}</FormError>;
+}


### PR DESCRIPTION
Closes [#700](https://github.com/ndelangen/dunezone/issues/700). Closes [#704](https://github.com/ndelangen/dunezone/issues/704).

Two deploy-window behaviours, argued separately because they are separate, in one PR because they sit on the same surface and reviewing them apart means reading it twice.

---

# #700, the swallowed refresh prompt

`StaleClientDataError` exists so a tab running an older bundle, sent data that no longer matches what it was compiled against, gets a way forward instead of a crash. The router's error component honours it: "This page changed", and a Refresh button.

Five routes override `errorComponent`, and none of them asked the question. TanStack resolves a route's own `errorComponent` ahead of the default, so on the homepage, the faction catalogue, the faction detail, the ruleset detail and the asset detail, the stale case arrived as a red alert reading "Faction data does not match this version of the app" with nothing to click. The mechanism was working; the message was simply losing its button.

## One owner for the question, two answers

The question is now `isStaleClientData`, beside the error it asks about.

Two answers rather than one, because the two callers cannot share a presentation. The router's component also covers routes outside `MantineProvider` and styles itself inline; a route's own component renders inside it. That is the split [#700](https://github.com/ndelangen/dunezone/issues/700) itself predicted.

Inside Mantine, `LoadError` is `FormError`'s sibling and composes it: an action that did not happen and a page that did not load are the same sentence with the same treatment, so the colour and the live region stay stated once. What it adds is the second case, and the fallback the five routes each wrote by hand for an error carrying no message.

It is a kit Block and not a Widget, which is worth saying because I built it as a Widget first and the lint told me otherwise: widgets may not import a data-layer value either. That is the taxonomy working rather than an obstacle. The page classifies the error, the component renders it, and `stale` arrives as a prop.

`StaleClientDataError` is no longer exported. The throw is its module's and so is the question about it, and knip noticed the moment nothing matched the class by name any more.

## Proof

The stale condition is **staged**: the catalogue's client schema is given a field no stored row has, which is precisely what a narrowing deploy does to a tab running the previous bundle. Identical staging on both sides, so the pair compares like with like, and reverted rather than committed.

Both sides are real code. The before is `main` with the app restarted against it, and I checked which tree the dev server was serving each way.

| on `main` | this branch |
|---|---|
| ![a red alert saying faction data does not match this version of the app, with nothing to click](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-700-catalogue-before.png) | ![this page changed, with a refresh button](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-700-catalogue-after.png) |

Read off the same renders:

| | alert text | refresh button |
|---|---|---|
| on `main` | "Faction catalogue could not be loaded / Faction data does not match this version of the app" | **absent** |
| this branch | "This page changed / The data no longer matches this version of the app." | **present** |

The page keeps its own chrome either way, since a header and a way back are that route's to choose.

---

# #704, the deleted shell-held query

This one is not a bug in a file, and the change is a rule rather than code.

Production ships the Convex functions first and the browser bundle last, so between those two steps every visitor downloads the *previous* bundle against the *new* functions. That order is right for adding a function and wrong for removing one: an old bundle subscribing to a deleted query gets "Could not find public function", `useQuery` rethrows during render, and a query held by an always-mounted component takes every `_app` page down with it.

Both of the issue's load-bearing claims check out, and I verified them rather than quoting them: the pipeline order is as filed, and `migrations:deploy` carries a **2,700,000 ms** guard budget, so the 45 minutes is real. The measured window was 58 seconds only because that deploy ran no migrations.

The rule now sits beside the other Convex doorway rules in `AGENTS.md`: add the new query, move the client, ship, and delete the old one in a later release.

## What I deliberately did not build

A safety net on `_app` or `__root`, which is the obvious next thought and which I think is wrong here.

The affordance such a component would offer is a refresh, and inside the window a refresh does not help: the Worker is still serving the bundle that asks for the missing function, so it loops until the Worker deploy lands. A message that named the deploy instead would have to guess, and would mislabel every unrelated shell error as a deploy in progress. Detecting the specific Convex wording would make a second source out of someone else's error string.

The asymmetry that causes this cannot be fixed by reordering either, since deploying the Worker first would break additive changes instead. The release discipline is the fix, which is what the issue argued and what I am agreeing with rather than adding to.

Say the word if you want the net anyway and I will build it, but I would rather not ship an affordance that does not work.

---

## Where this sits against the composition wave

Asked in review, and worth answering in the body because the wave should build on this rather than beside it.

[#701](https://github.com/ndelangen/dunezone/issues/701) item 1 is the page-message widget: the pending, error, not-found and login-gate **frames** pasted across about seventeen sites, with the assets editor's local extraction as the proven shape.

`LoadError` is not that widget and does not overlap it. The line between them is chrome and words:

- the **frame** owns the page around a message, a header, a way back, and a slot;
- the **body** owns what goes in the slot for one kind of message, its words and its affordance.

`LoadError` is the body for the error kind, and only that. It renders no chrome, which is why all five routes still supply their own.

This PR already shows the two composing, because one of the five routes had extracted its frame already. `AssetDetailMessage` in the asset detail route is exactly #701's proven shape: chrome plus a slot, holding three different bodies for loading, absent and failed. Its error case now reads:

```tsx
<AssetDetailMessage>
  <LoadError title="This asset could not be loaded" stale={isStaleClientData(error)}>{error.message}</LoadError>
</AssetDetailMessage>
```

So the answer is: deliberately the error kind's body, designed to be held by the frame the wave builds, not a first slice of the frame itself.

What that asks of the wave, concretely: when the page-message widget lands it should take the body as a slot and leave the error body here, rather than growing an error case of its own. The other three kinds want bodies beside this one, and the pending body is already written twice in this repo, in `AssetDetailPending` and wherever the other sites paste it.

I did not design this against #701, to be clear. It came out as the body because the chrome differs per route and the words do not. It happens to land on the right side of that line, and the constraint above is what keeps it there.

## About the `AGENTS.md` change

Operational documentation rather than a taxonomy amendment: a release rule with a measured window, filed beside the other Convex doorway rules. It changes no category, no boundary and no lint.

---

## Verified

Gates: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 731 unit tests, 364 storybook tests, and `publisher:release:verify` clean with no manifest diff.

`LoadError` carries three stories, including the stale state and an error with no message of its own, because both are states nobody sees by accident.
