### PR TITLE
The shell stops writing a route attribute nothing reads

### DIFF
--- a/src/app/shell/AppRoot.test.tsx
+++ b/src/app/shell/AppRoot.test.tsx
@@ -101,7 +101,7 @@ describe('AppRoot page header', () => {
     act(() => root.unmount());
   });
 
-  it('releases its document-level route and scroll state on unmount', () => {
+  it('releases its document-level page effects on unmount', () => {
     const container = document.createElement('div');
     const root = createRoot(container);
 

--- a/src/app/shell/AppRoot.test.tsx
+++ b/src/app/shell/AppRoot.test.tsx
@@ -115,13 +115,11 @@ describe('AppRoot page header', () => {
       );
     });
 
-    expect(document.documentElement.dataset.route).toBe('/privacy');
     expect(document.documentElement.hasAttribute('data-initial-animate')).toBe(true);
     expect(document.documentElement.style.getPropertyValue('--scroll-pct')).not.toBe('');
 
     act(() => root.unmount());
 
-    expect(document.documentElement.hasAttribute('data-route')).toBe(false);
     expect(document.documentElement.hasAttribute('data-initial-animate')).toBe(false);
     expect(document.documentElement.style.getPropertyValue('--scroll-pct')).toBe('');
   });

--- a/src/app/shell/AppRoot.tsx
+++ b/src/app/shell/AppRoot.tsx
@@ -73,13 +73,18 @@ export function AppRoot({ children, pathname }: AppRootProps) {
     };
   }, [motion]);
 
+  /*
+   * Re-arms the backdrop's eased arrival on every navigation.
+   * `pathname` is the whole point of the dependency rather than a value this reads: the attribute
+   * carries no route, it only says a route just changed, and `page.css` gives the backdrop its
+   * transition for as long as it is present. The scroll handler above drops it the moment the
+   * reader takes over, so the wheel pans the photograph directly instead of chasing an ease.
+   */
   useEffect(() => {
     const root = document.documentElement;
-    root.dataset.route = pathname;
     root.setAttribute('data-initial-animate', '');
 
     return () => {
-      delete root.dataset.route;
       root.removeAttribute('data-initial-animate');
     };
   }, [pathname]);


### PR DESCRIPTION
First of the three AppRoot items on [#707](https://github.com/ndelangen/dunezone/issues/707), split out because it is the only one that needs no decision. The other two are [proposed on the issue](https://github.com/ndelangen/dunezone/issues/707#issuecomment-5399971378).

## `data-route` had no reader

Not a stylesheet, not the shell, not an e2e spec. A repo-wide search for `data-route` and `dataset.route` finds it in exactly two places: where `AppRoot` writes it, and where `AppRoot.test.tsx` asserts that it did.

A write-only document attribute fails the census's defence trivially, so it goes.

## The assertion goes with it

`AppRoot.test.tsx` asserted the attribute on mount and its absence after unmount. With nothing reading the attribute, that test's only subject was that the write happened.

That is worth naming rather than quietly deleting: a test whose subject is an implementation detail keeps dead state alive, because removing the state then looks like a regression. The two assertions covering `data-initial-animate` and `--scroll-pct` stay, since both have real readers in `page.css`.

## What stays, and why the dependency now says so

The effect stays, and so does its `pathname` dependency, because the other attribute it writes is the point. `data-initial-animate` re-arms the backdrop's eased arrival on every navigation and carries no route of its own, so `pathname` is the trigger rather than a value the effect reads.

That is now stated in the file. An unused-looking dependency is exactly the thing a later reader tidies away, and doing so would silently stop the attribute being re-stamped on navigation.

## Verified

Gates: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 731 unit tests, 361 storybook tests, and `publisher:release:verify` clean with no manifest diff.

No behaviour changes, so there is nothing to photograph: the attribute this removes was never read by anything that renders.
