### PR TITLE
Wait for the Storybook edge before deployment smoke

### DIFF
--- a/scripts/storybook-deployment-smoke.ts
+++ b/scripts/storybook-deployment-smoke.ts
@@ -1,5 +1,7 @@
 const STORYBOOK_ORIGIN = 'https://storybook.dune.zone';
 const PAGE_STORY_ID = 'pages-rulesets-create--authenticated';
+const PUBLICATION_READY_TIMEOUT_MS = 120_000;
+const PUBLICATION_RETRY_MS = 5000;
 
 function invariant(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -7,16 +9,42 @@ function invariant(condition: unknown, message: string): asserts condition {
   }
 }
 
-async function response(path: string) {
-  const result = await fetch(`${STORYBOOK_ORIGIN}${path}`, {
+async function fetchResponse(path: string) {
+  return fetch(`${STORYBOOK_ORIGIN}${path}`, {
     redirect: 'error',
     signal: AbortSignal.timeout(15_000),
   });
+}
+
+async function response(path: string) {
+  const result = await fetchResponse(path);
   invariant(result.status === 200, `${path} returned HTTP ${result.status}.`);
   return result;
 }
 
-const manager = await response('/');
+async function waitForPublication() {
+  const deadline = Date.now() + PUBLICATION_READY_TIMEOUT_MS;
+
+  while (true) {
+    let result: Response;
+    try {
+      result = await fetchResponse('/');
+    } catch (error) {
+      if (Date.now() >= deadline) {
+        throw new Error(`The live Storybook did not accept connections within ${PUBLICATION_READY_TIMEOUT_MS}ms.`, {
+          cause: error,
+        });
+      }
+      await Bun.sleep(PUBLICATION_RETRY_MS);
+      continue;
+    }
+
+    invariant(result.status === 200, `/ returned HTTP ${result.status}.`);
+    return result;
+  }
+}
+
+const manager = await waitForPublication();
 const managerCsp = manager.headers.get('Content-Security-Policy') ?? '';
 invariant(managerCsp.includes("connect-src 'self'"), 'The live Storybook has no same-origin connection boundary.');
 invariant(managerCsp.includes("worker-src 'self'"), 'The live Storybook cannot start its Convex worker.');


### PR DESCRIPTION
## Outcome

The production smoke now tolerates the short connection-refused window after Cloudflare first attaches `storybook.dune.zone`. Once the edge accepts a connection, every HTTP, CSP, index, page-story, and shared-asset assertion still fails immediately when its contract is wrong.

This follows the first isolated Storybook publication from #762. Deployment run 32900280992 uploaded the Worker and attached the custom domain, then began its smoke about 80 ms later. The first connection was refused; the same host returned 200 seconds later.

## Verification

- `bun run ./scripts/storybook-deployment-smoke.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run check:prose`
- `VITE_CONVEX_URL=https://exuberant-finch-263.convex.cloud bun run publisher:release:verify`
- Live `/` and `/index.json` return 200 with CSP, `nosniff`, and `noindex`

## Visual proof

Before: Wrangler had attached the custom domain, but the smoke reached it before the first edge connection was accepted.

![The failed production smoke shows ConnectionRefused for storybook.dune.zone](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-766-before-first-edge-refused.png)

After: the public subdomain serves the Pages-first Storybook, and the authenticated page story reports that its interaction completed successfully.

![The live Storybook shows Pages first and the authenticated create-ruleset page](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-766-after-live-page-story.png)

Tracks #742.