### PR TITLE
The turning dice stay behind the header instead of drawing across it

### DIFF
--- a/src/app/styles/page.css
+++ b/src/app/styles/page.css
@@ -17,7 +17,11 @@ html[data-mantine-color-scheme="dark"] {
 html::after {
   content: "";
   position: fixed;
-  z-index: -1;
+  /* One step further back than the page's own content, which sits at -1: the band artwork and the
+     dice shared that level, so tree order decided, and generated content on `html` paints last.
+     The dice therefore drew across the header on any window short enough for the two to meet. At
+     -2 it stays what it is, a texture on the page background, and blends against that alone. */
+  z-index: -2;
   bottom: -40vh;
   left: 0;
   width: 100%;


### PR DESCRIPTION
Spotted by Norbert while reviewing #726: the turning dice draw across the header artwork.

## Why it happens

The dice are `html::after`, fixed to the viewport at `z-index: -1`. The band artwork is also `z-index: -1`, and `.band` is `position: relative` with `z-index: auto`, so it opens no stacking context of its own. Both therefore land in the root stacking context at the same level, where paint order falls to tree order, and generated content on `html` comes last. The dice win.

`z-index: -2` settles it without touching anything else. The dice are a texture on the page background, which is what -2 means here, and the blend now composites against that background alone rather than against whatever `-1` content happened to paint first.

## When it shows

Not on every window, which is why it survived this long. The band's height follows the content column rather than the viewport (`100cqw * 1125/3064`, and the column caps at 1200px), so the band bottom settles at about 478px on any wide window. The dice sit at 60vh to 120vh. They meet once the viewport is shorter than roughly 800px.

Reproduced at 1660x700 on `/rulesets`. At 1280x860 the page looks fine on both sides of this change, so a taller window is not evidence of anything.

## Verified

Same server, same page, same viewport, only `page.css` differing between the rows.

| | dice `z-index` | band artwork `z-index` | dice over the artwork |
|---|---|---|---|
| before | -1 | -1 | yes |
| after | -2 | -1 | no |

Checked in both schemes and at both band heights: `/rulesets` light, `/rulesets` dark, and `/rulesets/create` for the compact band. The dice still show below the band in all six, so this pushes them behind the header rather than turning them off.

Gates: lint, format:check, check:prose, check:css-orphans. No TypeScript and no stories touch this file, and `page.css` is not among the stylesheets Storybook's preview loads.

One line of CSS plus its reason. Separate from #726 because it has nothing to do with the page-message widget; it was simply visible in the same window.
