### PR TITLE
The last four message frames join the rest, and three more crashes land on a page

### DIFF
--- a/src/app/routes/_app/factions/index.tsx
+++ b/src/app/routes/_app/factions/index.tsx
@@ -4,7 +4,6 @@ import {
   Drawer,
   Group,
   InputBase,
-  Loader,
   Popover,
   RangeSlider,
   Select,
@@ -17,6 +16,7 @@ import { Link, createFileRoute } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { FactionCatalogueSpotlight } from '@ui/block/FactionCatalogueSpotlight';
 import { LoadError } from '@ui/block/LoadError';
+import { LoadPending } from '@ui/block/LoadPending';
 import { PageTitle } from '@ui/block/PageTitle';
 import { complexityTierSliderMarks } from '@ui/content/ComplexityGlyph';
 import { formatFactionCatalogueDate } from '@ui/content/dates';
@@ -33,6 +33,7 @@ import type { KeyboardEvent } from 'react';
 import { loadFactionCataloguePage, useFactionCataloguePage } from '@db/factions';
 import type { FactionCatalogueEntry, FactionCataloguePageData, FactionRulesetSummary } from '@db/factions';
 import { isStaleClientData } from '@app/db/core/clientBoundary';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import {
   complexityRangeSearchValue,
@@ -103,37 +104,30 @@ function FactionsPage() {
   );
 }
 
+/*
+ * No way back on either frame: the catalogue is the top of its own branch, so a link here would
+ * point at the page the reader is already on.
+ *
+ * These two states lose the catalogue header's eyebrow, its description and its create-a-faction
+ * call to action, which the frame does not carry. That is the one place in this slice where the
+ * shared frame costs a reader something they could have used, and it is a deliberate trade for one
+ * spelling of "still loading" and one of "did not load" across the tree.
+ */
 function FactionCataloguePending() {
   return (
-    <PageLayout>
-      <PageLayout.Header>
-        <CatalogueHeader />
-      </PageLayout.Header>
-      <PageLayout.Content>
-        <Surface padding="xl">
-          <Stack align="center" gap="sm">
-            <Loader size="sm" />
-            <Title order={2}>Loading factions</Title>
-            <Text c="dimmed">The faction catalogue is still loading.</Text>
-          </Stack>
-        </Surface>
-      </PageLayout.Content>
-    </PageLayout>
+    <PageMessage title="Faction catalogue">
+      <LoadPending title="Loading factions">The faction catalogue is still loading.</LoadPending>
+    </PageMessage>
   );
 }
 
 function FactionCatalogueError({ error }: ErrorComponentProps) {
   return (
-    <PageLayout>
-      <PageLayout.Header>
-        <CatalogueHeader />
-      </PageLayout.Header>
-      <PageLayout.Content>
-        <LoadError title="Faction catalogue could not be loaded" stale={isStaleClientData(error)}>
-          {error.message}
-        </LoadError>
-      </PageLayout.Content>
-    </PageLayout>
+    <PageMessage title="Faction catalogue">
+      <LoadError title="Faction catalogue could not be loaded" stale={isStaleClientData(error)}>
+        {error.message}
+      </LoadError>
+    </PageMessage>
   );
 }
 

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -1,5 +1,8 @@
-import { Alert, Anchor, Avatar, Badge, Box, Button, Divider, Group, Skeleton, Stack, Text } from '@mantine/core';
+import { Alert, Anchor, Avatar, Badge, Box, Button, Divider, Group, Stack, Text } from '@mantine/core';
+import type { ErrorComponentProps } from '@tanstack/react-router';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { LoadError } from '@ui/block/LoadError';
+import { LoadPending } from '@ui/block/LoadPending';
 import { PageTitle } from '@ui/block/PageTitle';
 import { formatRelativeDate } from '@ui/content/dates';
 import { ProfileLink } from '@ui/content/ProfileLink';
@@ -7,7 +10,6 @@ import { AssignPopover } from '@ui/control/AssignPopover';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
-import { Surface } from '@ui/surface';
 import { Card } from '@ui/surface/Card';
 import { Toolbar } from '@ui/surface/Toolbar';
 import { ArrowLeft, BookOpen, Check, Crown, Pencil, Plus, UserPlus, UserRoundMinus, UsersRound, X } from 'lucide-react';
@@ -21,8 +23,10 @@ import type { GroupDetailPageData, MembershipState } from '@db/groups';
 import { useGroupMembershipWorkflow } from '@db/members';
 import { useSetRulesetGroup } from '@db/rulesets';
 import type { RulesetEntry } from '@db/rulesets';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
 import { OwnedFactionAssignPicker, OwnedRulesetAssignPicker } from '@app/pickers/GroupAssignPicker';
 import type { OwnedAssignItem } from '@app/pickers/GroupAssignPicker';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import styles from './index.module.css';
 
@@ -33,8 +37,25 @@ export const Route = createFileRoute('/_app/groups/$groupSlug/')({
     const groupDetail = await loadGroupDetailBySlug(params.groupSlug);
     return { groupDetail };
   },
+  errorComponent: GroupDetailError,
   component: GroupDetailPage,
 });
