### PR TITLE
The motion verdict reaches the first frame

### DIFF
--- a/src/app/routes/_app.tsx
+++ b/src/app/routes/_app.tsx
@@ -17,6 +17,16 @@ export const Route = createFileRoute('/_app')({
           `matchMedia('(prefers-color-scheme: dark)').matches);` +
           `document.documentElement.setAttribute('data-mantine-color-scheme',d?'dark':'light')})()`,
       },
+      {
+        /* Pre-hydration twin of styles/motion.ts: stamps the motion verdict before first paint so
+           the dice never contradict the profile's toggle for a frame. Routes outside this layout
+           never stamp and keep the OS hint, as does a visitor with scripts disabled (the
+           stylesheets' media blocks cover both). */
+        children:
+          `(function(){var m=/(?:^|;\\s*)motion=(on|off)(?:;|$)/.exec(document.cookie);` +
+          `var r=typeof matchMedia==='function'&&matchMedia('(prefers-reduced-motion: reduce)').matches;` +
+          `document.documentElement.setAttribute('data-motion',(m?m[1]==='on':!r)?'ok':'reduce')})()`,
+      },
     ],
   }),
   component: AppLayout,

--- a/src/app/shell/AppRoot.test.tsx
+++ b/src/app/shell/AppRoot.test.tsx
@@ -101,7 +101,7 @@ describe('AppRoot page header', () => {
     act(() => root.unmount());
   });
 
-  it('releases the scroll progress it publishes on unmount', () => {
+  it('releases the scroll progress and motion verdict it publishes on unmount', () => {
     const container = document.createElement('div');
     const root = createRoot(container);
 
@@ -116,10 +116,12 @@ describe('AppRoot page header', () => {
     });
 
     expect(document.documentElement.style.getPropertyValue('--scroll-pct')).not.toBe('');
+    expect(document.documentElement.dataset.motion).toBe('ok');
 
     act(() => root.unmount());
 
     expect(document.documentElement.style.getPropertyValue('--scroll-pct')).toBe('');
+    expect(document.documentElement.dataset.motion).toBeUndefined();
   });
 
   it('publishes the approved project waypoints in the footer', () => {

--- a/src/app/styles/page.css
+++ b/src/app/styles/page.css
@@ -32,8 +32,10 @@ html::after {
   mix-blend-mode: overlay;
 }
 
-/* The dice hold still for reduced-motion visitors. Before the shell stamps `data-motion` the OS
-   hint decides; once stamped, the site-local override (see shell/motion.ts) wins either way. */
+/* The dice hold still for reduced-motion visitors. The `_app` layout's pre-hydration script
+   stamps `data-motion` before first paint, and the site-local override (see styles/motion.ts)
+   wins either way. The media block covers documents that never stamp (routes outside that
+   layout, and visitors with scripts disabled), where the OS hint decides alone. */
 html[data-motion="reduce"]::after {
   animation: none;
 }

--- a/src/app/widgets/faction-editor/FactionEditor.module.css
+++ b/src/app/widgets/faction-editor/FactionEditor.module.css
@@ -247,10 +247,10 @@
   box-shadow: var(--panel-shadow);
 }
 
-/* The turn obeys the site's Ambient motion verdict, like the dice: the shell stamps
-   `data-motion` from the footer toggle with the OS hint as its System default, so an
-   explicit "On" animates even for reduced-motion visitors. Before the stamp, the OS
-   hint decides alone. */
+/* The turn obeys the site's Ambient motion verdict, like the dice: `data-motion` is stamped
+   before first paint from the profile's Appearance toggle with the OS hint as its System
+   default, so an explicit "On" animates even for reduced-motion visitors. The media block
+   covers documents that never stamp, where the OS hint decides alone. */
 html[data-motion="reduce"] .flipCard {
   transition: none;
 }


### PR DESCRIPTION
A pre-hydration twin of `styles/motion.ts` joins the colour-scheme script in the `_app` layout's head: read the `motion` cookie, fall back to the reduced-motion hint, stamp `data-motion` on `<html>` before first paint. Decided on [the census](https://github.com/ndelangen/dunezone/issues/707#issuecomment-5400638786): until now the stylesheet fell back to the OS hint until React hydrated, so a motion-off visitor got spinning dice on first paint and an OS-quieted opt-in visitor got still ones. The script owns only the first frames; `AppRoot`'s effect keeps owning updates after hydration. The two stylesheet comments describing the pre-stamp window are trued to the new mechanics, including the motion toggle's actual home (profile Appearance, not the footer).

## Proof

All measurements against the real dev server on this branch, dev Convex data.

**The stamp beats first paint, measured.** An init-script `MutationObserver` (attached before any document script) timed the attribute against the paint timeline:

| event | t | readyState |
|---|---|---|
| `data-motion="ok"` first stamped | **23.8ms** | `loading` |
| first paint / first contentful paint | 88ms | |
| AppRoot's hydration effect re-stamps (same value) | 822.9ms | `complete` |

`readyState: loading` at stamp time means the verdict landed during document parse, 64ms before any pixel. Structurally: the IIFE is the second inline script in the served `<head>`, before any external bundle, so it is parser-synchronous by construction (verified in the served bytes with curl).

**The verdict matches `motionAllowed()` in all six cells** (Playwright contexts, `reducedMotion` emulation by cookie state):

| OS hint | cookie | stamped | dice |
|---|---|---|---|
| no-preference | unset | ok | spin |
| no-preference | on | ok | spin |
| **no-preference** | **off** | **reduce** | **none** |
| reduce | unset | reduce | none |
| **reduce** | **on** | **ok** | **spin** |
| reduce | off | reduce | none |

The two bold rows are the census's two defect directions, both now correct from the first frame. The browser-pane pass on this machine (whose OS is genuinely reduced-motion) independently confirmed the `reduce` column.

Steady-state screenshot follows in a comment once uploaded — pixels are unchanged by design; the whole change is temporal.

## Gates

Local gates green: lint, format, prose, typecheck, knip, css-orphans, app-layout, 732 unit tests. Changed paths (`src/app/routes/`, `src/app/styles/`, `src/app/widgets/`) are outside the renderer capture graph per the verified classification, so no manifest movement is expected; CI's publisher_release confirms.

## Follow-up, now landed

With #723 merged, the branch is rebased onto its merge and the `data-motion` release assertion has joined the unmount contract test in `AppRoot.test.tsx`, whose title widens to name both pieces of published document state.

Closes #722
