### PR TITLE
Page stories run against browser-local Convex

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -17,7 +17,7 @@ jobs:
   deploy:
     environment: production
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
@@ -105,6 +105,24 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+
+      - uses: ./.github/actions/playwright-chromium
+      - name: Verify isolated Storybook publication
+        run: bun run verify:storybook-publication
+
+      - name: Deploy isolated Storybook
+        run: >-
+          bunx wrangler deploy
+          --strict
+          --config workers/storybook/wrangler.jsonc
+          --tag "$GITHUB_SHA"
+          --message "GitHub Actions Storybook $GITHUB_SHA"
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Smoke isolated Storybook
+        run: bun run ./scripts/storybook-deployment-smoke.ts
 
       - name: Activate higher checked-in Renderer revisions
         run: bun run ./scripts/publication-revisions.ts activate

--- a/.github/workflows/reusable-verify.yml
+++ b/.github/workflows/reusable-verify.yml
@@ -261,9 +261,9 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/generated-images
-      - name: Build Storybook
-        run: bun run build-storybook
       - uses: ./.github/actions/playwright-chromium
+      - name: Verify the public Storybook artifact
+        run: bun run verify:storybook-publication
       - name: Verify generated images structurally
         run: bun run verify:images
       - name: Run story tests with coverage

--- a/.storybook/async-hooks.ts
+++ b/.storybook/async-hooks.ts
@@ -1,0 +1,38 @@
+import 'zone.js';
+
+type Callback<Args extends unknown[], Result> = (...args: Args) => Result;
+
+const missingStore = Symbol('missing AsyncLocalStorage store');
+let nextStorageId = 0;
+
+/* Maps Node's AsyncLocalStorage contract onto Zone.js.
+   Every async function in the worker closure must be lowered to Promise continuations because
+   native await bypasses ZoneAwarePromise. The Storybook build guard enforces that closure. */
+export class AsyncLocalStorage<Store> {
+  private readonly key = `dunezone.asyncLocalStorage.${nextStorageId++}`;
+
+  getStore(): Store | undefined {
+    const store = Zone.current.get(this.key) as Store | typeof missingStore | undefined;
+    return store === missingStore ? undefined : store;
+  }
+
+  run<Args extends unknown[], Result>(store: Store, callback: Callback<Args, Result>, ...args: Args): Result {
+    return this.withStore(store, callback, args);
+  }
+
+  exit<Args extends unknown[], Result>(callback: Callback<Args, Result>, ...args: Args): Result {
+    return this.withStore(missingStore, callback, args);
+  }
+
+  private withStore<Args extends unknown[], Result>(
+    store: Store | typeof missingStore,
+    callback: Callback<Args, Result>,
+    args: Args
+  ): Result {
+    const zone = Zone.current.fork({
+      name: this.key,
+      properties: { [this.key]: store },
+    });
+    return zone.run(callback, undefined, args);
+  }
+}

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -25,6 +25,34 @@ const managerTitleScript = `
 export default defineMain({
   stories: [
     {
+      directory: '../src/app/routes',
+      titlePrefix: 'Pages',
+    },
+    {
+      directory: '../src/game/assets/faction',
+      titlePrefix: 'Game Assets/Faction',
+    },
+    {
+      directory: '../src/game/assets/card',
+      titlePrefix: 'Game Assets/Cards',
+    },
+    {
+      directory: '../src/game/assets/treachery',
+      titlePrefix: 'Game Assets/Cards/Treachery',
+    },
+    {
+      directory: '../src/game/assets/token',
+      titlePrefix: 'Game Assets/Tokens',
+    },
+    {
+      directory: '../src/game/assets/utils',
+      titlePrefix: 'Game Assets/Composition',
+    },
+    {
+      directory: '../src/game/components/block',
+      titlePrefix: 'Game Assets/Composition/Blocks',
+    },
+    {
       directory: '../src/app/widgets/faction-editor',
       titlePrefix: 'Widgets/Faction Editor',
     },
@@ -85,28 +113,8 @@ export default defineMain({
       titlePrefix: 'Shell',
     },
     {
-      directory: '../src/game/assets/faction',
-      titlePrefix: 'Game Assets/Faction',
-    },
-    {
-      directory: '../src/game/assets/card',
-      titlePrefix: 'Game Assets/Cards',
-    },
-    {
-      directory: '../src/game/assets/treachery',
-      titlePrefix: 'Game Assets/Cards/Treachery',
-    },
-    {
-      directory: '../src/game/assets/token',
-      titlePrefix: 'Game Assets/Tokens',
-    },
-    {
-      directory: '../src/game/assets/utils',
-      titlePrefix: 'Game Assets/Composition',
-    },
-    {
-      directory: '../src/game/components/block',
-      titlePrefix: 'Game Assets/Composition/Blocks',
+      directory: '../src/app/db/storybook',
+      titlePrefix: 'Foundation',
     },
   ],
   addons: ['@storybook/addon-docs', '@storybook/addon-vitest'],
@@ -122,5 +130,5 @@ export default defineMain({
     reactDocgen: 'react-docgen-typescript',
   },
   managerHead: (head) => `${head}${managerTitleScript}`,
-  staticDirs: (existing = [], { configType }) => (configType === 'DEVELOPMENT' ? [...existing, '../public'] : existing),
+  staticDirs: (existing = []) => [...existing, '../public', './static'],
 });

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,6 +7,8 @@ import '@mantine/core/styles.layer.css';
 import '../src/app/styles/fonts.css';
 import '../src/app/styles/tokens.css';
 import '../src/app/styles/mantine-shell-compatibility.css';
+import { StorybookDatabaseProvider, storybookViewer } from '../src/app/db/storybook';
+import type { DatabaseDefinition, WorkerIdentity } from '../src/app/db/storybook';
 import { setMotionOverride } from '../src/app/styles/motion';
 import { appContentTheme } from '../src/app/ui/theme';
 import * as sizes from '../src/game/data/sizes';
@@ -16,6 +18,7 @@ import * as sizes from '../src/game/data/sizes';
 sb.mock(import('convex/react'));
 sb.mock(import('convex/browser'));
 sb.mock(import('@convex-dev/auth/react'));
+sb.mock(import('../src/app/db/core/index.ts'));
 
 export default definePreview({
   addons: [addonDocs()],
@@ -195,6 +198,19 @@ export default definePreview({
       }
 
       return story;
+    },
+    (Story, { parameters }) => {
+      const database = parameters.database as DatabaseDefinition | undefined;
+      if (!database) {
+        return <Story />;
+      }
+      const identity =
+        parameters.identity === undefined ? storybookViewer : (parameters.identity as WorkerIdentity | null);
+      return (
+        <StorybookDatabaseProvider database={database} identity={identity ?? undefined}>
+          <Story />
+        </StorybookDatabaseProvider>
+      );
     },
   ],
   initialGlobals: {

--- a/.storybook/static/_headers
+++ b/.storybook/static/_headers
@@ -1,0 +1,9 @@
+/*
+  Content-Security-Policy: default-src 'self'; base-uri 'none'; connect-src 'self'; font-src 'self' data:; form-action 'none'; frame-ancestors 'self'; frame-src 'self'; img-src 'self' data: blob:; manifest-src 'self'; media-src 'self' blob:; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; worker-src 'self'
+  Permissions-Policy: camera=(), geolocation=(), microphone=(), payment=(), usb=()
+  Referrer-Policy: no-referrer
+  X-Content-Type-Options: nosniff
+  X-Robots-Tag: noindex
+
+/assets/convexStorybook.worker-*.js
+  Content-Security-Policy: default-src 'none'; connect-src 'none'; script-src 'self'; worker-src 'none'

--- a/.storybook/static/_redirects
+++ b/.storybook/static/_redirects
@@ -1,0 +1,1 @@
+/ /index.html 200

--- a/.storybook/vite.config.ts
+++ b/.storybook/vite.config.ts
@@ -2,6 +2,14 @@ import viteReact from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import type { Plugin } from 'vite';
 
+import {
+  convexWorkerAliases,
+  convexWorkerBuildPlugins,
+  convexWorkerOptimizeDeps,
+  convexWorkerOxc,
+  convexWorkerServePlugins,
+} from './worker-async-transform.ts';
+
 /*
  * Only the URLs `verify:images` actually validates, which is narrower than the warning.
  * Vite reports the same way for a relative miss like `./missing.woff2`, and nothing checks those, so a filter on the message alone would bury a genuine broken reference (CodeRabbit, PR #614).
@@ -38,18 +46,26 @@ function quietDeferredAssetWarnings(): Plugin {
 export default defineConfig({
   build: {
     assetsDir: 'public',
+    target: 'es2020',
   },
   define: {
     /**
      * Never copy a developer or production deployment URL into the public catalogue.
      * The global manual mock ignores this inert value when app database modules load.
      */
-    'import.meta.env.VITE_CONVEX_URL': JSON.stringify('storybook-disconnected'),
+    'import.meta.env.VITE_CONVEX_URL': JSON.stringify('https://storybook.invalid'),
   },
   publicDir: false,
+  oxc: convexWorkerOxc,
+  optimizeDeps: convexWorkerOptimizeDeps,
   resolve: {
     // Keep Storybook path resolution aligned with the app config.
     ...({ tsconfigPaths: true } as Record<string, unknown>),
+    alias: convexWorkerAliases,
   },
-  plugins: [viteReact(), quietDeferredAssetWarnings()],
+  plugins: [...convexWorkerServePlugins(), viteReact(), quietDeferredAssetWarnings()],
+  worker: {
+    format: 'es',
+    plugins: convexWorkerBuildPlugins,
+  },
 });

--- a/.storybook/worker-async-transform.ts
+++ b/.storybook/worker-async-transform.ts
@@ -1,0 +1,143 @@
+import { fileURLToPath } from 'node:url';
+
+import { parseSync, transformWithOxc } from 'vite';
+import type { Plugin } from 'vite';
+
+const SCRIPT_FILE = /\.[cm]?[jt]sx?$/;
+const WORKER_PACKAGE_PATHS = [
+  '/node_modules/@auth/core/',
+  '/node_modules/@convex-dev/aggregate/',
+  '/node_modules/@convex-dev/auth/',
+  '/node_modules/@convex-dev/migrations/',
+  '/node_modules/@oslojs/',
+  '/node_modules/@panva/hkdf/',
+  '/node_modules/cookie/',
+  '/node_modules/convex/',
+  '/node_modules/convex-helpers/',
+  '/node_modules/convex-test/',
+  '/node_modules/jose/',
+  '/node_modules/lucia/',
+  '/node_modules/oauth4webapi/',
+  '/node_modules/preact/',
+  '/node_modules/preact-render-to-string/',
+  '/node_modules/unicode-segmenter/',
+  '/node_modules/zod/',
+];
+
+function containsNativeAsync(value: unknown, seen = new Set<object>()): boolean {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+  const node = value as Record<string, unknown>;
+  if (node.type === 'AwaitExpression' || node.async === true) {
+    return true;
+  }
+  return Object.values(node).some((child) => containsNativeAsync(child, seen));
+}
+
+function assertNoNativeAsync(code: string, filename: string) {
+  const { program } = parseSync(filename, code, { lang: 'js', sourceType: 'module' });
+  if (containsNativeAsync(program)) {
+    throw new Error(`The Convex Storybook worker retained native async syntax in ${filename}.`);
+  }
+}
+
+export const convexWorkerOxc = { target: 'es2020' } as const;
+
+export const convexWorkerOptimizeDeps = {
+  /* Optimized dependencies bypass Vite's Oxc transform and retain native await.
+     Keep the complete Convex server closure on the transform path. */
+  exclude: [
+    '@auth/core',
+    '@auth/core/providers/discord',
+    '@auth/core/providers/google',
+    '@convex-dev/aggregate',
+    '@convex-dev/auth/providers/Password',
+    '@convex-dev/auth/server',
+    '@convex-dev/migrations',
+    'convex/server',
+    'convex/values',
+    'convex-helpers',
+    'convex-helpers/server/customFunctions',
+    'convex-helpers/server/triggers',
+    'convex-helpers/server/zod4',
+    'convex-helpers/validators',
+    'convex-test',
+  ],
+  include: ['@auth/core > cookie', 'zone.js'],
+};
+
+export const convexWorkerAliases = {
+  'node:async_hooks': fileURLToPath(new URL('./async-hooks.ts', import.meta.url)),
+};
+
+function isolateConvexTestStorageUrls(): Plugin {
+  return {
+    name: 'dunezone:isolate-convex-test-storage-urls',
+    enforce: 'pre',
+    transform(code, id) {
+      if (!id.includes('/convex-test/dist/index.js')) {
+        return;
+      }
+      return code
+        .replaceAll('https://some-deployment.convex.cloud', 'https://storybook.invalid')
+        .replaceAll('https://some.convex.site', 'https://storybook.invalid');
+    },
+  };
+}
+
+/**
+ * Lowers every async function that can enter the Convex Storybook worker.
+ * Storybook itself keeps a modern target so Convex BigInt values remain valid.
+ */
+function lowerConvexWorkerAsync({
+  serveOnly = false,
+  verifyBundle = false,
+}: { serveOnly?: boolean; verifyBundle?: boolean } = {}): Plugin {
+  return {
+    name: 'dunezone:lower-convex-worker-async',
+    apply: serveOnly ? 'serve' : undefined,
+    enforce: 'pre',
+    async transform(code, id) {
+      const filename = id.split('?', 1)[0];
+      const belongsToWorkerClosure =
+        filename.includes('/convex/') ||
+        filename.includes('/src/shared/') ||
+        filename.endsWith('/src/app/db/storybook/convexStorybook.worker.ts') ||
+        WORKER_PACKAGE_PATHS.some((packagePath) => filename.includes(packagePath));
+      if (!belongsToWorkerClosure || !SCRIPT_FILE.test(filename)) {
+        return;
+      }
+      const result = await transformWithOxc(code, filename, { target: 'es2016' });
+      assertNoNativeAsync(result.code, filename);
+      return { code: result.code, map: result.map };
+    },
+    generateBundle(_options, bundle) {
+      if (!verifyBundle) {
+        return;
+      }
+      for (const [filename, output] of Object.entries(bundle)) {
+        if (output.type === 'chunk') {
+          try {
+            assertNoNativeAsync(output.code, filename);
+          } catch (error) {
+            const modules = Object.keys(output.modules).join(', ');
+            throw new Error(`${error instanceof Error ? error.message : String(error)} Sources: ${modules}`);
+          }
+        }
+      }
+    },
+  };
+}
+
+export function convexWorkerServePlugins(): Plugin[] {
+  return [lowerConvexWorkerAsync({ serveOnly: true })];
+}
+
+export function convexWorkerBuildPlugins(): Plugin[] {
+  return [lowerConvexWorkerAsync({ verifyBundle: true }), isolateConvexTestStorageUrls()];
+}

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
         "@tanstack/react-router-devtools": "^1.167.0",
         "@tanstack/react-start": "^1.168.35",
         "clsx": "^2.1.1",
-        "convex": "^1.43.0",
+        "convex": "1.45.0",
         "convex-helpers": "^0.1.121",
         "crypto-js": "^4.2.0",
         "fuse.js": "^7.5.0",
@@ -58,7 +58,7 @@
         "@vitejs/plugin-react": "^6.0.5",
         "@vitest/browser-playwright": "4.1.10",
         "@vitest/coverage-v8": "^4.1.10",
-        "convex-test": "^0.0.55",
+        "convex-test": "0.0.56",
         "jsdom": "^30.0.1",
         "knip": "^6.32.0",
         "linkedom": "0.18.12",
@@ -77,6 +77,7 @@
         "vite": "^8.2.0",
         "vitest": "^4.1.10",
         "wrangler": "^4.118.0",
+        "zone.js": "0.16.2",
       },
     },
     "tools/svg-authoring": {
@@ -1078,11 +1079,11 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "convex": ["convex@1.43.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.21.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-huZWEUZQYxIRG104o22ZI99HkviSEVltwezZRDi+pQDPrQbc5EoCPa4Y7pJDqUBQw9dc/iEEXj2/rLZg1j7Dww=="],
+    "convex": ["convex@1.45.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.21.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-AV3B56Ptu/14d76g3urBJ50dwpiZa6uJaLT84OWox5aCwZIJiuAamdjv3lLHDzs8vv5kC31anEZohhUe3qJ2bA=="],
 
     "convex-helpers": ["convex-helpers@0.1.121", "", { "peerDependencies": { "@standard-schema/spec": "^1.0.0", "convex": "^1.43.0", "hono": "^4.0.5", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "typescript": "^5.5 || ^6.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@standard-schema/spec", "hono", "react", "typescript", "zod"], "bin": { "convex-helpers": "bin.cjs" } }, "sha512-qLrAr8p3dGI59xVa4485ARaGPuBRMjKOXC56FELKVnJ5AoIHFOkjPSKR8phE3KZUxyi6eZtb54Z/MYcS+pxoAQ=="],
 
-    "convex-test": ["convex-test@0.0.55", "", { "peerDependencies": { "convex": "^1.43.0" } }, "sha512-ablJ6vR3WUpyTaYrrRQf8yxInGrhHyqBEQsCFzloda3G0MDEu2RMKNGUkvlBXYWPiiEP0UIKPS7gZuLbqGnvQw=="],
+    "convex-test": ["convex-test@0.0.56", "", { "peerDependencies": { "convex": "^1.43.0" } }, "sha512-dLYXlQjKFoGqvjAmPzyLgb2HsYI7iLo1iuNTU2DZmSrMRLWosYk94erjSU67GG5ovfP6+MjX8RJO+ebhmL6QYA=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -1753,6 +1754,8 @@
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zone.js": ["zone.js@0.16.2", "", {}, "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q=="],
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ bun run format           # Format files
 bun run test             # Run tests
 bun run storybook        # Storybook dev (port 6006)
 bun run build-storybook  # Static Storybook → storybook-static
+bun run verify:storybook-publication # Public bytes, headers, isolation, and browser runtime
 bun run generate         # Regenerate the public asset catalog in src/game/data/generated.ts
 bun run publisher:release:verify # Exact pre-PR publisher build, manifest, and dry-run gate
 ```
