### PR TITLE
Rulebook text fields explain formatted-text repairs

### DIFF
--- a/e2e/rulebook-editor-route.spec.ts
+++ b/e2e/rulebook-editor-route.spec.ts
@@ -15,6 +15,11 @@ test('the local Rulebook editor keeps its preview synchronized', async ({ page }
   await page.getByRole('textbox', { name: 'Text block' }).fill('A browser-local Rulebook revision.');
 
   await expect(preview).toContainText('A browser-local Rulebook revision.');
+
+  await page.getByRole('textbox', { name: 'Text block' }).fill('An *unfinished draft');
+  await expect(page.getByText('Line 1, column 4: Bold starts here but has no closing *.')).toBeVisible();
+  await expect(page.getByText('Suggestion: Add * after the words you want formatted, or remove this *.')).toBeVisible();
+  await expect(preview).toContainText('An *unfinished draft');
 });
 
 test('the fit toggle changes Page size while the document owns vertical scrolling', async ({ page }) => {
@@ -143,6 +148,10 @@ test('a repeated text item can be added, edited, previewed, and removed', async 
   const addedItem = page.getByRole('textbox', {
     name: `repeated text block, item ${originalCount + 1}`,
   });
+  await addedItem.fill('An *unfinished draft');
+  await expect(page.getByText('Line 1, column 4: Bold starts here but has no closing *.')).toBeVisible();
+  await expect(page.getByText('Suggestion: Add * after the words you want formatted, or remove this *.')).toBeVisible();
+
   await addedItem.fill('A newly repeated browser-local rule.');
   await expect(preview).toContainText('A newly repeated browser-local rule.');
 

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
@@ -1,10 +1,11 @@
-import { Accordion, Alert, Badge, Box, Button, Group, Stack, Text, Textarea } from '@mantine/core';
+import { Accordion, Alert, Badge, Box, Button, Group, Stack, Text } from '@mantine/core';
 import { parseFormattedText } from '@shared/formattedText';
 import type { FormattedTextParseResult } from '@shared/formattedText';
 import type { RulebookBlockDraft, RulebookContentsDraftV1, RulebookPageDraft } from '@shared/rulebooks/contents';
 import { createFileRoute } from '@tanstack/react-router';
 import { PageTitle } from '@ui/block/PageTitle';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
+import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { AddAction } from '@ui/control/ListLengthActions';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
@@ -142,17 +143,6 @@ function RulebookPagePreview({
   );
 }
 
-function sameTextTarget(
-  target: ReadyResult['diagnostics'][number]['target'],
-  expected: { kind: 'block'; blockId: string } | { kind: 'item'; blockId: string; itemId: string }
-) {
-  return (
-    target?.kind === expected.kind &&
-    target.blockId === expected.blockId &&
-    (target.kind !== 'item' || (expected.kind === 'item' && target.itemId === expected.itemId))
-  );
-}
-
 function createRepeatedTextItemId(): string {
   return `item-${globalThis.crypto.randomUUID()}`;
 }
@@ -177,18 +167,14 @@ function PageTextEditors({
         }
         if (block.kind === 'text') {
           const target = { kind: 'block' as const, blockId };
-          const error = result.diagnostics.find(
-            (diagnostic) => diagnostic.field === 'text' && sameTextTarget(diagnostic.target, target)
-          )?.message;
           return (
-            <Textarea
+            <FormattedTextInput
               key={blockId}
               label="Text block"
               value={block.text}
-              error={error}
               autosize
               minRows={6}
-              onChange={(event) => dispatch({ kind: 'set', target, field: 'text', value: event.currentTarget.value })}
+              onChange={(value) => dispatch({ kind: 'set', target, field: 'text', value })}
             />
           );
         }
@@ -226,22 +212,16 @@ function PageTextEditors({
                   return null;
                 }
                 const target = { kind: 'item' as const, blockId, itemId };
-                const error = result.diagnostics.find(
-                  (diagnostic) => diagnostic.field === 'text' && sameTextTarget(diagnostic.target, target)
-                )?.message;
                 return (
                   <Group key={itemId} align="flex-start" wrap="nowrap">
-                    <Textarea
+                    <FormattedTextInput
                       label={`Item ${index + 1}`}
                       aria-label={`${repeatedBlockLabel}, item ${index + 1}`}
                       value={item.text}
-                      error={error}
                       autosize
                       minRows={4}
                       style={{ flex: 1 }}
-                      onChange={(event) =>
-                        dispatch({ kind: 'set', target, field: 'text', value: event.currentTarget.value })
-                      }
+                      onChange={(value) => dispatch({ kind: 'set', target, field: 'text', value })}
                     />
                     <ConfirmDeleteAction
                       label={`Remove item ${index + 1} from ${repeatedBlockLabel}`}


### PR DESCRIPTION
Closes #755.

Text blocks and Repeated text items in the fixture-backed Rulebook editor now use the shared `FormattedTextInput`. The route still sends each edited string directly through the existing Rulebook state-manager membrane, which remains the draft and Save-eligibility authority. The preview renderer and all persistence boundaries are unchanged.

## Visual proof

The same invalid draft is shown in both captures. The raw textarea only named the parse failure. The shared control identifies its source location and gives the author a concrete repair.

| Before | After |
| --- | --- |
| ![Raw Rulebook textarea only names the error](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-757-before-raw-rulebook-textareas.png) | ![Rulebook formatted-text control gives location and repair guidance](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-757-after-production-formatted-text-control.png) |

## Checks

- `bun run test`: 114 files, 749 tests
- `bun run check`
- `bun run typecheck`
- `bun run knip`
- Focused disposable local E2E: 5/5 passed, covering Text blocks, Repeated text items, preview synchronization, fit behavior, and narrow scrolling
- `bun run publisher:release:verify`

The first complete local E2E run passed every Rulebook case and finished 12/13 overall. The unrelated FAQ happy-path case failed because `getByText("Accepted answer")` also matched the tooltip text `Unmark accepted answer`. No FAQ code or test is changed here.

## Production verification

[Deploy production run 32875493093](https://github.com/ndelangen/dunezone/actions/runs/32875493093) released merge commit f91c4981. The public fixture route returned HTTP 200. A headless production check entered the same invalid draft, confirmed the line-and-column diagnostic and repair suggestion, confirmed that the preview preserved the literal invalid draft, and captured the After image above from https://dune.zone/rulesets/local-rules/rulebooks/starter/edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and suggestions for unfinished Markdown emphasis in text and repeated-text editors.
  * Previews now correctly display formatted text content.
  * Text inputs consistently parse and preserve formatted text when editing rulebooks.
* **Tests**
  * Added end-to-end coverage for unfinished emphasis in standalone and repeated text editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->