### PR TITLE
The four editor pages say why you cannot edit, in the frame everything else uses

### DIFF
--- a/src/app/routes/_app/factions/$factionId/edit.tsx
+++ b/src/app/routes/_app/factions/$factionId/edit.tsx
@@ -1,13 +1,14 @@
-import { Alert, Anchor, Stack, Text } from '@mantine/core';
+import { Alert, Stack, Text } from '@mantine/core';
 import { isRouteNoticeCode } from '@shared/routeNotices';
 import type { RouteNoticeCode } from '@shared/routeNotices';
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
-import { PageTitle } from '@ui/block/PageTitle';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { LoadPending } from '@ui/block/LoadPending';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import { factionAuthoringStatusMessage } from '@ui/content/assetPublishingStatus';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
-import { Surface } from '@ui/surface';
 import { UserRoundMinus } from 'lucide-react';
 import { useRef, useState } from 'react';
 
@@ -23,6 +24,7 @@ import type { FactionAuthoringViewHandle } from '@app/widgets/faction-editor/Fac
 import { FactionGroupPopover } from '@app/widgets/faction-editor/FactionGroupPopover';
 import { FactionLoadPopover } from '@app/widgets/faction-editor/FactionLoadPopover';
 import { useFactionAuthoring } from '@app/widgets/faction-editor/useFactionAuthoring';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import { useFactionNameField } from '../-factionNameField';
 
