### PR TITLE
The app renders parsed formatted text as content

### DIFF
--- a/src/app/ui/content/FormattedText.stories.tsx
+++ b/src/app/ui/content/FormattedText.stories.tsx
@@ -1,0 +1,67 @@
+import preview from '@sb/preview';
+import { parseFormattedText } from '@shared/formattedText';
+
+import { FormattedText } from './FormattedText';
+import type { FormattedTextBlocks } from './FormattedText';
+
+function validBlocks(source: string): FormattedTextBlocks {
+  const parsed = parseFormattedText(source);
+  if (!parsed.valid) {
+    throw new Error('A FormattedText story contains invalid source.');
+  }
+  return parsed.blocks;
+}
+
+const mixedBlocks = validBlocks(
+  'Plans survive *first contact* until the Guild calls.\nAdjust without losing the _-*intent*-_.\n\n- Gather the spice\n- Guard the shipment\n- Pay the Guild'
+);
+
+const meta = preview.meta({
+  component: FormattedText,
+  globals: {
+    backgrounds: { value: 'light', grid: false },
+  },
+  parameters: { layout: 'padded' },
+});
+
+export const MixedBlocks = meta.story({
+  args: {
+    blocks: mixedBlocks,
+  },
+});
+
+export const Dark = meta.story({
+  globals: {
+    backgrounds: { value: 'dark', grid: false },
+    colorScheme: 'dark',
+  },
+  args: {
+    blocks: mixedBlocks,
+  },
+});
+
+export const ParagraphsAndLineBreaks = meta.story({
+  args: {
+    blocks: validBlocks(
+      'Plans survive first contact.\nAdjust without losing the intent.\n\nA blank line starts a new thought.'
+    ),
+  },
+});
+
+export const List = meta.story({
+  args: {
+    blocks: validBlocks('- Gather the spice\n- Guard the shipment\n- Pay the Guild'),
+  },
+});
+
+export const NestedMarks = meta.story({
+  args: {
+    blocks: validBlocks('Every _-*layer*-_ stays legible, including *bold*, -italic-, and _underlined_ words.'),
+  },
+});
+
+export const Empty = meta.story({
+  args: {
+    blocks: [],
+  },
+});

