### PR TITLE
A delimiter glued to punctuation stops opening a mark

### DIFF
--- a/src/shared/formattedText.test.ts
+++ b/src/shared/formattedText.test.ts
@@ -106,6 +106,31 @@ describe('formatted-text core', () => {
     });
   });
 
+  it('keeps a delimiter glued to punctuation as prose instead of opening a mark', () => {
+    const parsed = parseValid('the Supplies!-cache is revealed, wait!-really (see below)');
+
+    expect(parsed.source).toBe('the Supplies!-cache is revealed, wait!-really (see below)');
+    expect(parsed.blocks[0]).toMatchObject({
+      kind: 'paragraph',
+      children: [{ kind: 'text', value: 'the Supplies!-cache is revealed, wait!-really (see below)' }],
+    });
+
+    const nested = parseValid('_-*all three*-_ still nest, and -after a space- still opens');
+    expect(nested.blocks[0]).toMatchObject({
+      kind: 'paragraph',
+      children: [
+        {
+          kind: 'mark',
+          mark: 'underline',
+          children: [{ kind: 'mark', mark: 'italic', children: [{ kind: 'mark', mark: 'bold' }] }],
+        },
+        { kind: 'text', value: ' still nest, and ' },
+        { kind: 'mark', mark: 'italic', children: [{ kind: 'text', value: 'after a space' }] },
+        { kind: 'text', value: ' still opens' },
+      ],
+    });
+  });
+
   it('treats astral Unicode letters as prose-boundary word characters', () => {
     const parsed = parseValid('𝒜*bold* and *𝒜*');
 

--- a/src/shared/formattedText.ts
+++ b/src/shared/formattedText.ts
@@ -323,8 +323,14 @@ function parseInline(lines: readonly SourceLine[]): InlineParseResult {
 
     const previous = codePointBefore(source, index);
     const next = codePointAfter(source, index);
+    /* An opener's left flank is the start of the text, whitespace, or an enclosing delimiter (canonical
+       nesting puts the outer delimiter immediately before the inner one). Any-non-word-character was
+       too loose: a hyphen glued to punctuation ("Supplies!-cache") opened an italic that never closed,
+       turning prose into a diagnostic (#679). */
     const canOpen =
-      next !== undefined && !/\s/u.test(next) && (previous === undefined || !wordCharacter.test(previous));
+      next !== undefined &&
+      !/\s/u.test(next) &&
+      (previous === undefined || /\s/u.test(previous) || isDelimiter(previous));
     const canClose =
       previous !== undefined && !/\s/u.test(previous) && (next === undefined || !wordCharacter.test(next));
     const top = stack.at(-1);


### PR DESCRIPTION
Executes #679, decided when Norbert judged the one invalid document in the #670 collision inventory to be a parser bug rather than a data problem.

The fix: canOpen's left flank tightens from any-non-word-character to start-of-text, whitespace, or an enclosing delimiter. The enclosing-delimiter case is what keeps canonical `_-*` nesting legal (an inner opener is preceded by the outer delimiter); the constraint and its reason sit in a comment at the site. Consequence stated: an opener glued to non-delimiter punctuation ("(-aside-)") is now prose, which is the trade #679 records.

Evidence, non-visual change so the proof is tests and data rather than pixels:
- 20 of 20 contract tests pass, including the new regression case: punctuation-glued delimiters stay prose while nesting and space-opened marks still work.
- The #670 classifier re-run over the dev clone's real stored prose (read-only, via convex data): 402 prose values, zero invalid; the same sweep found exactly one (trishula's "Supplies!-cache", present in this corpus) before the fix.
- Full gate list green locally: lint, format:check, check:prose, typecheck, knip, unit tests.
- Renderer closure: nothing under src/game, src/app/print, or workers imports formattedText yet (adoption has not started), so the manifest is untouched by the import-graph rule.

Closes #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline text formatting so punctuation-adjacent delimiters remain regular text.
  * Preserved expected formatting for nested delimiters and delimiters following spaces.

* **Tests**
  * Added coverage for punctuation, nested formatting, and whitespace-related delimiter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->