### PR TITLE
Keep Convex 1.45 generated server bindings exact

### DIFF
--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -22,6 +22,17 @@ import {
 import type { DataModel } from "./dataModel.js";
 
 /**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+type Env = {
+  readonly CONVEX_CLOUD_URL: string;
+  readonly CONVEX_SITE_URL: string;
+};
+
+/**
  * Define a query in this Convex app's public API.
  *
  * This function will be allowed to read your Convex database and will be accessible from the client.
@@ -94,6 +105,14 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+export declare const env: Env;
 
 /**
  * A set of services for use within Convex query functions.

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -91,3 +91,11 @@ export const internalAction = internalActionGeneric;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+export const env = process.env;


### PR DESCRIPTION
## What changed

- Check in the Convex 1.45 generated `env` binding in `server.d.ts` and `server.js`.
- Keep the production deployment exact-source guard unchanged.

## Why

The #762 deployment successfully shipped the Convex functions, then stopped before the Worker and Storybook releases because Convex 1.45 regenerated these tracked files during `convex deploy`. The guard correctly rejected the dirty checkout. Committing the generator output makes a second production regeneration byte-for-byte clean.

The regeneration targeted the already-deployed production function graph. It did not contact or claim the shared hosted dev database.

## Verification

- `CONVEX_DEPLOYMENT=prod:exuberant-finch-263 bunx convex codegen --typecheck disable`
- `git diff --exit-code -- convex/_generated`
- `bun run typecheck`
- `bun run test` (753 tests)
- `VITE_CONVEX_URL=https://storybook.invalid bun run check`
- `VITE_CONVEX_URL=https://storybook.invalid bun run publisher:release:verify`

A second production codegen completed with `Generated Convex bindings remain exact after regeneration.` and a clean worktree.

## Visual proof

| Before: deployment stopped on generated drift | After: generator output is checked in |
| --- | --- |
| ![The production deployment exact-source preflight rejects generated drift](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-765-before-deploy-preflight-failure.png) | ![The Convex 1.45 generated environment bindings are checked into the repair](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-765-after-generated-bindings-checked-in.png) |

The [failed production run](https://github.com/ndelangen/dunezone/actions/runs/32899507122/job/97969767827) is the source for the before receipt. The after receipt shows the exact generated additions; the clean second codegen above proves they are complete.

Tracks #742.