--- a/src/app/ui/content/FormattedText.test.tsx
+++ b/src/app/ui/content/FormattedText.test.tsx
@@ -1,0 +1,86 @@
+/** @vitest-environment jsdom */
+
+import { MantineProvider } from '@mantine/core';
+import { cleanup, render, screen } from '@testing-library/react';
+import { appContentTheme } from '@ui/theme';
+import { afterEach, expect, it, vi } from 'vitest';
+
+import { FormattedText } from './FormattedText';
+import type { FormattedTextBlocks } from './FormattedText';
+
+window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+afterEach(cleanup);
+
+function renderFormattedText(blocks: FormattedTextBlocks) {
+  return render(
+    <MantineProvider theme={appContentTheme} forceColorScheme="light">
+      <div data-testid="formatted-text-host">
+        <FormattedText blocks={blocks} />
+      </div>
+    </MantineProvider>
+  );
+}
+
+it('renders paragraph line breaks and fully nested marks as semantic HTML', () => {
+  const blocks: FormattedTextBlocks = [
+    {
+      kind: 'paragraph',
+      children: [
+        { kind: 'text', value: 'Opening' },
+        { kind: 'line-break' },
+        {
+          kind: 'mark',
+          mark: 'underline',
+          children: [
+            {
+              kind: 'mark',
+              mark: 'italic',
+              children: [{ kind: 'mark', mark: 'bold', children: [{ kind: 'text', value: 'emphasis' }] }],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const view = renderFormattedText(blocks);
+
+  expect(view.container.querySelector('p > br')).not.toBeNull();
+  expect(view.container.querySelector('p > span > em > strong')?.textContent).toBe('emphasis');
+});
+
+it('renders parsed list items as one semantic list', () => {
+  const blocks: FormattedTextBlocks = [
+    {
+      kind: 'list',
+      items: [
+        { children: [{ kind: 'text', value: 'Gather the spice' }] },
+        { children: [{ kind: 'text', value: 'Pay the Guild' }] },
+      ],
+    },
+  ];
+
+  renderFormattedText(blocks);
+
+  expect(screen.getByRole('list')).toBeTruthy();
+  expect(screen.getAllByRole('listitem').map((item) => item.textContent)).toEqual([
+    'Gather the spice',
+    'Pay the Guild',
+  ]);
+});
+
+it('renders no placeholder for empty parsed blocks', () => {
+  renderFormattedText([]);
+
+  expect(screen.getByTestId('formatted-text-host').childElementCount).toBe(0);
+});

--- a/src/app/ui/content/FormattedText.tsx
+++ b/src/app/ui/content/FormattedText.tsx
@@ -1,0 +1,63 @@
+import { List, Stack, Text } from '@mantine/core';
+import type { FormattedTextParseResult } from '@shared/formattedText';
+import { Fragment } from 'react';
+import type { ReactNode } from 'react';
+
+export type FormattedTextBlocks = FormattedTextParseResult['blocks'];
+
+type FormattedTextBlock = FormattedTextBlocks[number];
+type FormattedTextInlineNode = Extract<FormattedTextBlock, { kind: 'paragraph' }>['children'][number];
+
+function renderInline(nodes: readonly FormattedTextInlineNode[]): ReactNode {
+  return nodes.map((node, index) => {
+    if (node.kind === 'text') {
+      return <Fragment key={index}>{node.value}</Fragment>;
+    }
+    if (node.kind === 'line-break') {
+      return <br key={index} />;
+    }
+
+    const children = renderInline(node.children);
+    if (node.mark === 'bold') {
+      return <strong key={index}>{children}</strong>;
+    }
+    if (node.mark === 'italic') {
+      return <em key={index}>{children}</em>;
+    }
+    return (
+      <Text key={index} component="span" inherit td="underline">
+        {children}
+      </Text>
+    );
+  });
+}
+
+/**
+ * Renders parsed formatted-text blocks with the app's prose and list treatment.
+ *
+ * Callers own parsing and decide what to do with invalid or empty source.
+ * This component owns the app-side HTML semantics for every valid block and mark.
+ */
+export function FormattedText({ blocks }: { blocks: FormattedTextBlocks }) {
+  if (blocks.length === 0) {
+    return null;
+  }
+
+  return (
+    <Stack gap="xs">
+      {blocks.map((block, index) =>
+        block.kind === 'paragraph' ? (
+          <Text key={index} component="p">
+            {renderInline(block.children)}
+          </Text>
+        ) : (
+          <List key={index} spacing="xs">
+            {block.items.map((item, itemIndex) => (
+              <List.Item key={itemIndex}>{renderInline(item.children)}</List.Item>
+            ))}
+          </List>
+        )
+      )}
+    </Stack>
+  );
+}

--- a/src/app/ui/content/FormattedText.tsx
+++ b/src/app/ui/content/FormattedText.tsx
@@ -7,28 +7,43 @@ export type FormattedTextBlocks = FormattedTextParseResult['blocks'];
 
 type FormattedTextBlock = FormattedTextBlocks[number];
 type FormattedTextInlineNode = Extract<FormattedTextBlock, { kind: 'paragraph' }>['children'][number];
+type FormattedTextMark = Extract<FormattedTextInlineNode, { kind: 'mark' }>['mark'];
+
+function FormattedMark({
+  mark,
+  children,
+}: Readonly<{
+  mark: FormattedTextMark;
+  children: ReactNode;
+}>) {
+  switch (mark) {
+    case 'bold':
+      return <strong>{children}</strong>;
+    case 'italic':
+      return <em>{children}</em>;
+    case 'underline':
+      return (
+        <Text component="span" inherit td="underline">
+          {children}
+        </Text>
+      );
+  }
+}
 
 function renderInline(nodes: readonly FormattedTextInlineNode[]): ReactNode {
-  return nodes.map((node, index) => {
-    if (node.kind === 'text') {
-      return <Fragment key={index}>{node.value}</Fragment>;
+  return nodes.map((node, position) => {
+    switch (node.kind) {
+      case 'text':
+        return <Fragment key={position}>{node.value}</Fragment>;
+      case 'line-break':
+        return <br key={position} />;
+      case 'mark':
+        return (
+          <FormattedMark key={position} mark={node.mark}>
+            {renderInline(node.children)}
+          </FormattedMark>
+        );
     }
-    if (node.kind === 'line-break') {
-      return <br key={index} />;
-    }
-
-    const children = renderInline(node.children);
-    if (node.mark === 'bold') {
-      return <strong key={index}>{children}</strong>;
-    }
-    if (node.mark === 'italic') {
-      return <em key={index}>{children}</em>;
-    }
-    return (
-      <Text key={index} component="span" inherit td="underline">
-        {children}
-      </Text>
-    );
   });
 }
 
@@ -38,7 +53,7 @@ function renderInline(nodes: readonly FormattedTextInlineNode[]): ReactNode {
  * Callers own parsing and decide what to do with invalid or empty source.
  * This component owns the app-side HTML semantics for every valid block and mark.
  */
-export function FormattedText({ blocks }: { blocks: FormattedTextBlocks }) {
+export function FormattedText({ blocks }: Readonly<{ blocks: FormattedTextBlocks }>) {
   if (blocks.length === 0) {
     return null;
   }


### PR DESCRIPTION
## Summary

- add the app's shared `FormattedText` Content component for already-parsed blocks
- render semantic paragraphs, hard line breaks, lists, and recursively nested bold, italic, and underline marks
- cover every block kind, empty content, mark nesting, and light and dark themes in tests and Storybook

The membrane is deliberately narrow: callers hand the component parsed blocks. Parsing, invalid-source handling, fetching, navigation, and game-document rendering stay outside it.

## Visual proof

Before, formatted text stopped at the editing control. The app had no shared Content renderer, so the source syntax remained visible here.

![Before: formatted text available only as editable source](https://github.com/ndelangen/dunezone/releases/download/proof-assets/issue-674-before-editor-only.png)

After, the same vocabulary has an app-owned reader treatment: paragraphs and hard breaks retain their structure, list items stay semantic, and nested marks render together.

![After: formatted text rendered as app content](https://github.com/ndelangen/dunezone/releases/download/proof-assets/issue-674-after-content-renderer.png)

The dark-theme story verifies that the Content component inherits the surrounding theme without painting its own surface.

![After: formatted text rendered in the dark theme](https://github.com/ndelangen/dunezone/releases/download/proof-assets/issue-674-after-content-renderer-dark.png)

## Verification

- `bun run test` (111 files, 734 tests)
- `bun run typecheck`
- `bun run storybook:test FormattedText` (2 files, 12 tests)
- `bun run check`
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:release:verify`
- visual inspection of the representative light and dark Storybook stories

Closes #674
