### PR TITLE
Live queries leave failures to route boundaries

### DIFF
--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -39,9 +39,10 @@ export function useFaction(slug: string, options?: { initialData?: FactionDetail
 ```
 
 `toLiveQueryResult` exists to keep call sites uniform: it returns
-`{ data, isPending, isLoading, isError, error }`, falling back to `initialData` while the
-subscription is still undefined. `isError` is always `false`, because a failed Convex subscription
-throws to the route's error boundary rather than resolving into a result object.
+`{ data, isPending, isLoading }`, falling back to `initialData` while the subscription is still
+undefined. A failed Convex subscription throws to the route's `errorComponent` rather than
+resolving into a result object. The route handles the failure there instead of carrying a second,
+unreachable error branch in its component.
 
 **Example**: [`src/app/db/factions.ts`](../src/app/db/factions.ts)
 

--- a/src/app/db/core/live.ts
+++ b/src/app/db/core/live.ts
@@ -12,8 +12,6 @@ export type LiveQueryResult<TData> = {
   data: TData | undefined;
   isPending: boolean;
   isLoading: boolean;
-  isError: boolean;
-  error: Error | null;
 };
 
 export type LiveMutationResult<TVariables, TResult> = {
@@ -36,8 +34,6 @@ export function toLiveQueryResult<TData>(
     data,
     isPending: enabled && liveData === undefined,
     isLoading: enabled && liveData === undefined,
-    isError: false,
-    error: null,
   };
 }
 

--- a/src/app/routes/_app/groups/$groupSlug/edit.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/edit.tsx
@@ -116,7 +116,7 @@ function GroupEditPage() {
   const groupData = useGroupEditBySlug(groupSlug, { initialData: loaderData.groupEdit });
 
   const editPage = groupData.data;
-  if (groupData.isError || !editPage) {
+  if (!editPage) {
     return (
       <PageMessage title="Edit group" back={<PageMessage.Back to="/profiles">Back to profiles</PageMessage.Back>}>
         <NotAvailable title="Group not found">This group does not exist or was deleted.</NotAvailable>

--- a/src/app/routes/_app/groups/$groupSlug/index.tsx
+++ b/src/app/routes/_app/groups/$groupSlug/index.tsx
@@ -45,7 +45,7 @@ const backToProfiles = <PageMessage.Back to="/profiles">Back to profiles</PageMe
 
 /**
  * The frame for a load that failed, most often a slug naming no group.
- * The page used to carry its own `groupData.isError` branch for this, which could never run: `toLiveQueryResult` reports `isError: false` for every query, so the failure went past it to the router's unstyled default.
+ * A failed Convex query throws to this route boundary, so the live-query result has no separate error state.
  */
 function GroupDetailError({ error }: ErrorComponentProps) {
   return (


### PR DESCRIPTION
## What changed

- Remove the `isError` and `error` fields that every live query returned as `false` and `null`.
- Remove the remaining dead group-edit check.
- Document one query-failure path: Convex throws to the route's `errorComponent`.
- Leave mutation error state unchanged.

The prerequisite composition slice is already on main through #733.

## Visual proof

Both images use the same ready query input. The base commit returns five fields, including an error channel that can never fire. This branch returns three fields and makes `query.isError` a TypeScript error.

| Before at `618c02a581b` | After at `b27760b40e3` |
|---|---|
| ![Before: the live query result includes isError false and error null](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-735-live-query-result-before.png) | ![After: the live query result contains only data, isPending, and isLoading](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-735-live-query-result-after.png) |

This change deliberately leaves the rendered route error frame alone. Failed Convex queries still reach the route `errorComponent`. The change removes the false result-level alternative.

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:prose`
- `bun run check:app-layout`
- `bun run check:css-orphans`
- `bun run test` (728 tests)
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:release:verify`

The shared hosted development database was not used.

Closes #732


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified live query results to expose only loading and data states.
  * Updated group pages to display “Group not found” appropriately when group data is unavailable.
  * Failed subscriptions now use the route’s error component for error handling.

* **Documentation**
  * Updated state-management guidance to reflect the revised live query and error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
