### PR TITLE
The FAQ tag fieldset stops being pasted between its two forms

### DIFF
--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.module.css
@@ -60,29 +60,6 @@
   color: var(--color-muted, #666);
 }
 
-.tagFieldset {
-  border: 0;
-  margin: 0;
-  padding: 0;
-}
-
-.tagOption {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.visuallyHidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .error {
   font-size: 0.9rem;
   color: var(--color-error, #c33);

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
@@ -1,9 +1,8 @@
-import { Group, Input, Stack, Textarea } from '@mantine/core';
-import { FAQ_TAG_VALUES } from '@shared/faq/tags';
+import { Group, Stack, Textarea } from '@mantine/core';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
-import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
+import { FaqTagFieldset } from '@ui/control/FaqTagFieldset';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
@@ -152,21 +151,10 @@ function FaqDetailPage() {
                     onChange={(e) => editingSession.setQuestionValue(e.target.value)}
                     rows={2}
                   />
-                  <Input.Wrapper label="Tags">
-                    <Stack component="fieldset" gap="xs" className={styles.tagFieldset}>
-                      <legend className={styles.visuallyHidden}>FAQ tags</legend>
-                      {FAQ_TAG_VALUES.map((tag) => (
-                        <label key={tag} className={styles.tagOption}>
-                          <input
-                            type="checkbox"
-                            checked={editing.tagValues.includes(tag)}
-                            onChange={(e) => editingSession.toggleTag(tag, e.target.checked)}
-                          />
-                          <span>{FAQ_TAG_LABELS[tag]}</span>
-                        </label>
-                      ))}
-                    </Stack>
-                  </Input.Wrapper>
+                  <FaqTagFieldset
+                    value={editing.tagValues}
+                    onToggle={(tag, checked) => editingSession.toggleTag(tag, checked)}
+                  />
                   <Group gap="xs" wrap="nowrap">
                     <IconAction
                       label="Save question"

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.module.css
@@ -1,26 +1,3 @@
-.tagFieldset {
-  border: 0;
-  margin: 0;
-  padding: 0;
-}
-
-.tagOption {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-2);
-}
-
-.visuallyHidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .error {
   font-size: 0.9rem;
   color: var(--color-error, #c33);

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
@@ -1,8 +1,7 @@
-import { Button, Group, Input, Stack, TextInput, Textarea } from '@mantine/core';
+import { Button, Group, Stack, TextInput, Textarea } from '@mantine/core';
 import type { FaqTag } from '@shared/faq/tags';
-import { FAQ_TAG_VALUES } from '@shared/faq/tags';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
-import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
+import { FaqTagFieldset } from '@ui/control/FaqTagFieldset';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
 
@@ -118,17 +117,7 @@ function FaqCreatePage() {
               rows={3}
               placeholder="Optional answer..."
             />
-            <Input.Wrapper label="Tags">
-              <Stack component="fieldset" gap="xs" className={styles.tagFieldset}>
-                <legend className={styles.visuallyHidden}>FAQ tags</legend>
-                {FAQ_TAG_VALUES.map((tag) => (
-                  <label key={tag} className={styles.tagOption}>
-                    <input type="checkbox" name="tags" value={tag} defaultChecked={tag === 'other'} />
-                    <span>{FAQ_TAG_LABELS[tag]}</span>
-                  </label>
-                ))}
-              </Stack>
-            </Input.Wrapper>
+            <FaqTagFieldset />
             <Group gap="xs" wrap="nowrap">
               <Button variant="filled" color="confirm" type="submit" disabled={askQuestion.isPending}>
                 {askQuestion.isPending ? 'Asking…' : 'Ask'}

--- a/src/app/ui/control/FaqTagFieldset.module.css
+++ b/src/app/ui/control/FaqTagFieldset.module.css
@@ -1,0 +1,11 @@
+.tagFieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+.tagOption {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}

--- a/src/app/ui/control/FaqTagFieldset.stories.tsx
+++ b/src/app/ui/control/FaqTagFieldset.stories.tsx
@@ -1,0 +1,21 @@
+import preview from '@sb/preview';
+import { fn } from 'storybook/test';
+
+import { FaqTagFieldset } from './FaqTagFieldset';
+
+const meta = preview.meta({
+  component: FaqTagFieldset,
+  parameters: { layout: 'centered' },
+  globals: { backgrounds: { value: 'light', grid: false } },
+});
+
+/** The ask form's shape: an uncontrolled form field named `tags`, with the default tag pre-checked. */
+export const Default = meta.story({});
+
+/** The edit session's shape: the caller owns the selection and hears every flip. */
+export const Controlled = meta.story({
+  args: {
+    value: ['rules', 'other'],
+    onToggle: fn(),
+  },
+});

--- a/src/app/ui/control/FaqTagFieldset.tsx
+++ b/src/app/ui/control/FaqTagFieldset.tsx
@@ -1,0 +1,50 @@
+import { Input, Stack, VisuallyHidden } from '@mantine/core';
+import type { FaqTag } from '@shared/faq/tags';
+import { DEFAULT_FAQ_TAG, FAQ_TAG_VALUES } from '@shared/faq/tags';
+import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
+
+import styles from './FaqTagFieldset.module.css';
+
+interface ControlledProps {
+  /** The checked tags. Providing it makes the fieldset controlled; `onToggle` comes with it. */
+  value: readonly FaqTag[];
+  /** Fires when a tag's checkbox flips. The caller owns the selection. */
+  onToggle: (tag: FaqTag, checked: boolean) => void;
+}
+
+interface UncontrolledProps {
+  value?: undefined;
+  onToggle?: undefined;
+}
+
+export type FaqTagFieldsetProps = ControlledProps | UncontrolledProps;
+
+/**
+ * The one vocabulary of FAQ tags, rendered identically wherever a question is tagged.
+ * Owns the labelled fieldset, the hidden legend, and the tag wording, so the ask form and the edit session cannot drift apart.
+ * Uncontrolled without props: the inputs are a form field named `tags` with the default tag pre-checked, read at submit time.
+ * Controlled with `value` and `onToggle`: the caller's editing session owns the selection.
+ */
+export function FaqTagFieldset(props: FaqTagFieldsetProps) {
+  return (
+    <Input.Wrapper label="Tags">
+      <Stack component="fieldset" gap="xs" className={styles.tagFieldset}>
+        <VisuallyHidden component="legend">FAQ tags</VisuallyHidden>
+        {FAQ_TAG_VALUES.map((tag) => (
+          <label key={tag} className={styles.tagOption}>
+            {props.value === undefined ? (
+              <input type="checkbox" name="tags" value={tag} defaultChecked={tag === DEFAULT_FAQ_TAG} />
+            ) : (
+              <input
+                type="checkbox"
+                checked={props.value.includes(tag)}
+                onChange={(event) => props.onToggle(tag, event.target.checked)}
+              />
+            )}
+            <span>{FAQ_TAG_LABELS[tag]}</span>
+          </label>
+        ))}
+      </Stack>
+    </Input.Wrapper>
+  );
+}


### PR DESCRIPTION
Item 4 of [the composition wave](https://github.com/ndelangen/dunezone/issues/701): the ask form (`faq/create.tsx`) and the edit session (`faq/$questionSlug.tsx`) carried the same labelled fieldset, hidden legend, and tag rendering verbatim, plus three CSS blocks duplicated across both route modules.

One kit control owns it now — `FaqTagFieldset` in `@ui/control` — with a two-shape contract enforced by a props union: **uncontrolled** without props (a form field named `tags`, default tag pre-checked, read at submit — the ask form's shape), **controlled** with `value`/`onToggle` (the edit session's shape). Two truths improved in passing: the pre-checked default now reads `DEFAULT_FAQ_TAG` instead of restating `'other'`, and the hidden legend uses the house Mantine `VisuallyHidden` idiom, retiring both hand-rolled copies of the class. No copy or rendered structure changed at either site.

## Proof

Both shapes verified in the rendered stories (Storybook, this branch), facts read from the DOM, not the picture:

| story | inputs | checked |
|---|---|---|
| Default (ask form) | six checkboxes, all `name="tags"` | Other only (the default tag) |
| Controlled (edit session) | six checkboxes, no name | Rules + Other, per args |

Legend "FAQ tags" present and visually hidden in both; labels render the vocabulary in order. Screenshots follow in a comment.

## Gates

Local gates green: lint, format, prose, typecheck, knip, css-orphans (64 stylesheets, no orphans), app-layout, 732 unit tests, 366 storybook tests (two new stories). Changed paths (`src/app/ui/`, `src/app/routes/`) are outside the renderer capture graph; CI's publisher_release confirms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a reusable FAQ tag selector with accessible checkbox options.
  - Supports preselected defaults and controlled editing of selected tags.
  - Applied consistent styling across FAQ creation and editing workflows.

- **Enhancements**
  - FAQ pages now share the same tag-selection experience.
  - Added component previews for default and controlled selection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->