### PR TITLE
A page with nothing to show wears one frame, and says which nothing it is

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -53,6 +53,10 @@ export default defineMain({
       titlePrefix: 'Widgets/Asset Face',
     },
     {
+      directory: '../src/app/widgets/page-message',
+      titlePrefix: 'Widgets/Page Message',
+    },
+    {
       directory: '../src/app/ui/block',
       titlePrefix: 'Blocks',
     },

--- a/src/app/routes/_app/assets/$type/$slug/index.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/index.tsx
@@ -16,8 +16,9 @@ import type { RulesetAssetSlot } from '@shared/rulesets/assetSlots';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { createFileRoute, Link, notFound } from '@tanstack/react-router';
 import { LoadError } from '@ui/block/LoadError';
+import { LoadPending } from '@ui/block/LoadPending';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import { OpenableTile } from '@ui/block/OpenableTile';
-import { PageTitle } from '@ui/block/PageTitle';
 import { Section } from '@ui/block/Section';
 import { formatRelativeDate } from '@ui/content/dates';
 import { ProfileLink } from '@ui/content/ProfileLink';
@@ -50,6 +51,7 @@ import { loadAssetPage, useAssetPage } from '@app/db/assets';
 import type { AssetPageData } from '@app/db/assets';
 import { isStaleClientData } from '@app/db/core/clientBoundary';
 import { AssetFace } from '@app/widgets/asset-face/AssetFace';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import { useAssetDeletion, useAssetGroupActions } from '../../-assetEditorStates';
 import { compositionTiles, DUPLICATED_TILE_CAP, omissionNote } from './-composition';
@@ -76,37 +78,31 @@ export const Route = createFileRoute('/_app/assets/$type/$slug/')({
 });
 
 /**
- * The frame this page wears before it has an asset: loading, absent, failed to load.
- * One component because all three are the same page with different words;
- * the three detail pages before this each repeat the markup two or three times.
+ * The words `PageMessage` wears on this route: the asset type's own name, and a way back to that type's browse page.
+ * A local component rather than a repeated prop because the type is a route param and every message on this page reads it.
+ * An unknown type still gets a frame, since the loader's `notFound` throw has to land somewhere.
  */
 function AssetDetailMessage({ children }: { children: ReactNode }) {
   const { type } = Route.useParams();
   const label = isAssetType(type) ? ASSET_TYPES[type].label : 'Assets';
   return (
-    <PageLayout>
-      <PageLayout.Header>
-        <Stack align="center" gap="xs">
-          <PageTitle title={label} />
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/assets/$type" params={{ type }} />}>
-            Back to {label.toLowerCase()}
-          </Anchor>
-        </Stack>
-      </PageLayout.Header>
-      <PageLayout.Content>{children}</PageLayout.Content>
-    </PageLayout>
+    <PageMessage
+      title={label}
+      back={
+        <PageMessage.Back to="/assets/$type" params={{ type }}>
+          Back to {label.toLowerCase()}
+        </PageMessage.Back>
+      }
+    >
+      {children}
+    </PageMessage>
   );
 }
 
 function AssetDetailPending() {
   return (
     <AssetDetailMessage>
-      <Surface padding="xl">
-        <Stack gap="xs">
-          <Title order={2}>Loading</Title>
-          <Text c="dimmed">This asset is still loading.</Text>
-        </Stack>
-      </Surface>
+      <LoadPending title="Loading">This asset is still loading.</LoadPending>
     </AssetDetailMessage>
   );
 }
@@ -477,15 +473,9 @@ function AssetDetailPage() {
   if (!page) {
     return (
       <AssetDetailMessage>
-        <Surface padding="xl">
-          <Stack gap="xs">
-            <Title order={2}>Asset not found</Title>
-            <Text c="dimmed">
-              This asset does not exist or was deleted. Renaming an asset re-slugs its URL, so an old link may have
-              moved.
-            </Text>
-          </Stack>
-        </Surface>
+        <NotAvailable title="Asset not found">
+          This asset does not exist or was deleted. Renaming an asset re-slugs its URL, so an old link may have moved.
+        </NotAvailable>
       </AssetDetailMessage>
     );
   }

--- a/src/app/routes/_app/factions/$factionId/index.tsx
+++ b/src/app/routes/_app/factions/$factionId/index.tsx
@@ -17,7 +17,7 @@ import {
 import { createFileRoute, Link } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { LoadError } from '@ui/block/LoadError';
-import { PageTitle } from '@ui/block/PageTitle';
+import { LoadPending } from '@ui/block/LoadPending';
 import { Section } from '@ui/block/Section';
 import { factionAssetPublishingCopy } from '@ui/content/assetPublishingStatus';
 import { complexityOutOfTen, complexityTier, effectiveComplexity } from '@ui/content/complexity';
@@ -39,6 +39,7 @@ import { loadFaction, useFaction } from '@db/factions';
 import type { FactionData } from '@db/factions';
 import { useGroupMembershipWorkflow } from '@db/members';
 import { isStaleClientData } from '@app/db/core/clientBoundary';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 import { LeaderToken } from '@game/assets/faction/leader/Leader';
 import { Token as FactionToken } from '@game/assets/faction/token/Token';
 import { TroopToken } from '@game/assets/faction/troop/Troop';
@@ -54,24 +55,13 @@ export const Route = createFileRoute('/_app/factions/$factionId/')({
   component: FactionDetailPage,
 });
 
+const backToFactions = <PageMessage.Back to="/factions">Back to factions</PageMessage.Back>;
+
 function FactionDetailPending() {
   return (
-    <PageLayout>
-      <PageLayout.Header>
-        <Stack align="center" gap="xs">
-          <PageTitle title="Faction" />
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>Back to factions</Anchor>
-        </Stack>
-      </PageLayout.Header>
-      <PageLayout.Content>
-        <Surface padding="xl">
-          <Stack gap="xs">
-            <Title order={2}>Loading faction</Title>
-            <Text c="dimmed">The faction details are still loading.</Text>
-          </Stack>
-        </Surface>
-      </PageLayout.Content>
-    </PageLayout>
+    <PageMessage title="Faction" back={backToFactions}>
+      <LoadPending title="Loading faction">The faction details are still loading.</LoadPending>
+    </PageMessage>
   );
 }
 
@@ -109,19 +99,11 @@ function FactionSidebarOverview({ data }: { data: FactionData }) {
 
 function FactionDetailError({ error }: ErrorComponentProps) {
   return (
-    <PageLayout>
-      <PageLayout.Header>
-        <Stack align="center" gap="xs">
-          <PageTitle title="Faction" />
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>Back to factions</Anchor>
-        </Stack>
-      </PageLayout.Header>
-      <PageLayout.Content>
-        <LoadError title="Faction could not be loaded" stale={isStaleClientData(error)}>
-          {error.message}
-        </LoadError>
-      </PageLayout.Content>
-    </PageLayout>
+    <PageMessage title="Faction" back={backToFactions}>
+      <LoadError title="Faction could not be loaded" stale={isStaleClientData(error)}>
+        {error.message}
+      </LoadError>
+    </PageMessage>
   );
 }
 
@@ -137,24 +119,7 @@ function FactionDetailPage() {
   const page = factionQuery.data;
 
   if (!page) {
-    return (
-      <PageLayout>
-        <PageLayout.Header>
-          <Stack align="center" gap="xs">
-            <PageTitle title="Faction" />
-            <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>Back to factions</Anchor>
-          </Stack>
-        </PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Stack gap="xs">
-              <Title order={2}>Loading faction</Title>
-              <Text c="dimmed">The faction details are still loading.</Text>
-            </Stack>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
-    );
+    return <FactionDetailPending />;
   }
 
   const { faction, viewerAccess, owner, assetPublishing, rulesets } = page;

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -7,7 +7,8 @@ import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { FactionCard } from '@ui/block/FactionCard';
 import { LoadError } from '@ui/block/LoadError';
-import { PageTitle } from '@ui/block/PageTitle';
+import { LoadPending } from '@ui/block/LoadPending';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import { ProposedContent } from '@ui/block/ProposedContent';
 import { Section } from '@ui/block/Section';
 import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
@@ -53,6 +54,7 @@ import {
 import { isStaleClientData } from '@app/db/core/clientBoundary';
 import { FactionPicker } from '@app/pickers/FactionPicker';
 import { resolveRouteNotice } from '@app/routes/-routeNotices';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import styles from '../RulesetDetail.module.css';
 
@@ -189,42 +191,23 @@ export const Route = createFileRoute('/_app/rulesets/$rulesetSlug/')({
   component: RulesetDetailPage,
 });
 
+const backToRulesets = <PageMessage.Back to="/rulesets">Back to rulesets</PageMessage.Back>;
+
 function RulesetDetailPending() {
   return (
-    <PageLayout>
-      <PageLayout.Header>
-        <Stack align="center" gap="xs">
-          <PageTitle title="Ruleset" />
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>Back to rulesets</Anchor>
-        </Stack>
-      </PageLayout.Header>
-      <PageLayout.Content>
-        <Surface padding="xl">
-          <Stack gap="xs">
-            <Title order={2}>Loading ruleset</Title>
-            <Text c="dimmed">The ruleset details are still loading.</Text>
-          </Stack>
-        </Surface>
-      </PageLayout.Content>
-    </PageLayout>
+    <PageMessage title="Ruleset" back={backToRulesets}>
+      <LoadPending title="Loading ruleset">The ruleset details are still loading.</LoadPending>
+    </PageMessage>
   );
 }
 
 function RulesetDetailError({ error }: ErrorComponentProps) {
   return (
-    <PageLayout>
-      <PageLayout.Header>
-        <Stack align="center" gap="xs">
-          <PageTitle title="Ruleset" />
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>Back to rulesets</Anchor>
-        </Stack>
-      </PageLayout.Header>
-      <PageLayout.Content>
-        <LoadError title="Ruleset could not be loaded" stale={isStaleClientData(error)}>
-          {error.message}
-        </LoadError>
-      </PageLayout.Content>
-    </PageLayout>
+    <PageMessage title="Ruleset" back={backToRulesets}>
+      <LoadError title="Ruleset could not be loaded" stale={isStaleClientData(error)}>
+        {error.message}
+      </LoadError>
+    </PageMessage>
   );
 }
 
@@ -245,22 +228,9 @@ function RulesetDetailPage() {
 
   if (loaderData.notFound || !page) {
     return (
-      <PageLayout>
-        <PageLayout.Header>
-          <Stack align="center" gap="xs">
-            <PageTitle title="Ruleset" />
-            <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>Back to rulesets</Anchor>
-          </Stack>
-        </PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Stack gap="xs">
-              <Title order={2}>Ruleset not found</Title>
-              <Text c="dimmed">This ruleset does not exist or was deleted.</Text>
-            </Stack>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Ruleset" back={backToRulesets}>
+        <NotAvailable title="Ruleset not found">This ruleset does not exist or was deleted.</NotAvailable>
+      </PageMessage>
     );
   }
 

--- a/src/app/ui/block/LoadPending.stories.tsx
+++ b/src/app/ui/block/LoadPending.stories.tsx
@@ -1,0 +1,12 @@
+import preview from '@sb/preview';
+
+import { LoadPending } from './LoadPending';
+
+const meta = preview.meta({
+  component: LoadPending,
+  parameters: { layout: 'padded' },
+  args: { title: 'Loading faction', children: 'The faction details are still loading.' },
+});
+
+/** A page waiting for its own subject. The heading names what is coming, the sentence says it is still on its way, and both are announced. */
+export const Pending = meta.story({});

--- a/src/app/ui/block/LoadPending.tsx
+++ b/src/app/ui/block/LoadPending.tsx
@@ -1,0 +1,29 @@
+import { Stack, Text, Title } from '@mantine/core';
+
+export interface LoadPendingProps {
+  /** What has not arrived, as the reader would say it, "Loading faction". */
+  title: string;
+  /** The second line, naming what is still on its way. */
+  children: string;
+}
+
+/**
+ * Says that a page's content has not arrived yet.
+ *
+ * `LoadError`'s sibling on the other side of the wait, and the same shape: words in, one arrangement out.
+ * What it owns beyond the arrangement is the announcement.
+ * The message is a `status` live region, so a reader who cannot see the page hears that it is loading instead of meeting silence, which is the part every hand-written copy of this left out.
+ *
+ * Both sentences are the caller's, because "Loading faction" and "The faction catalogue is still loading" are the page's words about its own subject;
+ * a component that supplied them would be guessing the noun.
+ *
+ * It exists because the heading-and-sentence pair was written out five times across four routes while five further routes said the same thing as a loose line with no heading and nothing announced, so whether a waiting reader was told anything at all depended on which page they had opened.
+ */
+export function LoadPending({ title, children }: LoadPendingProps) {
+  return (
+    <Stack gap="xs" role="status">
+      <Title order={2}>{title}</Title>
+      <Text c="dimmed">{children}</Text>
+    </Stack>
+  );
+}

--- a/src/app/ui/block/LoginGate.stories.tsx
+++ b/src/app/ui/block/LoginGate.stories.tsx
@@ -1,0 +1,12 @@
+import preview from '@sb/preview';
+
+import { LoginGate } from './LoginGate';
+
+const meta = preview.meta({
+  component: LoginGate,
+  parameters: { layout: 'padded' },
+  args: { action: 'create a faction' },
+});
+
+/** The offer a signed-out reader gets. The words after "Log in to" are the page's, so the sentence names the thing they came to do rather than signing in for its own sake. */
+export const Gated = meta.story({});

--- a/src/app/ui/block/LoginGate.tsx
+++ b/src/app/ui/block/LoginGate.tsx
@@ -1,0 +1,24 @@
+import { Anchor, Text } from '@mantine/core';
+import { Link } from '@tanstack/react-router';
+
+export interface LoginGateProps {
+  /** What signing in would let the reader do, as the tail of "Log in to ...": "create a faction", "start a group", "view migration activity". */
+  action: string;
+}
+
+/**
+ * Tells a signed-out reader that signing in is what stands between them and this page.
+ *
+ * The load state that is nobody's fault: the page works, the data is fine, and the reader is not the audience yet.
+ * Caller hands the verb phrase, since only the page knows what it is for;
+ * this owns the sentence around it and the one destination, which is allowed to be hardcoded here for the same reason `ProfileLink`'s is, that the destination is the component's name.
+ *
+ * It exists because nine routes wrote this sentence and three of them spelled the link as a themed anchor while six left it as the browser's default blue one, so the same offer looked like two different things depending on where you met it.
+ */
+export function LoginGate({ action }: LoginGateProps) {
+  return (
+    <Text>
+      <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to {action}.
+    </Text>
+  );
+}

--- a/src/app/ui/block/NotAvailable.stories.tsx
+++ b/src/app/ui/block/NotAvailable.stories.tsx
@@ -1,0 +1,20 @@
+import preview from '@sb/preview';
+
+import { NotAvailable } from './NotAvailable';
+
+const meta = preview.meta({
+  component: NotAvailable,
+  parameters: { layout: 'padded' },
+  args: { title: 'Ruleset not found', children: 'This ruleset does not exist or was deleted.' },
+});
+
+/** The thing is not there. The page deliberately does not distinguish "never existed" from "deleted", so a deleted row leaks nothing by its absence. */
+export const Absent = meta.story({});
+
+/** The thing is there and is not the reader's. The heading says what they cannot do, the sentence says who can. */
+export const NotYours = meta.story({
+  args: {
+    title: 'You cannot edit this ruleset',
+    children: 'Only the ruleset owner or an active member of its group can edit this ruleset.',
+  },
+});

--- a/src/app/ui/block/NotAvailable.tsx
+++ b/src/app/ui/block/NotAvailable.tsx
@@ -1,0 +1,29 @@
+import { Stack, Text, Title } from '@mantine/core';
+
+export interface NotAvailableProps {
+  /** What the reader does not get, in their words, "Ruleset not found" or "You cannot edit this ruleset". */
+  title: string;
+  /** Why not, in one sentence. */
+  children: string;
+}
+
+/**
+ * Says that a page has nothing to show, and why not.
+ *
+ * The third of the load states beside `LoadPending` and `LoadError`, covering both ways a page ends up empty on purpose: the thing is not there, or it is not the reader's.
+ * They are one component because they are one sentence to the reader and one arrangement on screen;
+ * the difference between "deleted" and "not yours" lives entirely in the words, which is why the words are the caller's.
+ *
+ * Unlike `LoadError` this announces nothing, and that is deliberate.
+ * Nothing failed and nothing is in flight, so the page has finished, with this as its content.
+ *
+ * It exists because nine of these sentences are spelled out across seven routes and only three carry a heading, one of them a raw `h2`, so on the rest a screen reader meets a loose sentence with no outline entry above it.
+ */
+export function NotAvailable({ title, children }: NotAvailableProps) {
+  return (
+    <Stack gap="xs">
+      <Title order={2}>{title}</Title>
+      <Text c="dimmed">{children}</Text>
+    </Stack>
+  );
+}

--- a/src/app/widgets/page-message/PageMessage.stories.tsx
+++ b/src/app/widgets/page-message/PageMessage.stories.tsx
@@ -1,0 +1,56 @@
+import preview from '@sb/preview';
+import { LoadError } from '@ui/block/LoadError';
+import { LoadPending } from '@ui/block/LoadPending';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
+
+import { PageMessage } from './PageMessage';
+
+const meta = preview.meta({
+  component: PageMessage,
+  parameters: { layout: 'fullscreen' },
+  args: {
+    title: 'Faction',
+    back: <PageMessage.Back to="/factions">Back to factions</PageMessage.Back>,
+    children: <LoadPending title="Loading faction">The faction details are still loading.</LoadPending>,
+  },
+});
+
+/** Waiting for the route's data. The band carries the name the loaded page will carry, so nothing moves when it arrives. */
+export const Loading = meta.story({});
+
+/** The slug resolves to nothing, or to something the reader may not open. */
+export const Absent = meta.story({
+  args: {
+    children: <NotAvailable title="Faction not found">This faction does not exist or was deleted.</NotAvailable>,
+  },
+});
+
+/** The load failed for its own reasons. The body brings its own alert colour and live region; the frame is unchanged. */
+export const Failed = meta.story({
+  args: {
+    children: (
+      <LoadError title="Faction could not be loaded" stale={false}>
+        Faction data could not be read.
+      </LoadError>
+    ),
+  },
+});
+
+/** A page that works and is not for this reader yet. The way back is still offered, since signing in is not the only thing they might want to do. */
+export const SignedOut = meta.story({
+  args: {
+    title: 'Create faction',
+    size: 'compact',
+    children: <LoginGate action="create a faction" />,
+  },
+});
+
+/** A catalogue at the top of its own branch has nowhere to send anyone back to, so it omits the way back rather than pointing at itself. */
+export const NoWayBack = meta.story({
+  args: {
+    title: 'Factions',
+    back: undefined,
+    children: <LoadPending title="Loading factions">The faction catalogue is still loading.</LoadPending>,
+  },
+});

--- a/src/app/widgets/page-message/PageMessage.tsx
+++ b/src/app/widgets/page-message/PageMessage.tsx
@@ -1,0 +1,57 @@
+import { Anchor, Stack } from '@mantine/core';
+import { createLink } from '@tanstack/react-router';
+import { PageTitle } from '@ui/block/PageTitle';
+import { PageLayout } from '@ui/layout/PageLayout';
+import type { PageHeaderSize } from '@ui/layout/PageLayout';
+import { Surface } from '@ui/surface';
+import { forwardRef } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+
+const BackAnchor = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(function BackAnchor(props, ref) {
+  return <Anchor ref={ref} {...props} />;
+});
+
+export interface PageMessageProps {
+  /** The page's own name, the same one it wears when it has its content: "Faction", "Ruleset", "Edit group". */
+  title: string;
+  /**
+   * The band this page would have had.
+   * Match the loaded page so the header does not resize under the reader the moment the data lands.
+   */
+  size?: PageHeaderSize;
+  /** The way out, as a `PageMessage.Back`. Omit it on a page that is already the top of its own branch. */
+  back?: ReactNode;
+  /** What the page has to say: `LoadPending`, `NotAvailable`, `LoadError`, `LoginGate`. */
+  children: ReactNode;
+}
+
+/**
+ * The page a route shows instead of its content: still loading, not there, not yours, not loaded, not signed in.
+ *
+ * All five are the same page with different words, so this owns everything that is not the words.
+ * The frame, the band and its name, the pane, and the way back out, which is the piece a reader most needs from a page that cannot show them what they came for and the piece hand-written copies most often left off.
+ * The words themselves are blocks the caller drops in, one per state, and that split is deliberate: an error body has a live region and a reload button that a pending body must not have, so the states cannot be one component with a mode.
+ *
+ * The message never says which state it is showing;
+ * the caller has already decided that by choosing which block to hand it.
+ *
+ * It exists because about seventeen sites framed these messages themselves, and the frames drifted apart while nobody was comparing them: some centred the header and some did not, some offered a way back inside the pane and some in a toolbar and some not at all, and the pane came at two paddings depending on which page you had reached.
+ */
+export function PageMessage({ title, size = 'default', back, children }: PageMessageProps) {
+  return (
+    <PageLayout>
+      <PageLayout.Header size={size}>
+        <Stack align="center" gap="xs">
+          <PageTitle title={title} />
+          {back}
+        </Stack>
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <Surface padding="xl">{children}</Surface>
+      </PageLayout.Content>
+    </PageLayout>
+  );
+}
+
+/** The way back out, taking the same route props as the router's own `Link`. Rendered as the themed anchor, in the band, wherever the message puts it. */
+PageMessage.Back = createLink(BackAnchor);


### PR DESCRIPTION
First slice of item 1 on [#701](https://github.com/ndelangen/dunezone/issues/701): the page-message widget, its bodies, and three routes adopting it. The frame and body split is the [constraint Norbert set on the ticket](https://github.com/ndelangen/dunezone/issues/701#issuecomment-5399892600) after #719, and the site inventory is finding 1 plus finding 3 of the route sweep (#631).

The remaining sites come in two follow-ups, so the shape gets reviewed before it is installed fourteen more times.

## What owns what

`PageMessage` owns everything that is not the words: the layout, the band and its name, the pane, and the way back. Four blocks own the words, one per state, and the caller picks which one to hand over. That is the whole membrane.

| | what it says | what it owns beyond the words |
|---|---|---|
| `LoadPending` | still loading | a `status` live region, so a reader who cannot see the page hears that it is loading |
| `NotAvailable` | not there, or not yours | nothing announced: nothing failed and nothing is in flight |
| `LoadError` (already existed) | failed to load | the alert colour, the live region, the stale-tab reload |
| `LoginGate` | not signed in | the sentence around the caller's verb phrase, and the one destination |

The way back is `PageMessage.Back`, a `createLink` over a themed `Anchor`. It is the same idiom `Links.Item` already uses, so the destination stays router-typed at the call site while the anchor treatment stays with the frame. Nine of the sites this replaces spelled that anchor as the browser's default blue one.

## Two calls worth arguing with

**Three bodies, not four.** Norbert's constraint names pending, not-found and login-gate as three kinds beside `LoadError`. Not-found and access-denied render identically and differ only in words, so I folded them into `NotAvailable` rather than ship two components answering one question. The sweep groups them the same way ("pending / error / not found / access denied"). I read "kinds" as reader-facing states rather than a component count, and if that reading is wrong the split is one file.

**The pane moved from the body to the frame.** `AssetDetailMessage`, the shape the ticket calls proven, does not paint; its pending child paints a `Surface` of its own. I inverted that, because only Surfaces paint, and a Block rendering its own `Surface` would be a Block painting a pane. `FormError`'s JSDoc is careful to justify painting only because its colour is content rather than a pane, which is the exception that fixes the rule.

That inversion is visible, and it is the one thing in this PR a reader would notice.

## The visible change

A `LoadError` inside a message frame used to float on the page background. It now sits on the pane the frame paints, like every other message body.

Measured on `/rulesets/dreamrules` against the worktree dev server, with the route's loader made to throw. Same server, same data, same viewport; only the route file differs between the rows.

| | holder of the alert | painted | alert width at 1280 | alert width at 375 | inset |
|---|---|---|---|---|---|
| before (`10b19d1ab24`) | `main` | no | 1200px | 351px | 0px |
| after | the frame's `Surface` | yes | 1134px | 285px | 33px |

Neither width overflows its viewport. The mobile row is the interesting one: at 375px the alert used to run to the content edge with no side gutter, and now it keeps the pane's 32px inset like the pending and absent bodies always did.

To see it rather than take my word: check out `10b19d1ab24`, add `throw new Error('x')` as the first line of the ruleset detail loader, and open `/rulesets/dreamrules`. Then do the same on this branch.

## Verified in the browser, not only in the gates

Dev server run from this worktree on 3207, confirmed serving this branch by its bytes rather than by which directory I thought it was in. Every state below was reached by typing a URL, except the pending row, which needs a client-side navigation and a slow loader because a cold load blocks before React mounts anything.

| state | route | outline | live region | way back | on a pane |
|---|---|---|---|---|---|
| absent | `/rulesets/there-is-no-such-ruleset` | `h1` Ruleset, `h2` Ruleset not found | none, correctly | Back to rulesets | yes |
| absent | `/assets/token-disc/there-is-no-such-token` | `h1` Disc tokens, `h2` Asset not found | none, correctly | Back to disc tokens | yes |
| failed | `/factions/there-is-no-such-faction` | `h1` Faction | `alert` | Back to factions | yes |
| pending | `/rulesets/dreamrules`, loader slowed | `h1` Ruleset, `h2` Loading ruleset | `status` | Back to rulesets | yes |

The asset row is worth reading twice: the per-type words work, so the frame says "Disc tokens" and offers "Back to disc tokens" rather than a generic label. The pending row's live region is new behaviour. Five routes wrote that heading and sentence by hand and none of them announced it.

## Adopted

Three routes, chosen to cover all four bodies between them rather than to be easy:

- `assets/$type/$slug/index.tsx` keeps its local `AssetDetailMessage`, which now supplies only the per-type words. That is the split working: the route knows the type, the widget knows the frame.
- `rulesets/$rulesetSlug/index.tsx`, all three frames.
- `factions/$factionId/index.tsx`, including the verbatim inline copy of its own pending component that #631 called out. It is now a call to that component.

No copy changed on any of them. The three routes lose 124 lines and gain 49. The four components and their stories cost 239, which the remaining fourteen sites are what pays back.

## Verified

Local gates: typecheck, lint, format:check, check:prose, check:app-layout, check:css-orphans, knip, 732 unit tests, 373 storybook tests (was 364; nine new stories).

`bun run check` reports "no capture-bundle changes since real-origin/main", so the renderer manifest is untouched and `publisher:release:verify` is not owed here. That is the repo's own classifier answering, not my reading of the path list.

CI has not run yet at the time of writing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent page messages for loading, unavailable, error, and signed-out states.
  - Added reusable loading, unavailable, and sign-in prompt components.
  - Updated asset, faction, and ruleset pages with clearer state messaging and navigation links.

- **Documentation**
  - Added Storybook examples for page messages and shared state components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->