### PR TITLE
The formatted-text control explains invalid drafts

### DIFF
--- a/src/app/ui/control/FormattedTextInput.stories.tsx
+++ b/src/app/ui/control/FormattedTextInput.stories.tsx
@@ -1,7 +1,23 @@
 import preview from '@sb/preview';
+import { useArgs } from 'storybook/preview-api';
 import { fn } from 'storybook/test';
 
 import { FormattedTextInput } from './FormattedTextInput';
+import type { FormattedTextInputProps } from './FormattedTextInput';
+
+function ControlledFormattedTextInput(args: FormattedTextInputProps) {
+  const [{ value }, updateArgs] = useArgs<FormattedTextInputProps>();
+  return (
+    <FormattedTextInput
+      {...args}
+      value={value}
+      onChange={(nextValue) => {
+        args.onChange(nextValue);
+        updateArgs({ value: nextValue });
+      }}
+    />
+  );
+}
 
 const meta = preview.meta({
   component: FormattedTextInput,
@@ -11,6 +27,7 @@ const meta = preview.meta({
   parameters: {
     layout: 'centered',
   },
+  render: ControlledFormattedTextInput,
   args: {
     label: 'Text',
     minRows: 5,

--- a/src/app/ui/control/FormattedTextInput.stories.tsx
+++ b/src/app/ui/control/FormattedTextInput.stories.tsx
@@ -1,0 +1,57 @@
+import preview from '@sb/preview';
+import { fn } from 'storybook/test';
+
+import { FormattedTextInput } from './FormattedTextInput';
+
+const meta = preview.meta({
+  component: FormattedTextInput,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    label: 'Text',
+    minRows: 5,
+    onChange: fn(),
+    w: 520,
+  },
+});
+
+export const ValidDraft = meta.story({
+  args: {
+    value:
+      'Lead with *bold words*, add _underlining_, and finish with /italics/.\n\n- One clear point\n- Another clear point',
+  },
+});
+
+export const Empty = meta.story({
+  args: {
+    value: '',
+  },
+});
+
+export const CrossedMark = meta.story({
+  args: {
+    value: '*bold _underline* still underline_',
+  },
+});
+
+export const EmptyListItem = meta.story({
+  args: {
+    value: '- ',
+  },
+});
+
+export const EmptyMark = meta.story({
+  args: {
+    value: '**',
+  },
+});
+
+export const UnclosedMark = meta.story({
+  args: {
+    value: 'An *unfinished draft',
+  },
+});

--- a/src/app/ui/control/FormattedTextInput.test.tsx
+++ b/src/app/ui/control/FormattedTextInput.test.tsx
@@ -1,0 +1,56 @@
+/** @vitest-environment jsdom */
+
+import { MantineProvider } from '@mantine/core';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { appContentTheme } from '@ui/theme';
+import { afterEach, expect, it, vi } from 'vitest';
+
+import { FormattedTextInput } from './FormattedTextInput';
+
+window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+function renderInput(value: string, onChange = vi.fn(), error?: string) {
+  render(
+    <MantineProvider theme={appContentTheme} forceColorScheme="light">
+      <FormattedTextInput label="Text" value={value} onChange={onChange} error={error} />
+    </MantineProvider>
+  );
+  return onChange;
+}
+
+it('reports the source location, explanation, and repair for an invalid draft', () => {
+  renderInput('*unfinished');
+
+  const field = screen.getByRole('textbox', { name: 'Text' });
+  const error = document.getElementById(field.getAttribute('aria-describedby')!);
+  expect(error?.textContent).toContain('Line 1, column 1: Bold starts here but has no closing *.');
+  expect(error?.textContent).toContain('Suggestion: Add * after the words you want formatted, or remove this *.');
+  expect(field.getAttribute('aria-invalid')).toBe('true');
+});
+
+it('keeps field-specific validation while formatted text is valid', () => {
+  renderInput('', vi.fn(), 'Text is required');
+
+  expect(screen.getByText('Text is required')).toBeTruthy();
+});
+
+it('passes the edited string through the control membrane', () => {
+  const onChange = renderInput('Opening');
+
+  fireEvent.change(screen.getByRole('textbox', { name: 'Text' }), {
+    target: { value: 'Opening words' },
+  });
+
+  expect(onChange).toHaveBeenCalledExactlyOnceWith('Opening words');
+});

--- a/src/app/ui/control/FormattedTextInput.tsx
+++ b/src/app/ui/control/FormattedTextInput.tsx
@@ -1,0 +1,71 @@
+import { Textarea } from '@mantine/core';
+import type { TextareaProps } from '@mantine/core';
+import { parseFormattedText } from '@shared/formattedText';
+import type { FormattedTextParseResult } from '@shared/formattedText';
+import { Fragment } from 'react';
+import type { ReactNode } from 'react';
+
+type FormattedTextDiagnostic = Extract<FormattedTextParseResult, { valid: false }>['diagnostics'][number];
+
+export interface FormattedTextInputProps extends Omit<TextareaProps, 'defaultValue' | 'onChange' | 'value'> {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function Diagnostic({ diagnostic }: { diagnostic: FormattedTextDiagnostic }) {
+  return (
+    <span>
+      Line {diagnostic.line}, column {diagnostic.column}: {diagnostic.message}
+      <br />
+      Suggestion: {diagnostic.suggestion}
+    </span>
+  );
+}
+
+function validationError(diagnostics: readonly FormattedTextDiagnostic[], fieldError: ReactNode): ReactNode {
+  if (diagnostics.length === 0) {
+    return fieldError;
+  }
+  return (
+    <>
+      {diagnostics.map((diagnostic, index) => (
+        <Fragment key={`${diagnostic.code}-${diagnostic.offset}`}>
+          {index > 0 ? (
+            <>
+              <br />
+              <br />
+            </>
+          ) : null}
+          <Diagnostic diagnostic={diagnostic} />
+        </Fragment>
+      ))}
+      {fieldError ? (
+        <>
+          <br />
+          <br />
+          {fieldError}
+        </>
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * A Textarea for the shared formatted-text language, with repair guidance beside an invalid draft.
+ *
+ * The caller owns the draft and any field-specific validation such as requiredness.
+ * This control owns syntax validation so every author sees the same source location, explanation, and suggested repair.
+ */
+export function FormattedTextInput({ value, onChange, error, ...props }: FormattedTextInputProps) {
+  const parsed = parseFormattedText(value);
+  const diagnostics = parsed.valid ? [] : parsed.diagnostics;
+
+  return (
+    <Textarea
+      {...props}
+      value={value}
+      onChange={(event) => onChange(event.currentTarget.value)}
+      error={validationError(diagnostics, error)}
+    />
+  );
+}


### PR DESCRIPTION
## What changed

- Adds `FormattedTextInput`, a kit Control built on Mantine's Textarea.
- Keeps the draft and `onChange` with the caller while the control owns formatted-text syntax validation.
- Shows every syntax diagnostic with its line, column, message, and repair suggestion.
- Preserves caller-owned field validation, including requiredness for fields where empty text is not allowed.
- Covers a valid draft, an empty draft, and every diagnostic code in Storybook.

## Membrane

The caller provides the string, `onChange`, standard Textarea presentation props, and any field-specific error. The control parses the string and presents grammar diagnostics. It does not normalize, save, fetch, route, add a toolbar, or transform selected text.

## Visual proof

Before, the existing Textarea validation pattern identifies the problem but gives no source location or repair:

![Before: message-only Textarea validation](https://github.com/ndelangen/dunezone/releases/download/proof-assets/issue-673-before-message-only-textarea.png)

After, the formatted-text control identifies the exact line and column and tells the author how to repair the draft:

![After: formatted-text validation with source guidance](https://github.com/ndelangen/dunezone/releases/download/proof-assets/issue-673-after-formatted-text-guidance.png)

## Verification

- `bun run test`: 110 files, 731 tests passed
- `bun run storybook:test FormattedTextInput`: 6 stories passed
- `bun run typecheck`
- `bun run check`
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:release:verify`

Closes #673


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a formatted text input with real-time syntax diagnostics, including line, column, error details, and repair suggestions.
  * Preserves existing field validation messages while displaying formatting issues.
  * Added interactive examples covering valid, empty, and malformed formatting scenarios.

* **Tests**
  * Added coverage for validation diagnostics, existing field errors, and edited input values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->