### PR TITLE
A typed /auth lands on sign-in instead of scaffolding copy

### DIFF
--- a/src/app/routes/_app/auth/index.tsx
+++ b/src/app/routes/_app/auth/index.tsx
@@ -1,34 +1,11 @@
-import { createFileRoute, Link } from '@tanstack/react-router';
-import { PageLayout } from '@ui/layout/PageLayout';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
+/*
+ * Nothing links here; the page it used to show was TanStack starter copy left over from
+ * scaffolding. A typed /auth lands on the real sign-in page instead of a 404.
+ */
 export const Route = createFileRoute('/_app/auth/')({
-  component: AuthLandingPage,
+  beforeLoad: () => {
+    throw redirect({ to: '/auth/login' });
+  },
 });
-
-function AuthLandingPage() {
-  return (
-    <PageLayout>
-      <PageLayout.Header>
-        <h1>
-          <span>TANSTACK</span> <span>AUTH</span>
-        </h1>
-      </PageLayout.Header>
-      <PageLayout.Content>
-        <p>The framework for next generation AI applications</p>
-        <p>
-          Full-stack framework powered by TanStack Router for React and Solid. Build modern applications with server
-          functions, streaming, and type safety.
-        </p>
-        <div>
-          <Link to="/auth/login">Sign in</Link>
-          <a href="https://tanstack.com/start" target="_blank" rel="noopener noreferrer">
-            Documentation
-          </a>
-          <p>
-            Begin your TanStack Start journey by editing <code>/src/routes/index.tsx</code>
-          </p>
-        </div>
-      </PageLayout.Content>
-    </PageLayout>
-  );
-}


### PR DESCRIPTION
Item 6 of [the composition wave](https://github.com/ndelangen/dunezone/issues/701): the auth landing at `/_app/auth/index.tsx` was TanStack starter boilerplate — the TANSTACK AUTH masthead, framework marketing copy, a 'begin your journey by editing' hint — live on the site for anyone who typed `/auth`. Repo-wide, nothing links to it (verified by grep across src and e2e; `/auth/login` is the real page every flow uses).

The route stays and redirects: a typed `/auth` now lands on the sign-in page instead of scaffolding copy or a 404. Net −23 lines.

## Proof

Real dev server on this branch. Before (main serving `/auth`) and after (`/auth` redirecting — the captured URL is `/auth/login`, h1 'Sign in'). Screenshots follow in a comment.

Redirect confirmed live: navigating to `http://localhost:3000/auth` settles at `http://localhost:3000/auth/login`.

## Gates

Local gates green: lint, format, prose, typecheck, knip, 732 unit tests. Changed path is `src/app/routes/`, outside the renderer capture graph; CI's publisher_release confirms.