@@ -119,6 +120,40 @@ unpushable.
   demonstrate behavior or comparison that args cannot.
 - Represent controlled components with static values and noop callbacks unless interaction itself
   is the contract under test.
+
+#### Page stories
+
+Page stories run the real route, Convex query, and Convex mutation handlers in an isolated browser
+worker. They never contact a hosted Convex deployment. Start from the canonical valid database and
+make only the state changes that explain the rendered variation:
+
+```tsx
+export const Populated = meta.story({
+  parameters: {
+    database: db((baseline) => {
+      baseline.factions.push(faction({ name: 'House Atreides' }));
+    }),
+  },
+});
+```
+
+The callback receives a fresh mutable baseline. Return `emptyDatabase()` or another database to
+replace it. Helpers supply deterministic mechanical values and validate shared semantic contracts;
+the worker then applies the actual Convex schema. Invalid database state fails before the page
+renders. Identity is a separate `identity` parameter, and route or search parameters stay in the
+story's router setup rather than the database parameter.
+
+Use only variations that produce meaningfully different pages, including URL parameter cases when
+they change the result. A play function may exercise the page's normal mutations and navigation;
+`useStorybookDatabaseReset()` replaces the worker with the story's fresh declared state. Keep direct
+tests for unhappy query branches and server invariants. Keep end-to-end tests for a few application
+journeys instead of turning page stories into journeys.
+
+The runtime faithfully covers registered Convex handlers, schema checks, authentication identity,
+components, triggers, transactions, scheduling, HTTP handling, and query refresh. It does not cover
+hosted WebSockets, identity providers, deployment configuration, or production data. External
+network access and subworkers are disabled. An unregistered or unsupported path must fail instead
+of returning a fixture-shaped answer.
 
 ### Adding a new domain
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -38,13 +38,16 @@ Build the unified application and capture release with:
 VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:assets
 ```
 
-This builds `dist/client`, builds Storybook into `storybook-static`, builds the
-isolated capture bundle, and assembles all three into `workers/publisher/dist`.
-Storybook is part of the release, not an extra: the assembly requires
-`__storybook/index.html`, `__storybook/iframe.html`, and `__storybook/index.json`
-and reports a story count. The assembly also copies TanStack's `_shell.html` to the
+This builds `dist/client`, builds the isolated capture bundle, and assembles both into
+`workers/publisher/dist`. The assembly also copies TanStack's `_shell.html` to the
 `index.html` Cloudflare Static Assets requires for SPA fallback and fails if the
 final bundle violates Workers asset-count or per-file limits.
+
+Storybook is a separate secret-free Static Assets Worker at `https://storybook.dune.zone`.
+`bun run verify:storybook-publication` builds `storybook-static`, scans the final bytes for
+credentials and hosted Convex URLs, checks the CSP and exact hosting configuration, and runs the
+browser-local Convex page through both the root host and a non-root served path. The build copies
+the canonical `public/` files; there is no second maintained image or font source.
 
 For a local release rehearsal:
 
@@ -67,7 +70,6 @@ are Worker-first:
 | `/published` and `/published/*` | Stable public generated-asset delivery |
 | `/__asset-publisher` and `/__asset-publisher/*` | Health and operational endpoints |
 | `/publisher-capture`, `/publisher-capture.html`, `/publisher-capture/*` | Protected capture document and bundle |
-| `/__storybook` and `/__storybook/` | Rewritten to the built Storybook's `index.html` |
 | Everything else, including `/factions/*` | Static asset lookup, then SPA fallback |
 
 The faction-sheet delivery path is
@@ -120,15 +122,17 @@ On every push to `main`:
 6. Regenerate and verify generated output, meaning images (`verify:images`),
    vectors (`verify:vectors`) and OBJ pieces (`generate:objs`), then log the
    output digest.
-7. Build the SPA, Storybook, and capture bundle once with the production Convex URL.
+7. Build the SPA and capture bundle once with the production Convex URL.
 8. Verify assembled assets and reject generated-source drift.
 9. Dry-run, then deploy the Worker with the full merged Git SHA.
-10. Smoke the workers.dev and `dune.zone` health endpoints, including `/__storybook`.
-11. Read the stored Renderer revisions. If any checked-in revision is higher,
+10. Smoke the workers.dev and `dune.zone` health endpoints.
+11. Build and verify the secret-free Storybook artifact, deploy it to `storybook.dune.zone`, and
+    smoke its manager, page index, preview entry, CSP, and shared public assets.
+12. Read the stored Renderer revisions. If any checked-in revision is higher,
     activate all higher revisions in one mutation and schedule bounded
     regeneration scans. CI does not wait for scanning or capture.
-12. Set Convex Auth `SITE_URL` to `https://dune.zone`.
-13. A follow-on `dev_rebuild` job (`needs: deploy`) rebuilds the dev deployment
+13. Set Convex Auth `SITE_URL` to `https://dune.zone`.
+14. A follow-on `dev_rebuild` job (`needs: deploy`) rebuilds the dev deployment
     from production; see
     [`dev-rebuild.yml`](../.github/workflows/dev-rebuild.yml).
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "migrations:run-local-required": "bun run migrations:dev-strict",
     "migrations:static-check": "bun run ./scripts/migration-guards.ts static-check",
     "provision": "bun run ./scripts/provision.ts",
-    "publisher:assets": "bun run app:build && bun run build-storybook && vite build --config workers/publisher/vite.config.ts && bun run ./scripts/assemble-publisher-assets.ts",
+    "publisher:assets": "bun run app:build && vite build --config workers/publisher/vite.config.ts && bun run ./scripts/assemble-publisher-assets.ts",
     "publisher:assets:check": "bun run ./scripts/assemble-publisher-assets.ts --check-only",
     "publisher:capture-contract-regression": "bun run publisher:assets && bun run workers/publisher/capture-contract-regression.ts",
     "publisher:dry-run": "bun run publisher:assets && wrangler deploy --dry-run --config workers/publisher/wrangler.jsonc",
@@ -60,6 +60,7 @@
     "tool:typecheck": "bun run --cwd tools/svg-authoring typecheck",
     "typecheck": "node ./node_modules/@typescript/native/bin/tsc --noEmit",
     "verify:images": "bun run ./scripts/verify-images.ts",
+    "verify:storybook-publication": "bun run ./scripts/verify-storybook-publication.ts",
     "verify:vectors": "bun run ./scripts/verify-vectors.ts",
     "worktree:setup": "bash ./scripts/codex-worktree-setup.sh"
   },
@@ -83,7 +84,7 @@
     "@tanstack/react-router-devtools": "^1.167.0",
     "@tanstack/react-start": "^1.168.35",
     "clsx": "^2.1.1",
-    "convex": "^1.43.0",
+    "convex": "1.45.0",
     "convex-helpers": "^0.1.121",
     "crypto-js": "^4.2.0",
     "fuse.js": "^7.5.0",
@@ -117,7 +118,7 @@
     "@vitejs/plugin-react": "^6.0.5",
     "@vitest/browser-playwright": "4.1.10",
     "@vitest/coverage-v8": "^4.1.10",
-    "convex-test": "^0.0.55",
+    "convex-test": "0.0.56",
     "jsdom": "^30.0.1",
     "knip": "^6.32.0",
     "linkedom": "0.18.12",
@@ -135,7 +136,8 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^8.2.0",
     "vitest": "^4.1.10",