+
+const backToProfiles = <PageMessage.Back to="/profiles">Back to profiles</PageMessage.Back>;
+
+/**
+ * The frame for a load that failed, most often a slug naming no group.
+ * The page used to carry its own `groupData.isError` branch for this, which could never run: `toLiveQueryResult` reports `isError: false` for every query, so the failure went past it to the router's unstyled default.
+ */
+function GroupDetailError({ error }: ErrorComponentProps) {
+  return (
+    <PageMessage title="Group" back={backToProfiles}>
+      <LoadError title="Group could not be loaded" stale={isStaleClientData(error)}>
+        {error.message}
+      </LoadError>
+    </PageMessage>
+  );
+}
 
 function GroupDetailPage() {
   const { groupSlug } = Route.useParams();
@@ -46,43 +67,16 @@ function GroupDetailPage() {
   const setFactionGroup = useSetFactionGroup();
   const setRulesetGroup = useSetRulesetGroup();
 
-  if (groupData.isError) {
-    return (
-      <PageLayout>
-        <PageLayout.Header>
-          <PageTitle title="Group" />
-        </PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Alert color="red" title="Group could not be loaded" role="alert">
-              <Text size="sm">This group may have been deleted, or the link may be incorrect.</Text>
-            </Alert>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
-    );
-  }
-
+  /* The failed case is the route's `errorComponent` now, since the branch that used to sit here
+     could not run. What is left is the wait, which every other page in the tree spells this way:
+     the skeleton grid was the only one of its kind and announced nothing to a reader who cannot
+     see it. */
   const page = groupData.data;
   if (!page) {
     return (
-      <PageLayout>
-        <PageLayout.Header>
-          <PageTitle title="Group" />
-        </PageLayout.Header>
-        <PageLayout.Content>
-          <Box className={styles.twoColumnGrid}>
-            <Stack gap="lg">
-              <Skeleton height={140} radius="md" />
-              <Skeleton height={140} radius="md" />
-            </Stack>
-            <Stack gap="lg">
-              <Skeleton height={160} radius="md" />
-              <Skeleton height={160} radius="md" />
-            </Stack>
-          </Box>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Group" back={backToProfiles}>
+        <LoadPending title="Loading group">The group details are still loading.</LoadPending>
+      </PageMessage>
     );
   }
 

--- a/src/app/routes/_app/profiles/$profileSlug/index.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/index.tsx
@@ -1,7 +1,9 @@
 import { useAuthActions } from '@convex-dev/auth/react';
 import { Group, Stack, Text } from '@mantine/core';
+import type { ErrorComponentProps } from '@tanstack/react-router';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
-import { PageTitle } from '@ui/block/PageTitle';
+import { LoadError } from '@ui/block/LoadError';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import { ProposedContent } from '@ui/block/ProposedContent';
 import { Section } from '@ui/block/Section';
 import { formatRelativeDate } from '@ui/content/dates';
@@ -32,6 +34,8 @@ import {
 
 import type { ProfilePageData } from '@db/profiles';
 import { loadProfileBySlug, useCurrentProfile, useProfileBySlug } from '@db/profiles';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import styles from '../ProfileDetail.module.css';
 
@@ -40,8 +44,25 @@ export const Route = createFileRoute('/_app/profiles/$profileSlug/')({
     const profilePage = await loadProfileBySlug(params.profileSlug);
     return { profilePage };
   },
+  errorComponent: ProfileDetailError,
   component: ProfileDetailPage,
 });
+
+const backToProfiles = <PageMessage.Back to="/profiles">Back to profiles</PageMessage.Back>;
+
+/**
+ * The frame for a load that failed, most often a slug naming no profile.
+ * The loader throws rather than returning nothing, so the component's absent branch below never sees that case and the reader met the router's unstyled default instead.
+ */
+function ProfileDetailError({ error }: ErrorComponentProps) {
+  return (
+    <PageMessage title="Profile" back={backToProfiles}>
+      <LoadError title="Profile could not be loaded" stale={isStaleClientData(error)}>
+        {error.message}
+      </LoadError>
+    </PageMessage>
+  );
+}
 
 type FaqQuestionAsked = ProfilePageData['faqAsked'][number];
 type FaqAnswerGiven = ProfilePageData['faqAnswers'][number];
@@ -184,19 +205,9 @@ function ProfileDetailPage() {
 
   if (!page) {
     return (
-      <PageLayout>
-        <PageLayout.Header>
-          <PageTitle title="Profile" />
-        </PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="lg">
-            <p>Profile not found.</p>
-            <p>
-              <Link to="/profiles">Back to profiles</Link>
-            </p>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Profile" back={backToProfiles}>
+        <NotAvailable title="Profile not found">This profile does not exist or was deleted.</NotAvailable>
+      </PageMessage>
     );
   }
 

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
@@ -1,5 +1,9 @@
 import { Group, Stack, Textarea } from '@mantine/core';
+import type { ErrorComponentProps } from '@tanstack/react-router';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { LoadError } from '@ui/block/LoadError';
+import { LoadPending } from '@ui/block/LoadPending';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { FaqTagFieldset } from '@ui/control/FaqTagFieldset';
@@ -10,6 +14,8 @@ import { Check, MessageSquarePlus, Pencil, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { loadFaqQuestionPage, useFaqQuestionPage } from '@db/faq';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import styles from './$questionSlug.module.css';
 import { INITIAL_FAQ_EDITING_STATE, createFaqEditingSession } from './-faqEditingSession';
@@ -27,10 +33,65 @@ export const Route = createFileRoute('/_app/rulesets/$rulesetSlug/faq/$questionS
       return { notFound: true };
     }
   },
+  errorComponent: FaqDetailError,
   component: FaqDetailPage,
 });
 
+/**
+ * The frame for a load that failed.
+ * Unlike its siblings this route's loader already catches, returning `notFound`;
+ * what escapes is the live query, which throws after mount when the question is not there, so the reader met the router's unstyled default with a page half-built behind it.
+ */
+function FaqDetailError({ error }: ErrorComponentProps) {
+  const { rulesetSlug } = Route.useParams();
+  return (
+    <PageMessage
+      title="FAQ"
+      back={
+        <PageMessage.Back to="/rulesets/$rulesetSlug" params={{ rulesetSlug }}>
+          Back to ruleset
+        </PageMessage.Back>
+      }
+    >
+      <LoadError title="This question could not be loaded" stale={isStaleClientData(error)}>
+        {error.message}
+      </LoadError>
+    </PageMessage>
+  );
+}
+
+/**
+ * The absent case, decided before anything subscribes.
+ *
+ * It has to live above the body: the question page's hook calls `useQuery` unconditionally, and a
+ * Convex query for a question that is not there throws while rendering, which the route's
+ * `errorComponent` would catch before any guard further down the body could run.
+ * So the guard that was written inside the body could never fire, and a missing question read as a failed load.
+ * `AssetDetailPage` splits for the same reason: a guard that must run before a subscription cannot share a component with it.
+ */
 function FaqDetailPage() {
+  const { rulesetSlug } = Route.useParams();
+  const loaderData = Route.useLoaderData();
+
+  if (loaderData?.notFound) {
+    return (
+      <PageMessage
+        title="FAQ"
+        back={
+          <PageMessage.Back to="/rulesets/$rulesetSlug" params={{ rulesetSlug }}>
+            Back to ruleset
+          </PageMessage.Back>
+        }
+      >
+        <NotAvailable title="Question not found">This FAQ question does not exist in this ruleset.</NotAvailable>
+      </PageMessage>
+    );
+  }
+
+  return <LoadedFaqQuestion />;
+}
+
+function LoadedFaqQuestion() {
   const { rulesetSlug, questionSlug } = Route.useParams();
   const loaderData = Route.useLoaderData();
   const navigate = useNavigate();
@@ -94,26 +155,21 @@ function FaqDetailPage() {
     return () => window.removeEventListener('hashchange', scrollToHash);
   }, [item, answers]);
 
-  if (loaderData?.notFound) {
-    return (
-      <PageLayout>
-        <PageLayout.Header>{header}</PageLayout.Header>
-        <PageLayout.Content>
-          <Surface padding="lg">
-            <h2>Question not found</h2>
-            <p>This FAQ question does not exist in this ruleset.</p>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
-    );
-  }
-
+  /* Only the message frames move here. The loaded page keeps its hand-rolled `h1` header, which is
+     item 5 of this wave rather than item 1, so the two states spell the same words two ways until
+     that lands. */
   if (!item) {
     return (
-      <PageLayout>
-        <PageLayout.Header>{header}</PageLayout.Header>
-        <PageLayout.Content>Loading question…</PageLayout.Content>
-      </PageLayout>
+      <PageMessage
+        title="FAQ"
+        back={
+          <PageMessage.Back to="/rulesets/$rulesetSlug" params={{ rulesetSlug }}>
+            Back to ruleset
+          </PageMessage.Back>
+        }
+      >
+        <LoadPending title="Loading question">This question and its answers are still loading.</LoadPending>
+      </PageMessage>
     );
   }
 


### PR DESCRIPTION
Last slice of item 1 on [#701](https://github.com/ndelangen/dunezone/issues/701). Groups detail, profiles detail, the faction catalogue and the FAQ question page.

With this, every site the route sweep counted under finding 1 wears the shared frame, and finding 3's nine login gates all use `LoginGate`.

## A class defect, five routes, two causes, one fix

Three more routes render the router's error overlay for a slug that names nothing:

- `/groups/there-is-no-such-group`
- `/profiles/there-is-no-such-profile`
- `/rulesets/dreamrules/faq/there-is-no-such-question`

With the editor pair fixed in #730, that is five routes in this wave. Verified on main at `b5e246bdfe0` rather than inferred: open any of those three and you get a stack trace where a page should be.

Two causes. Groups detail and profiles detail throw from their loaders, like the editor pair. The FAQ route's loader already catches and returns `notFound`; what throws is its live query, after mount. An `errorComponent` answers both, because a route's catch boundary covers render as well as load.

**A guard that could not fire.** The FAQ page's not-found frame was written inside the component body, below a hook that calls `useQuery` unconditionally. A missing question therefore threw during the same render that would have shown the frame, so a question that does not exist read as a question that failed to load. The guard now sits in a thin route component above the subscription, and the body it used to share moved into `LoadedFaqQuestion`. `AssetDetailPage` splits for exactly this reason and says so in its own comment.

**A branch that could never run.** Groups detail carried its own `groupData.isError` frame. `toLiveQueryResult` reports `isError: false` for every query, so that branch was unreachable, which is why the page crashed instead of showing it. It is deleted rather than converted. The seam itself is [#732](https://github.com/ndelangen/dunezone/issues/732), which holds the wire-it-or-strike-it decision; deleting this consumer and the half-dead one in groups edit is what makes the strike option a pure type narrowing.

## Two deliberate losses

**The groups detail skeleton grid.** Four grey boxes in a two-column layout, the only skeletons in the tree, replaced by the same "Loading group" every other page shows. Skeletons preserve layout and read as fast; this one also announced nothing to a reader who cannot see it, and was a second spelling of a state the wave exists to spell once. If you would rather keep skeletons, the right move is a kit block for them and adoption everywhere, not one page keeping its own.

**The faction catalogue's header on its two frames.** They lose the eyebrow, the description and the create-a-faction call to action, since the frame carries a title and a way back and nothing else. On the pending frame that is a transient loss; on the error frame the call to action was arguably wrong anyway. This is the one place in three slices where the shared frame costs a reader something they could have used, and I would rather you weighed it than discovered it.

## Proof

Signed out, at 1280x860, against the worktree dev server. Every row is a typeable URL. Each "before" is a detached `real-origin/main` checkout at `b5e246bdfe0` on the same server and port.

| route | before | after |
|---|---|---|
| `/groups/nope` | stack trace, no `h1`, no way out | `h1` Group, alert body, Back to profiles |
| `/profiles/nope` | stack trace, no `h1`, no way out | `h1` Profile, alert body, Back to profiles |
| `/rulesets/dreamrules/faq/nope` | stack trace, no `h1`, no way out | `h1` FAQ, `h2` Question not found, Back to ruleset |
| `/factions` | loads normally | unchanged |

The FAQ row is the one worth reading twice. Before the guard moved it showed the alert body, meaning it had reached the `errorComponent`; after the split it shows "Question not found" with no live region, which is the not-found body doing its job. Both states are correct pages, but only the second tells the reader the truth.

Images follow in a comment.

## On the commit shape

One commit rather than a frames commit and a fixes commit. Two of these files carry both concerns, and the error component introduces the back-link constant the converted frames use, so neither half compiles alone. I would rather say that than offer a split that does not build.

## Verified

Local gates: typecheck, lint, format:check, check:prose, check:app-layout, check:css-orphans, knip, 732 unit tests, 375 storybook tests. `bun run check` reports no capture-bundle changes.
