### PR TITLE
The backdrop keeps its parallax and loses an arrival nobody saw

### DIFF
--- a/src/app/routes/_app.tsx
+++ b/src/app/routes/_app.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Outlet, useLocation } from '@tanstack/react-router';
+import { createFileRoute, Outlet } from '@tanstack/react-router';
 
 import { ApplicationChrome } from '@app/shell/ApplicationChrome';
 import { AppNotFound } from '@app/shell/AppNotFound';
@@ -24,10 +24,8 @@ export const Route = createFileRoute('/_app')({
 });
 
 function AppLayout() {
-  const pathname = useLocation({ select: (location) => location.pathname });
-
   return (
-    <ApplicationChrome pathname={pathname}>
+    <ApplicationChrome>
       <Outlet />
     </ApplicationChrome>
   );

--- a/src/app/shell/AppNotFound.tsx
+++ b/src/app/shell/AppNotFound.tsx
@@ -1,14 +1,12 @@
-import { Link, useLocation } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
 import { PageTitle } from '@ui/block/PageTitle';
 import { PageLayout } from '@ui/layout/PageLayout';
 
 import { ApplicationChrome } from './ApplicationChrome';
 
 export function AppNotFound() {
-  const pathname = useLocation({ select: (location) => location.pathname });
-
   return (
-    <ApplicationChrome pathname={pathname}>
+    <ApplicationChrome>
       <PageLayout>
         <PageLayout.Header>
           <PageTitle title="404 - Page Not Found" />

--- a/src/app/shell/AppRoot.stories.tsx
+++ b/src/app/shell/AppRoot.stories.tsx
@@ -16,7 +16,6 @@ const meta = preview.meta({
     },
   },
   args: {
-    pathname: '/factions',
     children: shellPageOptionLabels[0],
   },
   argTypes: {

--- a/src/app/shell/AppRoot.test.tsx
+++ b/src/app/shell/AppRoot.test.tsx
@@ -64,7 +64,7 @@ describe('AppRoot page header', () => {
     act(() => {
       root.render(
         chrome(
-          <AppRoot pathname="/privacy">
+          <AppRoot>
             <PageLayout>
               <PageLayout.Header>
                 <h1>Privacy policy</h1>
@@ -85,7 +85,7 @@ describe('AppRoot page header', () => {
     act(() => {
       root.render(
         chrome(
-          <AppRoot pathname="/assets">
+          <AppRoot>
             <PageLayout>
               <h2>Assets</h2>
               <p>Asset content</p>
@@ -101,26 +101,24 @@ describe('AppRoot page header', () => {
     act(() => root.unmount());
   });
 
-  it('releases its document-level page effects on unmount', () => {
+  it('releases the scroll progress it publishes on unmount', () => {
     const container = document.createElement('div');
     const root = createRoot(container);
 
     act(() => {
       root.render(
         chrome(
-          <AppRoot pathname="/privacy">
+          <AppRoot>
             <p>Privacy content</p>
           </AppRoot>
         )
       );
     });
 
-    expect(document.documentElement.hasAttribute('data-initial-animate')).toBe(true);
     expect(document.documentElement.style.getPropertyValue('--scroll-pct')).not.toBe('');
 
     act(() => root.unmount());
 
-    expect(document.documentElement.hasAttribute('data-initial-animate')).toBe(false);
     expect(document.documentElement.style.getPropertyValue('--scroll-pct')).toBe('');
   });
 
@@ -131,7 +129,7 @@ describe('AppRoot page header', () => {
     act(() => {
       root.render(
         chrome(
-          <AppRoot pathname="/privacy">
+          <AppRoot>
             <p>Privacy content</p>
           </AppRoot>
         )

--- a/src/app/shell/AppRoot.tsx
+++ b/src/app/shell/AppRoot.tsx
@@ -20,11 +20,10 @@ function updateScrollProgress() {
 
 export interface AppRootProps {
   children: ReactNode;
-  pathname: string;
 }
 
 /** Persistent application chrome and document-level page effects. */
-export function AppRoot({ children, pathname }: AppRootProps) {
+export function AppRoot({ children }: AppRootProps) {
   useEffect(() => {
     const root = document.documentElement;
     let animationFrameId: number | null = null;
@@ -38,15 +37,9 @@ export function AppRoot({ children, pathname }: AppRootProps) {
         updateScrollProgress();
       });
     };
-    const handleScroll = () => {
-      root.removeAttribute('data-initial-animate');
-      scheduleUpdate();
-    };
-
-    root.setAttribute('data-initial-animate', '');
     root.style.setProperty(SCROLL_VAR, '0');
     window.addEventListener('resize', updateScrollProgress);
-    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('scroll', scheduleUpdate, { passive: true });
 
     const resizeObserver = new ResizeObserver(scheduleUpdate);
     resizeObserver.observe(document.body);
@@ -56,7 +49,7 @@ export function AppRoot({ children, pathname }: AppRootProps) {
         cancelAnimationFrame(animationFrameId);
       }
       window.removeEventListener('resize', updateScrollProgress);
-      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('scroll', scheduleUpdate);
       resizeObserver.disconnect();
       root.style.removeProperty(SCROLL_VAR);
     };
@@ -72,22 +65,6 @@ export function AppRoot({ children, pathname }: AppRootProps) {
       delete root.dataset.motion;
     };
   }, [motion]);
-
-  /*
-   * Re-arms the backdrop's eased arrival on every navigation.
-   * `pathname` is the whole point of the dependency rather than a value this reads: the attribute
-   * carries no route, it only says a route just changed, and `page.css` gives the backdrop its
-   * transition for as long as it is present. The scroll handler above drops it the moment the
-   * reader takes over, so the wheel pans the photograph directly instead of chasing an ease.
-   */
-  useEffect(() => {
-    const root = document.documentElement;
-    root.setAttribute('data-initial-animate', '');
-
-    return () => {
-      root.removeAttribute('data-initial-animate');
-    };
-  }, [pathname]);
 
   return (
     <div className={styles.container} data-app-root>

--- a/src/app/shell/ApplicationChrome.tsx
+++ b/src/app/shell/ApplicationChrome.tsx
@@ -25,7 +25,6 @@ const schemeBridge: MantineColorSchemeManager = {
 
 export interface ApplicationChromeProps {
   children: ReactNode;
-  pathname: string;
 }
 
 /**
@@ -35,7 +34,7 @@ export interface ApplicationChromeProps {
  * the provider only relays the resolved verdict, so
  * Mantine and tokens.css agree without a second writer.
  */
-export function ApplicationChrome({ children, pathname }: ApplicationChromeProps) {
+export function ApplicationChrome({ children }: ApplicationChromeProps) {
   const scheme = useResolvedScheme();
 
   useEffect(
@@ -47,7 +46,7 @@ export function ApplicationChrome({ children, pathname }: ApplicationChromeProps
 
   return (
     <MantineProvider theme={appContentTheme} forceColorScheme={scheme} colorSchemeManager={schemeBridge}>
-      <AppRoot pathname={pathname}>{children}</AppRoot>
+      <AppRoot>{children}</AppRoot>
     </MantineProvider>
   );
 }

--- a/src/app/styles/page.css
+++ b/src/app/styles/page.css
@@ -14,10 +14,6 @@ html[data-mantine-color-scheme="dark"] {
   background-image: url("/web/page-dark-large.jpg");
 }
 
-html[data-initial-animate] {
-  transition: background-position 1.2s cubic-bezier(0.25, 0.05, 0.35, 1);
-}
-
 html::after {
   content: "";
   position: fixed;


### PR DESCRIPTION
Closes the scroll half of [#707](https://github.com/ndelangen/dunezone/issues/707), [decided by Norbert](https://github.com/ndelangen/dunezone/issues/707#issuecomment-5400638786) after both halves were measured. The motion half is #722, built separately.

## The decision, and what each half of it rests on

**The parallax keeps its JavaScript.** The scroll listener writing `--scroll-pct` stays, because CSS cannot carry it everywhere. Measured in all three engines with a page that actually scrolls:

| engine | `CSS.supports('animation-timeline', 'scroll()')` | backdrop pans |
|---|---|---|
| Chromium 151 | yes | yes |
| **Firefox 153** | **no** | **no** |
| WebKit 26.5 | yes | yes |

Mozilla's own [experimental features page](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Experimental_features) has `layout.css.scroll-driven-animations.enabled` on by default in Nightly since 136 and **off by default in Release since 110**, with no announced target. That is why this is unlike CanvasScale, where the gap was eight days against a named version.

**The eased arrival goes**, because measurement showed it almost never runs:

| scenario | position changes | |
|---|---|---|
| navigate from a scrolled page | **1** | a jump. The navigation's own scroll stripped the attribute at 237ms; the position changed at 260ms |
| navigate from an unscrolled page | **0** | nothing to animate |
| first load on `/privacy`, `/terms`, `/` | **0** | nothing to animate |
| first load, page shorter than the viewport | **49 over 1194ms** | the only place it fired |

So `data-initial-animate`, the pathname effect that re-armed it on every navigation, and the 1.2s transition rule in `page.css` are all removed.

**The accepted cost, stated plainly:** on a page shorter than the viewport the backdrop now settles at its end position instantly instead of drifting there over 1.2s. That is a real if narrow loss, and it is what Norbert weighed against carrying the machinery.

## Removing it emptied a chain

The scroll handler existed only to wrap the attribute write, so the listener now takes `scheduleUpdate` directly.

`pathname` had no consumer once the effect went. It is gone from `AppRoot`, from `ApplicationChrome` which only forwarded it, and from both of that component's callers, taking a `useLocation` subscription with it in each. `AppNotFound` was the one the type error found rather than the trace, which is the trace's fault and worth admitting.

## Proof

Re-run of the same rig, against this branch. I verified the dev server was serving this branch by its bytes, because another session's vite from the root checkout held port 3000 and would have answered for `main`.

| check | result |
|---|---|
| parallax tracks the wheel | `50% 0%` → `24.99%` → `50.02%` → `75.01%` → `50% 100%`, **5 of 5 distinct** |
| the ease, on the one page that used to show it | **1 step, was 49 over 1194ms**; `data-initial-animate` absent; settles at `50% 100%` |

The first row is the behaviour the JS is kept for. The second is both the removal working and the accepted cost visible: it still arrives at the end position, it just no longer drifts.

## A note on the test

The unmount test's title is narrowed rather than left overstating. It covered `data-initial-animate` and `--scroll-pct`; with the first gone it covers one thing, so it says so.

`data-motion`'s release on unmount is covered by no test. Worth knowing, and it belongs to #722 rather than here, since that ticket is actively editing the motion path and a second writer in this file would only conflict.

## Verified

Gates: lint, format:check, check:prose, typecheck, knip, check:css-orphans, check:app-layout, 732 unit tests, 364 storybook tests, and `publisher:release:verify` clean with no manifest diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page transition behavior by removing route-dependent animation handling.
  * Preserved scroll-progress updates and cleanup when navigating or unmounting.
  * Ensured the application shell renders consistently across routes and not-found pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->