-    "wrangler": "^4.118.0"
+    "wrangler": "^4.118.0",
+    "zone.js": "0.16.2"
   },
   "overrides": {
     "@babel/core": "7.29.7",

--- a/scripts/assemble-publisher-assets.test.ts
+++ b/scripts/assemble-publisher-assets.test.ts
@@ -22,19 +22,13 @@ function fixture() {
   const root = temporaryDirectory('publisher-assets');
   const app = path.join(root, 'app');
   const publisher = path.join(root, 'publisher');
-  const storybook = path.join(root, 'storybook');
   mkdirSync(path.join(app, 'public'), { recursive: true });
   mkdirSync(path.join(publisher, 'publisher-capture'), { recursive: true });
-  mkdirSync(path.join(storybook, 'assets'), { recursive: true });
   writeFileSync(path.join(app, '_shell.html'), '<html>spa shell</html>');
   writeFileSync(path.join(app, 'public', 'app-hash.js'), 'application');
   writeFileSync(path.join(publisher, 'publisher-capture.html'), '<html>capture</html>');
   writeFileSync(path.join(publisher, 'publisher-capture', 'entry-hash.js'), 'capture');
-  writeFileSync(path.join(storybook, 'index.html'), '<html>Dune Zone Storybook</html>');
-  writeFileSync(path.join(storybook, 'iframe.html'), '<html>preview</html>');
-  writeFileSync(path.join(storybook, 'index.json'), JSON.stringify({ entries: { example: { type: 'story' } } }));
-  writeFileSync(path.join(storybook, 'assets', 'preview-hash.js'), 'preview');
-  return { root, app, publisher, storybook };
+  return { root, app, publisher };
 }
 
 afterEach(() => {
@@ -45,24 +39,23 @@ afterEach(() => {
 
 describe('publisher Static Assets assembly', () => {
   test('combines the SPA and capture outputs for Cloudflare Static Assets', () => {
-    const { app, publisher, storybook } = fixture();
-    const report = assemblePublisherAssets(app, publisher, storybook);
+    const { app, publisher } = fixture();
+    const report = assemblePublisherAssets(app, publisher);
 
-    expect(report.assetCount).toBe(9);
-    expect(report.storyCount).toBe(1);
+    expect(report.assetCount).toBe(5);
     expect(readFileSync(path.join(publisher, 'index.html'), 'utf8')).toBe('<html>spa shell</html>');
     expect(readFileSync(path.join(publisher, '_shell.html'), 'utf8')).toBe('<html>spa shell</html>');
     expect(report.largestAsset.bytes).toBeGreaterThan(0);
   });
 
   test('canonicalizes only the volatile TanStack root hydration timestamp', () => {
-    const { app, publisher, storybook } = fixture();
+    const { app, publisher } = fixture();
     writeFileSync(
       path.join(app, '_shell.html'),
       '<script>before;i:"__root__\0",u:1784218854699,s:"success",ssr:!0;after</script>'
     );
 
-    assemblePublisherAssets(app, publisher, storybook);
+    assemblePublisherAssets(app, publisher);
 
     const expected = '<script>before;i:"__root__\0",u:0,s:"success",ssr:!0;after</script>';
     expect(readFileSync(path.join(publisher, '_shell.html'), 'utf8')).toBe(expected);
@@ -75,9 +68,7 @@ describe('publisher Static Assets assembly', () => {
       path.join(oversized.publisher, 'too-large.bin'),
       new Uint8Array(WORKERS_STATIC_ASSET_FILE_LIMIT_BYTES + 1)
     );
-    expect(() => assemblePublisherAssets(oversized.app, oversized.publisher, oversized.storybook)).toThrow(
-      'exceeds 25 MiB'
-    );
+    expect(() => assemblePublisherAssets(oversized.app, oversized.publisher)).toThrow('exceeds 25 MiB');
 
     const linked = fixture();
     symlinkSync(
@@ -85,26 +76,5 @@ describe('publisher Static Assets assembly', () => {
       path.join(linked.publisher, 'publisher-capture', 'linked.html')
     );
     expect(() => inspectPublisherAssets(linked.publisher)).toThrow('symbolic link');
-  });
-
-  test('fails closed for unsafe Storybook runtime references', () => {
-    const current = fixture();
-    writeFileSync(path.join(current.storybook, 'assets', 'preview-hash.js'), 'fetch("https://example.convex.cloud")');
-
-    expect(() => assemblePublisherAssets(current.app, current.publisher, current.storybook)).toThrow(
-      'forbidden runtime reference .convex.cloud'
-    );
-  });
-
-  test('fails closed when Storybook duplicates an application-owned root asset', () => {
-    const current = fixture();
-    mkdirSync(path.join(current.app, 'image'), { recursive: true });
-    mkdirSync(path.join(current.storybook, 'image'), { recursive: true });
-    writeFileSync(path.join(current.app, 'image', 'shared.png'), 'shared application asset');
-    writeFileSync(path.join(current.storybook, 'image', 'shared.png'), 'shared application asset');
-
-    expect(() => assemblePublisherAssets(current.app, current.publisher, current.storybook)).toThrow(
-      'duplicates application-owned root asset image/shared.png'
-    );
   });
 });

--- a/scripts/assemble-publisher-assets.test.ts
+++ b/scripts/assemble-publisher-assets.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -62,10 +62,23 @@ describe('publisher Static Assets assembly', () => {
     expect(readFileSync(path.join(publisher, 'index.html'), 'utf8')).toBe(expected);
   });
 
+  test('removes stale assembled assets while preserving the fresh capture build', () => {
+    const { app, publisher } = fixture();
+    mkdirSync(path.join(publisher, '__storybook'));
+    writeFileSync(path.join(publisher, '__storybook', 'index.html'), 'stale Storybook');
+    writeFileSync(path.join(publisher, 'old-application.js'), 'stale application');
+
+    assemblePublisherAssets(app, publisher);
+
+    expect(existsSync(path.join(publisher, '__storybook'))).toBe(false);
+    expect(existsSync(path.join(publisher, 'old-application.js'))).toBe(false);
+    expect(readFileSync(path.join(publisher, 'publisher-capture.html'), 'utf8')).toBe('<html>capture</html>');
+  });
+
   test('fails closed for oversized files and symbolic links', () => {
     const oversized = fixture();
     writeFileSync(
-      path.join(oversized.publisher, 'too-large.bin'),
+      path.join(oversized.publisher, 'publisher-capture', 'too-large.bin'),
       new Uint8Array(WORKERS_STATIC_ASSET_FILE_LIMIT_BYTES + 1)
     );
     expect(() => assemblePublisherAssets(oversized.app, oversized.publisher)).toThrow('exceeds 25 MiB');

--- a/scripts/assemble-publisher-assets.ts
+++ b/scripts/assemble-publisher-assets.ts
@@ -6,11 +6,10 @@ import { assemblePublisherAssets, inspectPublisherAssets } from './lib/publisher
 const repositoryRoot = path.resolve(import.meta.dir, '..');
 const appDirectory = path.join(repositoryRoot, 'dist/client');
 const publisherDirectory = path.join(repositoryRoot, 'workers/publisher/dist');
-const storybookDirectory = path.join(repositoryRoot, 'storybook-static');
 const checkOnly = process.argv.includes('--check-only');
 const report = checkOnly
   ? inspectPublisherAssets(publisherDirectory)
-  : assemblePublisherAssets(appDirectory, publisherDirectory, storybookDirectory);
+  : assemblePublisherAssets(appDirectory, publisherDirectory);
 const rendererManifest = checkOnly ? undefined : writeRendererManifest(repositoryRoot, publisherDirectory);
 
 console.log(JSON.stringify({ ok: true, ...report, rendererManifest }));

--- a/scripts/lib/publisher-assets.ts
+++ b/scripts/lib/publisher-assets.ts
@@ -5,6 +5,7 @@ import {
   lstatSync,
   readdirSync,
   readFileSync,
+  rmSync,
   statSync,
   writeFileSync,
 } from 'node:fs';
@@ -98,6 +99,13 @@ export function inspectPublisherAssets(directory: string): PublisherAssetReport 
 export function assemblePublisherAssets(appDirectory: string, publisherDirectory: string): PublisherAssetReport {
   assertDirectory(appDirectory, 'Application build');
   assertDirectory(publisherDirectory, 'Publisher capture build');
+
+  const captureEntries = new Set(['publisher-capture', 'publisher-capture.html']);
+  for (const entry of readdirSync(publisherDirectory, { withFileTypes: true })) {
+    if (!captureEntries.has(entry.name)) {
+      rmSync(path.join(publisherDirectory, entry.name), { recursive: true, force: true });
+    }
+  }
 
   for (const entry of readdirSync(appDirectory, { withFileTypes: true })) {
     cpSync(path.join(appDirectory, entry.name), path.join(publisherDirectory, entry.name), {

--- a/scripts/lib/publisher-assets.ts
+++ b/scripts/lib/publisher-assets.ts
@@ -15,24 +15,9 @@ export const WORKERS_STATIC_ASSET_FILE_LIMIT_BYTES = 25 * 1024 * 1024;
 
 export type PublisherAssetReport = {
   assetCount: number;
-  storyCount: number;
   totalBytes: number;
   largestAsset: { path: string; bytes: number };
 };
-
-const STORYBOOK_REQUIRED_ASSETS = [
-  '__storybook/index.html',
-  '__storybook/iframe.html',
-  '__storybook/index.json',
-] as const;
-const STORYBOOK_FORBIDDEN_RUNTIME_REFERENCES = [
-  '/generated/',
-  '.convex.cloud',
-  '.convex.site',
-  'fonts.googleapis.com',
-  'fonts.gstatic.com',
-] as const;
-const STORYBOOK_TEXT_EXTENSIONS = new Set(['.css', '.html', '.js', '.json']);
 
 function normalizePublisherShell(shell: string): string {
   return shell.replace(
@@ -85,19 +70,6 @@ export function inspectPublisherAssets(directory: string): PublisherAssetReport 
   }
 
   const paths = new Set(files.map((file) => file.path));
-  const storybookPrefix = '__storybook/';
-  const duplicatedRootAsset = files.find(
-    (file) =>
-      file.path.startsWith(storybookPrefix) &&
-      file.path !== '__storybook/index.html' &&
-      paths.has(file.path.slice(storybookPrefix.length))
-  );
-  if (duplicatedRootAsset) {
-    throw new Error(
-      `Published Storybook duplicates application-owned root asset ${duplicatedRootAsset.path.slice(storybookPrefix.length)}`
-    );
-  }
-
   for (const required of ['_shell.html', 'index.html', 'publisher-capture.html']) {
     if (!paths.has(required)) {
       throw new Error(`Publisher Static Assets are missing ${required}`);
@@ -109,33 +81,6 @@ export function inspectPublisherAssets(directory: string): PublisherAssetReport 
   if (![...paths].some((file) => file.startsWith('publisher-capture/'))) {
     throw new Error('Publisher Static Assets are missing the capture bundle');
   }
-  for (const required of STORYBOOK_REQUIRED_ASSETS) {
-    if (!paths.has(required)) {
-      throw new Error(`Publisher Static Assets are missing ${required}`);
-    }
-  }
-  if (![...paths].some((file) => file.startsWith('__storybook/assets/'))) {
-    throw new Error('Publisher Static Assets are missing the Storybook preview bundle');
-  }
-
-  const storyIndex = JSON.parse(readFileSync(path.join(directory, '__storybook/index.json'), 'utf8')) as {
-    entries?: Record<string, { type?: string }>;
-  };
-  const storyCount = Object.values(storyIndex.entries ?? {}).filter((entry) => entry.type === 'story').length;
-  if (storyCount === 0) {
-    throw new Error('Publisher Storybook index contains no stories');
-  }
-
-  for (const file of files) {
-    if (!file.path.startsWith('__storybook/') || !STORYBOOK_TEXT_EXTENSIONS.has(path.extname(file.path))) {
-      continue;
-    }
-    const content = readFileSync(path.join(directory, file.path), 'utf8');
-    const forbidden = STORYBOOK_FORBIDDEN_RUNTIME_REFERENCES.find((value) => content.includes(value));
-    if (forbidden) {
-      throw new Error(`Published Storybook asset ${file.path} contains forbidden runtime reference ${forbidden}`);
-    }
-  }
   const shell = readFileSync(path.join(directory, '_shell.html'));
   const index = readFileSync(path.join(directory, 'index.html'));
   if (!shell.equals(index)) {
@@ -145,25 +90,14 @@ export function inspectPublisherAssets(directory: string): PublisherAssetReport 
   const largestAsset = files.reduce((largest, file) => (file.bytes > largest.bytes ? file : largest));
   return {
     assetCount: files.length,
-    storyCount,
     totalBytes: files.reduce((total, file) => total + file.bytes, 0),
     largestAsset,
   };
 }
 
-export function assemblePublisherAssets(
-  appDirectory: string,
-  publisherDirectory: string,
-  storybookDirectory: string
-): PublisherAssetReport {
+export function assemblePublisherAssets(appDirectory: string, publisherDirectory: string): PublisherAssetReport {
   assertDirectory(appDirectory, 'Application build');
   assertDirectory(publisherDirectory, 'Publisher capture build');
-  assertDirectory(storybookDirectory, 'Storybook build');
-
-  const storybookDestination = path.join(publisherDirectory, '__storybook');
-  if (existsSync(storybookDestination)) {
-    throw new Error(`Storybook destination already exists: ${storybookDestination}`);
-  }
 
   for (const entry of readdirSync(appDirectory, { withFileTypes: true })) {
     cpSync(path.join(appDirectory, entry.name), path.join(publisherDirectory, entry.name), {
@@ -171,11 +105,6 @@ export function assemblePublisherAssets(
       force: true,
     });
   }
-  if (existsSync(storybookDestination)) {
-    throw new Error('Application build conflicts with the reserved __storybook asset namespace');
-  }
-  cpSync(storybookDirectory, storybookDestination, { recursive: true, force: false });
-
   const shell = path.join(publisherDirectory, '_shell.html');
   if (!existsSync(shell)) {
     throw new Error('Application build is missing the TanStack SPA shell');

--- a/scripts/publisher-deployment-contract.ts
+++ b/scripts/publisher-deployment-contract.ts
@@ -16,7 +16,6 @@ const CONFIG_PATH = path.resolve(process.cwd(), 'workers/publisher/wrangler.json
 const PUBLISHER_CONVEX_SITE_ORIGIN = 'https://exuberant-finch-263.eu-west-1.convex.site';
 const PUBLISHER_CRON = '*/5 * * * *';
 const REQUIRED_SECRETS = ['ASSET_PUBLISHER_CACHE_TOKEN_SECRET', 'ASSET_PUBLISHER_EXECUTOR_SECRET'];
-const STORYBOOK_STORY_ID = 'game-assets-composition-background--radial-token';
 
 type JsonObject = Record<string, unknown>;
 
@@ -98,8 +97,6 @@ export function validatePublisherDeployContract(config: JsonObject, environment:
         '/publisher-capture',
         '/publisher-capture.html',
         '/publisher-capture/*',
-        '/__storybook',
-        '/__storybook/',
       ],
     },
     'Static Assets routing'
@@ -333,57 +330,6 @@ async function run(): Promise<void> {
         }
       }
     }
-
-    const noSlashUrl = `${APPLICATION_ORIGIN}/__storybook?path=/story/${STORYBOOK_STORY_ID}`;
-    const redirect = await fetch(noSlashUrl, {
-      redirect: 'manual',
-      signal: AbortSignal.timeout(5000),
-    });
-    invariant(redirect.status === 308, `Storybook redirect returned HTTP ${redirect.status}`);
-    invariant(
-      redirect.headers.get('Location') === `${APPLICATION_ORIGIN}/__storybook/?path=/story/${STORYBOOK_STORY_ID}`,
-      'Storybook redirect did not preserve the manager query'
-    );
-
-    const managerResponse = await fetch(`${APPLICATION_ORIGIN}/__storybook/?path=/story/${STORYBOOK_STORY_ID}`, {
-      signal: AbortSignal.timeout(5000),
-    });
-    invariant(managerResponse.status === 200, `Storybook manager returned HTTP ${managerResponse.status}`);
-    const managerHtml = await managerResponse.text();
-    invariant(
-      managerHtml.includes('sb-manager/runtime.js') && managerHtml.includes('Dune Zone Storybook'),
-      'Storybook manager response is not the published Dune Zone Storybook shell'
-    );
-
-    const indexResponse = await fetch(`${APPLICATION_ORIGIN}/__storybook/index.json`, {
-      signal: AbortSignal.timeout(5000),
-    });
-    invariant(indexResponse.status === 200, `Storybook index returned HTTP ${indexResponse.status}`);
-    const index = object(await indexResponse.json(), 'Storybook index');
-    const entries = object(index.entries, 'Storybook index entries');
-    invariant(STORYBOOK_STORY_ID in entries, `Storybook index is missing ${STORYBOOK_STORY_ID}`);
-
-    for (const path of [
-      `/__storybook/iframe.html?id=${STORYBOOK_STORY_ID}&viewMode=story`,
-      '/__storybook/sb-manager/runtime.js',
-      '/image/texture/054.jpg',
-    ]) {
-      const response = await fetch(`${APPLICATION_ORIGIN}${path}`, {
-        signal: AbortSignal.timeout(5000),
-      });
-      invariant(response.status === 200, `${path} returned HTTP ${response.status}`);
-    }
-
-    const rootResponse = await fetch(`${APPLICATION_ORIGIN}/`, {
-      headers: { Accept: 'text/html' },
-      signal: AbortSignal.timeout(5000),
-    });
-    invariant(rootResponse.status === 200, `Application root returned HTTP ${rootResponse.status}`);
-    invariant(
-      !(await rootResponse.text()).includes('sb-manager/runtime.js'),
-      'Application root was replaced by the Storybook manager'
-    );
-    console.log(`Storybook release smoke passed for ${STORYBOOK_STORY_ID} at ${APPLICATION_ORIGIN}/__storybook/.`);
     return;
   }
   throw new Error('Expected command: preflight or smoke');

--- a/scripts/storybook-deployment-smoke.ts
+++ b/scripts/storybook-deployment-smoke.ts
@@ -1,0 +1,34 @@
+const STORYBOOK_ORIGIN = 'https://storybook.dune.zone';
+const PAGE_STORY_ID = 'pages-rulesets-create--authenticated';
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function response(path: string) {
+  const result = await fetch(`${STORYBOOK_ORIGIN}${path}`, {
+    redirect: 'error',
+    signal: AbortSignal.timeout(15_000),
+  });
+  invariant(result.status === 200, `${path} returned HTTP ${result.status}.`);
+  return result;
+}
+
+const manager = await response('/');
+const managerCsp = manager.headers.get('Content-Security-Policy') ?? '';
+invariant(managerCsp.includes("connect-src 'self'"), 'The live Storybook has no same-origin connection boundary.');
+invariant(managerCsp.includes("worker-src 'self'"), 'The live Storybook cannot start its Convex worker.');
+invariant(managerCsp.includes("object-src 'none'"), 'The live Storybook CSP permits objects.');
+invariant(manager.headers.get('X-Robots-Tag') === 'noindex', 'The live Storybook is not marked noindex.');
+invariant((await manager.text()).includes('Dune Zone Storybook'), 'The live root is not the Storybook manager.');
+
+const index = (await (await response('/index.json')).json()) as { entries?: Record<string, unknown> };
+invariant(PAGE_STORY_ID in (index.entries ?? {}), `The live Storybook index is missing ${PAGE_STORY_ID}.`);
+await response(`/iframe.html?id=${PAGE_STORY_ID}&viewMode=story`);
+await response('/image/texture/054.jpg');
+
+console.log(`Live Storybook smoke passed for ${PAGE_STORY_ID} at ${STORYBOOK_ORIGIN}.`);
+
+export {};

--- a/scripts/verify-storybook-publication.ts
+++ b/scripts/verify-storybook-publication.ts
@@ -1,0 +1,281 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+
+import { chromium } from 'playwright';
+
+const repositoryRoot = path.resolve(import.meta.dir, '..');
+const artifactDirectory = path.join(repositoryRoot, 'storybook-static');
+const wranglerConfig = path.join(repositoryRoot, 'workers/storybook/wrangler.jsonc');
+const port = 6842;
+const origin = `http://127.0.0.1:${port}`;
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+async function run(command: string[], environment: Record<string, string>) {
+  const child = Bun.spawn(command, {
+    cwd: repositoryRoot,
+    env: environment,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  const [status, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  if (status !== 0) {
+    process.stderr.write(stderr);
+    process.stdout.write(stdout);
+  }
+  invariant(status === 0, `${command.join(' ')} exited with status ${status}.`);
+}
+
+function buildEnvironment() {
+  return {
+    CI: 'true',
+    NODE_ENV: 'production',
+    PATH: process.env.PATH ?? '',
+    VITE_CONVEX_URL: 'https://storybook.invalid',
+  };
+}
+
+function artifactFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true })
+    .flatMap((entry) => {
+      const absolute = path.join(directory, entry.name);
+      return entry.isDirectory() ? artifactFiles(absolute) : [absolute];
+    })
+    .sort();
+}
+
+function inspectArtifact() {
+  const files = artifactFiles(artifactDirectory);
+  invariant(files.length > 0, 'The Storybook publication artifact is empty.');
+
+  const forbiddenText = ['.convex.cloud', '.convex.site', 'CLOUDFLARE_API_TOKEN', 'CONVEX_DEPLOY_KEY'];
+  for (const file of files) {
+    const bytes = readFileSync(file);
+    for (const forbidden of forbiddenText) {
+      invariant(
+        !bytes.includes(Buffer.from(forbidden)),
+        `The Storybook artifact contains forbidden publication text ${forbidden} in ${path.relative(
+          artifactDirectory,
+          file
+        )}.`
+      );
+    }
+    const text = bytes.toString('utf8');
+    invariant(
+      !/-----BEGIN PRIVATE KEY-----[A-Za-z0-9+/=\s]{64,}-----END PRIVATE KEY-----/.test(text),
+      `The Storybook artifact contains a private key block in ${path.relative(artifactDirectory, file)}.`
+    );
+  }
+
+  for (const [name, value] of Object.entries(process.env)) {
+    if (!value || value.length < 12 || !/(?:SECRET|TOKEN|PASSWORD|DEPLOY_KEY|API_KEY)$/i.test(name)) {
+      continue;
+    }
+    invariant(
+      !files.some((file) => readFileSync(file).includes(Buffer.from(value))),
+      `The Storybook artifact contains the value of ${name}.`
+    );
+  }
+
+  const worker = files.find((file) => /^convexStorybook\.worker-[\w-]+\.js$/.test(path.basename(file)));
+  invariant(worker, 'The Storybook artifact has no browser-local Convex worker.');
+  invariant(statSync(worker).size > 0, 'The browser-local Convex worker is empty.');
+  return `/${path.relative(artifactDirectory, worker).split(path.sep).join('/')}`;
+}
+
+async function waitForServer(process: ReturnType<typeof Bun.spawn>) {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    invariant(process.exitCode === null, `Wrangler stopped before ${origin} became ready.`);
+    try {
+      const response = await fetch(origin);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      /* The local socket is not ready yet. */
+    }
+    await Bun.sleep(100);
+  }
+  throw new Error(`Wrangler did not start ${origin}.`);
+}
+
+function assertDocumentCsp(value: string | null) {
+  invariant(value, 'The Storybook document has no CSP.');
+  invariant(value.includes("default-src 'self'"), 'The Storybook document CSP has no same-origin default.');
+  invariant(value.includes("connect-src 'self'"), 'The Storybook document CSP permits external connections.');
+  invariant(value.includes("worker-src 'self'"), 'The Storybook document CSP cannot start its same-origin worker.');
+  invariant(value.includes("object-src 'none'"), 'The Storybook document CSP permits objects.');
+}
+
+function assertWorkerCsp(value: string | null) {
+  invariant(value, 'The browser-local Convex worker has no CSP.');
+  invariant(value.includes("default-src 'none'"), 'The Convex worker CSP has no deny-by-default policy.');
+  invariant(value.includes("script-src 'self'"), 'The Convex worker CSP cannot load its same-origin chunks.');
+  invariant(value.includes("connect-src 'none'"), 'The Convex worker CSP permits connections.');
+  invariant(value.includes("worker-src 'none'"), 'The Convex worker CSP permits subworkers.');
+}
+
+async function verifyHeaders(workerPath: string) {
+  for (const documentPath of ['/', '/iframe.html']) {
+    const response = await fetch(`${origin}${documentPath}`);
+    invariant(response.status === 200, `${documentPath} returned HTTP ${response.status}.`);
+    assertDocumentCsp(response.headers.get('Content-Security-Policy'));
+    invariant(response.headers.get('X-Content-Type-Options') === 'nosniff', `${documentPath} can sniff content.`);
+  }
+  const worker = await fetch(`${origin}${workerPath}`);
+  invariant(worker.status === 200, `${workerPath} returned HTTP ${worker.status}.`);
+  assertWorkerCsp(worker.headers.get('Content-Security-Policy'));
+}
+
+async function verifyBrowser(workerPath: string) {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    const externalRequests: string[] = [];
+    const consoleErrors: string[] = [];
+    page.on('request', (request) => {
+      const url = new URL(request.url());
+      if (url.protocol === 'http:' && url.origin !== origin) {
+        externalRequests.push(request.url());
+      }
+      if (url.protocol === 'https:') {
+        externalRequests.push(request.url());
+      }
+    });
+    page.on('console', (message) => {
+      if (message.type() === 'error') {
+        consoleErrors.push(message.text());
+      }
+    });
+
+    await page.goto(`${origin}/iframe.html?id=pages-rulesets-create--authenticated&viewMode=story`, {
+      waitUntil: 'networkidle',
+    });
+    await page.getByRole('heading', { name: 'Create ruleset' }).waitFor({ timeout: 45_000 });
+    await page.waitForTimeout(1000);
+    invariant(externalRequests.length === 0, `Storybook requested an external URL: ${externalRequests.join(', ')}`);
+    invariant(consoleErrors.length === 0, `Storybook logged browser errors: ${consoleErrors.join('\n')}`);
+
+    const networkResult = await page.evaluate(async () => {
+      try {
+        await fetch('https://example.com');
+        return 'connected';
+      } catch (error) {
+        return error instanceof Error ? error.message : String(error);
+      }
+    });
+    invariant(networkResult !== 'connected', 'The Storybook document connected to an external origin.');
+
+    const subworkerResult = await page.evaluate(async (url) => {
+      return await new Promise<string>((resolve, reject) => {
+        const worker = new Worker(url, { type: 'module' });
+        const timeout = window.setTimeout(() => reject(new Error('The subworker probe timed out.')), 15_000);
+        worker.addEventListener('message', (event: MessageEvent<{ id: number; result?: unknown }>) => {
+          if (event.data.id !== 1) {
+            return;
+          }
+          window.clearTimeout(timeout);
+          worker.terminate();
+          resolve(String(event.data.result));
+        });
+        worker.addEventListener('error', (event) => reject(new Error(event.message)));
+        worker.postMessage({ id: 1, operation: 'subworkerProbe' });
+      });
+    }, `${origin}${workerPath}`);
+    invariant(
+      subworkerResult !== 'The Convex Storybook worker started a subworker.',
+      'The Convex Storybook worker started a subworker despite its CSP.'
+    );
+  } finally {
+    await browser.close();
+  }
+}
+
+async function verifyNonRootPath() {
+  const nonRootOrigin = 'http://127.0.0.1:6843';
+  const prefix = '/catalogue/';
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 6843,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (!url.pathname.startsWith(prefix)) {
+        return new Response('Not found', { status: 404 });
+      }
+      const requested = url.pathname.slice(prefix.length) || 'index.html';
+      const normalized = path.posix.normalize(requested);
+      if (normalized.startsWith('../')) {
+        return new Response('Not found', { status: 404 });
+      }
+      const file = Bun.file(path.join(artifactDirectory, normalized));
+      return file.exists().then((exists) => (exists ? new Response(file) : new Response('Not found', { status: 404 })));
+    },
+  });
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    const externalRequests: string[] = [];
+    page.on('request', (request) => {
+      if (new URL(request.url()).origin !== nonRootOrigin) {
+        externalRequests.push(request.url());
+      }
+    });
+    await page.goto(`${nonRootOrigin}${prefix}iframe.html?id=pages-rulesets-create--authenticated&viewMode=story`, {
+      waitUntil: 'networkidle',
+    });
+    await page.getByRole('heading', { name: 'Create ruleset' }).waitFor({ timeout: 45_000 });
+    invariant(
+      externalRequests.length === 0,
+      `Non-root Storybook requested an external URL: ${externalRequests.join(', ')}`
+    );
+  } finally {
+    await browser.close();
+    server.stop(true);
+  }
+}
+
+await run([process.execPath, 'run', 'build-storybook'], buildEnvironment());
+const workerPath = inspectArtifact();
+await run([process.execPath, 'x', 'wrangler', 'deploy', '--dry-run', '--config', wranglerConfig], buildEnvironment());
+
+const wrangler = Bun.spawn(
+  [
+    process.execPath,
+    'x',
+    'wrangler',
+    'dev',
+    '--local',
+    '--ip',
+    '127.0.0.1',
+    '--port',
+    String(port),
+    '--config',
+    wranglerConfig,
+  ],
+  {
+    cwd: repositoryRoot,
+    env: buildEnvironment(),
+    stderr: 'inherit',
+    stdout: 'inherit',
+  }
+);
+try {
+  await waitForServer(wrangler);
+  await verifyHeaders(workerPath);
+  await verifyBrowser(workerPath);
+} finally {
+  wrangler.kill();
+  await wrangler.exited;
+}
+
+await verifyNonRootPath();
+
+console.log(JSON.stringify({ ok: true, workerPath, origin }));

--- a/scripts/verify-storybook-publication.ts
+++ b/scripts/verify-storybook-publication.ts
@@ -52,10 +52,7 @@ function artifactFiles(directory: string): string[] {
     .sort();
 }
 
-function inspectArtifact() {
-  const files = artifactFiles(artifactDirectory);
-  invariant(files.length > 0, 'The Storybook publication artifact is empty.');
-
+function assertNoForbiddenText(files: string[]) {
   const forbiddenText = ['.convex.cloud', '.convex.site', 'CLOUDFLARE_API_TOKEN', 'CONVEX_DEPLOY_KEY'];
   for (const file of files) {
     const bytes = readFileSync(file);
@@ -74,9 +71,12 @@ function inspectArtifact() {
       `The Storybook artifact contains a private key block in ${path.relative(artifactDirectory, file)}.`
     );
   }
+}
 
+function assertNoSensitiveEnvironmentValues(files: string[]) {
   for (const [name, value] of Object.entries(process.env)) {
-    if (!value || value.length < 12 || !/(?:SECRET|TOKEN|PASSWORD|DEPLOY_KEY|API_KEY)$/i.test(name)) {
+    const isSensitiveValue = value && value.length >= 12 && /(?:SECRET|TOKEN|PASSWORD|DEPLOY_KEY|API_KEY)$/i.test(name);
+    if (!isSensitiveValue) {
       continue;
     }
     invariant(
@@ -84,7 +84,13 @@ function inspectArtifact() {
       `The Storybook artifact contains the value of ${name}.`
     );
   }
+}
 
+function inspectArtifact() {
+  const files = artifactFiles(artifactDirectory);
+  invariant(files.length > 0, 'The Storybook publication artifact is empty.');
+  assertNoForbiddenText(files);
+  assertNoSensitiveEnvironmentValues(files);
   const worker = files.find((file) => /^convexStorybook\.worker-[\w-]+\.js$/.test(path.basename(file)));
   invariant(worker, 'The Storybook artifact has no browser-local Convex worker.');
   invariant(statSync(worker).size > 0, 'The browser-local Convex worker is empty.');

--- a/src/app/db/storybook/Runtime.stories.tsx
+++ b/src/app/db/storybook/Runtime.stories.tsx
@@ -1,0 +1,84 @@
+import preview from '@sb/preview';
+import { useState } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { db, useStorybookDatabaseClient, useStorybookDatabaseReset } from '@db/storybook';
+
+import { convexStorybookReferences } from './runtime';
+
+function assertContext(
+  result: Awaited<ReturnType<ReturnType<typeof useStorybookDatabaseClient>['runContextConformance']>>
+) {
+  if (
+    result.ambient.mismatches !== 0 ||
+    result.explicit.mismatches !== 0 ||
+    result.convexHelper.status !== 'supported'
+  ) {
+    throw new Error(`The browser-local Convex context check failed: ${JSON.stringify(result)}`);
+  }
+}
+
+function RuntimeProof() {
+  const client = useStorybookDatabaseClient();
+  const reset = useStorybookDatabaseReset();
+  const [status, setStatus] = useState('Ready to run the browser-local Convex conformance checks');
+
+  return (
+    <main style={{ maxWidth: 760, padding: 32 }}>
+      <h1>Browser-local Convex foundation</h1>
+      <p>{status}</p>
+      <button
+        type="button"
+        onClick={async () => {
+          assertContext(await client.runContextConformance());
+          expect(await client.runNetworkProbe()).toBe('Convex Storybook workers cannot make network requests.');
+          expect(await client.runHttpProbe()).toEqual({ body: { error: 'Not found' }, status: 404 });
+          expect(await client.runRollbackProbe()).toEqual({
+            error: 'Intentional rollback probe',
+            usersAfterFailure: 0,
+          });
+          const scheduled = await client.runSchedulerProbe();
+          expect(scheduled.after.users).toBe(1);
+          expect(scheduled.after.rulesets).toBe(0);
+          expect(await client.query(convexStorybookReferences.migrationsAdminDashboard, { ids: [] })).toMatchObject({
+            snapshots: [],
+          });
+          expect(await client.mutation(convexStorybookReferences.migrationsSyncRuns, { ids: [] })).toEqual({
+            synced: 0,
+          });
+          for (let count = 0; count < 20; count += 1) {
+            const nextClient = await reset();
+            expect(await nextClient.query(convexStorybookReferences.rulesetsList, {})).toEqual([]);
+          }
+          setStatus('Context, components, scheduling, rollback, network isolation, and 20 resets passed');
+        }}
+      >
+        Run foundation checks
+      </button>
+    </main>
+  );
+}
+
+const meta = preview.meta({
+  title: 'Browser-local Convex',
+  component: RuntimeProof,
+  parameters: {
+    database: db((baseline) => {
+      baseline.users.push({ $key: 'storybook-observer', name: 'Storybook observer' });
+    }),
+  },
+});
+
+export const Conformance = meta.story({
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await page.findByRole('button', { name: 'Run foundation checks' }, { timeout: 30_000 }));
+    await expect(
+      page.findByText(
+        'Context, components, scheduling, rollback, network isolation, and 20 resets passed',
+        {},
+        { timeout: 45_000 }
+      )
+    ).resolves.toBeVisible();
+  },
+});

--- a/src/app/db/storybook/Runtime.stories.tsx
+++ b/src/app/db/storybook/Runtime.stories.tsx
@@ -12,6 +12,8 @@ function assertContext(
   if (
     result.ambient.mismatches !== 0 ||
     result.explicit.mismatches !== 0 ||
+    !result.date.deterministicDefault ||
+    !result.date.multiArgumentMatchesNative ||
     result.convexHelper.status !== 'supported'
   ) {
     throw new Error(`The browser-local Convex context check failed: ${JSON.stringify(result)}`);

--- a/src/app/db/storybook/StorybookDatabaseProvider.tsx
+++ b/src/app/db/storybook/StorybookDatabaseProvider.tsx
@@ -1,0 +1,122 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+import { mocked } from 'storybook/test';
+
+import { db as applicationDb } from '../core';
+import type { DatabaseDefinition } from './database';
+import type { WorkerIdentity } from './protocol';
+import {
+  ConvexStorybookWorkerClient,
+  ConvexStorybookWorkerContext,
+  convexUseMutation,
+  convexUseQuery,
+  useConvexStorybookMutation,
+  useConvexStorybookQuery,
+} from './runtime';
+
+type WorkerState =
+  | { status: 'loading' }
+  | { status: 'success'; client: ConvexStorybookWorkerClient }
+  | { status: 'error'; message: string };
+
+type StorybookDatabaseSession = {
+  client: ConvexStorybookWorkerClient;
+  reset: () => Promise<ConvexStorybookWorkerClient>;
+};
+
+const StorybookDatabaseContext = createContext<StorybookDatabaseSession | null>(null);
+
+async function startWorker(database: DatabaseDefinition) {
+  const client = new ConvexStorybookWorkerClient();
+  try {
+    await client.reset(database.create());
+    return client;
+  } catch (error) {
+    client.terminate();
+    throw error;
+  }
+}
+
+async function retireWorker(client: ConvexStorybookWorkerClient | null) {
+  if (!client) {
+    return;
+  }
+  await client.waitForIdle();
+  client.terminate();
+}
+
+export function StorybookDatabaseProvider({
+  children,
+  database,
+  identity,
+}: Readonly<{
+  children: ReactNode;
+  database: DatabaseDefinition;
+  identity?: WorkerIdentity;
+}>) {
+  const activeClient = useRef<ConvexStorybookWorkerClient | null>(null);
+  const mounted = useRef(true);
+  const [state, setState] = useState<WorkerState>({ status: 'loading' });
+
+  const reset = useCallback(async () => {
+    const nextClient = await startWorker(database);
+    if (!mounted.current) {
+      nextClient.terminate();
+      throw new Error('The story stopped before its replacement database started.');
+    }
+    await retireWorker(activeClient.current);
+    activeClient.current = nextClient;
+    setState({ status: 'success', client: nextClient });
+    return nextClient;
+  }, [database]);
+
+  useEffect(() => {
+    mounted.current = true;
+    void reset().catch((error: unknown) => {
+      setState({ status: 'error', message: error instanceof Error ? error.message : String(error) });
+    });
+    return () => {
+      mounted.current = false;
+      activeClient.current?.terminate();
+      activeClient.current = null;
+    };
+  }, [reset]);
+
+  if (state.status === 'loading') {
+    return <div role="status">Starting the browser-local Convex database…</div>;
+  }
+  if (state.status === 'error') {
+    return <div role="alert">{state.message}</div>;
+  }
+
+  mocked(applicationDb.query).mockImplementation(((fn, args) =>
+    state.client.query(fn, args, identity)) as typeof applicationDb.query);
+  mocked(applicationDb.mutation).mockImplementation(((fn, args) =>
+    state.client.mutation(fn, args, identity)) as typeof applicationDb.mutation);
+  mocked(convexUseQuery).mockImplementation(useConvexStorybookQuery as typeof convexUseQuery);
+  mocked(convexUseMutation).mockImplementation(useConvexStorybookMutation as typeof convexUseMutation);
+
+  return (
+    <StorybookDatabaseContext.Provider value={{ client: state.client, reset }}>
+      <ConvexStorybookWorkerContext.Provider value={{ client: state.client, identity }}>
+        {children}
+      </ConvexStorybookWorkerContext.Provider>
+    </StorybookDatabaseContext.Provider>
+  );
+}
+
+export function useStorybookDatabaseReset() {
+  const session = useContext(StorybookDatabaseContext);
+  if (!session) {
+    throw new Error('The story has no browser-local Convex database.');
+  }
+  return session.reset;
+}
+
+export function useStorybookDatabaseClient() {
+  const session = useContext(StorybookDatabaseContext);
+  if (!session) {
+    throw new Error('The story has no browser-local Convex database.');
+  }
+  return session.client;
+}

--- a/src/app/db/storybook/convexStorybook.worker.ts
+++ b/src/app/db/storybook/convexStorybook.worker.ts
@@ -1,0 +1,405 @@
+/// <reference lib="webworker" />
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+import { convexTest } from 'convex-test';
+import { createFunctionHandle, makeFunctionReference } from 'convex/server';
+import type { WithoutSystemFields } from 'convex/server';
+
+import type { Doc, TableNames } from '../../../../convex/_generated/dataModel';
+import type { DatabaseWriter } from '../../../../convex/_generated/server';
+import schema from '../../../../convex/schema';
+import aggregateSchema from '../../../../node_modules/@convex-dev/aggregate/src/component/schema';
+import migrationsSchema from '../../../../node_modules/@convex-dev/migrations/src/component/schema';
+import type {
+  ContextConformanceResult,
+  ContextTraceEntry,
+  SeedDocument,
+  SeedDocumentFor,
+  RollbackProbeResult,
+  SchedulerProbeResult,
+  WorkerIdentity,
+  WorkerRequest,
+  WorkerResponse,
+} from './protocol';
+
+Object.assign(globalThis, { global: globalThis, process: { env: {} } });
+const NativeDate = Date;
+const STORYBOOK_NOW = Date.parse('2026-01-01T12:00:00.000Z');
+class DeterministicStorybookDate extends NativeDate {
+  constructor(value?: string | number) {
+    super(value ?? STORYBOOK_NOW);
+  }
+
+  static override now() {
+    return STORYBOOK_NOW;
+  }
+}
+Object.defineProperty(globalThis, 'Date', {
+  configurable: false,
+  value: DeterministicStorybookDate,
+  writable: false,
+});
+Object.defineProperty(globalThis, 'fetch', {
+  configurable: false,
+  value: () => Promise.reject(new Error('Convex Storybook workers cannot make network requests.')),
+  writable: false,
+});
+Object.defineProperty(globalThis, 'Worker', {
+  configurable: false,
+  value: class DisabledStorybookSubworker {
+    constructor() {
+      throw new Error('Convex Storybook workers cannot start subworkers.');
+    }
+  },
+  writable: false,
+});
+
+const modules = import.meta.glob([
+  '../../../../convex/**/*.{ts,js}',
+  '!../../../../convex/convex.config.ts',
+  '!../../../../convex/**/*.d.ts',
+  '!../../../../convex/**/*.test.ts',
+  '!../../../../convex/**/*.stories.ts',
+]);
+
+const aggregateModules = import.meta.glob([
+  '../../../../node_modules/@convex-dev/aggregate/src/component/**/*.{ts,js}',
+  '!../../../../node_modules/@convex-dev/aggregate/src/component/convex.config.ts',
+  '!../../../../node_modules/@convex-dev/aggregate/src/component/**/*.helpers.ts',
+  '!../../../../node_modules/@convex-dev/aggregate/src/component/**/*.test.ts',
+]);
+
+const migrationsModules = import.meta.glob([
+  '../../../../node_modules/@convex-dev/migrations/src/component/**/*.{ts,js}',
+  '!../../../../node_modules/@convex-dev/migrations/src/component/convex.config.ts',
+  '!../../../../node_modules/@convex-dev/migrations/src/component/**/*.test.ts',
+]);
+
+type TestWorld = ReturnType<typeof convexTest>;
+type World = { test: TestWorld; references: Map<string, string> };
+type WorldRequest = Exclude<
+  WorkerRequest,
+  { operation: 'contextConformance' | 'networkProbe' | 'ping' | 'reset' | 'subworkerProbe' }
+>;
+
+function resolveSeedObject(value: Record<string, unknown>, references: Map<string, string>) {
+  if (typeof value.$seedRef === 'string') {
+    const resolved = references.get(value.$seedRef);
+    if (!resolved) {
+      throw new Error(`Unknown seed reference: ${value.$seedRef}`);
+    }
+    return resolved;
+  }
+  return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, resolveSeedValue(item, references)]));
+}
+
+function resolveSeedValue(value: unknown, references: Map<string, string>): unknown {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => resolveSeedValue(item, references));
+  }
+  if (value instanceof ArrayBuffer) {
+    return value;
+  }
+  return resolveSeedObject(value as Record<string, unknown>, references);
+}
+
+async function insertDocument<TableName extends TableNames>(
+  db: DatabaseWriter,
+  document: SeedDocumentFor<TableName>,
+  references: Map<string, string>
+) {
+  const value = resolveSeedValue(document.value, references) as WithoutSystemFields<Doc<TableName>>;
+  return await db.insert(document.table, value);
+}
+
+async function insertDocuments(world: World, documents: SeedDocument[], delay = 0) {
+  await world.test.run(async (ctx) => {
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    for (const document of documents) {
+      const id = await insertDocument(ctx.db, document, world.references);
+      if (document.key) {
+        world.references.set(document.key, id);
+      }
+    }
+  });
+}
+
+async function createWorld(seed: SeedDocument[]): Promise<World> {
+  const world = { test: convexTest(schema, modules), references: new Map<string, string>() };
+  world.test.registerComponent('statistics', aggregateSchema, aggregateModules);
+  world.test.registerComponent('profileActivity', aggregateSchema, aggregateModules);
+  world.test.registerComponent('profileDiscovery', aggregateSchema, aggregateModules);
+  world.test.registerComponent('migrations', migrationsSchema, migrationsModules);
+  await insertDocuments(world, seed);
+  return world;
+}
+
+function clientFor(world: World, identity?: WorkerIdentity) {
+  if (!identity) {
+    return world.test;
+  }
+  const subject = world.references.get(identity.subjectKey);
+  if (!subject) {
+    throw new Error(`Unknown identity seed reference: ${identity.subjectKey}`);
+  }
+  return world.test.withIdentity({ subject, name: identity.name });
+}
+
+async function queryWorld(world: World, name: string, args: unknown, identity?: WorkerIdentity) {
+  const query = makeFunctionReference<'query', Record<string, unknown>, unknown>(name);
+  return await clientFor(world, identity).query(query, args as Record<string, unknown>);
+}
+
+async function mutateWorld(world: World, name: string, args: unknown, identity?: WorkerIdentity) {
+  const mutation = makeFunctionReference<'mutation', Record<string, unknown>, unknown>(name);
+  return await clientFor(world, identity).mutation(mutation, args as Record<string, unknown>);
+}
+
+async function runNetworkProbe() {
+  try {
+    await fetch('https://example.com');
+    throw new Error('The worker unexpectedly completed a network request.');
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+function runSubworkerProbe() {
+  try {
+    const worker = new Worker(new URL('./protocol.ts', import.meta.url), { type: 'module' });
+    worker.terminate();
+    return 'The Convex Storybook worker started a subworker.';
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
+}
+
+async function runHttpProbe(world: World) {
+  const response = await world.test.fetch('/asset-publishing/render', {
+    headers: { Authorization: 'Bearer missing-story-job' },
+  });
+  return { body: await response.json(), status: response.status };
+}
+
+async function runSchedulerProbe(world: World): Promise<SchedulerProbeResult> {
+  await mutateWorld(world, 'statistics:rebuild', {});
+  await world.test.finishAllScheduledFunctions(() => undefined);
+  const after = (await queryWorld(world, 'statistics:getGlobalTotals', {})) as SchedulerProbeResult['after'];
+  return { after };
+}
+
+async function runRollbackProbe(): Promise<RollbackProbeResult> {
+  const isolated = await createWorld([]);
+  let error = '';
+  try {
+    await isolated.test.run(async (ctx) => {
+      await ctx.db.insert('users', { name: 'This user must roll back' });
+      throw new Error('Intentional rollback probe');
+    });
+  } catch (caught) {
+    error = caught instanceof Error ? caught.message : String(caught);
+  }
+  const usersAfterFailure = await isolated.test.run(async (ctx) => (await ctx.db.query('users').collect()).length);
+  return { error, usersAfterFailure };
+}
+
+type ExplicitFrame = Readonly<{
+  auth: string | null;
+  componentPath: string;
+  depth: number;
+  udfPath: string;
+  world: string;
+}>;
+
+function delay(milliseconds: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function nextMessage() {
+  return new Promise<void>((resolve) => {
+    const { port1, port2 } = new MessageChannel();
+    port2.onmessage = () => {
+      port1.close();
+      port2.close();
+      resolve();
+    };
+    port1.postMessage(null);
+  });
+}
+
+function traceContext(trace: ContextTraceEntry[], step: string, expected: string, actual?: string) {
+  trace.push({ actual: actual ?? null, expected, step });
+}
+
+async function runAmbientContextBaseline() {
+  const context = new AsyncLocalStorage<string>();
+  const trace: ContextTraceEntry[] = [];
+  const component = async (name: string, milliseconds: number) => {
+    return await context.run(name, async () => {
+      traceContext(trace, `${name}:start`, name, context.getStore());
+      await delay(milliseconds);
+      traceContext(trace, `${name}:resume`, name, context.getStore());
+      return context.getStore() ?? null;
+    });
+  };
+
+  await context.run('root', async () => {
+    await Promise.all([component('statistics', 5), component('profileDiscovery', 15)]);
+    traceContext(trace, 'root:after', 'root', context.getStore());
+  });
+  return { mismatches: trace.filter(({ actual, expected }) => actual !== expected).length, trace };
+}
+
+function childFrame(parent: ExplicitFrame, componentPath: string, udfPath: string): ExplicitFrame {
+  return Object.freeze({
+    auth: componentPath === parent.componentPath ? parent.auth : null,
+    componentPath,
+    depth: parent.depth + 1,
+    udfPath,
+    world: parent.world,
+  });
+}
+
+async function resumeExplicitFrame(frame: ExplicitFrame, milliseconds: number) {
+  await Promise.resolve();
+  await delay(milliseconds);
+  await nextMessage();
+  await import('./protocol');
+  return frame;
+}
+
+async function runExplicitFrameBaseline() {
+  let mismatches = 0;
+  const iterations = 100;
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const root = Object.freeze({
+      auth: `identity-${iteration}`,
+      componentPath: '',
+      depth: 0,
+      udfPath: 'root:probe',
+      world: `world-${iteration}`,
+    });
+    const statistics = childFrame(root, 'statistics', 'public:probe');
+    const discovery = childFrame(root, 'profileDiscovery', 'public:probe');
+    const [statisticsAfter, discoveryAfter] = await Promise.all([
+      resumeExplicitFrame(statistics, iteration % 3),
+      resumeExplicitFrame(discovery, (iteration + 1) % 3),
+    ]);
+    const returnedRoot = await resumeExplicitFrame(root, iteration % 2);
+    const expected = [statistics, discovery, root];
+    const actual = [statisticsAfter, discoveryAfter, returnedRoot];
+    mismatches += actual.filter((frame, index) => frame !== expected[index]).length;
+    const expectedAuth = [null, null, root.auth];
+    const actualAuth = [statisticsAfter.auth, discoveryAfter.auth, returnedRoot.auth];
+    mismatches += Number(actualAuth.some((auth, index) => auth !== expectedAuth[index]));
+  }
+  return {
+    iterations,
+    mismatches,
+    sources: ['native promise', 'setTimeout', 'MessageChannel', 'dynamic import'],
+  };
+}
+
+async function runConvexHelperGate() {
+  const reference = makeFunctionReference<'query'>('rulesets:list');
+  try {
+    const helperWorld = await createWorld([]);
+    const handle = await helperWorld.test.run(async () => {
+      await Promise.resolve();
+      return await createFunctionHandle(reference);
+    });
+    return {
+      error: '',
+      handle,
+      status: 'supported' as const,
+    };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+      handle: null,
+      status: 'blocked' as const,
+    };
+  }
+}
+
+async function runContextConformance(): Promise<ContextConformanceResult> {
+  return {
+    ambient: await runAmbientContextBaseline(),
+    explicit: await runExplicitFrameBaseline(),
+    convexHelper: await runConvexHelperGate(),
+  };
+}
+
+let world = createWorld([]);
+const unhandledRequest = Symbol('unhandledRequest');
+
+async function handleLifecycleRequest(request: WorkerRequest): Promise<unknown | typeof unhandledRequest> {
+  if (request.operation === 'ping') {
+    return null;
+  }
+  if (request.operation === 'reset') {
+    world = createWorld(request.seed);
+    await world;
+    return null;
+  }
+  if (request.operation === 'networkProbe') {
+    return await runNetworkProbe();
+  }
+  if (request.operation === 'subworkerProbe') {
+    return runSubworkerProbe();
+  }
+  if (request.operation === 'contextConformance') {
+    return await runContextConformance();
+  }
+  return unhandledRequest;
+}
+
+async function handleWorldRequest(request: WorldRequest, currentWorld: World): Promise<unknown> {
+  if (request.operation === 'httpProbe') {
+    return await runHttpProbe(currentWorld);
+  }
+  if (request.operation === 'schedulerProbe') {
+    return await runSchedulerProbe(currentWorld);
+  }
+  if (request.operation === 'rollbackProbe') {
+    return await runRollbackProbe();
+  }
+  if (request.operation === 'mutation') {
+    return await mutateWorld(currentWorld, request.name, request.args, request.identity);
+  }
+  return await queryWorld(currentWorld, request.name, request.args, request.identity);
+}
+
+async function handleRequest(request: WorkerRequest): Promise<unknown> {
+  const lifecycleResult = await handleLifecycleRequest(request);
+  if (lifecycleResult !== unhandledRequest) {
+    return lifecycleResult;
+  }
+  return await handleWorldRequest(request as WorldRequest, await world);
+}
+
+let lane = Promise.resolve();
+
+self.addEventListener('message', (event: MessageEvent<WorkerRequest>) => {
+  if (event.origin && event.origin !== self.location.origin) {
+    return;
+  }
+  const request = event.data;
+  lane = lane.then(async () => {
+    let response: WorkerResponse;
+    try {
+      response = { id: request.id, ok: true, result: await handleRequest(request) };
+    } catch (error) {
+      response = {
+        id: request.id,
+        ok: false,
+        error: error instanceof Error ? `${error.name}: ${error.message}\n${error.stack ?? ''}` : String(error),
+      };
+    }
+    self.postMessage(response);
+  });
+});

--- a/src/app/db/storybook/convexStorybook.worker.ts
+++ b/src/app/db/storybook/convexStorybook.worker.ts
@@ -27,8 +27,27 @@ Object.assign(globalThis, { global: globalThis, process: { env: {} } });
 const NativeDate = Date;
 const STORYBOOK_NOW = Date.parse('2026-01-01T12:00:00.000Z');
 class DeterministicStorybookDate extends NativeDate {
-  constructor(value?: string | number) {
-    super(value ?? STORYBOOK_NOW);
+  constructor(
+    ...args:
+      | []
+      | [value: string | number]
+      | [
+          year: number,
+          monthIndex: number,
+          date?: number,
+          hours?: number,
+          minutes?: number,
+          seconds?: number,
+          ms?: number,
+        ]
+  ) {
+    if (args.length === 0) {
+      super(STORYBOOK_NOW);
+    } else if (args.length === 1) {
+      super(args[0]);
+    } else {
+      super(...args);
+    }
   }
 
   static override now() {
@@ -327,7 +346,12 @@ async function runConvexHelperGate() {
 }
 
 async function runContextConformance(): Promise<ContextConformanceResult> {
+  const dateParts = [2020, 4, 3, 2, 1, 0, 9] as const;
   return {
+    date: {
+      deterministicDefault: new Date().getTime() === STORYBOOK_NOW,
+      multiArgumentMatchesNative: new Date(...dateParts).getTime() === new NativeDate(...dateParts).getTime(),
+    },
     ambient: await runAmbientContextBaseline(),
     explicit: await runExplicitFrameBaseline(),
     convexHelper: await runConvexHelperGate(),

--- a/src/app/db/storybook/database.test.ts
+++ b/src/app/db/storybook/database.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('../core', () => ({ db: { mutation: vi.fn(), query: vi.fn() } }));
+
+import schema from '../../../../convex/schema';
+import { db, emptyDatabase, faction, ref, ruleset } from './index';
+import type { StorybookDatabase, StorybookRow } from './index';
+
+describe('Storybook database authoring', () => {
+  test('the accepted callback extends a fresh canonical baseline', () => {
+    const scenario = db((baseline) => {
+      baseline.factions.push(faction({ name: 'House Atreides' }));
+      baseline.rulesets.push(ruleset({ name: 'ClassicRules' }));
+    });
+
+    const first = scenario.create();
+    const second = scenario.create();
+
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+    expect(first.filter(({ table }) => table === 'users')).toHaveLength(1);
+    expect(first.filter(({ table }) => table === 'profiles')).toHaveLength(1);
+    expect(first.filter(({ table }) => table === 'factions')).toHaveLength(1);
+    expect(first.filter(({ table }) => table === 'rulesets')).toHaveLength(1);
+  });
+
+  test('a story can replace the baseline with a valid empty database', () => {
+    expect(db(() => emptyDatabase()).create()).toEqual([]);
+  });
+
+  test('the empty database follows the Convex schema table set', () => {
+    const database: StorybookDatabase = emptyDatabase();
+    const user: StorybookRow<'users'> = { $key: 'typed-user', name: 'Typed user' };
+    database.users.push(user);
+
+    expect(Object.keys(database).sort()).toEqual(Object.keys(schema.tables).sort());
+    expect(ref('typed-user')).toEqual({ $seedRef: 'typed-user' });
+  });
+
+  test('a dangling relationship fails before the story renders', () => {
+    const scenario = db((baseline) => {
+      baseline.rulesets.push({
+        ...ruleset({ name: 'MissingOwner' }),
+        owner_id: { $seedRef: 'missing-owner' },
+      });
+    });
+
+    expect(() => scenario.create()).toThrow('Storybook database reference missing-owner has no matching row.');
+  });
+});

--- a/src/app/db/storybook/database.ts
+++ b/src/app/db/storybook/database.ts
@@ -123,7 +123,7 @@ function visitReferences(value: unknown, visit: (key: string) => void) {
   }
 }
 
-function validateDatabase(database: StorybookDatabase) {
+function collectKeys(database: StorybookDatabase) {
   const keys = new Set<string>();
   for (const rows of Object.values(database)) {
     for (const row of rows as Array<{ $key?: string }>) {
@@ -136,7 +136,10 @@ function validateDatabase(database: StorybookDatabase) {
       keys.add(row.$key);
     }
   }
+  return keys;
+}
 
+function validateReferences(database: StorybookDatabase, keys: Set<string>) {
   for (const rows of Object.values(database)) {
     for (const row of rows) {
       visitReferences(row, (key) => {
@@ -146,7 +149,9 @@ function validateDatabase(database: StorybookDatabase) {
       });
     }
   }
+}
 
+function validateDomainRows(database: StorybookDatabase) {
   for (const row of database.factions) {
     FactionInputSchema.parse(row.data);
     FactionRowSlugSchema.parse(row.slug);
@@ -154,6 +159,12 @@ function validateDatabase(database: StorybookDatabase) {
   for (const row of database.rulesets) {
     rulesetInputSchema.parse({ name: row.name, about: row.about });
   }
+}
+
+function validateDatabase(database: StorybookDatabase) {
+  const keys = collectKeys(database);
+  validateReferences(database, keys);
+  validateDomainRows(database);
 }
 
 function toSeedDocuments(database: StorybookDatabase): SeedDocument[] {

--- a/src/app/db/storybook/database.ts
+++ b/src/app/db/storybook/database.ts
@@ -1,0 +1,187 @@
+import type { WithoutSystemFields } from 'convex/server';
+
+import type { Doc, TableNames } from '../../../../convex/_generated/dataModel';
+import schema from '../../../../convex/schema';
+import { assetPublishingFaction } from '../../../shared/factions/fixtures/assetPublishingFaction';
+import { FactionInputSchema, FactionRowSlugSchema } from '../../../shared/factions/schema';
+import type { FactionInput } from '../../../shared/factions/schema';
+import { rulesetInputSchema } from '../../../shared/rulesets/validation';
+import { slugify } from '../../../shared/slugify';
+import type { SeedDocument, SeedReference, WithSeedReferences, WorkerIdentity } from './protocol';
+
+const STORY_TIME = '2026-01-01T12:00:00.000Z';
+const VIEWER_KEY = 'storybook-viewer';
+
+export type StorybookRow<TableName extends TableNames> = WithSeedReferences<WithoutSystemFields<Doc<TableName>>> & {
+  $key?: string;
+};
+
+export type StorybookDatabase = {
+  [TableName in TableNames]: StorybookRow<TableName>[];
+};
+
+export type DatabaseDefinition = {
+  create: () => SeedDocument[];
+};
+
+type DatabaseChange = (baseline: StorybookDatabase) => StorybookDatabase | void;
+
+function emptyTables(): StorybookDatabase {
+  const tables: Record<string, unknown> = Object.fromEntries(Object.keys(schema.tables).map((table) => [table, []]));
+  return tables as StorybookDatabase;
+}
+
+export function ref(key: string): SeedReference {
+  return { $seedRef: key };
+}
+
+export function emptyDatabase(): StorybookDatabase {
+  return emptyTables();
+}
+
+function viewerRow(): StorybookRow<'users'> {
+  return { $key: VIEWER_KEY, name: 'Storybook viewer' };
+}
+
+function viewerProfileRow(): StorybookRow<'profiles'> {
+  return {
+    $key: 'storybook-viewer-profile',
+    user_id: ref(VIEWER_KEY),
+    username: 'storybook-viewer',
+    avatar_url: null,
+    account_state: 'active',
+    slug: 'storybook-viewer',
+    created_at: STORY_TIME,
+    updated_at: STORY_TIME,
+  };
+}
+
+function baselineDatabase(): StorybookDatabase {
+  const baseline = emptyTables();
+  baseline.users.push(viewerRow());
+  baseline.profiles.push(viewerProfileRow());
+  return baseline;
+}
+
+export function ruleset({ about, name }: Readonly<{ about?: string; name: string }>): StorybookRow<'rulesets'> {
+  const parsed = rulesetInputSchema.parse({
+    name,
+    about: about ?? `${name} is deterministic Storybook content for a complete page-level database scenario.`,
+  });
+  return {
+    $key: `ruleset:${slugify(parsed.name)}`,
+    name: parsed.name,
+    slug: slugify(parsed.name),
+    about: parsed.about,
+    owner_id: ref(VIEWER_KEY),
+    group_id: null,
+    is_deleted: false,
+    image_cover: null,
+    created_at: STORY_TIME,
+    updated_at: STORY_TIME,
+  };
+}
+
+export function faction({
+  data,
+  name,
+}: Readonly<{ data?: Partial<FactionInput>; name: string }>): StorybookRow<'factions'> {
+  const parsed = FactionInputSchema.parse({
+    ...structuredClone(assetPublishingFaction),
+    ...data,
+    name,
+  });
+  return {
+    $key: `faction:${slugify(parsed.name)}`,
+    owner_id: ref(VIEWER_KEY),
+    data: parsed,
+    slug: slugify(parsed.name),
+    created_at: STORY_TIME,
+    updated_at: STORY_TIME,
+    is_deleted: false,
+    group_id: null,
+  };
+}
+
+function visitReferences(value: unknown, visit: (key: string) => void) {
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      visitReferences(item, visit);
+    }
+    return;
+  }
+  const object = value as Record<string, unknown>;
+  if (typeof object.$seedRef === 'string') {
+    visit(object.$seedRef);
+    return;
+  }
+  for (const item of Object.values(object)) {
+    visitReferences(item, visit);
+  }
+}
+
+function validateDatabase(database: StorybookDatabase) {
+  const keys = new Set<string>();
+  for (const rows of Object.values(database)) {
+    for (const row of rows as Array<{ $key?: string }>) {
+      if (!row.$key) {
+        continue;
+      }
+      if (keys.has(row.$key)) {
+        throw new Error(`Storybook database key ${row.$key} is duplicated.`);
+      }
+      keys.add(row.$key);
+    }
+  }
+
+  for (const rows of Object.values(database)) {
+    for (const row of rows) {
+      visitReferences(row, (key) => {
+        if (!keys.has(key)) {
+          throw new Error(`Storybook database reference ${key} has no matching row.`);
+        }
+      });
+    }
+  }
+
+  for (const row of database.factions) {
+    FactionInputSchema.parse(row.data);
+    FactionRowSlugSchema.parse(row.slug);
+  }
+  for (const row of database.rulesets) {
+    rulesetInputSchema.parse({ name: row.name, about: row.about });
+  }
+}
+
+function toSeedDocuments(database: StorybookDatabase): SeedDocument[] {
+  validateDatabase(database);
+  const documents: SeedDocument[] = [];
+  for (const [table, rows] of Object.entries(database) as Array<[TableNames, Array<StorybookRow<TableNames>>]>) {
+    for (const row of rows) {
+      const { $key: key, ...value } = row;
+      documents.push({ key, table, value } as SeedDocument);
+    }
+  }
+  return documents;
+}
+
+/*
+ * Declares a fresh page-story database. The callback may mutate the canonical baseline or return
+ * a replacement, including `emptyDatabase()`.
+ */
+export function db(change: DatabaseChange): DatabaseDefinition {
+  return {
+    create: () => {
+      const baseline = baselineDatabase();
+      return toSeedDocuments(change(baseline) ?? baseline);
+    },
+  };
+}
+
+export const storybookViewer = {
+  name: 'Storybook viewer',
+  subjectKey: VIEWER_KEY,
+} satisfies WorkerIdentity;

--- a/src/app/db/storybook/index.ts
+++ b/src/app/db/storybook/index.ts
@@ -1,0 +1,8 @@
+export { db, emptyDatabase, faction, ref, ruleset, storybookViewer } from './database';
+export type { DatabaseDefinition, StorybookDatabase, StorybookRow } from './database';
+export type { WorkerIdentity } from './protocol';
+export {
+  StorybookDatabaseProvider,
+  useStorybookDatabaseClient,
+  useStorybookDatabaseReset,
+} from './StorybookDatabaseProvider';

--- a/src/app/db/storybook/protocol.ts
+++ b/src/app/db/storybook/protocol.ts
@@ -1,0 +1,78 @@
+import type { FunctionReturnType, WithoutSystemFields } from 'convex/server';
+import type { GenericId } from 'convex/values';
+
+import type { api } from '../../../../convex/_generated/api';
+import type { Doc, TableNames } from '../../../../convex/_generated/dataModel';
+
+export type SeedReference = { $seedRef: string };
+export type WithSeedReferences<Value> =
+  Value extends GenericId<string>
+    ? Value | SeedReference
+    : Value extends (infer Item)[]
+      ? WithSeedReferences<Item>[]
+      : Value extends ArrayBuffer
+        ? Value
+        : Value extends object
+          ? { [Key in keyof Value]: WithSeedReferences<Value[Key]> }
+          : Value;
+
+export type SeedDocumentFor<TableName extends TableNames> = {
+  key?: string;
+  table: TableName;
+  value: WithSeedReferences<WithoutSystemFields<Doc<TableName>>>;
+};
+
+export type SeedDocument = {
+  [TableName in TableNames]: SeedDocumentFor<TableName>;
+}[TableNames];
+
+export type WorkerIdentity = {
+  name?: string;
+  subjectKey: string;
+};
+
+export type SchedulerProbeResult = {
+  after: FunctionReturnType<typeof api.statistics.getGlobalTotals>;
+};
+
+export type RollbackProbeResult = {
+  error: string;
+  usersAfterFailure: number;
+};
+
+export type ContextTraceEntry = {
+  actual: string | null;
+  expected: string;
+  step: string;
+};
+
+export type ContextConformanceResult = {
+  ambient: {
+    mismatches: number;
+    trace: ContextTraceEntry[];
+  };
+  explicit: {
+    iterations: number;
+    mismatches: number;
+    sources: string[];
+  };
+  convexHelper: {
+    error: string;
+    handle: string | null;
+    status: 'blocked' | 'supported';
+  };
+};
+
+export type WorkerRequest =
+  | { id: number; operation: 'ping' }
+  | { id: number; operation: 'networkProbe' }
+  | { id: number; operation: 'subworkerProbe' }
+  | { id: number; operation: 'httpProbe' }
+  | { id: number; operation: 'schedulerProbe' }
+  | { id: number; operation: 'rollbackProbe' }
+  | { id: number; operation: 'contextConformance' }
+  | { id: number; operation: 'query'; name: string; args: unknown; identity?: WorkerIdentity }
+  | { id: number; operation: 'mutation'; name: string; args: unknown; identity?: WorkerIdentity }
+  | { id: number; operation: 'reset'; seed: SeedDocument[] };
+
+export type WorkerResponse = { id: number; ok: true; result: unknown } | { id: number; ok: false; error: string };

--- a/src/app/db/storybook/protocol.ts
+++ b/src/app/db/storybook/protocol.ts
@@ -47,6 +47,10 @@ export type ContextTraceEntry = {
 };
 
 export type ContextConformanceResult = {
+  date: {
+    deterministicDefault: boolean;
+    multiArgumentMatchesNative: boolean;
+  };
   ambient: {
     mismatches: number;
     trace: ContextTraceEntry[];

--- a/src/app/db/storybook/runtime.test.tsx
+++ b/src/app/db/storybook/runtime.test.tsx
@@ -1,0 +1,54 @@
+/* @vitest-environment jsdom */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { expect, test, vi } from 'vitest';
+
+import { api } from '../../../../convex/_generated/api';
+import { ConvexStorybookWorkerContext, useConvexStorybookQuery } from './runtime';
+import type { ConvexStorybookWorkerClient } from './runtime';
+
+function deferred<Value>() {
+  let resolve: (value: Value) => void = () => undefined;
+  const promise = new Promise<Value>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+test('a revision refresh preserves the current query value until its replacement arrives', async () => {
+  const initial = [{ name: 'Initial ruleset' }];
+  const replacement = [{ name: 'Replacement ruleset' }];
+  const firstQuery = deferred<unknown>();
+  const refreshedQuery = deferred<unknown>();
+  const listeners = new Set<() => void>();
+  let revision = 0;
+  const query = vi.fn().mockReturnValueOnce(firstQuery.promise).mockReturnValueOnce(refreshedQuery.promise);
+  const client = {
+    getRevision: () => revision,
+    query,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+  } as unknown as ConvexStorybookWorkerClient;
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <ConvexStorybookWorkerContext.Provider value={{ client }}>{children}</ConvexStorybookWorkerContext.Provider>
+  );
+  const hook = renderHook(() => useConvexStorybookQuery(api.rulesets.list, {}), { wrapper });
+
+  firstQuery.resolve(initial);
+  await waitFor(() => expect(hook.result.current).toBe(initial));
+
+  act(() => {
+    revision += 1;
+    for (const listener of listeners) {
+      listener();
+    }
+  });
+  expect(hook.result.current).toBe(initial);
+
+  refreshedQuery.resolve(replacement);
+  await waitFor(() => expect(hook.result.current).toBe(replacement));
+  expect(query).toHaveBeenCalledTimes(2);
+});

--- a/src/app/db/storybook/runtime.tsx
+++ b/src/app/db/storybook/runtime.tsx
@@ -175,8 +175,11 @@ export function useConvexStorybookQuery<Query extends FunctionReference<'query'>
   const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
-    let active = true;
     setValue(undefined);
+  }, [client, identity, stableArgs, stableQuery]);
+
+  useEffect(() => {
+    let active = true;
     setError(null);
     void client
       .query(stableQuery, stableArgs, identity)

--- a/src/app/db/storybook/runtime.tsx
+++ b/src/app/db/storybook/runtime.tsx
@@ -1,0 +1,220 @@
+import { useMutation as convexUseMutation, useQuery as convexUseQuery } from 'convex/react';
+import { getFunctionName, makeFunctionReference } from 'convex/server';
+import type { FunctionArgs, FunctionReference, FunctionReturnType } from 'convex/server';
+import { convexToJson } from 'convex/values';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+
+import { api } from '../../../../convex/_generated/api';
+import type {
+  ContextConformanceResult,
+  RollbackProbeResult,
+  SchedulerProbeResult,
+  SeedDocument,
+  WorkerIdentity,
+  WorkerRequest,
+  WorkerResponse,
+} from './protocol';
+
+type WithoutId<Request> = Request extends unknown ? Omit<Request, 'id'> : never;
+type WorkerRequestPayload = WithoutId<WorkerRequest>;
+
+export class ConvexStorybookWorkerClient {
+  private readonly worker = new Worker(new URL('./convexStorybook.worker.ts', import.meta.url), { type: 'module' });
+  private readonly pending = new Map<number, { resolve: (value: unknown) => void; reject: (error: Error) => void }>();
+  private readonly listeners = new Set<() => void>();
+  private nextId = 1;
+  private revision = 0;
+
+  constructor() {
+    this.worker.addEventListener('message', (event: MessageEvent<WorkerResponse>) => {
+      const response = event.data;
+      const pending = this.pending.get(response.id);
+      if (!pending) {
+        return;
+      }
+      this.pending.delete(response.id);
+      if (response.ok) {
+        pending.resolve(response.result);
+      } else {
+        pending.reject(new Error(response.error));
+      }
+    });
+    this.worker.addEventListener('error', (event) => {
+      this.rejectPending(new Error(event.message));
+    });
+  }
+
+  query = async <Query extends FunctionReference<'query'>>(
+    fn: Query,
+    args: FunctionArgs<Query>,
+    identity?: WorkerIdentity
+  ): Promise<FunctionReturnType<Query>> => {
+    return (await this.request({
+      operation: 'query',
+      name: getFunctionName(fn),
+      args,
+      identity,
+    })) as FunctionReturnType<Query>;
+  };
+
+  mutation = async <Mutation extends FunctionReference<'mutation'>>(
+    fn: Mutation,
+    args: FunctionArgs<Mutation>,
+    identity?: WorkerIdentity
+  ): Promise<FunctionReturnType<Mutation>> => {
+    const result = (await this.request({
+      operation: 'mutation',
+      name: getFunctionName(fn),
+      args,
+      identity,
+    })) as FunctionReturnType<Mutation>;
+    this.notifyQueries();
+    return result;
+  };
+
+  reset = async (seed: SeedDocument[]) => {
+    await this.request({ operation: 'reset', seed });
+    this.notifyQueries();
+  };
+
+  runNetworkProbe = async () => (await this.request({ operation: 'networkProbe' })) as string;
+
+  runSubworkerProbe = async () => (await this.request({ operation: 'subworkerProbe' })) as string;
+
+  runHttpProbe = async () =>
+    (await this.request({ operation: 'httpProbe' })) as { body: { error?: string }; status: number };
+
+  runSchedulerProbe = async () => (await this.request({ operation: 'schedulerProbe' })) as SchedulerProbeResult;
+
+  runRollbackProbe = async () => (await this.request({ operation: 'rollbackProbe' })) as RollbackProbeResult;
+
+  runContextConformance = async () =>
+    (await this.request({ operation: 'contextConformance' })) as ContextConformanceResult;
+
+  waitForIdle = async () => await this.request({ operation: 'ping' });
+
+  subscribe = (listener: () => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  getRevision = () => this.revision;
+
+  terminate() {
+    this.worker.terminate();
+    this.rejectPending(new Error('The Convex Storybook worker stopped.'));
+  }
+
+  private notifyQueries() {
+    this.revision += 1;
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  private async request(request: WorkerRequestPayload): Promise<unknown> {
+    const id = this.nextId;
+    this.nextId += 1;
+    return await new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.worker.postMessage({ ...request, id } satisfies WorkerRequest);
+    });
+  }
+
+  private rejectPending(error: Error) {
+    for (const pending of this.pending.values()) {
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+export type ConvexStorybookWorkerSession = {
+  client: ConvexStorybookWorkerClient;
+  identity?: WorkerIdentity;
+};
+
+export const ConvexStorybookWorkerContext = createContext<ConvexStorybookWorkerSession | null>(null);
+
+function useConvexStorybookWorkerSession() {
+  const session = useContext(ConvexStorybookWorkerContext);
+  if (!session) {
+    throw new Error('The story has no Convex worker client.');
+  }
+  return session;
+}
+
+function useStableConvexArgs<Query extends FunctionReference<'query'>>(args: FunctionArgs<Query>) {
+  const serialized = JSON.stringify(convexToJson(args));
+  const stable = useRef<{ serialized: string; value: FunctionArgs<Query> } | undefined>(undefined);
+  if (!stable.current || stable.current.serialized !== serialized) {
+    stable.current = { serialized, value: args };
+  }
+  return stable.current.value;
+}
+
+export function useConvexStorybookQuery<Query extends FunctionReference<'query'>>(
+  query: Query,
+  args: FunctionArgs<Query>
+): FunctionReturnType<Query> | undefined {
+  const { client, identity } = useConvexStorybookWorkerSession();
+  const revision = useSyncExternalStore(client.subscribe, client.getRevision, client.getRevision);
+  const name = getFunctionName(query);
+  const stableQuery = useMemo(() => makeFunctionReference(name) as Query, [name]);
+  const stableArgs = useStableConvexArgs(args);
+  const [value, setValue] = useState<FunctionReturnType<Query>>();
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    setValue(undefined);
+    setError(null);
+    void client
+      .query(stableQuery, stableArgs, identity)
+      .then((result) => {
+        if (active) {
+          setValue(result);
+        }
+      })
+      .catch((queryError: unknown) => {
+        if (active) {
+          setError(queryError instanceof Error ? queryError : new Error(String(queryError)));
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [client, identity, revision, stableArgs, stableQuery]);
+
+  if (error) {
+    throw error;
+  }
+  return value;
+}
+
+export function useConvexStorybookMutation<Mutation extends FunctionReference<'mutation'>>(mutation: Mutation) {
+  const { client, identity } = useConvexStorybookWorkerSession();
+  return useCallback(
+    async (args: FunctionArgs<Mutation>) => await client.mutation(mutation, args, identity),
+    [client, identity, mutation]
+  );
+}
+
+export const convexStorybookReferences = {
+  migrationsAdminDashboard: api.migrations.adminDashboard,
+  migrationsSyncRuns: api.migrations.syncMigrationRuns,
+  profileSession: api.profiles.session,
+  rulesetsList: api.rulesets.list,
+};
+
+export { convexUseMutation, convexUseQuery };
+export type { FunctionArgs, FunctionReference, FunctionReturnType };

--- a/src/app/routes/_app/rulesets/-create.stories.tsx
+++ b/src/app/routes/_app/rulesets/-create.stories.tsx
@@ -1,0 +1,143 @@
+import preview from '@sb/preview';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute as createStoryRoute,
+  createRouter,
+  Outlet,
+  RouterProvider,
+} from '@tanstack/react-router';
+import { useMemo } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { db, useStorybookDatabaseReset } from '@db/storybook';
+
+import { Route as RulesetDetailRoute } from './$rulesetSlug/index';
+import { Route } from './create';
+
+const createdRuleset = {
+  name: 'WorkerCreatedRuleset',
+  about: 'This ruleset was created by the real page and mutation inside an isolated Storybook database.',
+};
+
+function ActualCreateRulesetPage() {
+  const Page = Route.options.component;
+  if (!Page) {
+    throw new Error('The create ruleset route has no page component.');
+  }
+  return <Page />;
+}
+
+function ActualRulesetDetailPage() {
+  const Page = RulesetDetailRoute.options.component;
+  if (!Page) {
+    throw new Error('The ruleset detail route has no page component.');
+  }
+  return <Page />;
+}
+
+const rootRoute = createRootRoute({ component: Outlet });
+const appRoute = createStoryRoute({
+  getParentRoute: () => rootRoute,
+  id: '_app',
+  component: Outlet,
+});
+const createPageRoute = createStoryRoute({
+  getParentRoute: () => appRoute,
+  path: '/rulesets/create',
+  component: ActualCreateRulesetPage,
+});
+const rulesetRoute = createStoryRoute({
+  getParentRoute: () => appRoute,
+  path: '/rulesets/$rulesetSlug',
+  component: Outlet,
+});
+const rulesetDetailPageRoute = createStoryRoute({
+  getParentRoute: () => rulesetRoute,
+  path: '/',
+  loader: async (context) => {
+    const loader = RulesetDetailRoute.options.loader as
+      | ((loaderContext: typeof context) => Promise<unknown>)
+      | undefined;
+    if (!loader) {
+      throw new Error('The ruleset detail route has no loader.');
+    }
+    return await loader(context);
+  },
+  validateSearch: RulesetDetailRoute.options.validateSearch,
+  component: ActualRulesetDetailPage,
+});
+const routeTree = rootRoute.addChildren([
+  appRoute.addChildren([createPageRoute, rulesetRoute.addChildren([rulesetDetailPageRoute])]),
+]);
+
+function CreateRulesetStoryPage() {
+  const resetDatabase = useStorybookDatabaseReset();
+  const router = useMemo(
+    () =>
+      createRouter({
+        history: createMemoryHistory({ initialEntries: ['/rulesets/create'] }),
+        routeTree,
+      }),
+    []
+  );
+
+  return (
+    <>
+      <RouterProvider router={router} />
+      <button
+        type="button"
+        hidden
+        data-storybook-database-reset
+        onClick={async () => {
+          await resetDatabase();
+          await router.navigate({ to: '/rulesets/create' });
+        }}
+      >
+        Reset the story database
+      </button>
+    </>
+  );
+}
+
+const meta = preview.meta({
+  title: 'Rulesets/Create',
+  component: CreateRulesetStoryPage,
+  parameters: {
+    layout: 'fullscreen',
+    database: db((baseline) => baseline),
+  },
+  globals: { viewport: { value: 'appDesktop' } },
+});
+
+async function createThroughPage(canvasElement: HTMLElement) {
+  const page = within(canvasElement.ownerDocument.body);
+  const name = await page.findByRole('textbox', { name: 'Name' }, { timeout: 30_000 });
+  await userEvent.type(name, createdRuleset.name);
+  await userEvent.type(page.getByRole('textbox', { name: 'About' }), createdRuleset.about);
+  await userEvent.click(page.getByRole('button', { name: 'Create' }));
+  await expect(page.findByRole('heading', { name: createdRuleset.name }, { timeout: 30_000 })).resolves.toBeVisible();
+  await expect(page.findByText(createdRuleset.about, {}, { timeout: 30_000 })).resolves.toBeVisible();
+  return page;
+}
+
+export const Authenticated = meta.story({
+  play: async ({ canvasElement }) => {
+    const page = await createThroughPage(canvasElement);
+    const reset = canvasElement.ownerDocument.querySelector<HTMLButtonElement>('[data-storybook-database-reset]');
+    if (!reset) {
+      throw new Error('The story database reset control is missing.');
+    }
+    reset.click();
+    await expect(page.findByRole('heading', { name: 'Create ruleset' }, { timeout: 30_000 })).resolves.toBeVisible();
+  },
+});
+
+export const SignedOut = meta.story({
+  parameters: { identity: null },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(page.findByRole('heading', { name: 'Create ruleset' }, { timeout: 30_000 })).resolves.toBeVisible();
+    await expect(page.findByRole('link', { name: 'Log in' }, { timeout: 30_000 })).resolves.toBeVisible();
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "paths": {
       "@sb/*": ["./.storybook/*"],
       "@db/core": ["./src/app/db/core/index.ts"],
+      "@db/storybook": ["./src/app/db/storybook/index.ts"],
       "@db/*": ["./src/app/db/*.ts"],
       "@app/*": ["./src/app/*"],
       "@ui/*": ["./src/app/ui/*"],

--- a/vitest.storybook.config.ts
+++ b/vitest.storybook.config.ts
@@ -9,15 +9,23 @@ import viteReact from '@vitejs/plugin-react';
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
+import {
+  convexWorkerAliases,
+  convexWorkerBuildPlugins,
+  convexWorkerOptimizeDeps,
+  convexWorkerOxc,
+  convexWorkerServePlugins,
+} from './.storybook/worker-async-transform.ts';
 import { coverageExclude, coverageIncludeSrc } from './coverage-denominator.ts';
 
 export default defineConfig({
+  oxc: convexWorkerOxc,
   /**
    * Mirrors .storybook/vite.config.ts, because the addon does not load the custom builder viteConfigPath on its own.
    * Without the react plugin every story fails on CJS interop (react-dom flushSync).
    */
   define: {
-    'import.meta.env.VITE_CONVEX_URL': JSON.stringify('storybook-disconnected'),
+    'import.meta.env.VITE_CONVEX_URL': JSON.stringify('https://storybook.invalid'),
   },
   /**
    * Only `scripts/` imports these two modules, so the story-file scan never crawls them, and the v8 coverage pass over untested `src/` files discovers `svgpath` and `three` after the last test.
@@ -27,16 +35,24 @@ export default defineConfig({
    * Entries rather than `include`, so Vite keeps following their imports and a new transitive dependency cannot reintroduce the reload without anyone noticing.
    */
   optimizeDeps: {
+    ...convexWorkerOptimizeDeps,
     entries: ['src/shared/svgToObj.ts', 'src/shared/vectorNormalize.ts'],
+    include: [...convexWorkerOptimizeDeps.include, '@mantine/hooks', 'crypto-js/sha256'],
   },
   resolve: {
     /* Typings in the current Vite package lag behind docs/runtime support
        (same cast as .storybook/vite.config.ts). */
     ...({ tsconfigPaths: true } as Record<string, unknown>),
+    alias: convexWorkerAliases,
   },
-  plugins: [viteReact(), storybookTest({ configDir: '.storybook' })],
+  plugins: [...convexWorkerServePlugins(), viteReact(), storybookTest({ configDir: '.storybook' })],
+  worker: {
+    format: 'es',
+    plugins: convexWorkerBuildPlugins,
+  },
   test: {
     name: 'storybook',
+    testTimeout: 45_000,
     browser: {
       enabled: true,
       provider: playwright(),

--- a/workers/publisher/deployment-config.test.ts
+++ b/workers/publisher/deployment-config.test.ts
@@ -76,8 +76,6 @@ describe('scheduled production deployment shape', () => {
       '/publisher-capture',
       '/publisher-capture.html',
       '/publisher-capture/*',
-      '/__storybook',
-      '/__storybook/',
     ]);
   });
 });

--- a/workers/publisher/index.test.ts
+++ b/workers/publisher/index.test.ts
@@ -48,37 +48,6 @@ afterEach(() => {
 });
 
 describe('publisher Worker Publication flow', () => {
-  test('redirects the Storybook entry to its canonical trailing-slash URL', async () => {
-    const currentEnv = publisherEnv();
-    const response = await publisherWorker.fetch(
-      new Request('https://dune.zone/__storybook?path=/story/example'),
-      currentEnv,
-      {
-        waitUntil: vi.fn(),
-      } as unknown as ExecutionContext
-    );
-
-    expect(response.status).toBe(308);
-    expect(response.headers.get('Location')).toBe('https://dune.zone/__storybook/?path=/story/example');
-    expect(currentEnv.ASSETS.fetch).not.toHaveBeenCalled();
-  });
-
-  test('serves the Storybook manager entry while preserving its query string', async () => {
-    const currentEnv = publisherEnv();
-    const response = await publisherWorker.fetch(
-      new Request('https://dune.zone/__storybook/?path=/story/example'),
-      currentEnv,
-      {
-        waitUntil: vi.fn(),
-      } as unknown as ExecutionContext
-    );
-
-    expect(response.status).toBe(200);
-    expect(currentEnv.ASSETS.fetch).toHaveBeenCalledOnce();
-    const [assetRequest] = vi.mocked(currentEnv.ASSETS.fetch).mock.calls[0];
-    expect((assetRequest as Request).url).toBe('https://dune.zone/__storybook/index.html?path=/story/example');
-  });
-
   test('owns reserved namespaces without Static Assets fallthrough', async () => {
     const currentEnv = publisherEnv();
     const response = await publisherWorker.fetch(

--- a/workers/publisher/index.ts
+++ b/workers/publisher/index.ts
@@ -40,19 +40,6 @@ function reservedNotFound(): Response {
   return Response.json({ error: 'Not found' }, { status: 404, headers: { 'Cache-Control': 'no-store' } });
 }
 
-function handleStorybookEntry(request: Request, env: Env): Response | Promise<Response> | undefined {
-  const url = new URL(request.url);
-  if (url.pathname === '/__storybook') {
-    url.pathname = '/__storybook/';
-    return Response.redirect(url.href, 308);
-  }
-  if (url.pathname === '/__storybook/') {
-    url.pathname = '/__storybook/index.html';
-    return env.ASSETS.fetch(new Request(url.href, request));
-  }
-  return undefined;
-}
-
 const publisherWorker = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const publicAsset = await handlePublicAssetRequest(request, env, ctx);
@@ -62,10 +49,6 @@ const publisherWorker = {
     const capture = await handleCaptureRoute(request, env);
     if (capture) {
       return capture;
-    }
-    const storybook = handleStorybookEntry(request, env);
-    if (storybook) {
-      return storybook;
     }
     const pathname = new URL(request.url).pathname;
     if (pathname === '/__asset-publisher/health') {

--- a/workers/publisher/renderer-manifest.generated.ts
+++ b/workers/publisher/renderer-manifest.generated.ts
@@ -4,12 +4,12 @@
 // sharp version), so this file is reproducible on any machine (wayfinder #269).
 export const rendererManifest = {
   schemaVersion: 2,
-  rendererIdentity: 'faction-sheet/sha256:001ea9cb1ea510797fd30532c853944e56f819c8ac85533f0d4892e5aad7a2be',
-  digest: '001ea9cb1ea510797fd30532c853944e56f819c8ac85533f0d4892e5aad7a2be',
+  rendererIdentity: 'faction-sheet/sha256:15dc1fb4e4dd6f9f60ad1d872e2fcbf7df769238c17dc9eac8f8fb9e635f75a7',
+  digest: '15dc1fb4e4dd6f9f60ad1d872e2fcbf7df769238c17dc9eac8f8fb9e635f75a7',
   components: {
     sources: '5289b6254320530ee857ff2912681e9d6a30135dbb3a92239296365f53397813',
     toolchain: 'e7e830225f6973a7d7e43aada3bcbcd5de3c169378aa25849d24d8de97ea517a',
-    code: 'a0b6428d20c9acbedead99b313b2eb1f9d187f61cc1cc8fa19c452d0bfb17659',
+    code: '918e5224398f7baa679342d4495c569bfff209ddd1fad88401427cfc863a3d27',
     contract: '2920714c87493d104342355dda2b956202259513c78ce6195670034f31a656a6',
   },
   contract: {

--- a/workers/publisher/wrangler.jsonc
+++ b/workers/publisher/wrangler.jsonc
@@ -25,9 +25,7 @@
       "/published/*",
       "/publisher-capture",
       "/publisher-capture.html",
-      "/publisher-capture/*",
-      "/__storybook",
-      "/__storybook/"
+      "/publisher-capture/*"
     ]
   },
   "browser": { "binding": "BROWSER" },

--- a/workers/storybook/deployment-config.test.ts
+++ b/workers/storybook/deployment-config.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+
+const config = JSON.parse(
+  readFileSync(path.resolve(process.cwd(), 'workers/storybook/wrangler.jsonc'), 'utf8')
+) as Record<string, unknown>;
+
+describe('public Storybook deployment', () => {
+  test('owns only the isolated Storybook hostname', () => {
+    expect(config.name).toBe('dune-zone-storybook');
+    expect(config.routes).toEqual([{ pattern: 'storybook.dune.zone', custom_domain: true }]);
+    expect(config.workers_dev).toBe(false);
+    expect(config.preview_urls).toBe(false);
+  });
+
+  test('is a secret-free Static Assets deployment', () => {
+    expect(config).not.toHaveProperty('main');
+    expect(config).not.toHaveProperty('vars');
+    expect(config).not.toHaveProperty('secrets');
+    expect(config).not.toHaveProperty('r2_buckets');
+    expect(config).not.toHaveProperty('browser');
+    expect(config).not.toHaveProperty('images');
+    expect(config.assets).toEqual({
+      directory: '../../storybook-static',
+      html_handling: 'none',
+      not_found_handling: '404-page',
+    });
+  });
+});

--- a/workers/storybook/wrangler.jsonc
+++ b/workers/storybook/wrangler.jsonc
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "dune-zone-storybook",
+  "compatibility_date": "2026-08-18",
+  "workers_dev": false,
+  "preview_urls": false,
+  "routes": [{ "pattern": "storybook.dune.zone", "custom_domain": true }],
+  "assets": {
+    "directory": "../../storybook-static",
+    "html_handling": "none",
+    "not_found_handling": "404-page"
+  }
+}


### PR DESCRIPTION
## What changed

- Runs real Convex queries, mutations, components, triggers, transactions, scheduling, and HTTP handlers in one isolated browser worker per active page story.
- Adds the accepted `database: db((baseline) => { ... })` authoring API with a valid canonical baseline, schema-derived table types, deterministic helpers, direct seed insertion, identity separation, and fresh-worker reset.
- Adds authenticated and signed-out variants of the real ruleset create route. The authenticated play function creates through the production mutation, follows production navigation, renders the production detail query, and resets to the declared state.
- Orders Storybook roots as Pages, Game Assets, Widgets, then the remaining roots.
- Moves the public Storybook out of the production publisher Worker and into a secret-free Static Assets deployment for `storybook.dune.zone`.

## Publication boundary

`verify:storybook-publication` builds with a scrubbed environment, scans every output byte for credentials and hosted Convex URLs, dry-runs the exact Cloudflare configuration, verifies CSP headers, blocks external browser requests, proves worker network and subworker denial, and runs the page story from both the root host and a non-root served path. The artifact copies the canonical `public/` directory rather than maintaining another asset source.

The application remains on `dune.zone`. The footer link stays unchanged here because #750 owns that cutover.

## Verification

- `bun run typecheck`
- `bun run test` (753 tests)
- `bun run storybook:test` (393 stories)
- `bun run knip`
- `bun run verify:storybook-publication`
- `VITE_CONVEX_URL=https://storybook.invalid bun run check`
- `VITE_CONVEX_URL=https://storybook.invalid bun run publisher:release:verify`

## Visual proof

Before, Storybook had no Pages root and started with Widgets. After, the first three roots are Pages, Game Assets, and Widgets, and the real ruleset route is available under Pages.

| Before | After |
| --- | --- |
| ![Storybook before page stories](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-762-before-no-page-stories.png) | ![Storybook with Pages first](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-762-after-pages-first.png) |

The page receipt uses the production create route, production mutation, production navigation, and production detail query. Reset replaces the worker and returns the same route to its fresh declared database.

| Declared state | After real mutation | After reset |
| --- | --- | --- |
| ![Create ruleset before mutation](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-762-after-page-before-mutation.png) | ![Created ruleset from the real mutation and query](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-762-after-page-after-mutation.png) | ![Create ruleset after fresh worker reset](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-762-after-page-after-reset.png) |

Tracks #742.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added interactive Storybook examples for authenticated and signed-out ruleset creation.
  - Added an in-browser, isolated database environment for realistic Storybook interactions and repeatable data resets.
  - Storybook is now published separately at `storybook.dune.zone`.

- **Bug Fixes**
  - Improved Storybook support for browser-based database queries, mutations, routing, and worker behavior.
  - Added deployment checks covering security headers, redirects, assets, and interactive stories.

- **Documentation**
  - Added guidance for creating page stories, configuring isolated data, identities, and routing.
  - Updated deployment instructions for the separate Storybook site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