@@ -78,67 +80,39 @@ function FactionEditPage() {
   const { nameField, conflictWarnings } = useFactionNameField({ currentSlug: faction.slug });
   const allWarnings = [...authoring.editing.warnings, ...conflictWarnings];
   const validationHeaderOpen = useValidationHeaderOpen(allWarnings.length, settleTick);
-  const header = (
-    <Stack align="center" gap={4}>
-      <Anchor
-        size="sm"
-        renderRoot={(rootProps) => <Link {...rootProps} to="/factions/$factionId" params={{ factionId }} />}
-      >
-        View faction
-      </Anchor>
-      <PageTitle title={faction ? `Edit ${faction.data.name}` : 'Edit faction'} />
-      <Text c="dimmed">Changes stay local until you explicitly save them.</Text>
-    </Stack>
+  const backToFaction = (
+    <PageMessage.Back to="/factions/$factionId" params={{ factionId }}>
+      Back to faction
+    </PageMessage.Back>
   );
 
   if (viewerAccess?.viewer.kind === 'anonymous') {
+    /* The name stays conditional here, as it was in the old header: this guard runs before the one
+       below that answers whether there is a faction at all, so the title cannot assume one. */
     return (
-      <PageLayout>
-        <PageLayout.Header size="compact">{header}</PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Stack gap="sm">
-              <Text>
-                <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to edit
-                factions.
-              </Text>
-              <Anchor
-                renderRoot={(rootProps) => <Link {...rootProps} to="/factions/$factionId" params={{ factionId }} />}
-              >
-                Back to faction
-              </Anchor>
-            </Stack>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage size="compact" title={faction ? `Edit ${faction.data.name}` : 'Edit faction'} back={backToFaction}>
+        <LoginGate action="edit factions" />
+      </PageMessage>
     );
   }
 
   if (!faction) {
     return (
-      <PageLayout>
-        <PageLayout.Header size="compact">{header}</PageLayout.Header>
-        <PageLayout.Content>
-          <Text>Loading faction…</Text>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage size="compact" title="Edit faction" back={backToFaction}>
+        <LoadPending title="Loading faction">The faction is still loading.</LoadPending>
+      </PageMessage>
     );
   }
 
   if (!viewerAccess?.capabilities.edit) {
     return (
-      <PageLayout>
-        <PageLayout.Header size="compact">{header}</PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Text>
-              {faction.group_id
-                ? 'Only the faction owner or an active member of its group can edit this faction.'
-                : 'Only the faction owner can edit this faction.'}
-            </Text>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage size="compact" title={`Edit ${faction.data.name}`} back={backToFaction}>
+        <NotAvailable title="You cannot edit this faction">
+          {faction.group_id
+            ? 'Only the faction owner or an active member of its group can edit this faction.'
+            : 'Only the faction owner can edit this faction.'}
+        </NotAvailable>
+      </PageMessage>
     );
   }
 

--- a/src/app/routes/_app/factions/$factionId/edit.tsx
+++ b/src/app/routes/_app/factions/$factionId/edit.tsx
@@ -1,7 +1,9 @@
 import { Alert, Stack, Text } from '@mantine/core';
 import { isRouteNoticeCode } from '@shared/routeNotices';
 import type { RouteNoticeCode } from '@shared/routeNotices';
+import type { ErrorComponentProps } from '@tanstack/react-router';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { LoadError } from '@ui/block/LoadError';
 import { LoadPending } from '@ui/block/LoadPending';
 import { LoginGate } from '@ui/block/LoginGate';
 import { NotAvailable } from '@ui/block/NotAvailable';
@@ -14,6 +16,7 @@ import { useRef, useState } from 'react';
 
 import { useDeleteFaction, useFaction, useSetFactionGroup, useUpdateFaction } from '@db/factions';
 import { loadFaction } from '@db/factions';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
 import { resolveRouteNotice } from '@app/routes/-routeNotices';
 import { AuthoringToolbar } from '@app/widgets/authoring/AuthoringToolbar';
 import { useValidationHeaderOpen } from '@app/widgets/authoring/useValidationHeaderOpen';
@@ -36,8 +39,27 @@ export const Route = createFileRoute('/_app/factions/$factionId/edit')({
     return {};
   },
   loader: async ({ params }) => await loadFaction(params.factionId),
+  errorComponent: FactionEditError,
   component: FactionEditPage,
 });
+
+/**
+ * The frame for a load that failed, which on this route is most often a slug that names no faction: the query throws rather than returning nothing, so the component's own absent branch never runs.
+ * Without this the reader met the router's unstyled default and, in development, a stack trace.
+ */
+function FactionEditError({ error }: ErrorComponentProps) {
+  return (
+    <PageMessage
+      size="compact"
+      title="Edit faction"
+      back={<PageMessage.Back to="/factions">Back to factions</PageMessage.Back>}
+    >
+      <LoadError title="Faction could not be loaded" stale={isStaleClientData(error)}>
+        {error.message}
+      </LoadError>
+    </PageMessage>
+  );
+}
 
 const VALIDATION_HEADER_ID = 'faction-validation-header';
 

--- a/src/app/routes/_app/groups/$groupSlug/edit.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/edit.tsx
@@ -2,6 +2,8 @@ import { Group, Stack, TextInput } from '@mantine/core';
 import { groupInputSchema } from '@shared/groups/validation';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import { PageTitle } from '@ui/block/PageTitle';
 import { SlugRenameNotice } from '@ui/content/SlugRenameNotice';
 import { IconAction } from '@ui/control/IconAction';
@@ -14,6 +16,7 @@ import { useState } from 'react';
 
 import { loadGroupEditBySlug, useGroupEditBySlug, useUpdateGroup } from '@db/groups';
 import type { GroupEntry } from '@db/groups';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 function GroupSettings({ initial }: { initial: GroupEntry }) {
   const navigate = useNavigate();
@@ -97,19 +100,9 @@ function GroupEditPage() {
   const editPage = groupData.data;
   if (groupData.isError || !editPage) {
     return (
-      <PageLayout>
-        <PageLayout.Header>
-          <PageTitle title="Edit group" />
-        </PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="lg">
-            <p>Group not found.</p>
-            <p>
-              <Link to="/profiles">Back to profiles</Link>
-            </p>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Edit group" back={<PageMessage.Back to="/profiles">Back to profiles</PageMessage.Back>}>
+        <NotAvailable title="Group not found">This group does not exist or was deleted.</NotAvailable>
+      </PageMessage>
     );
   }
 
@@ -143,43 +136,27 @@ function GroupEditPage() {
     </Toolbar>
   );
 
+  /* Back to the group rather than to profiles, which is the more useful of the two destinations the
+     toolbar carried: a reader who cannot edit this group can still read it. */
+  const guardBack = (
+    <PageMessage.Back to="/groups/$groupSlug" params={{ groupSlug: group.slug }}>
+      Back to group
+    </PageMessage.Back>
+  );
+
   if (viewerAccess.viewer.kind === 'anonymous') {
     return (
-      <PageLayout>
-        <PageLayout.Header>{header}</PageLayout.Header>
-        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
-        <PageLayout.Content>
-          <Surface padding="lg">
-            <p>
-              <Link to="/auth/login">Log in</Link> to edit group settings.
-            </p>
-            <p>
-              <Link to="/groups/$groupSlug" params={{ groupSlug: group.slug }}>
-                Back to group
-              </Link>
-            </p>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title={`Edit ${group.name}`} back={guardBack}>
+        <LoginGate action="edit group settings" />
+      </PageMessage>
     );
   }
 
   if (!viewerAccess.capabilities.rename) {
     return (
-      <PageLayout>
-        <PageLayout.Header>{header}</PageLayout.Header>
-        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
-        <PageLayout.Content>
-          <Surface padding="lg">
-            <p>Only the owner can edit the group settings.</p>
-            <p>
-              <Link to="/groups/$groupSlug" params={{ groupSlug: group.slug }}>
-                Back to group
-              </Link>
-            </p>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title={`Edit ${group.name}`} back={guardBack}>
+        <NotAvailable title="You cannot edit this group">Only the owner can edit the group settings.</NotAvailable>
+      </PageMessage>
     );
   }
 

--- a/src/app/routes/_app/groups/$groupSlug/edit.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/edit.tsx
@@ -1,7 +1,9 @@
 import { Group, Stack, TextInput } from '@mantine/core';
 import { groupInputSchema } from '@shared/groups/validation';
+import type { ErrorComponentProps } from '@tanstack/react-router';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
+import { LoadError } from '@ui/block/LoadError';
 import { LoginGate } from '@ui/block/LoginGate';
 import { NotAvailable } from '@ui/block/NotAvailable';
 import { PageTitle } from '@ui/block/PageTitle';
@@ -16,6 +18,7 @@ import { useState } from 'react';
 
 import { loadGroupEditBySlug, useGroupEditBySlug, useUpdateGroup } from '@db/groups';
 import type { GroupEntry } from '@db/groups';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
 import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 function GroupSettings({ initial }: { initial: GroupEntry }) {
@@ -89,8 +92,23 @@ export const Route = createFileRoute('/_app/groups/$groupSlug/edit')({
     const groupEdit = await loadGroupEditBySlug(params.groupSlug);
     return { groupEdit };
   },
+  errorComponent: GroupEditError,
   component: GroupEditPage,
 });
+
+/**
+ * The frame for a load that failed, which on this route is most often a slug that names no group: the query throws rather than returning nothing, so the component's own absent branch never runs.
+ * Without this the reader met the router's unstyled default and, in development, a stack trace.
+ */
+function GroupEditError({ error }: ErrorComponentProps) {
+  return (
+    <PageMessage title="Edit group" back={<PageMessage.Back to="/profiles">Back to profiles</PageMessage.Back>}>
+      <LoadError title="Group could not be loaded" stale={isStaleClientData(error)}>
+        {error.message}
+      </LoadError>
+    </PageMessage>
+  );
+}
 
 function GroupEditPage() {
   const { groupSlug } = Route.useParams();

--- a/src/app/routes/_app/profiles/$profileSlug/edit.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/edit.tsx
@@ -2,12 +2,13 @@ import { Box, Button, Center, Image, SegmentedControl, Select, Stack, Text, Text
 import { profileSlugBaseFromName, profileUserEditFormSchema } from '@shared/profiles/validation';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import { SlugRenameNotice } from '@ui/content/SlugRenameNotice';
 import { ControlBlock } from '@ui/control/ControlBlock';
 import { IconAction } from '@ui/control/IconAction';
 import { SubmitAction } from '@ui/control/SubmitAction';
 import { PageLayout } from '@ui/layout/PageLayout';
-import { Surface } from '@ui/surface';
 import { ConnectedTabs } from '@ui/surface/ConnectedTabs';
 import { Toolbar } from '@ui/surface/Toolbar';
 import { ArrowLeft, CircleUserRound, Palette, Save, Trash2, User, UsersRound } from 'lucide-react';
@@ -19,6 +20,7 @@ import { setSchemePreference, useSchemePreference } from '@app/styles/colorSchem
 import type { SchemePreference } from '@app/styles/colorScheme';
 import { setMotionOverride, useMotionPreference } from '@app/styles/motion';
 import type { MotionPreference } from '@app/styles/motion';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 type ProfileTab = 'profile' | 'defaults' | 'appearance' | 'account';
 type LoadedAvatarPreview = { url: string; status: 'ready' | 'unavailable' };
@@ -445,32 +447,26 @@ function ProfileSettingsPage() {
 
   if (!profile.data) {
     return (
-      <PageLayout>
-        <PageLayout.Content>
-          <Surface padding="lg">
-            <p>
-              <Link to="/auth/login">Log in</Link> to edit your profile.
-            </p>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Profile settings" back={<PageMessage.Back to="/profiles">Back to profiles</PageMessage.Back>}>
+        <LoginGate action="edit your profile" />
+      </PageMessage>
     );
   }
 
   if (profile.data.slug !== profileSlug) {
+    /* The way out is the reader's own settings rather than a step backwards: they asked for this
+       page and there is a version of it that is theirs. */
     return (
-      <PageLayout>
-        <PageLayout.Content>
-          <Surface padding="lg">
-            <p>You can only edit your own profile.</p>
-            <p>
-              <Link to="/profiles/$profileSlug/edit" params={{ profileSlug: profile.data.slug }}>
-                Go to your profile settings
-              </Link>
-            </p>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage
+        title="Profile settings"
+        back={
+          <PageMessage.Back to="/profiles/$profileSlug/edit" params={{ profileSlug: profile.data.slug }}>
+            Go to your profile settings
+          </PageMessage.Back>
+        }
+      >
+        <NotAvailable title="This is not your profile">You can only edit your own profile.</NotAvailable>
+      </PageMessage>
     );
   }
 

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
@@ -4,6 +4,9 @@ import type { RulesetAssetSlot } from '@shared/rulesets/assetSlots';
 import { rulesetAboutSchema } from '@shared/rulesets/validation';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
+import { LoadPending } from '@ui/block/LoadPending';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import { rulesetAboutHint } from '@ui/content/rulesetAboutHint';
 import { SlugRenameNotice } from '@ui/content/SlugRenameNotice';
 import { IconAction } from '@ui/control/IconAction';
@@ -22,6 +25,7 @@ import {
 } from '@db/rulesets';
 import type { RulesetEntry } from '@db/rulesets';
 import { AssetPicker } from '@app/pickers/AssetPicker';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import styles from './edit.module.css';
 
@@ -145,14 +149,67 @@ function RulesetEditPage() {
   const pageQuery = useRulesetDetailPage(rulesetSlug, { initialData: detailSeed });
   const page = pageQuery.data;
 
-  const header = page?.ruleset ? (
+  /* One condition, because the loader's verdict and a missing row are the same page to the reader.
+     They were two identical blocks before, which is how they stayed identical. */
+  if (loaderData.notFound || !page?.ruleset) {
+    return (
+      <PageMessage title="Edit ruleset" back={<PageMessage.Back to="/rulesets">Back to rulesets</PageMessage.Back>}>
+        <NotAvailable title="Ruleset not found">This ruleset does not exist or was deleted.</NotAvailable>
+      </PageMessage>
+    );
+  }
+
+  const r = page.ruleset;
+  const viewerAccess = page.viewerAccess;
+  /* The ruleset's name rather than the identity band it wears when loaded: a message page says what
+     it is about in words, and the band with its cover art belongs to the page that has something to
+     edit. The way back points at the ruleset itself, which is the more useful of the two
+     destinations the toolbar offered. */
+  const guardBack = (
+    <PageMessage.Back to="/rulesets/$rulesetSlug" params={{ rulesetSlug: r.slug }}>
+      Back to ruleset
+    </PageMessage.Back>
+  );
+
+  if (!viewerAccess) {
+    return (
+      <PageMessage title={`Edit ${r.name}`} back={guardBack}>
+        <LoadPending title="Loading your profile">Checking what you may change here.</LoadPending>
+      </PageMessage>
+    );
+  }
+
+  if (viewerAccess.viewer.kind === 'anonymous') {
+    return (
+      <PageMessage title={`Edit ${r.name}`} back={guardBack}>
+        <LoginGate action="edit this ruleset" />
+      </PageMessage>
+    );
+  }
+
+  if (!viewerAccess.capabilities.edit) {
+    return (
+      <PageMessage title={`Edit ${r.name}`} back={guardBack}>
+        <NotAvailable title="You cannot edit this ruleset">
+          {r.group_id
+            ? 'Only the ruleset owner or an active member of its group can edit this ruleset.'
+            : 'Only the ruleset owner can edit this ruleset.'}
+        </NotAvailable>
+      </PageMessage>
+    );
+  }
+
+  /* Built here rather than above the guards: every path that lacked a ruleset now returns a
+     `PageMessage` before this point, so the band and the toolbar no longer need a shape for the
+     case where there is nothing to name. The band itself is unchanged, and stays #451's to revisit. */
+  const header = (
     <Group wrap="nowrap" align="center" gap="lg" className={styles.pageHead}>
       <Surface>
-        {page?.ruleset.image_cover ? (
+        {r.image_cover ? (
           <Image
-            src={page?.ruleset.image_cover}
+            src={r.image_cover}
             fallbackSrc="/image/background/card-large.jpg"
-            alt={`Cover for ${page?.ruleset.name}`}
+            alt={`Cover for ${r.name}`}
             className={styles.coverImage}
           />
         ) : (
@@ -165,12 +222,10 @@ function RulesetEditPage() {
       </Surface>
       <Stack gap={6} className={styles.pageHeadText}>
         <Title order={1} className={styles.rulesetTitle}>
-          Edit {page?.ruleset.name}
+          Edit {r.name}
         </Title>
       </Stack>
     </Group>
-  ) : (
-    <Title order={1}>Edit ruleset</Title>
   );
   const toolbar = (
     <Surface padding="sm">
@@ -183,105 +238,19 @@ function RulesetEditPage() {
           renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}
           icon={<ArrowLeft size={17} aria-hidden />}
         />
-        {page?.ruleset ? (
-          <IconAction
-            label="View ruleset"
-            variant="light"
-            color="gray"
-            size="lg"
-            renderRoot={(rootProps) => (
-              <Link
-                {...rootProps}
-                to="/rulesets/$rulesetSlug"
-                params={{ rulesetSlug: page?.ruleset?.slug ?? rulesetSlug }}
-              />
-            )}
-            icon={<BookOpen size={17} aria-hidden />}
-          />
-        ) : null}
+        <IconAction
+          label="View ruleset"
+          variant="light"
+          color="gray"
+          size="lg"
+          renderRoot={(rootProps) => (
+            <Link {...rootProps} to="/rulesets/$rulesetSlug" params={{ rulesetSlug: r.slug }} />
+          )}
+          icon={<BookOpen size={17} aria-hidden />}
+        />
       </Group>
     </Surface>
   );
-
-  if (loaderData.notFound) {
-    return (
-      <PageLayout>
-        <PageLayout.Header>{header}</PageLayout.Header>
-        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Text>Ruleset not found.</Text>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
-    );
-  }
-
-  if (!page?.ruleset) {
-    return (
-      <PageLayout>
-        <PageLayout.Header>{header}</PageLayout.Header>
-        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Text>Ruleset not found.</Text>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
-    );
-  }
-
-  const r = page.ruleset;
-  const viewerAccess = page.viewerAccess;
-
-  if (!viewerAccess) {
-    return (
-      <PageLayout>
-        <PageLayout.Header>{header}</PageLayout.Header>
-        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Text>Loading profile…</Text>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
-    );
-  }
-
-  if (viewerAccess.viewer.kind === 'anonymous') {
-    return (
-      <PageLayout>
-        <PageLayout.Header>{header}</PageLayout.Header>
-        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Text>
-              <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to edit this
-              ruleset.
-            </Text>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
-    );
-  }
-
-  if (!viewerAccess.capabilities.edit) {
-    return (
-      <PageLayout>
-        <PageLayout.Header>{header}</PageLayout.Header>
-        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Text>
-              {r.group_id
-                ? 'Only the ruleset owner or an active member of its group can edit this ruleset.'
-                : 'Only the ruleset owner can edit this ruleset.'}
-            </Text>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
-    );
-  }
 
   return (
     <PageLayout>


### PR DESCRIPTION
Second slice of item 1 on [#701](https://github.com/ndelangen/dunezone/issues/701), on the shape merged in #726: the pane belongs to the frame, and the bodies are blocks beside `LoadError`.

Eleven guard frames across the four editor routes. The remaining five sites, all one-line login gates on create pages, follow in the last slice.

## What changed on each route

| route | frames | becomes |
|---|---|---|
| `rulesets/$rulesetSlug/edit` | absent ×2, profile loading, signed out, denied | four frames, since the two absent branches were identical and are now one condition |
| `factions/$factionId/edit` | signed out, loading, denied | three frames |
| `groups/$groupSlug/edit` | absent, signed out, denied | three frames |
| `profiles/$profileSlug/edit` | signed out, not yours | two frames |

Every denied state gains a heading it did not have, so a screen reader meets an outline entry rather than a loose sentence. The two profile guards gain a page title, having previously rendered no `h1` at all.

**One way back per frame, replacing a toolbar of two icon-only buttons.** Where a guard carried a toolbar, its back arrow and its view-the-entity icon become a single named link, and the destination chosen is the entity rather than the step backwards: a reader who cannot edit a ruleset can usually still read it. That is a real trade, two affordances for one, and the one that remains is a named link rather than an unlabelled glyph.

**The identity band stays #451's.** Where a guard wore the band, the frame now carries the same name as its title. A message page says what it is about in words; the band with its cover art belongs to the page that has something to edit.

## A live defect on main, fixed here

`/groups/<bad-slug>/edit` and `/factions/<bad-slug>/edit` render a raw stack trace today.

Both loaders throw when the slug names nothing, rather than returning a null the component could check, so the component's own absent branch never runs. Neither route defined an `errorComponent`, so TanStack's unstyled default caught it and printed the Convex error into the page.

Verified on main rather than inferred: check out `e6b4fca925a`, run the dev server, and open either URL.

Each route now answers with the same frame everything else uses and the `LoadError` body, which is the case #719 added that block for. The reader still sees the server's own sentence, exactly as on the five routes #700 covered; what they no longer see is a stack trace under a broken header.

This rides with the slice rather than travelling separately because it is the same shape adoption in the same two files. Happy to cherry-pick it out if you would rather review it alone.

## Something worth knowing that this PR only half-fixes

On main, the ruleset editor's identity band renders its cover image **overflowing the band**, spilling outside the header and squeezing the title into a three-line wrap. It is visible in the before shot below at 1280x860.

The guard frames no longer show that band, so this slice removes it from the states it touches. The loaded editor page composes the same band and I could not reach it, since it needs a signed-in owner. So: this is not fixed, it is merely no longer on the pages I converted, and it belongs to #451 along with the rest of that band. Flagging it rather than letting the before/after imply a fix I did not make.

## Proof

Anonymous, against the worktree dev server. Every row is a URL a signed-out reader can type; nothing is staged, which is why no filename says so. Each "before" is a detached `real-origin/main` checkout on the same server and port, so only the checkout differs.

| state | route | `h1` before → after | way back before → after |
|---|---|---|---|
| signed out | `/rulesets/dreamrules/edit` | Edit Dreamrules → Edit Dreamrules | two icon buttons → "Back to ruleset" |
| absent | `/rulesets/nope/edit` | Edit ruleset → Edit ruleset, plus an `h2` | two icon buttons → "Back to rulesets" |
| signed out | `/factions/spacing-guild/edit` | Edit Spacing Guild → unchanged | "Back to faction" → unchanged |
| absent | `/factions/nope/edit` | **none, stack trace** → Edit faction | none → "Back to factions" |
| signed out | `/groups/testgroup/edit` | Edit testgroup → unchanged | "Back to group" → unchanged |
| absent | `/groups/nope/edit` | **none, stack trace** → Edit group | none → "Back to profiles" |
| signed out | `/profiles/central/edit` | **none at all** → Profile settings | none → "Back to profiles" |

Every frame sits on the frame's pane, and none overflows its viewport at 1280x860.

**Not covered, and worth stating plainly.** The three denied frames need a signed-in reader who is not the owner, and the two pending frames need a slow answer from the profile query. I reached neither, so five of the eleven frames are verified by types and gates only. They are the frames whose bodies (`NotAvailable`, `LoadPending`) are already exercised by the states above on other routes.

Images follow in a comment.

## Verified

Local gates: typecheck, lint, format:check, check:prose, check:app-layout, check:css-orphans, knip, 732 unit tests, 375 storybook tests. `bun run check` reports no capture-bundle changes, so the renderer manifest is untouched.

No e2e spec asserts on any copy this changes; I grepped the ten specs for the changed sentences and confirmed the grep was against real files rather than an empty directory.
