### PR TITLE
The five remaining login gates say it the same way

### DIFF
--- a/src/app/routes/_app/admin/migrations.tsx
+++ b/src/app/routes/_app/admin/migrations.tsx
@@ -1,5 +1,6 @@
 import { Group, Stack } from '@mantine/core';
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
 import { PageTitle } from '@ui/block/PageTitle';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -8,6 +9,7 @@ import { RefreshCw } from 'lucide-react';
 
 import { loadAdminMigrationDashboard, useAdminMigrationDashboard, useSyncMigrationRuns } from '@db/migrations';
 import { useCurrentProfile } from '@db/profiles';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 export const Route = createFileRoute('/_app/admin/migrations')({
   loader: async () => ({ dashboard: await loadAdminMigrationDashboard() }),
@@ -30,18 +32,14 @@ function AdminMigrationsPage() {
   const dashboard = dashboardQuery.data;
   const syncRuns = useSyncMigrationRuns();
 
+  /* The one gate with no way back, because this route has no parent in the navigation and today's
+     version offers none either. Where an admin page sends a signed-out reader is a question about
+     admin navigation rather than about this frame, so it is left as it was rather than invented. */
   if (!profile.data?._id) {
     return (
-      <PageLayout>
-        <PageLayout.Header>{migrationsHeader}</PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="lg">
-            <p>
-              <Link to="/auth/login">Log in</Link> to view migration activity.
-            </p>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Migration activity">
+        <LoginGate action="view migration activity" />
+      </PageMessage>
     );
   }
 

--- a/src/app/routes/_app/factions/create.tsx
+++ b/src/app/routes/_app/factions/create.tsx
@@ -1,10 +1,10 @@
 import { Anchor, Stack, Text } from '@mantine/core';
 import type { RouteNoticeCode } from '@shared/routeNotices';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
 import { PageTitle } from '@ui/block/PageTitle';
 import { factionAuthoringStatusMessage } from '@ui/content/assetPublishingStatus';
 import { PageLayout } from '@ui/layout/PageLayout';
-import { Surface } from '@ui/surface';
 import { useRef, useState } from 'react';
 
 import { useCreateFaction } from '@db/factions';
@@ -18,6 +18,7 @@ import { FactionEditor } from '@app/widgets/faction-editor/FactionEditor';
 import type { FactionAuthoringViewHandle } from '@app/widgets/faction-editor/FactionEditor';
 import { FactionLoadPopover } from '@app/widgets/faction-editor/FactionLoadPopover';
 import { useFactionAuthoring } from '@app/widgets/faction-editor/useFactionAuthoring';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import { useFactionNameField } from './-factionNameField';
 
@@ -73,20 +74,13 @@ function CreateFactionPage() {
 
   if (!ownerUserId) {
     return (
-      <PageLayout>
-        <PageLayout.Header size="compact">{header}</PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Stack gap="sm">
-              <Text>
-                <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to create a
-                faction.
-              </Text>
-              <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>Back to factions</Anchor>
-            </Stack>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage
+        size="compact"
+        title="Create faction"
+        back={<PageMessage.Back to="/factions">Back to factions</PageMessage.Back>}
+      >
+        <LoginGate action="create a faction" />
+      </PageMessage>
     );
   }
 

--- a/src/app/routes/_app/groups/create.tsx
+++ b/src/app/routes/_app/groups/create.tsx
@@ -1,5 +1,6 @@
 import { Group, Stack, TextInput } from '@mantine/core';
-import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
 import { PageTitle } from '@ui/block/PageTitle';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -10,6 +11,7 @@ import { useState } from 'react';
 
 import { useCreateGroup } from '@db/groups';
 import { useCurrentProfile } from '@db/profiles';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 export const Route = createFileRoute('/_app/groups/create')({
   component: GroupCreatePage,
@@ -27,19 +29,9 @@ function GroupCreatePage() {
 
   if (!profile.data?._id || !profile.data.slug) {
     return (
-      <PageLayout>
-        <PageLayout.Header>{groupCreateHeader}</PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="lg">
-            <p>
-              <Link to="/auth/login">Log in</Link> to start a group.
-            </p>
-            <p>
-              <Link to="/profiles">Back to profiles</Link>
-            </p>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Start group" back={<PageMessage.Back to="/profiles">Back to profiles</PageMessage.Back>}>
+        <LoginGate action="start a group" />
+      </PageMessage>
     );
   }
 

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
@@ -1,6 +1,8 @@
 import { Button, Group, Stack, TextInput, Textarea } from '@mantine/core';
 import type { FaqTag } from '@shared/faq/tags';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { LoadPending } from '@ui/block/LoadPending';
+import { LoginGate } from '@ui/block/LoginGate';
 import { FaqTagFieldset } from '@ui/control/FaqTagFieldset';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
@@ -8,6 +10,7 @@ import { Surface } from '@ui/surface';
 import { useAskFaqQuestion } from '@db/faq';
 import { useCurrentProfile } from '@db/profiles';
 import { loadRulesetBySlug, useRulesetBySlug } from '@db/rulesets';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import styles from './create.module.css';
 
@@ -39,28 +42,29 @@ function FaqCreatePage() {
     </div>
   );
 
+  /* Only this page's message frames move to `PageMessage`. The loaded page keeps its hand-rolled
+     `h1` header, which is a separate item of the same wave (#701 item 5, the FAQ pages' raw
+     elements), so for now the two states spell the same words two ways. */
+  const backToRuleset = (
+    <PageMessage.Back to="/rulesets/$rulesetSlug" params={{ rulesetSlug }}>
+      Back to ruleset
+    </PageMessage.Back>
+  );
+
   if (!rulesetRow) {
     return (
-      <PageLayout>
-        <PageLayout.Header>{header}</PageLayout.Header>
-        <PageLayout.Content>Loading ruleset…</PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Ask a question" back={backToRuleset}>
+        <LoadPending title="Loading ruleset">The ruleset this question belongs to is still loading.</LoadPending>
+      </PageMessage>
     );
   }
   const rulesetId = rulesetRow._id;
 
   if (!profile?.data?._id) {
     return (
-      <PageLayout>
-        <PageLayout.Header>{header}</PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="lg">
-            <p>
-              <Link to="/auth/login">Log in</Link> to ask a question.
-            </p>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Ask a question" back={backToRuleset}>
+        <LoginGate action="ask a question" />
+      </PageMessage>
     );
   }
 

--- a/src/app/routes/_app/rulesets/create.tsx
+++ b/src/app/routes/_app/rulesets/create.tsx
@@ -2,6 +2,7 @@ import { Button, Group, Stack, Textarea, TextInput } from '@mantine/core';
 import { rulesetAboutSchema } from '@shared/rulesets/validation';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
+import { LoginGate } from '@ui/block/LoginGate';
 import { PageTitle } from '@ui/block/PageTitle';
 import { rulesetAboutHint } from '@ui/content/rulesetAboutHint';
 import { IconAction } from '@ui/control/IconAction';
@@ -13,6 +14,7 @@ import { useState } from 'react';
 
 import { useCurrentProfile } from '@db/profiles';
 import { useCreateRuleset } from '@db/rulesets';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 export const Route = createFileRoute('/_app/rulesets/create')({
   component: CreateRulesetPage,
@@ -92,6 +94,17 @@ function CreateRulesetForm() {
 function CreateRulesetPage() {
   const profile = useCurrentProfile();
 
+  /* An early return rather than a branch inside the content, which is what the other four gates
+     always were: a page that cannot be used is a different page, not this one with its form
+     swapped out for a sentence. The toolbar goes with it, since the frame carries the way back. */
+  if (!profile.data?.user_id) {
+    return (
+      <PageMessage title="Create ruleset" back={<PageMessage.Back to="/rulesets">Back to rulesets</PageMessage.Back>}>
+        <LoginGate action="create a ruleset" />
+      </PageMessage>
+    );
+  }
+
   return (
     <PageLayout>
       <PageLayout.Header>
@@ -112,20 +125,9 @@ function CreateRulesetPage() {
         </Toolbar>
       </PageLayout.Toolbar>
       <PageLayout.Content>
-        {!profile.data?.user_id ? (
-          <Surface padding="lg">
-            <p>
-              <Link to="/auth/login">Log in</Link> to create a ruleset.
-            </p>
-            <p>
-              <Link to="/rulesets">Back to rulesets</Link>
-            </p>
-          </Surface>
-        ) : (
-          <Surface padding="lg">
-            <CreateRulesetForm />
-          </Surface>
-        )}
+        <Surface padding="lg">
+          <CreateRulesetForm />
+        </Surface>
       </PageLayout.Content>
     </PageLayout>
   );


### PR DESCRIPTION
Third slice of item 1 on [#701](https://github.com/ndelangen/dunezone/issues/701), and the last of the login gates. Five sites, one shape.

With this, all nine gates the route sweep counted use `LoginGate`, and the assets feature's own shared frame was already there.

## The drift, measured

Four of the five rendered the login link as the browser's default blue rather than the themed anchor. That is not a judgement about which looks better; it is the same offer looking like two different things depending on which page you reached.

| gate | link colour before | after |
|---|---|---|
| `/factions/create` | `rgb(248, 175, 64)` | unchanged |
| `/groups/create` | `rgb(158, 158, 255)` | `rgb(248, 175, 64)` |
| `/rulesets/create` | `rgb(158, 158, 255)` | `rgb(248, 175, 64)` |
| `/rulesets/$slug/faq/create` | `rgb(158, 158, 255)` | `rgb(248, 175, 64)` |
| `/admin/migrations` | `rgb(158, 158, 255)` | `rgb(248, 175, 64)` |

Read against `LoginGate`'s own JSDoc, which claims three of nine sites were themed and six were not: those three are the faction create and the two editor gates that landed in #726 and #730, so the claim holds across the whole set rather than just this slice.

## Three per-site calls

**`/rulesets/create` becomes an early return.** Its gate was a ternary inside the content, so the page kept its toolbar and swapped the form for a sentence. A page that cannot be used is a different page, not this one with a hole in it, and the toolbar's lone back arrow is what the frame's way back replaces.

**`/admin/migrations` keeps having no way back.** The route has no parent in the navigation and today's version offers none, so the frame omits it rather than inventing a destination. Where an admin page should send a signed-out reader is a question about admin navigation, and I would rather leave it visible than answer it here. It is the one row in the table below with `ABSENT` on both sides.

**The FAQ create page gets only its two message frames.** Its loaded state still renders a hand-rolled `h1` inside `PageLayout.Header`, which is item 5 of this wave rather than item 1. So for now that page spells the same words two ways depending on whether you are signed in. Flagging it because it is a mid-state I am knowingly leaving, not one I missed.

## Proof

Signed out, at 1280x860, against the worktree dev server. Nothing is staged: all five are URLs anyone can type while logged out, which is the point of the slice. Each "before" is a detached `real-origin/main` checkout at `b5e246bdfe0` on the same server and port.

| gate | `h1` | sentence | way back |
|---|---|---|---|
| `/factions/create` | Create faction | Log in to create a faction. | Back to factions |
| `/groups/create` | Start group | Log in to start a group. | Back to profiles |
| `/rulesets/create` | Create ruleset | Log in to create a ruleset. | Back to rulesets |
| `/rulesets/dreamrules/faq/create` | Ask a question | Log in to ask a question. | Back to ruleset |
| `/admin/migrations` | Migration activity | Log in to view migration activity. | absent, as above |

Every frame sits on the frame's pane and none overflows its viewport. All five states are verified in a browser; unlike #730 there is nothing here I could not reach.

Images follow in a comment.

## Verified

Local gates: typecheck, lint, format:check, check:prose, check:app-layout, check:css-orphans, knip, 732 unit tests, 375 storybook tests. `bun run check` reports no capture-bundle changes.

Rebased onto `b5e246bdfe0` after #730 merged, and the gates were re-run on the rebased tree rather than the pre-rebase one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UX Improvements**
  * Standardized signed-out states across migrations, faction creation, group creation, and ruleset pages.
  * Added consistent login prompts and back navigation using shared page messaging.
  * Improved FAQ creation feedback with dedicated loading and authentication states.
  * Simplified ruleset creation access flow for signed-out visitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->