### PR TITLE
Faction inline prose is ready for formatted text

### DIFF
--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -197,6 +197,16 @@
       "requires": ["faction_complexity_grouped_v1"]
     },
     {
+      "id": "faction_inline_formatted_text_v1",
+      "phase": "widen",
+      "requires": []
+    },
+    {
+      "id": "faction_inline_formatted_text_verify_v1",
+      "phase": "widen",
+      "requires": ["faction_inline_formatted_text_v1"]
+    },
+    {
       "id": "faction_complexity_grouped_narrow",
       "phase": "narrow",
       "requires": ["faction_complexity_grouped_v1", "faction_complexity_grouped_verify_v1"]

--- a/convex/migrations.factionInlineFormattedText.test.ts
+++ b/convex/migrations.factionInlineFormattedText.test.ts
@@ -1,0 +1,60 @@
+/// <reference types="vite/client" />
+// @vitest-environment edge-runtime
+
+import aggregateTest from '@convex-dev/aggregate/test';
+import migrationsTest from '@convex-dev/migrations/test';
+import { convexTest } from 'convex-test';
+import { describe, expect, test } from 'vitest';
+
+import { api, internal } from './_generated/api';
+import schema from './schema';
+
+const modules = import.meta.glob('./**/*.ts');
+
+function migrationTest() {
+  const t = convexTest(schema, modules);
+  aggregateTest.register(t, 'statistics');
+  aggregateTest.register(t, 'profileActivity');
+  aggregateTest.register(t, 'profileDiscovery');
+  migrationsTest.register(t);
+  return t;
+}
+
+describe('faction marks-only formatted text migration', () => {
+  test('joins legacy layout lines and records both migrations as complete', async () => {
+    const t = migrationTest();
+    const factionId = await t.run(async (ctx) => {
+      const ownerId = await ctx.db.insert('users', { name: 'Faction owner' });
+      return await ctx.db.insert('factions', {
+        owner_id: ownerId,
+        data: {
+          rules: {
+            startText: 'Start with 7 spice.\nKeep a separate cache.\nDo not add it to your hand.',
+            revivalText: '1 *free* revival.',
+          },
+        },
+        slug: 'inline-faction',
+        created_at: '2026-08-25T00:00:00.000Z',
+        updated_at: '2026-08-25T00:00:00.000Z',
+        is_deleted: false,
+        group_id: null,
+      });
+    });
+
+    await t.mutation(internal.migrations.faction_inline_formatted_text_v1, {});
+    await t.mutation(internal.migrations.faction_inline_formatted_text_verify_v1, {});
+
+    const faction = await t.run((ctx) => ctx.db.get('factions', factionId));
+    expect(faction?.data).toMatchObject({
+      rules: {
+        startText: 'Start with 7 spice. Keep a separate cache. Do not add it to your hand.',
+        revivalText: '1 *free* revival.',
+      },
+    });
+    await expect(
+      t.query(api.migrations.assertReadyForNarrow, {
+        required: ['faction_inline_formatted_text_v1', 'faction_inline_formatted_text_verify_v1'],
+      })
+    ).resolves.toMatchObject({ ok: true });
+  });
+});

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -3,6 +3,7 @@ import type { FunctionReference } from 'convex/server';
 import { v } from 'convex/values';
 
 import { DEFAULT_FAQ_TAG } from '../src/shared/faq/tags';
+import { normalizeFormattedText } from '../src/shared/formattedText';
 import { components, internal } from './_generated/api';
 import type { Id } from './_generated/dataModel';
 import { internalQuery, query } from './_generated/server';
@@ -60,6 +61,8 @@ const MIGRATION_IDS: Record<string, MigrationRef> = {
   groups_soft_delete_verify_v1: internal.migrations.groups_soft_delete_verify_v1,
   faction_complexity_grouped_v1: internal.migrations.faction_complexity_grouped_v1,
   faction_complexity_grouped_verify_v1: internal.migrations.faction_complexity_grouped_verify_v1,
+  faction_inline_formatted_text_v1: internal.migrations.faction_inline_formatted_text_v1,
+  faction_inline_formatted_text_verify_v1: internal.migrations.faction_inline_formatted_text_verify_v1,
   assets_about_v1: internal.migrations.assets_about_v1,
   assets_about_verify_v1: internal.migrations.assets_about_verify_v1,
   account_lifecycle_profiles_v1: internal.migrations.account_lifecycle_profiles_v1,
@@ -478,6 +481,66 @@ export const faction_complexity_grouped_verify_v1 = migrations.define({
   table: 'factions',
   batchSize: 50,
   migrateOne: async () => undefined,
+});
+
+function normalizedMarksOnlyValue(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${field} is not a string`);
+  }
+  const current = normalizeFormattedText(value, 'marks-only');
+  if (current.ok) {
+    return current.value;
+  }
+  const joined = value.replace(/[ \t]*\r?\n[ \t]*/gu, ' ');
+  const normalized = normalizeFormattedText(joined, 'marks-only');
+  if (!normalized.ok) {
+    throw new Error(`${field} cannot be normalized as marks-only formatted text`);
+  }
+  return normalized.value;
+}
+
+/** Joins legacy layout line breaks in faction setup and revival before those fields become marks-only. */
+export const faction_inline_formatted_text_v1 = migrations.define({
+  table: 'factions',
+  batchSize: 50,
+  migrateOne: async (_ctx, row) => {
+    const data = row.data as {
+      rules?: { startText?: unknown; revivalText?: unknown };
+    } | null;
+    if (!data?.rules) {
+      throw new Error(`Faction ${row._id} has no rules`);
+    }
+    const startText = normalizedMarksOnlyValue(data.rules.startText, `Faction ${row._id} setup`);
+    const revivalText = normalizedMarksOnlyValue(data.rules.revivalText, `Faction ${row._id} revival`);
+    if (startText === data.rules.startText && revivalText === data.rules.revivalText) {
+      return;
+    }
+    return {
+      data: { ...data, rules: { ...data.rules, startText, revivalText } },
+    };
+  },
+});
+
+/** Proves every stored faction setup and revival value fits the marks-only profile. */
+export const faction_inline_formatted_text_verify_v1 = migrations.define({
+  table: 'factions',
+  batchSize: 50,
+  migrateOne: async (_ctx, row) => {
+    const data = row.data as {
+      rules?: { startText?: unknown; revivalText?: unknown };
+    } | null;
+    if (!data?.rules) {
+      throw new Error(`Faction ${row._id} has no rules`);
+    }
+    for (const [field, value] of [
+      ['setup', data.rules.startText],
+      ['revival', data.rules.revivalText],
+    ] as const) {
+      if (typeof value !== 'string' || !normalizeFormattedText(value, 'marks-only').ok) {
+        throw new Error(`Faction ${row._id} ${field} is not marks-only formatted text`);
+      }
+    }
+  },
 });
 
 /** Retains the completed Group lifecycle backfill identity through the schema-narrowing release. */

--- a/src/shared/formattedText.test.ts
+++ b/src/shared/formattedText.test.ts
@@ -27,6 +27,35 @@ describe('formatted-text core', () => {
     expectTypeOf<string>().not.toMatchTypeOf<NormalizedFormattedText>();
   });
 
+  it('keeps marks in marks-only fields while rejecting lists, hard breaks, and paragraphs', () => {
+    const marked = parseFormattedText('One *bold* instruction.', 'marks-only');
+    const list = parseFormattedText('- first', 'marks-only');
+    const hardBreak = parseFormattedText('first\nsecond', 'marks-only');
+    const paragraph = parseFormattedText('first\n\nsecond', 'marks-only');
+
+    expect(marked.valid).toBe(true);
+    expect(list.valid).toBe(false);
+    expect(hardBreak.valid).toBe(false);
+    expect(paragraph.valid).toBe(false);
+    if (!list.valid && !hardBreak.valid && !paragraph.valid) {
+      expect(list.diagnostics[0]).toMatchObject({
+        code: 'marks-only-list',
+        line: 1,
+        column: 1,
+      });
+      expect(hardBreak.diagnostics[0]).toMatchObject({
+        code: 'marks-only-line-break',
+        line: 2,
+        column: 1,
+      });
+      expect(paragraph.diagnostics[0]).toMatchObject({
+        code: 'marks-only-line-break',
+        line: 2,
+        column: 1,
+      });
+    }
+  });
+
   it('normalizes plain text into paragraphs, separate lists, and multiline list items', () => {
     const parsed = parseValid(
       'Opening  \r\ncontinues\r\n\r\n\r\n• first  \r\n– second\r\n\r\n— third\r\n  continuation'
@@ -92,7 +121,11 @@ describe('formatted-text core', () => {
     });
     expect(invalid.valid).toBe(false);
     if (!invalid.valid) {
-      expect(invalid.diagnostics[0]).toMatchObject({ code: 'unclosed-mark', line: 1, column: 1 });
+      expect(invalid.diagnostics[0]).toMatchObject({
+        code: 'unclosed-mark',
+        line: 1,
+        column: 1,
+      });
     }
   });
 
@@ -102,7 +135,12 @@ describe('formatted-text core', () => {
     expect(parsed.source).toBe(String.raw`2*3 snake_case counter-clockwise \*plain\* \-plain\- \_plain\_ \\`);
     expect(parsed.blocks[0]).toMatchObject({
       kind: 'paragraph',
-      children: [{ kind: 'text', value: '2*3 snake_case counter-clockwise *plain* -plain- _plain_ \\' }],
+      children: [
+        {
+          kind: 'text',
+          value: '2*3 snake_case counter-clockwise *plain* -plain- _plain_ \\',
+        },
+      ],
     });
   });
 
@@ -112,7 +150,12 @@ describe('formatted-text core', () => {
     expect(parsed.source).toBe('the Supplies!-cache is revealed, wait!-really (see below)');
     expect(parsed.blocks[0]).toMatchObject({
       kind: 'paragraph',
-      children: [{ kind: 'text', value: 'the Supplies!-cache is revealed, wait!-really (see below)' }],
+      children: [
+        {
+          kind: 'text',
+          value: 'the Supplies!-cache is revealed, wait!-really (see below)',
+        },
+      ],
     });
 
     const nested = parseValid('_-*all three*-_ still nest, and -after a space- still opens');
@@ -122,10 +165,20 @@ describe('formatted-text core', () => {
         {
           kind: 'mark',
           mark: 'underline',
-          children: [{ kind: 'mark', mark: 'italic', children: [{ kind: 'mark', mark: 'bold' }] }],
+          children: [
+            {
+              kind: 'mark',
+              mark: 'italic',
+              children: [{ kind: 'mark', mark: 'bold' }],
+            },
+          ],
         },
         { kind: 'text', value: ' still nest, and ' },
-        { kind: 'mark', mark: 'italic', children: [{ kind: 'text', value: 'after a space' }] },
+        {
+          kind: 'mark',
+          mark: 'italic',
+          children: [{ kind: 'text', value: 'after a space' }],
+        },
         { kind: 'text', value: ' still opens' },
       ],
     });
@@ -139,7 +192,11 @@ describe('formatted-text core', () => {
       kind: 'paragraph',
       children: [
         { kind: 'text', value: '𝒜*bold* and ' },
-        { kind: 'mark', mark: 'bold', children: [{ kind: 'text', value: '𝒜' }] },
+        {
+          kind: 'mark',
+          mark: 'bold',
+          children: [{ kind: 'text', value: '𝒜' }],
+        },
       ],
     });
   });
@@ -162,7 +219,12 @@ describe('formatted-text core', () => {
 
     expect(parsed.valid).toBe(false);
     if (!parsed.valid) {
-      expect(parsed.diagnostics[0]).toMatchObject({ code: 'unclosed-mark', line: 1, column: 1, offset: 0 });
+      expect(parsed.diagnostics[0]).toMatchObject({
+        code: 'unclosed-mark',
+        line: 1,
+        column: 1,
+        offset: 0,
+      });
     }
   });
 

--- a/src/shared/formattedText.ts
+++ b/src/shared/formattedText.ts
@@ -6,7 +6,7 @@ const FORMATTED_TEXT_MARKS = [
   { delimiter: '*', mark: 'bold' },
 ] as const;
 
-export const FORMATTED_TEXT_PROFILES = ['prose', 'marks-only'] as const;
+const FORMATTED_TEXT_PROFILES = ['prose', 'marks-only'] as const;
 
 export type FormattedTextProfile = (typeof FORMATTED_TEXT_PROFILES)[number];
 

--- a/src/shared/formattedText.ts
+++ b/src/shared/formattedText.ts
@@ -6,6 +6,10 @@ const FORMATTED_TEXT_MARKS = [
   { delimiter: '*', mark: 'bold' },
 ] as const;
 
+export const FORMATTED_TEXT_PROFILES = ['prose', 'marks-only'] as const;
+
+export type FormattedTextProfile = (typeof FORMATTED_TEXT_PROFILES)[number];
+
 type FormattedTextDelimiter = (typeof FORMATTED_TEXT_MARKS)[number]['delimiter'];
 
 type FormattedTextMark = (typeof FORMATTED_TEXT_MARKS)[number]['mark'];
@@ -38,7 +42,14 @@ type FormattedTextBlock =
       }[];
     };
 
-const FORMATTED_TEXT_DIAGNOSTIC_CODES = ['crossed-mark', 'empty-list-item', 'empty-mark', 'unclosed-mark'] as const;
+const FORMATTED_TEXT_DIAGNOSTIC_CODES = [
+  'crossed-mark',
+  'empty-list-item',
+  'empty-mark',
+  'marks-only-line-break',
+  'marks-only-list',
+  'unclosed-mark',
+] as const;
 
 type FormattedTextDiagnosticCode = (typeof FORMATTED_TEXT_DIAGNOSTIC_CODES)[number];
 
@@ -107,10 +118,15 @@ type ParsedInlineNode =
     };
 
 type ParsedBlock =
-  | { readonly kind: 'paragraph'; readonly children: readonly ParsedInlineNode[] }
+  | {
+      readonly kind: 'paragraph';
+      readonly children: readonly ParsedInlineNode[];
+    }
   | {
       readonly kind: 'list';
-      readonly items: readonly { readonly children: readonly ParsedInlineNode[] }[];
+      readonly items: readonly {
+        readonly children: readonly ParsedInlineNode[];
+      }[];
     };
 
 type InlineParseResult = {
@@ -146,7 +162,10 @@ function delimiterForMark(mark: FormattedTextMark): FormattedTextDelimiter {
   return detail.delimiter;
 }
 
-function sourceColumns(text: string): { readonly positions: readonly number[]; readonly end: number } {
+function sourceColumns(text: string): {
+  readonly positions: readonly number[];
+  readonly end: number;
+} {
   const positions = Array<number>(text.length);
   let column = 1;
 
@@ -347,7 +366,11 @@ function parseInline(lines: readonly SourceLine[]): InlineParseResult {
           message: `${markName(delimiterDetails.get(character)!)} formatting has no text.`,
           suggestion: `Put words between the two ${character} marks, or remove both marks.`,
         });
-        currentNodes().push({ kind: 'text', value: `${character}${character}`, source: `${character}${character}` });
+        currentNodes().push({
+          kind: 'text',
+          value: `${character}${character}`,
+          source: `${character}${character}`,
+        });
       } else {
         currentNodes().push({
           kind: 'mark',
@@ -544,7 +567,9 @@ function canonicalizeBlocks(blocks: readonly ParsedBlock[]): readonly ParsedBloc
       ? { kind: 'paragraph', children: canonicalizeInlineNodes(block.children) }
       : {
           kind: 'list',
-          items: block.items.map((item) => ({ children: canonicalizeInlineNodes(item.children) })),
+          items: block.items.map((item) => ({
+            children: canonicalizeInlineNodes(item.children),
+          })),
         }
   );
 }
@@ -565,13 +590,46 @@ function toPublicBlocks(blocks: readonly ParsedBlock[]): readonly FormattedTextB
       ? { kind: 'paragraph', children: toPublicInlineNodes(block.children) }
       : {
           kind: 'list',
-          items: block.items.map((item) => ({ children: toPublicInlineNodes(item.children) })),
+          items: block.items.map((item) => ({
+            children: toPublicInlineNodes(item.children),
+          })),
         }
   );
 }
 
+function marksOnlyDiagnostic(
+  normalized: NormalizedPlainText,
+  blocks: readonly ParsedBlock[]
+): FormattedTextDiagnostic | undefined {
+  const listLine = normalized.lines.find((line) => /^-[ \t]/u.test(line.text));
+  if (blocks.some((block) => block.kind === 'list')) {
+    const position = listLine?.positions[0] ?? normalized.lines[0]?.positions[0] ?? { line: 1, column: 1, offset: 0 };
+    return {
+      code: 'marks-only-list',
+      ...position,
+      length: 1,
+      message: 'This field allows formatted words, but not lists.',
+      suggestion: 'Remove the list marker and keep the text in one paragraph.',
+    };
+  }
+
+  const secondLine = normalized.lines[1];
+  if (secondLine) {
+    const position = secondLine.positions[0] ?? secondLine.end;
+    return {
+      code: 'marks-only-line-break',
+      ...position,
+      length: 0,
+      message: 'This field allows formatted words, but not line breaks or paragraphs.',
+      suggestion: 'Replace the line break with a space.',
+    };
+  }
+
+  return undefined;
+}
+
 /** Parse an editable draft into renderer-safe data and source-located diagnostics. */
-export function parseFormattedText(input: string): FormattedTextParseResult {
+export function parseFormattedText(input: string, profile: FormattedTextProfile = 'prose'): FormattedTextParseResult {
   const normalizedDraft = normalizePlainText(input);
   const parsed = parseBlocks(normalizedDraft);
 
@@ -585,6 +643,16 @@ export function parseFormattedText(input: string): FormattedTextParseResult {
   }
 
   const canonicalBlocks = canonicalizeBlocks(parsed.blocks);
+  const profileDiagnostic =
+    profile === 'marks-only' ? marksOnlyDiagnostic(normalizedDraft, canonicalBlocks) : undefined;
+  if (profileDiagnostic) {
+    return {
+      valid: false,
+      source: normalizedDraft.source,
+      blocks: toPublicBlocks(canonicalBlocks),
+      diagnostics: [profileDiagnostic],
+    };
+  }
   return {
     valid: true,
     source: serializeBlocks(canonicalBlocks) as NormalizedFormattedText,
@@ -594,7 +662,10 @@ export function parseFormattedText(input: string): FormattedTextParseResult {
 }
 
 /** Mint a stored value only when the complete draft is valid and canonical. */
-export function normalizeFormattedText(input: string): FormattedTextNormalizationResult {
-  const parsed = parseFormattedText(input);
+export function normalizeFormattedText(
+  input: string,
+  profile: FormattedTextProfile = 'prose'
+): FormattedTextNormalizationResult {
+  const parsed = parseFormattedText(input, profile);
   return parsed.valid ? { ok: true, value: parsed.source } : { ok: false, diagnostics: parsed.diagnostics };
 }

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,12 +4,12 @@
 // sharp version), so this file is reproducible on any machine (wayfinder #269).
 export const rendererManifest = {
   schemaVersion: 2,
-  rendererIdentity: 'faction-sheet/sha256:587897b11c94c454bc23f0214cc66881cc31b0bef0fb56f110d00f05dad500fb',
-  digest: '587897b11c94c454bc23f0214cc66881cc31b0bef0fb56f110d00f05dad500fb',
+  rendererIdentity: 'faction-sheet/sha256:cd9435bcef4194e942ec50cbcb79eb147bbf13fa2e0b01ec748aaf7d92162702',
+  digest: 'cd9435bcef4194e942ec50cbcb79eb147bbf13fa2e0b01ec748aaf7d92162702',
   components: {
     sources: '5289b6254320530ee857ff2912681e9d6a30135dbb3a92239296365f53397813',
     toolchain: 'e7e830225f6973a7d7e43aada3bcbcd5de3c169378aa25849d24d8de97ea517a',
-    code: '91dfe1e7302f1aa9efadc2528db674a9a2c1606e2c120c879f24d72b4ca178c6',
+    code: 'a12108750367295d4948d75e861db9ee3089fe48f11db779750d652283447cf7',
     contract: '2920714c87493d104342355dda2b956202259513c78ce6195670034f31a656a6',
   },
   contract: {


### PR DESCRIPTION
Part of #752.

This prerequisite release adds the shared marks-only formatted-text profile and normalizes the one production faction value that still contains layout line breaks. The narrow editor and reader changes follow after production completes this migration.

## Production evidence before migration

Richese currently renders without a visual layout regression. The migration changes stored structure, not the published sheet appearance. I will post the production after image and pixel comparison after deployment.

![Richese before migration](https://github.com/ndelangen/dunezone/releases/download/proof-assets/issue-752-before-richese-page-1.png)

## Checks

- bun run test
- bun run typecheck
- bun run migrations:static-check
- VITE_CONVEX_URL set to production: bun run check
- VITE_CONVEX_URL set to production: bun run publisher:release:verify
- Shared-development migration and verification completed successfully