### PR TITLE
Stored prose editors prevent accidental layout breaks

### DIFF
--- a/convex/lib/assetInput.ts
+++ b/convex/lib/assetInput.ts
@@ -1,9 +1,9 @@
 import {
-  BundleAsset,
-  DeckAsset,
-  RectangleTokenAsset,
-  TokenAsset,
-  TreacheryAsset,
+  BundleAssetInput,
+  DeckAssetInput,
+  RectangleTokenAssetInput,
+  TokenAssetInput,
+  TreacheryAssetInput,
 } from '../../src/shared/assets/schema';
 import { ASSET_TYPES } from '../../src/shared/assets/types';
 
@@ -25,28 +25,28 @@ export function assetDisplayName(row: { data: unknown }): string {
 export function parseAssetDataForWrite(type: string, data: unknown): { data: unknown; name: string } {
   switch (type) {
     case 'card-treachery': {
-      const parsed = TreacheryAsset.parse(data);
+      const parsed = TreacheryAssetInput.parse(data);
       return { data: parsed, name: parsed.name };
     }
     case 'deck': {
-      const parsed = DeckAsset.parse(data);
+      const parsed = DeckAssetInput.parse(data);
       return { data: parsed, name: parsed.name };
     }
     /* A container of tokens. It publishes nothing, so nothing downstream of this branch enqueues. */
     case 'bundle': {
-      const parsed = BundleAsset.parse(data);
+      const parsed = BundleAssetInput.parse(data);
       return { data: parsed, name: parsed.name };
     }
     /* The three shapes share one schema: shape is the Asset type, never a field, so only the clip differs downstream. */
     case 'token-disc':
     case 'token-tech':
     case 'token-plate': {
-      const parsed = TokenAsset.parse(data);
+      const parsed = TokenAssetInput.parse(data);
       return { data: parsed, name: parsed.name };
     }
     /* The rectangle is a token by category and by backside rules, and its own schema by face: a free composition rather than a symbol in a fixed slot. */
     case 'token-enhance': {
-      const parsed = RectangleTokenAsset.parse(data);
+      const parsed = RectangleTokenAssetInput.parse(data);
       return { data: parsed, name: parsed.name };
     }
     default:

--- a/convex/migration-guards.json
+++ b/convex/migration-guards.json
@@ -207,6 +207,11 @@
       "requires": ["faction_inline_formatted_text_v1"]
     },
     {
+      "id": "faction_inline_formatted_text_narrow",
+      "phase": "narrow",
+      "requires": ["faction_inline_formatted_text_v1", "faction_inline_formatted_text_verify_v1"]
+    },
+    {
       "id": "faction_complexity_grouped_narrow",
       "phase": "narrow",
       "requires": ["faction_complexity_grouped_v1", "faction_complexity_grouped_verify_v1"]

--- a/src/app/routes/_app/assets/$type/$slug/index.module.css
+++ b/src/app/routes/_app/assets/$type/$slug/index.module.css
@@ -39,8 +39,3 @@
   width: 100%;
   height: auto;
 }
-
-/* An About is authored in a textarea, so the author's own line breaks are the only structure it carries. */
-.about {
-  white-space: pre-line;
-}

--- a/src/app/routes/_app/assets/$type/$slug/index.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/index.tsx
@@ -21,6 +21,7 @@ import { NotAvailable } from '@ui/block/NotAvailable';
 import { OpenableTile } from '@ui/block/OpenableTile';
 import { Section } from '@ui/block/Section';
 import { formatRelativeDate } from '@ui/content/dates';
+import { FormattedTextSource } from '@ui/content/FormattedText';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { TopicIcon } from '@ui/content/TopicIcon';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
@@ -299,7 +300,7 @@ function AboutSection({ about }: { about: string }) {
     <Section id="about" icon={<TopicIcon topic="about" size={20} />} title="About">
       <Surface padding="lg">
         {about.trim() ? (
-          <Text className={styles.about}>{about}</Text>
+          <FormattedTextSource source={about} />
         ) : (
           <Text size="sm" c="dimmed">
             Nothing written about this yet.

--- a/src/app/routes/_app/factions/$factionId/index.tsx
+++ b/src/app/routes/_app/factions/$factionId/index.tsx
@@ -23,6 +23,7 @@ import { factionAssetPublishingCopy } from '@ui/content/assetPublishingStatus';
 import { complexityOutOfTen, complexityTier, effectiveComplexity } from '@ui/content/complexity';
 import { COMPLEXITY_TIER_PRESENTATION, ComplexityGlyph } from '@ui/content/ComplexityGlyph';
 import { Eyebrow } from '@ui/content/Eyebrow';
+import { FormattedTextSource, InlineFormattedTextSource } from '@ui/content/FormattedText';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { StatusBadge } from '@ui/content/StatusBadge';
 import { TopicIcon } from '@ui/content/TopicIcon';
@@ -267,9 +268,7 @@ function FactionDetailPage() {
                             </Badge>
                           </Group>
                           {troop.description ? (
-                            <Text size="xs" c="dimmed">
-                              {troop.description}
-                            </Text>
+                            <FormattedTextSource source={troop.description} size="xs" c="dimmed" />
                           ) : null}
                         </Stack>
                       </Group>
@@ -290,9 +289,7 @@ function FactionDetailPage() {
                       >
                         <Stack gap="xs">
                           <Text fw={700}>{planet.name}</Text>
-                          <Text size="xs" c="dimmed">
-                            {planet.description}
-                          </Text>
+                          <FormattedTextSource source={planet.description} size="xs" c="dimmed" />
                         </Stack>
                       </Surface>
                     ))}
@@ -309,13 +306,11 @@ function FactionDetailPage() {
                         title={advantage.title ?? `Advantage ${index + 1}`}
                       >
                         <Stack gap="sm">
-                          <Text size="sm">{advantage.text}</Text>
+                          <FormattedTextSource source={advantage.text} size="sm" />
                           {advantage.karama ? (
                             <Group gap="xs" wrap="nowrap" align="flex-start">
                               <TopicIcon topic="karama" size={16} />
-                              <Text size="sm" c="dimmed">
-                                {advantage.karama}
-                              </Text>
+                              <FormattedTextSource source={advantage.karama} size="sm" c="dimmed" />
                             </Group>
                           ) : null}
                         </Stack>
@@ -331,10 +326,10 @@ function FactionDetailPage() {
 
               <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md">
                 <Card icon={<TopicIcon topic="alliance" size={20} />} title="Alliance">
-                  <Text size="sm">{data.rules.alliance.text}</Text>
+                  <FormattedTextSource source={data.rules.alliance.text} size="sm" />
                 </Card>
                 <Card icon={<TopicIcon topic="fate" size={20} />} title={data.rules.fate.title || 'Fate'}>
-                  <Text size="sm">{data.rules.fate.text}</Text>
+                  <FormattedTextSource source={data.rules.fate.text} size="sm" />
                 </Card>
               </SimpleGrid>
             </Stack>
@@ -410,7 +405,7 @@ function FactionDetailPage() {
                       At start
                     </Title>
                     <Text size="sm" mt="xs">
-                      {data.rules.startText}
+                      <InlineFormattedTextSource source={data.rules.startText} />
                     </Text>
                   </Box>
                   <Divider />
@@ -419,7 +414,7 @@ function FactionDetailPage() {
                       Revival
                     </Title>
                     <Text size="sm" mt="xs">
-                      {data.rules.revivalText}
+                      <InlineFormattedTextSource source={data.rules.revivalText} />
                     </Text>
                   </Box>
                 </Stack>

--- a/src/app/routes/_app/profiles/$profileSlug/index.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/index.tsx
@@ -7,6 +7,7 @@ import { NotAvailable } from '@ui/block/NotAvailable';
 import { ProposedContent } from '@ui/block/ProposedContent';
 import { Section } from '@ui/block/Section';
 import { formatRelativeDate } from '@ui/content/dates';
+import { FormattedTextSource, InlineFormattedTextSource } from '@ui/content/FormattedText';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { TopicIcon } from '@ui/content/TopicIcon';
 import { IconAction } from '@ui/control/IconAction';
@@ -67,14 +68,6 @@ function ProfileDetailError({ error }: ErrorComponentProps) {
 type FaqQuestionAsked = ProfilePageData['faqAsked'][number];
 type FaqAnswerGiven = ProfilePageData['faqAnswers'][number];
 
-function truncate(text: string, max = 200): string {
-  const t = text.trim();
-  if (t.length <= max) {
-    return t;
-  }
-  return `${t.slice(0, max).trim()}…`;
-}
-
 function AskerChip({
   profile,
   viewedProfileId,
@@ -129,7 +122,9 @@ function FaqQuestionsAsked({ items }: { items: FaqQuestionAsked[] }) {
               questionSlug: item.slug,
             }}
           >
-            <span className={styles.question}>{item.question}</span>
+            <span className={styles.question}>
+              <InlineFormattedTextSource source={item.question} />
+            </span>
           </Link>
         </SectionedSurface.Row>
       ))}
@@ -170,7 +165,9 @@ function FaqAnswersGiven({ items, viewedProfileId }: { items: FaqAnswerGiven[]; 
               <time dateTime={row.created_at}>{formatRelativeDate(row.created_at)}</time>
             </div>
 
-            <p className={styles.parentQuestion}>{row.faq_item.question}</p>
+            <p className={styles.parentQuestion}>
+              <InlineFormattedTextSource source={row.faq_item.question} />
+            </p>
 
             <Link
               to="/rulesets/$rulesetSlug/faq/$questionSlug"
@@ -179,7 +176,7 @@ function FaqAnswersGiven({ items, viewedProfileId }: { items: FaqAnswerGiven[]; 
                 questionSlug: row.faq_item.slug,
               }}
             >
-              <p className={styles.answerPreview}>{truncate(row.answer)}</p>
+              <FormattedTextSource source={row.answer} className={styles.answerPreview} />
             </Link>
 
             {isPicked ? (

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Button, Center, Group, Image, Popover, Stack, Text, Textarea, TextInput, Title } from '@mantine/core';
+import { Anchor, Button, Center, Group, Image, Popover, Stack, Text, TextInput, Title } from '@mantine/core';
 import { RULESET_ASSET_SLOT_ORDER, RULESET_ASSET_SLOTS } from '@shared/rulesets/assetSlots';
 import type { RulesetAssetSlot } from '@shared/rulesets/assetSlots';
 import { rulesetAboutSchema } from '@shared/rulesets/validation';
@@ -9,6 +9,7 @@ import { LoginGate } from '@ui/block/LoginGate';
 import { NotAvailable } from '@ui/block/NotAvailable';
 import { rulesetAboutHint } from '@ui/content/rulesetAboutHint';
 import { SlugRenameNotice } from '@ui/content/SlugRenameNotice';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { IconAction } from '@ui/control/IconAction';
 import { SubmitAction } from '@ui/control/SubmitAction';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -92,7 +93,7 @@ function RulesetSettings({ initial, canRename }: { initial: RulesetEntry; canRen
         disabled={!canRename}
       />
 
-      <Textarea
+      <FormattedTextInput
         id="ruleset-settings-about"
         name="about"
         label="About"
@@ -102,7 +103,7 @@ function RulesetSettings({ initial, canRename }: { initial: RulesetEntry; canRen
         autosize
         minRows={4}
         value={about}
-        onChange={(event) => setAbout(event.currentTarget.value)}
+        onChange={setAbout}
       />
 
       <TextInput

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
@@ -1,12 +1,14 @@
-import { Group, Stack, Textarea } from '@mantine/core';
+import { Group, Stack } from '@mantine/core';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { LoadError } from '@ui/block/LoadError';
 import { LoadPending } from '@ui/block/LoadPending';
 import { NotAvailable } from '@ui/block/NotAvailable';
+import { FormattedTextSource, InlineFormattedTextSource } from '@ui/content/FormattedText';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { FaqTagFieldset } from '@ui/control/FaqTagFieldset';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
@@ -103,6 +105,7 @@ function LoadedFaqQuestion() {
   );
 
   const [editing, setEditing] = useState(INITIAL_FAQ_EDITING_STATE);
+  const [newAnswer, setNewAnswer] = useState('');
   const editingSessionRef = useRef<FaqEditingSession>(undefined);
   const commandsRef = useRef({ faq });
   commandsRef.current = { faq };
@@ -201,10 +204,11 @@ function LoadedFaqQuestion() {
             <Stack gap="sm">
               {editing.editingQuestion ? (
                 <Stack gap="sm">
-                  <Textarea
+                  <FormattedTextInput
                     label="Edit question"
                     value={editing.questionValue}
-                    onChange={(e) => editingSession.setQuestionValue(e.target.value)}
+                    onChange={(value) => editingSession.setQuestionValue(value)}
+                    profile="marks-only"
                     rows={2}
                   />
                   <FaqTagFieldset
@@ -246,7 +250,9 @@ function LoadedFaqQuestion() {
                       />
                     )}
                     <div>
-                      <h2 className={styles.questionTitle}>{item.text}</h2>
+                      <h2 className={styles.questionTitle}>
+                        <InlineFormattedTextSource source={item.text} />
+                      </h2>
                     </div>
                   </div>
                   {item.capabilities.editQuestion && (
@@ -279,18 +285,16 @@ function LoadedFaqQuestion() {
                 gap="sm"
                 onSubmit={(e) => {
                   e.preventDefault();
-                  const formEl = e.target as HTMLFormElement;
-                  const answer = (formEl.elements.namedItem('answer') as HTMLTextAreaElement).value.trim();
-                  if (!answer) {
+                  if (!newAnswer.trim()) {
                     return;
                   }
                   void faq.createAnswer
-                    .run({ answer })
-                    .then(() => formEl.reset())
+                    .run({ answer: newAnswer })
+                    .then(() => setNewAnswer(''))
                     .catch(() => undefined);
                 }}
               >
-                <Textarea
+                <FormattedTextInput
                   description="Add your answer (1 per person-you can edit it later)"
                   error={faq.createAnswer.isError ? faq.createAnswer.error?.message : undefined}
                   name="answer"
@@ -298,6 +302,8 @@ function LoadedFaqQuestion() {
                   required
                   minLength={1}
                   placeholder="Your answer..."
+                  value={newAnswer}
+                  onChange={setNewAnswer}
                 />
                 <Group gap="xs" wrap="nowrap">
                   <IconAction
@@ -332,10 +338,10 @@ function LoadedFaqQuestion() {
                     >
                       {isEditing ? (
                         <Stack gap="sm">
-                          <Textarea
+                          <FormattedTextInput
                             label="Edit your answer"
                             value={editing.answerValue}
-                            onChange={(e) => editingSession.setAnswerValue(e.target.value)}
+                            onChange={(value) => editingSession.setAnswerValue(value)}
                             rows={3}
                           />
                           <Group gap="xs" wrap="nowrap">
@@ -376,7 +382,9 @@ function LoadedFaqQuestion() {
                               )}
                             </div>
                           )}
-                          <div className={styles.answerContent}>{a.text}</div>
+                          <div className={styles.answerContent}>
+                            <FormattedTextSource source={a.text} />
+                          </div>
                           <Group gap="xs" wrap="nowrap">
                             {a.capabilities.acceptAnswer && (
                               <IconAction

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/$questionSlug.tsx
@@ -93,6 +93,52 @@ function FaqDetailPage() {
   return <LoadedFaqQuestion />;
 }
 
+type FaqQuestionCommands = ReturnType<typeof useFaqQuestionPage>;
+
+function AddAnswerForm({ createAnswer }: { createAnswer: FaqQuestionCommands['createAnswer'] }) {
+  const [answer, setAnswer] = useState('');
+
+  return (
+    <Stack
+      component="form"
+      gap="sm"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!answer.trim()) {
+          return;
+        }
+        void createAnswer
+          .run({ answer })
+          .then(() => setAnswer(''))
+          .catch(() => undefined);
+      }}
+    >
+      <FormattedTextInput
+        description="Add your answer (1 per person-you can edit it later)"
+        error={createAnswer.isError ? createAnswer.error?.message : undefined}
+        name="answer"
+        rows={3}
+        required
+        minLength={1}
+        placeholder="Your answer..."
+        value={answer}
+        onChange={setAnswer}
+      />
+      <Group gap="xs" wrap="nowrap">
+        <IconAction
+          label="Add answer"
+          variant="filled"
+          color="confirm"
+          size="lg"
+          type="submit"
+          disabled={createAnswer.isPending}
+          icon={<MessageSquarePlus size={16} aria-hidden />}
+        />
+      </Group>
+    </Stack>
+  );
+}
+
 function LoadedFaqQuestion() {
   const { rulesetSlug, questionSlug } = Route.useParams();
   const loaderData = Route.useLoaderData();
@@ -105,7 +151,6 @@ function LoadedFaqQuestion() {
   );
 
   const [editing, setEditing] = useState(INITIAL_FAQ_EDITING_STATE);
-  const [newAnswer, setNewAnswer] = useState('');
   const editingSessionRef = useRef<FaqEditingSession>(undefined);
   const commandsRef = useRef({ faq });
   commandsRef.current = { faq };
@@ -279,45 +324,7 @@ function LoadedFaqQuestion() {
               )}
             </Stack>
 
-            {showAddAnswerForm && (
-              <Stack
-                component="form"
-                gap="sm"
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  if (!newAnswer.trim()) {
-                    return;
-                  }
-                  void faq.createAnswer
-                    .run({ answer: newAnswer })
-                    .then(() => setNewAnswer(''))
-                    .catch(() => undefined);
-                }}
-              >
-                <FormattedTextInput
-                  description="Add your answer (1 per person-you can edit it later)"
-                  error={faq.createAnswer.isError ? faq.createAnswer.error?.message : undefined}
-                  name="answer"
-                  rows={3}
-                  required
-                  minLength={1}
-                  placeholder="Your answer..."
-                  value={newAnswer}
-                  onChange={setNewAnswer}
-                />
-                <Group gap="xs" wrap="nowrap">
-                  <IconAction
-                    label="Add answer"
-                    variant="filled"
-                    color="confirm"
-                    size="lg"
-                    type="submit"
-                    disabled={faq.createAnswer.isPending}
-                    icon={<MessageSquarePlus size={16} aria-hidden />}
-                  />
-                </Group>
-              </Stack>
-            )}
+            {showAddAnswerForm ? <AddAnswerForm createAnswer={faq.createAnswer} /> : null}
 
             {hasUserAnswered && !showAddAnswerForm && (
               <p className={styles.hintBlock}>You&apos;ve answered. You can edit your answer below.</p>

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
@@ -1,11 +1,13 @@
-import { Button, Group, Stack, TextInput, Textarea } from '@mantine/core';
+import { Button, Group, Stack } from '@mantine/core';
 import type { FaqTag } from '@shared/faq/tags';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { LoadPending } from '@ui/block/LoadPending';
 import { LoginGate } from '@ui/block/LoginGate';
 import { FaqTagFieldset } from '@ui/control/FaqTagFieldset';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
+import { useState } from 'react';
 
 import { useAskFaqQuestion } from '@db/faq';
 import { useCurrentProfile } from '@db/profiles';
@@ -26,6 +28,8 @@ function FaqCreatePage() {
   const ruleset = useRulesetBySlug(rulesetSlug, { initialData: loaderData.ruleset });
   const profile = useCurrentProfile();
   const askQuestion = useAskFaqQuestion();
+  const [question, setQuestion] = useState('');
+  const [answer, setAnswer] = useState('');
   const rulesetRow = ruleset.data?.ruleset;
 
   const header = (
@@ -79,12 +83,10 @@ function FaqCreatePage() {
             onSubmit={(e) => {
               e.preventDefault();
               const formEl = e.target as HTMLFormElement;
-              const question = (formEl.elements.namedItem('question') as HTMLInputElement).value.trim();
-              const answer = (formEl.elements.namedItem('answer') as HTMLTextAreaElement).value.trim();
               const selectedTags = Array.from(
                 formEl.querySelectorAll<HTMLInputElement>('input[name="tags"]:checked')
               ).map((input) => input.value as FaqTag);
-              if (!question) {
+              if (!question.trim()) {
                 return;
               }
               if (selectedTags.length === 0) {
@@ -94,11 +96,13 @@ function FaqCreatePage() {
                 .run({
                   rulesetId,
                   question,
-                  initialAnswer: answer || undefined,
+                  initialAnswer: answer.trim() ? answer : undefined,
                   tags: selectedTags,
                 })
                 .then((locator) => {
                   formEl.reset();
+                  setQuestion('');
+                  setAnswer('');
                   navigate({
                     to: '/rulesets/$rulesetSlug/faq/$questionSlug',
                     params: locator,
@@ -107,19 +111,23 @@ function FaqCreatePage() {
                 .catch(() => undefined);
             }}
           >
-            <TextInput
+            <FormattedTextInput
               label="Ask a question"
-              type="text"
               name="question"
+              profile="marks-only"
               required
               minLength={1}
               placeholder="Your question..."
+              value={question}
+              onChange={setQuestion}
             />
-            <Textarea
+            <FormattedTextInput
               label="Your answer (optional-you can add or edit it later)"
               name="answer"
               rows={3}
               placeholder="Optional answer..."
+              value={answer}
+              onChange={setAnswer}
             />
             <FaqTagFieldset />
             <Group gap="xs" wrap="nowrap">

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -12,6 +12,7 @@ import { NotAvailable } from '@ui/block/NotAvailable';
 import { ProposedContent } from '@ui/block/ProposedContent';
 import { Section } from '@ui/block/Section';
 import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
+import { FormattedTextSource } from '@ui/content/FormattedText';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { StatusBadge } from '@ui/content/StatusBadge';
 import { TopicIcon } from '@ui/content/TopicIcon';
@@ -513,7 +514,7 @@ function RulesetDetailPage() {
               <Section id="overview" icon={<TopicIcon topic="about" size={20} />} title="About this ruleset">
                 <Surface padding="lg">
                   {r.about.trim() ? (
-                    <Text className={styles.about}>{r.about}</Text>
+                    <FormattedTextSource source={r.about} />
                   ) : (
                     <Text size="sm" c="dimmed" fs="italic">
                       Nothing written about this yet.

--- a/src/app/routes/_app/rulesets/RulesetDetail.module.css
+++ b/src/app/routes/_app/rulesets/RulesetDetail.module.css
@@ -24,14 +24,6 @@
   height: 6rem;
 }
 
-/*
- * About is authored in a textarea, so the author's own line breaks are the only structure it carries.
- * `pre-line` keeps them while still collapsing runs of spaces and wrapping normally.
- */
-.about {
-  white-space: pre-line;
-}
-
 .rulesetTitle {
   overflow-wrap: anywhere;
   color: var(--color-text, var(--mantine-color-dark-8));

--- a/src/app/routes/_app/rulesets/create.tsx
+++ b/src/app/routes/_app/rulesets/create.tsx
@@ -1,10 +1,11 @@
-import { Button, Group, Stack, Textarea, TextInput } from '@mantine/core';
+import { Button, Group, Stack, TextInput } from '@mantine/core';
 import { rulesetAboutSchema } from '@shared/rulesets/validation';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
 import { LoginGate } from '@ui/block/LoginGate';
 import { PageTitle } from '@ui/block/PageTitle';
 import { rulesetAboutHint } from '@ui/content/rulesetAboutHint';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
@@ -62,7 +63,7 @@ function CreateRulesetForm() {
         value={name}
         onChange={(event) => setName(event.target.value)}
       />
-      <Textarea
+      <FormattedTextInput
         label="About"
         name="about"
         description={rulesetAboutHint(about)}
@@ -71,7 +72,7 @@ function CreateRulesetForm() {
         autosize
         minRows={4}
         value={about}
-        onChange={(event) => setAbout(event.currentTarget.value)}
+        onChange={setAbout}
       />
       {createRuleset.error ? (
         <FormError title="Ruleset could not be created">{createRuleset.error.message}</FormError>

--- a/src/app/ui/content/FormattedText.stories.tsx
+++ b/src/app/ui/content/FormattedText.stories.tsx
@@ -1,7 +1,7 @@
 import preview from '@sb/preview';
 import { parseFormattedText } from '@shared/formattedText';
 
-import { FormattedText } from './FormattedText';
+import { FormattedText, FormattedTextSource, InlineFormattedTextSource } from './FormattedText';
 import type { FormattedTextBlocks } from './FormattedText';
 
 function validBlocks(source: string): FormattedTextBlocks {
@@ -64,4 +64,18 @@ export const Empty = meta.story({
   args: {
     blocks: [],
   },
+});
+
+export const StoredSource = meta.story({
+  args: { blocks: [] },
+  render: () => <FormattedTextSource source={'A *formatted* paragraph.\n\n- First point\n- Second point'} />,
+});
+
+export const InlineSource = meta.story({
+  args: { blocks: [] },
+  render: () => (
+    <h2>
+      Can I use <InlineFormattedTextSource source="*this* effect" />?
+    </h2>
+  ),
 });

--- a/src/app/ui/content/FormattedText.test.tsx
+++ b/src/app/ui/content/FormattedText.test.tsx
@@ -5,7 +5,7 @@ import { cleanup, render, screen } from '@testing-library/react';
 import { appContentTheme } from '@ui/theme';
 import { afterEach, expect, it, vi } from 'vitest';
 
-import { FormattedText } from './FormattedText';
+import { FormattedText, FormattedTextSource, InlineFormattedTextSource } from './FormattedText';
 import type { FormattedTextBlocks } from './FormattedText';
 
 window.matchMedia = vi.fn().mockImplementation((query: string) => ({
@@ -83,4 +83,29 @@ it('renders no placeholder for empty parsed blocks', () => {
   renderFormattedText([]);
 
   expect(screen.getByTestId('formatted-text-host').childElementCount).toBe(0);
+});
+
+it('parses stored prose and marks through the Content reader', () => {
+  render(
+    <MantineProvider theme={appContentTheme} forceColorScheme="light">
+      <FormattedTextSource source={'Opening *bold*.\n\n- First\n- Second'} />
+      <h2>
+        <InlineFormattedTextSource source="A _marked_ question" />
+      </h2>
+    </MantineProvider>
+  );
+
+  expect(screen.getByText('bold').tagName).toBe('STRONG');
+  expect(screen.getByText('marked').tagName).toBe('SPAN');
+  expect(screen.getAllByRole('listitem')).toHaveLength(2);
+});
+
+it('shows legacy invalid source as plain text instead of dropping it', () => {
+  render(
+    <MantineProvider theme={appContentTheme} forceColorScheme="light">
+      <FormattedTextSource source="*unfinished" />
+    </MantineProvider>
+  );
+
+  expect(screen.getByText('*unfinished')).toBeTruthy();
 });

--- a/src/app/ui/content/FormattedText.tsx
+++ b/src/app/ui/content/FormattedText.tsx
@@ -1,5 +1,7 @@
 import { List, Stack, Text } from '@mantine/core';
-import type { FormattedTextParseResult } from '@shared/formattedText';
+import type { ListProps, TextProps } from '@mantine/core';
+import { parseFormattedText } from '@shared/formattedText';
+import type { FormattedTextParseResult, FormattedTextProfile } from '@shared/formattedText';
 import { Fragment } from 'react';
 import type { ReactNode } from 'react';
 
@@ -53,20 +55,30 @@ function renderInline(nodes: readonly FormattedTextInlineNode[]): ReactNode {
  * Callers own parsing and decide what to do with invalid or empty source.
  * This component owns the app-side HTML semantics for every valid block and mark.
  */
-export function FormattedText({ blocks }: Readonly<{ blocks: FormattedTextBlocks }>) {
+export function FormattedText({
+  blocks,
+  className,
+  size,
+  c,
+}: Readonly<{
+  blocks: FormattedTextBlocks;
+  className?: string;
+  size?: ListProps['size'];
+  c?: TextProps['c'];
+}>) {
   if (blocks.length === 0) {
     return null;
   }
 
   return (
-    <Stack gap="xs">
+    <Stack gap="xs" className={className}>
       {blocks.map((block, index) =>
         block.kind === 'paragraph' ? (
-          <Text key={index} component="p">
+          <Text key={index} component="p" size={size} c={c}>
             {renderInline(block.children)}
           </Text>
         ) : (
-          <List key={index} spacing="xs">
+          <List key={index} spacing="xs" size={size} c={c}>
             {block.items.map((item, itemIndex) => (
               <List.Item key={itemIndex}>{renderInline(item.children)}</List.Item>
             ))}
@@ -75,4 +87,41 @@ export function FormattedText({ blocks }: Readonly<{ blocks: FormattedTextBlocks
       )}
     </Stack>
   );
+}
+
+/** A marks-only block rendered inside the caller's existing text element. */
+function InlineFormattedText({ blocks }: Readonly<{ blocks: FormattedTextBlocks }>) {
+  const paragraph = blocks[0];
+  return paragraph?.kind === 'paragraph' ? renderInline(paragraph.children) : null;
+}
+
+/** Parse stored prose and render it through the app's Content treatment, with plain text as the legacy fallback. */
+export function FormattedTextSource({
+  source,
+  profile = 'prose',
+  className,
+  size,
+  c,
+}: Readonly<{
+  source: string;
+  profile?: FormattedTextProfile;
+  className?: string;
+  size?: ListProps['size'];
+  c?: TextProps['c'];
+}>) {
+  const parsed = parseFormattedText(source, profile);
+  if (!parsed.valid) {
+    return (
+      <Text className={className} size={size} c={c}>
+        {source}
+      </Text>
+    );
+  }
+  return <FormattedText blocks={parsed.blocks} className={className} size={size} c={c} />;
+}
+
+/** Parse stored inline prose and render its marks inside the caller's existing text element. */
+export function InlineFormattedTextSource({ source }: Readonly<{ source: string }>) {
+  const parsed = parseFormattedText(source, 'marks-only');
+  return parsed.valid ? <InlineFormattedText blocks={parsed.blocks} /> : source;
 }

--- a/src/app/ui/control/FormattedTextInput.stories.tsx
+++ b/src/app/ui/control/FormattedTextInput.stories.tsx
@@ -39,7 +39,7 @@ const meta = preview.meta({
 export const ValidDraft = meta.story({
   args: {
     value:
-      'Lead with *bold words*, add _underlining_, and finish with /italics/.\n\n- One clear point\n- Another clear point',
+      'Lead with *bold words*, add _underlining_, and finish with -italics-.\n\n- One clear point\n- Another clear point',
   },
 });
 
@@ -70,5 +70,13 @@ export const EmptyMark = meta.story({
 export const UnclosedMark = meta.story({
   args: {
     value: 'An *unfinished draft',
+  },
+});
+
+export const MarksOnlyRejectsParagraphs = meta.story({
+  args: {
+    label: 'Revival instructions',
+    profile: 'marks-only',
+    value: '1 *free* revival.\nThis second line is not allowed.',
   },
 });

--- a/src/app/ui/control/FormattedTextInput.test.tsx
+++ b/src/app/ui/control/FormattedTextInput.test.tsx
@@ -20,10 +20,10 @@ window.matchMedia = vi.fn().mockImplementation((query: string) => ({
 
 afterEach(cleanup);
 
-function renderInput(value: string, onChange = vi.fn(), error?: string) {
+function renderInput(value: string, onChange = vi.fn(), error?: string, profile?: 'prose' | 'marks-only') {
   render(
     <MantineProvider theme={appContentTheme} forceColorScheme="light">
-      <FormattedTextInput label="Text" value={value} onChange={onChange} error={error} />
+      <FormattedTextInput label="Text" value={value} onChange={onChange} error={error} profile={profile} />
     </MantineProvider>
   );
   return onChange;
@@ -43,6 +43,12 @@ it('keeps field-specific validation while formatted text is valid', () => {
   renderInput('', vi.fn(), 'Text is required');
 
   expect(screen.getByText('Text is required')).toBeTruthy();
+});
+
+it('rejects paragraphs in marks-only fields without rejecting marks', () => {
+  renderInput('First *bold* line\nsecond line', vi.fn(), undefined, 'marks-only');
+
+  expect(screen.getByText(/not line breaks or paragraphs/)).toBeTruthy();
 });
 
 it('passes the edited string through the control membrane', () => {

--- a/src/app/ui/control/FormattedTextInput.tsx
+++ b/src/app/ui/control/FormattedTextInput.tsx
@@ -1,7 +1,7 @@
 import { Textarea } from '@mantine/core';
 import type { TextareaProps } from '@mantine/core';
 import { parseFormattedText } from '@shared/formattedText';
-import type { FormattedTextParseResult } from '@shared/formattedText';
+import type { FormattedTextParseResult, FormattedTextProfile } from '@shared/formattedText';
 import { Fragment } from 'react';
 import type { ReactNode } from 'react';
 
@@ -10,6 +10,7 @@ type FormattedTextDiagnostic = Extract<FormattedTextParseResult, { valid: false 
 export interface FormattedTextInputProps extends Omit<TextareaProps, 'defaultValue' | 'onChange' | 'value'> {
   value: string;
   onChange: (value: string) => void;
+  profile?: FormattedTextProfile;
 }
 
 function Diagnostic({ diagnostic }: { diagnostic: FormattedTextDiagnostic }) {
@@ -56,8 +57,8 @@ function validationError(diagnostics: readonly FormattedTextDiagnostic[], fieldE
  * The caller owns the draft and any field-specific validation such as requiredness.
  * This control owns syntax validation so every author sees the same source location, explanation, and suggested repair.
  */
-export function FormattedTextInput({ value, onChange, error, ...props }: FormattedTextInputProps) {
-  const parsed = parseFormattedText(value);
+export function FormattedTextInput({ value, onChange, error, profile = 'prose', ...props }: FormattedTextInputProps) {
+  const parsed = parseFormattedText(value, profile);
   const diagnostics = parsed.valid ? [] : parsed.diagnostics;
 
   return (

--- a/src/app/ui/list/FaqList.tsx
+++ b/src/app/ui/list/FaqList.tsx
@@ -3,6 +3,7 @@ import type { FaqTag } from '@shared/faq/tags';
 import { Link } from '@tanstack/react-router';
 import { formatRelativeDate } from '@ui/content/dates';
 import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
+import { InlineFormattedTextSource } from '@ui/content/FormattedText';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { SectionedSurface } from '@ui/surface/SectionedSurface';
 import Fuse from 'fuse.js';
@@ -98,7 +99,7 @@ export function FaqList({
                         />
                       )}
                     >
-                      {item.question}
+                      <InlineFormattedTextSource source={item.question} />
                     </Anchor>
                     {(item.tags ?? []).map((tag) => (
                       <Badge key={`${item._id}:${tag}`} size="xs" variant="outline" color="dune">

--- a/src/app/widgets/asset-about/AboutChapter.tsx
+++ b/src/app/widgets/asset-about/AboutChapter.tsx
@@ -1,6 +1,7 @@
-import { Stack, Text, Textarea } from '@mantine/core';
+import { Stack, Text } from '@mantine/core';
 import { TopicIcon } from '@ui/content/TopicIcon';
 import { ControlBlock } from '@ui/control/ControlBlock';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import type { ConnectedTabsItem } from '@ui/surface/ConnectedTabs';
 
 /**
@@ -23,15 +24,9 @@ export function aboutChapter(about: string, onChange: (about: string) => void): 
           description="Rule details that do not belong on the artwork. Shown on this asset's page, never on the face."
           input={
             <Stack gap="xs">
-              <Textarea
-                aria-label="About"
-                autosize
-                minRows={4}
-                value={about}
-                onChange={(event) => onChange(event.currentTarget.value)}
-              />
+              <FormattedTextInput aria-label="About" autosize minRows={4} value={about} onChange={onChange} />
               <Text size="xs" c="dimmed">
-                Optional. Line breaks are kept; there is no formatting.
+                Optional. Use *bold*, -italics-, _underline_, paragraphs, or dash lists.
               </Text>
             </Stack>
           }

--- a/src/app/widgets/card-editor/TreacheryCardEditor.tsx
+++ b/src/app/widgets/card-editor/TreacheryCardEditor.tsx
@@ -1,19 +1,8 @@
-import {
-  Alert,
-  Divider,
-  Grid,
-  Group,
-  NumberInput,
-  Slider,
-  Stack,
-  Switch,
-  Text,
-  Textarea,
-  TextInput,
-} from '@mantine/core';
+import { Alert, Divider, Grid, Group, NumberInput, Slider, Stack, Switch, Text, TextInput } from '@mantine/core';
 import { TopicIcon } from '@ui/content/TopicIcon';
 import { AssetSelect } from '@ui/control/AssetSelect';
 import { ControlBlock } from '@ui/control/ControlBlock';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { ListLengthActions } from '@ui/control/ListLengthActions';
 import { CanvasScale } from '@ui/layout/CanvasScale';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
@@ -367,12 +356,12 @@ function BodyField({ draft, patch }: { draft: TreacheryDraft; patch: Patch }) {
       title="Body"
       description="Line breaks become paragraphs on the card."
       input={
-        <Textarea
+        <FormattedTextInput
           aria-label="Body"
           autosize
           minRows={4}
           value={draft.text}
-          onChange={(event) => patch({ text: event.currentTarget.value })}
+          onChange={(text) => patch({ text })}
         />
       }
     />

--- a/src/app/widgets/faction-editor/FactionCollectionShelf.tsx
+++ b/src/app/widgets/faction-editor/FactionCollectionShelf.tsx
@@ -2,6 +2,7 @@ import { closestCenter, DndContext, KeyboardSensor, PointerSensor, useSensor, us
 import type { DragEndEvent } from '@dnd-kit/core';
 import { rectSortingStrategy, SortableContext, sortableKeyboardCoordinates } from '@dnd-kit/sortable';
 import { Box, Text, UnstyledButton } from '@mantine/core';
+import { FormattedTextSource } from '@ui/content/FormattedText';
 import { IconAction } from '@ui/control/IconAction';
 import { GripVertical } from 'lucide-react';
 
@@ -52,9 +53,7 @@ function ShelfItem({
           {index + 1}. {item.label}
         </Text>
         {item.description ? (
-          <Text className={styles.description} size="xs" c="dimmed">
-            {item.description}
-          </Text>
+          <FormattedTextSource source={item.description} className={styles.description} size="xs" c="dimmed" />
         ) : null}
       </UnstyledButton>
     </Box>

--- a/src/app/widgets/faction-editor/FactionFormFields.tsx
+++ b/src/app/widgets/faction-editor/FactionFormFields.tsx
@@ -3,6 +3,7 @@ import { recalculateFactionComplexity } from '@shared/factions/complexity';
 import { FactionCard } from '@ui/block/FactionCard';
 import { effectiveComplexity } from '@ui/content/complexity';
 import { ComplexityGlyph } from '@ui/content/ComplexityGlyph';
+import { FormattedTextSource, InlineFormattedTextSource } from '@ui/content/FormattedText';
 import { TopicIcon } from '@ui/content/TopicIcon';
 import { CanvasScale } from '@ui/layout/CanvasScale';
 import { ConnectedTabs } from '@ui/surface/ConnectedTabs';
@@ -313,13 +314,14 @@ function ArtifactProof({
                 At start
               </Text>
               <Text ff="serif" size="sm">
-                Starting spice: {faction.rules.spiceCount} · {faction.rules.startText}
+                Starting spice: {faction.rules.spiceCount} ·{' '}
+                <InlineFormattedTextSource source={faction.rules.startText} />
               </Text>
               <Text ff="serif" fw={800} tt="uppercase" mt="md">
                 Revival
               </Text>
               <Text ff="serif" size="sm">
-                {faction.rules.revivalText}
+                <InlineFormattedTextSource source={faction.rules.revivalText} />
               </Text>
             </Box>
           );
@@ -330,13 +332,14 @@ function ArtifactProof({
               <Text ff="serif" fw={800} tt="uppercase">
                 {selectedAdvantage.title || 'Faction advantage'}
               </Text>
-              <Text ff="serif" size="sm">
-                {selectedAdvantage.text}
-              </Text>
+              <FormattedTextSource source={selectedAdvantage.text} size="sm" />
               {selectedAdvantage.karama ? (
-                <Text ff="serif" size="sm" mt="md">
-                  <strong>Karama:</strong> {selectedAdvantage.karama}
-                </Text>
+                <Box mt="md">
+                  <Text ff="serif" size="sm" fw={700}>
+                    Karama
+                  </Text>
+                  <FormattedTextSource source={selectedAdvantage.karama} size="sm" />
+                </Box>
               ) : null}
             </Box>
           ) : (

--- a/src/app/widgets/faction-editor/FactionFormSectionAdvantages.tsx
+++ b/src/app/widgets/faction-editor/FactionFormSectionAdvantages.tsx
@@ -1,6 +1,7 @@
 import { arrayMove } from '@dnd-kit/sortable';
-import { Alert, Box, Group, Stack, Text, TextInput, Textarea } from '@mantine/core';
+import { Alert, Box, Group, Stack, Text, TextInput } from '@mantine/core';
 import { ControlBlock } from '@ui/control/ControlBlock';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { ListLengthActions } from '@ui/control/ListLengthActions';
 import { useState } from 'react';
 
@@ -50,7 +51,7 @@ function AdvantageCard({ form, index }: { form: FactionFormApi; index: number })
               <ControlBlock
                 title="Advantage rule"
                 input={
-                  <Textarea
+                  <FormattedTextInput
                     id={`adv-${index}-text`}
                     aria-label="Advantage rule"
                     autosize
@@ -58,7 +59,7 @@ function AdvantageCard({ form, index }: { form: FactionFormApi; index: number })
                     value={field.state.value}
                     aria-describedby={textIsBlank ? warningId : undefined}
                     onBlur={field.handleBlur}
-                    onChange={(event) => field.handleChange(event.currentTarget.value)}
+                    onChange={field.handleChange}
                   />
                 }
               />
@@ -78,14 +79,14 @@ function AdvantageCard({ form, index }: { form: FactionFormApi; index: number })
             title="Karama interaction (optional)"
             description="Describe the Karama effect only when this advantage has one."
             input={
-              <Textarea
+              <FormattedTextInput
                 id={`adv-${index}-karama`}
                 aria-label="Karama interaction (optional)"
                 autosize
                 minRows={2}
                 value={field.state.value ?? ''}
                 onBlur={field.handleBlur}
-                onChange={(event) => field.handleChange(event.currentTarget.value || undefined)}
+                onChange={(value) => field.handleChange(value || undefined)}
               />
             }
           />

--- a/src/app/widgets/faction-editor/FactionFormSectionAlliance.tsx
+++ b/src/app/widgets/faction-editor/FactionFormSectionAlliance.tsx
@@ -1,5 +1,6 @@
-import { Alert, Divider, Grid, Group, Stack, Text, Textarea } from '@mantine/core';
+import { Alert, Divider, Grid, Group, Stack, Text } from '@mantine/core';
 import { ControlBlock } from '@ui/control/ControlBlock';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { ListLengthActions } from '@ui/control/ListLengthActions';
 import { CanvasScale } from '@ui/layout/CanvasScale';
 
@@ -85,9 +86,9 @@ export function FactionFormSectionAlliance({
                   <Stack gap="md">
                     <ControlBlock
                       title="Alliance ability"
-                      description="Rules text printed on the alliance card. Markdown is supported."
+                      description="Rules text printed on the alliance card. Use the shared formatted-text syntax."
                       input={
-                        <Textarea
+                        <FormattedTextInput
                           id="rules-alliance"
                           aria-label="Alliance ability"
                           autosize
@@ -95,7 +96,7 @@ export function FactionFormSectionAlliance({
                           value={field.state.value}
                           aria-describedby={blank ? 'rules-alliance-warning' : undefined}
                           onBlur={field.handleBlur}
-                          onChange={(event) => field.handleChange(event.currentTarget.value)}
+                          onChange={field.handleChange}
                         />
                       }
                     />

--- a/src/app/widgets/faction-editor/FactionFormSectionPlanets.tsx
+++ b/src/app/widgets/faction-editor/FactionFormSectionPlanets.tsx
@@ -1,5 +1,6 @@
-import { Alert, Divider, Group, Input, SimpleGrid, Stack, TextInput, Textarea } from '@mantine/core';
+import { Alert, Divider, Group, Input, SimpleGrid, Stack, TextInput } from '@mantine/core';
 import { AssetSelect } from '@ui/control/AssetSelect';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { ListLengthActions } from '@ui/control/ListLengthActions';
 import { useState } from 'react';
 
@@ -70,15 +71,15 @@ function PlanetFields({ form, index, onFocus }: { form: FactionFormApi; index: n
 
             <form.Field name={`planet[${index}].description`}>
               {(field) => (
-                <Textarea
+                <FormattedTextInput
                   id={`planet-${index}-description`}
                   label="Description"
                   autosize
                   minRows={2}
-                  value={field.state.value}
+                  value={field.state.value ?? ''}
                   onFocus={onFocus}
                   onBlur={field.handleBlur}
-                  onChange={(event) => field.handleChange(event.currentTarget.value)}
+                  onChange={field.handleChange}
                 />
               )}
             </form.Field>

--- a/src/app/widgets/faction-editor/FactionFormSectionRules.tsx
+++ b/src/app/widgets/faction-editor/FactionFormSectionRules.tsx
@@ -1,5 +1,6 @@
-import { Divider, NumberInput, SimpleGrid, Stack, Text, TextInput, Textarea } from '@mantine/core';
+import { Divider, NumberInput, SimpleGrid, Stack, Text, TextInput } from '@mantine/core';
 import { ControlBlock } from '@ui/control/ControlBlock';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 
 import type { FactionFormApi } from './factionFormTypes';
 
@@ -29,15 +30,16 @@ function SetupFields({ form }: { form: FactionFormApi }) {
                     title="Starting instructions"
                     description="Free-form setup instructions shown in the faction rules output. Do not repeat the structured spice amount here unless the prose genuinely needs it."
                     input={
-                      <Textarea
+                      <FormattedTextInput
                         id="rules-start"
                         aria-label="Starting instructions"
                         autosize
                         minRows={4}
+                        profile="marks-only"
                         value={field.state.value}
                         aria-describedby={isBlank(field.state.value) ? warningId : undefined}
                         onBlur={field.handleBlur}
-                        onChange={(event) => field.handleChange(event.currentTarget.value)}
+                        onChange={field.handleChange}
                       />
                     }
                   />
@@ -57,15 +59,16 @@ function SetupFields({ form }: { form: FactionFormApi }) {
                   <ControlBlock
                     title="Revival instructions"
                     input={
-                      <Textarea
+                      <FormattedTextInput
                         id="rules-revival"
                         aria-label="Revival instructions"
                         autosize
                         minRows={3}
+                        profile="marks-only"
                         value={field.state.value}
                         aria-describedby={isBlank(field.state.value) ? warningId : undefined}
                         onBlur={field.handleBlur}
-                        onChange={(event) => field.handleChange(event.currentTarget.value)}
+                        onChange={field.handleChange}
                       />
                     }
                   />
@@ -139,7 +142,7 @@ function FateFields({ form }: { form: FactionFormApi }) {
             const warningId = 'rules-fate-text-warning';
             return (
               <Stack gap="md">
-                <Textarea
+                <FormattedTextInput
                   id="rules-fate-text"
                   label="Fate rule"
                   autosize
@@ -147,7 +150,7 @@ function FateFields({ form }: { form: FactionFormApi }) {
                   value={field.state.value}
                   aria-describedby={isBlank(field.state.value) ? warningId : undefined}
                   onBlur={field.handleBlur}
-                  onChange={(event) => field.handleChange(event.currentTarget.value)}
+                  onChange={field.handleChange}
                 />
                 {isBlank(field.state.value) ? <Advisory id={warningId}>Fate text is empty.</Advisory> : null}
               </Stack>

--- a/src/app/widgets/faction-editor/TroopSideFields.tsx
+++ b/src/app/widgets/faction-editor/TroopSideFields.tsx
@@ -1,7 +1,8 @@
-import { Box, ColorInput, SimpleGrid, Stack, Switch, TextInput, Textarea } from '@mantine/core';
+import { Box, ColorInput, SimpleGrid, Stack, Switch, TextInput } from '@mantine/core';
 import { TROOP, TROOP_MODIFIER } from '@shared/assetIds';
 import { AssetSelect } from '@ui/control/AssetSelect';
 import { ControlBlock } from '@ui/control/ControlBlock';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { useEffect } from 'react';
 
 import type { Faction } from '@db/factions';
@@ -154,14 +155,14 @@ export function TroopSideFields({
               title={title}
               description="Used as the troop rules description on the faction sheet."
               input={
-                <Textarea
+                <FormattedTextInput
                   id={`${idBase}-desc`}
                   aria-label={title}
                   autosize
                   minRows={2}
-                  value={field.state.value}
+                  value={field.state.value ?? ''}
                   onBlur={field.handleBlur}
-                  onChange={(event) => field.handleChange(event.currentTarget.value)}
+                  onChange={field.handleChange}
                 />
               }
             />

--- a/src/shared/assets/schema.ts
+++ b/src/shared/assets/schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { ALL } from '../assetIds';
 import { Background, Decal } from '../factions/schema';
+import { proseFormattedTextSchema } from '../formattedText';
 
 const OFFSET = z.tuple([z.number(), z.number()]);
 const SCALE = z.number().min(0).max(1);
@@ -22,6 +23,7 @@ const URL = z.string().url();
  * `assets.data` is `v.any()`, so no Convex validator gates this: the migration is the only thing that makes it true.
  */
 const About = z.string().trim();
+const FormattedAbout = z.string().trim().pipe(proseFormattedTextSchema);
 
 export { Decal };
 
@@ -333,3 +335,14 @@ export const RectangleTokenAsset = z.strictObject({
   front: RectangleTokenFace,
   back: tokenBackUnion(RectangleTokenFace),
 });
+
+/** Write contracts normalize stored prose while the wider renderer contracts keep legacy rows readable. */
+export const TreacheryAssetInput = TreacheryAsset.extend({
+  about: FormattedAbout,
+  text: proseFormattedTextSchema,
+});
+
+export const DeckAssetInput = DeckAsset.extend({ about: FormattedAbout });
+export const BundleAssetInput = BundleAsset.extend({ about: FormattedAbout });
+export const TokenAssetInput = TokenAsset.extend({ about: FormattedAbout });
+export const RectangleTokenAssetInput = RectangleTokenAsset.extend({ about: FormattedAbout });

--- a/src/shared/factions/schema.test.ts
+++ b/src/shared/factions/schema.test.ts
@@ -27,6 +27,18 @@ describe('faction schema', () => {
     expect(CanonicalFactionStoredSchema.parse(historical).name).toBe('');
   });
 
+  it('narrows authored prose while keeping legacy stored prose readable', () => {
+    const multilineSetup = structuredClone(assetPublishingFaction);
+    multilineSetup.rules.startText = 'First line\nsecond line';
+    const invalidBody = structuredClone(assetPublishingFaction);
+    invalidBody.rules.advantages[0]!.text = '*unfinished';
+
+    expect(FactionInputSchema.safeParse(multilineSetup).success).toBe(false);
+    expect(FactionInputSchema.safeParse(invalidBody).success).toBe(false);
+    expect(CanonicalFactionStoredSchema.safeParse(multilineSetup).success).toBe(true);
+    expect(CanonicalFactionStoredSchema.safeParse(invalidBody).success).toBe(true);
+  });
+
   it('requires grouped complexity at authoring, storage, and client-read boundaries', () => {
     const { complexity: _complexity, ...withoutComplexity } = structuredClone(assetPublishingFaction);
 

--- a/src/shared/factions/schema.ts
+++ b/src/shared/factions/schema.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { ALL, BACKGROUND, GENERIC, LEADERS, LOGO, PLANET, TEXTURE, TROOP, TROOP_MODIFIER } from '../assetIds';
+import { marksOnlyFormattedTextSchema, proseFormattedTextSchema } from '../formattedText';
 
 const STRENGTH = z.union([z.number().int(), z.string().length(1)]);
 const OFFSET = z.tuple([z.number(), z.number()]);
@@ -150,8 +151,51 @@ const factionShape = {
   complexity: FactionComplexitySchema,
 };
 
+const AuthoringRule = RULE.extend({
+  text: proseFormattedTextSchema,
+  karama: proseFormattedTextSchema.optional(),
+});
+
+const AuthoringTroopSide = TroopSide.extend({ description: proseFormattedTextSchema });
+
+const AuthoringTroop = Troop.extend({
+  description: proseFormattedTextSchema,
+  back: AuthoringTroopSide.optional(),
+});
+
+const factionAuthoringShape = {
+  ...factionShape,
+  planet: z
+    .array(
+      z.strictObject({
+        image: PLANET.or(URL),
+        name: z.string(),
+        description: proseFormattedTextSchema,
+      })
+    )
+    .optional(),
+  troops: z.array(AuthoringTroop),
+  rules: z.strictObject({
+    startText: marksOnlyFormattedTextSchema,
+    revivalText: marksOnlyFormattedTextSchema,
+    spiceCount: z.number().int().positive(),
+    advantages: z.array(AuthoringRule),
+    fate: AuthoringRule.omit({ karama: true }),
+    alliance: AuthoringRule.omit({ karama: true, title: true }).required(),
+  }),
+  extras: z
+    .array(
+      z.strictObject({
+        name: z.string(),
+        description: proseFormattedTextSchema.optional(),
+        items: z.array(z.strictObject({ url: URL, description: proseFormattedTextSchema.optional() })),
+      })
+    )
+    .optional(),
+};
+
 /** Rejects unknown keys (e.g. `slug` must live on the Convex row, not in `data`). */
-export const FactionInputSchema = z.strictObject(factionShape);
+export const FactionInputSchema = z.strictObject(factionAuthoringShape);
 
 /**
  * Canonical storage is intentionally wider than current authoring semantics: historical rows with a blank name must remain readable while the UI requires a name for all new canonical writes.

--- a/src/shared/faq/validation.ts
+++ b/src/shared/faq/validation.ts
@@ -1,9 +1,18 @@
 import { z } from 'zod';
 
+import { marksOnlyFormattedTextSchema, proseFormattedTextSchema } from '../formattedText';
 import { FAQ_TAG_VALUES } from './tags';
 
-export const faqQuestionSchema = z.string().trim().min(1, 'Question is required');
+export const faqQuestionSchema = z
+  .string()
+  .trim()
+  .pipe(marksOnlyFormattedTextSchema)
+  .pipe(z.string().min(1, 'Question is required'));
 
-export const faqAnswerSchema = z.string().trim().min(1, 'Answer is required');
+export const faqAnswerSchema = z
+  .string()
+  .trim()
+  .pipe(proseFormattedTextSchema)
+  .pipe(z.string().min(1, 'Answer is required'));
 const faqTagSchema = z.enum(FAQ_TAG_VALUES);
 export const faqTagsSchema = z.array(faqTagSchema).min(1, 'Select at least one tag');

--- a/src/shared/formattedText.test.ts
+++ b/src/shared/formattedText.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import type { NormalizedFormattedText } from './formattedText';
-import { normalizeFormattedText, parseFormattedText } from './formattedText';
+import {
+  marksOnlyFormattedTextSchema,
+  normalizeFormattedText,
+  parseFormattedText,
+  proseFormattedTextSchema,
+} from './formattedText';
 
 function parseValid(input: string) {
   const result = parseFormattedText(input);
@@ -13,6 +18,14 @@ function parseValid(input: string) {
 }
 
 describe('formatted-text core', () => {
+  it('gives Zod writes the same normalization and profile diagnostics as the parser', () => {
+    expect(proseFormattedTextSchema.parse('Opening  \r\n\r\n- first')).toBe('Opening\n\n- first');
+    expect(marksOnlyFormattedTextSchema.safeParse('*one* line').success).toBe(true);
+    expect(marksOnlyFormattedTextSchema.safeParse('first\nsecond').error?.issues[0]?.message).toContain(
+      'not line breaks or paragraphs'
+    );
+  });
+
   it('accepts an empty value without deciding field requiredness', () => {
     const parsed = parseValid('');
     const normalized = normalizeFormattedText('');

--- a/src/shared/formattedText.ts
+++ b/src/shared/formattedText.ts
@@ -1,4 +1,5 @@
 import { graphemeSegments } from 'unicode-segmenter/grapheme';
+import { z } from 'zod';
 
 const FORMATTED_TEXT_MARKS = [
   { delimiter: '_', mark: 'underline' },
@@ -669,3 +670,26 @@ export function normalizeFormattedText(
   const parsed = parseFormattedText(input, profile);
   return parsed.valid ? { ok: true, value: parsed.source } : { ok: false, diagnostics: parsed.diagnostics };
 }
+
+function formattedTextSchema(profile: FormattedTextProfile) {
+  return z.string().transform((input, context): string => {
+    const normalized = normalizeFormattedText(input, profile);
+    if (normalized.ok) {
+      return normalized.value;
+    }
+
+    for (const diagnostic of normalized.diagnostics) {
+      context.addIssue({
+        code: 'custom',
+        message: `Line ${diagnostic.line}, column ${diagnostic.column}: ${diagnostic.message}`,
+      });
+    }
+    return z.NEVER;
+  });
+}
+
+/** Canonical stored prose with paragraphs, lists, hard breaks, and inline marks. */
+export const proseFormattedTextSchema = formattedTextSchema('prose');
+
+/** Canonical stored inline prose with marks, but no lists, hard breaks, or paragraphs. */
+export const marksOnlyFormattedTextSchema = formattedTextSchema('marks-only');

--- a/src/shared/rulesets/validation.ts
+++ b/src/shared/rulesets/validation.ts
@@ -1,6 +1,8 @@
 import { alphanumericNameSchema } from '@shared/validation/names';
 import { z } from 'zod';
 
+import { proseFormattedTextSchema } from '../formattedText';
+
 const rulesetNameSchema = alphanumericNameSchema('Ruleset name');
 
 /**
@@ -13,7 +15,10 @@ export const RULESET_ABOUT_MIN_LENGTH = 50;
 export const rulesetAboutSchema = z
   .string()
   .trim()
-  .min(RULESET_ABOUT_MIN_LENGTH, `Ruleset About must be at least ${RULESET_ABOUT_MIN_LENGTH} characters`);
+  .pipe(proseFormattedTextSchema)
+  .pipe(
+    z.string().min(RULESET_ABOUT_MIN_LENGTH, `Ruleset About must be at least ${RULESET_ABOUT_MIN_LENGTH} characters`)
+  );
 
 /**
  * Every ruleset write carries both fields.

--- a/src/shared/storedProseValidation.test.ts
+++ b/src/shared/storedProseValidation.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { publishingTreacheryCard } from './assets/fixtures/publishingTreacheryCard';
+import { TreacheryAsset, TreacheryAssetInput } from './assets/schema';
+import { faqAnswerSchema, faqQuestionSchema } from './faq/validation';
+import { rulesetAboutSchema } from './rulesets/validation';
+
+describe('stored prose write validation', () => {
+  it('normalizes valid asset prose and rejects invalid source only at the write boundary', () => {
+    const valid = { ...publishingTreacheryCard, about: 'Opening  \r\n\r\n- first' };
+    const invalid = { ...publishingTreacheryCard, text: '*unfinished' };
+
+    expect(TreacheryAssetInput.parse(valid).about).toBe('Opening\n\n- first');
+    expect(TreacheryAssetInput.safeParse(invalid).success).toBe(false);
+    expect(TreacheryAsset.safeParse(invalid).success).toBe(true);
+  });
+
+  it('allows blocks in ruleset About and FAQ answers, but keeps FAQ questions inline', () => {
+    const about = `${'*Formatted* rules explain the complete game clearly. '.repeat(2)}\n\n- First rule`;
+
+    expect(rulesetAboutSchema.safeParse(about).success).toBe(true);
+    expect(faqAnswerSchema.safeParse('Paragraph one\n\n- one\n- two').success).toBe(true);
+    expect(faqQuestionSchema.safeParse('Can I use *this* effect?').success).toBe(true);
+    expect(faqQuestionSchema.safeParse('First line\nsecond line').success).toBe(false);
+  });
+});

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,12 +4,12 @@
 // sharp version), so this file is reproducible on any machine (wayfinder #269).
 export const rendererManifest = {
   schemaVersion: 2,
-  rendererIdentity: 'faction-sheet/sha256:cd9435bcef4194e942ec50cbcb79eb147bbf13fa2e0b01ec748aaf7d92162702',
-  digest: 'cd9435bcef4194e942ec50cbcb79eb147bbf13fa2e0b01ec748aaf7d92162702',
+  rendererIdentity: 'faction-sheet/sha256:001ea9cb1ea510797fd30532c853944e56f819c8ac85533f0d4892e5aad7a2be',
+  digest: '001ea9cb1ea510797fd30532c853944e56f819c8ac85533f0d4892e5aad7a2be',
   components: {
     sources: '5289b6254320530ee857ff2912681e9d6a30135dbb3a92239296365f53397813',
     toolchain: 'e7e830225f6973a7d7e43aada3bcbcd5de3c169378aa25849d24d8de97ea517a',
-    code: 'a12108750367295d4948d75e861db9ee3089fe48f11db779750d652283447cf7',
+    code: 'a0b6428d20c9acbedead99b313b2eb1f9d187f61cc1cc8fa19c452d0bfb17659',
     contract: '2920714c87493d104342355dda2b956202259513c78ce6195670034f31a656a6',
   },
   contract: {


### PR DESCRIPTION
Closes #752.

PR #753 first normalized production and verified all faction setup and revival values. This release applies the narrow contract:

- Setup, Revival, and FAQ questions allow bold, italics, and underline, but reject line breaks, paragraphs, and lists.
- Faction rule bodies, treachery-card text, Asset About, ruleset About, and FAQ answers allow the full formatted-text block language.
- Shared Zod schemas normalize every write, while wider read schemas keep legacy rows readable.
- Asset, ruleset, faction, FAQ, profile, list, and editor previews render stored prose through app Content.

## Visual proof

The old field was a plain Textarea, so the second line was accepted without feedback. The production-deployed marks-only field identifies the exact line and explains that it must become a space.

| Before | After on production |
| --- | --- |
| ![Plain Textarea accepts the layout line break](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-754-before-marks-only-control.png) | ![Production marks-only control rejects the layout line break](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-754-after-production-marks-only-control.png) |

The production migration proof is on PR #753: https://github.com/ndelangen/dunezone/pull/753#issuecomment-5412182058

## Production data gate

The classifier was rerun immediately before narrowing:

- 76 faction inline values, 0 invalid
- 415 faction body values, 0 invalid
- 41 Asset prose values, 0 invalid
- 2 ruleset About values, 0 invalid
- Production currently has 0 FAQ questions and 0 FAQ answers

## Checks

- bun run test: 114 files, 749 tests
- bun run typecheck
- bun run knip
- bun run migrations:static-check
- bun run migrations:narrow-check
- VITE_CONVEX_URL set to production: bun run check
- VITE_CONVEX_URL set to production: bun run publisher:release:verify
- Exact branch functions deployed successfully to the claimed shared development deployment

## Production verification

- Merge commit 371836b32e03cacfeeefbef9fa42eab6a8268d84 deployed in workflow run 32863867052.
- Production Convex deploy, required migrations, exact Worker release, and Worker smoke test passed.
- Production schema narrowing prerequisites passed after deployment.
- The public Richese page returned HTTP 200.
- The deployed Storybook story above shows the marks-only paragraph rejection on production.