### PR TITLE
Bound Storybook verifier process shutdown

### DIFF
--- a/scripts/verify-storybook-publication.ts
+++ b/scripts/verify-storybook-publication.ts
@@ -8,6 +8,7 @@ const artifactDirectory = path.join(repositoryRoot, 'storybook-static');
 const wranglerConfig = path.join(repositoryRoot, 'workers/storybook/wrangler.jsonc');
 const port = 6842;
 const origin = `http://127.0.0.1:${port}`;
+const PROCESS_SHUTDOWN_TIMEOUT_MS = 5000;
 
 function invariant(condition: unknown, message: string): asserts condition {
   if (!condition) {
@@ -111,6 +112,20 @@ async function waitForServer(process: ReturnType<typeof Bun.spawn>) {
     await Bun.sleep(100);
   }
   throw new Error(`Wrangler did not start ${origin}.`);
+}
+
+async function stopProcess(process: ReturnType<typeof Bun.spawn>) {
+  process.kill();
+  const exited = await Promise.race([
+    process.exited.then(() => true),
+    Bun.sleep(PROCESS_SHUTDOWN_TIMEOUT_MS).then(() => false),
+  ]);
+  if (exited) {
+    return;
+  }
+
+  process.kill('SIGKILL');
+  await process.exited;
 }
 
 function assertDocumentCsp(value: string | null) {
@@ -278,8 +293,7 @@ try {
   await verifyHeaders(workerPath);
   await verifyBrowser(workerPath);
 } finally {
-  wrangler.kill();
-  await wrangler.exited;
+  await stopProcess(wrangler);
 }
 
 await verifyNonRootPath();


### PR DESCRIPTION
## Outcome

The static Storybook publication verifier now gives Wrangler five seconds to stop cleanly, then sends `SIGKILL` and waits for the process to exit. A wedged cleanup can no longer hold the production workflow until its 45-minute job limit.

Production run 32901220614 completed every page and browser-local worker probe, then stopped emitting output while awaiting Wrangler shutdown. I cancelled it after nine minutes without progress. The same verifier completed locally three consecutive times after this change.

## Verification

- `bun run verify:storybook-publication` three consecutive times
- `bun run typecheck`
- `bun run lint`
- `bun run check:prose`
- The cancelled production run left the application Worker healthy and did not replace the already-live Storybook

## Visual proof

Before: the production job stayed inside the publication verifier until it was cancelled after more than eleven minutes.

![The production deployment is cancelled after the Storybook verifier stopped making progress](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-767-before-verifier-hung.png)

After: the verifier cleanup now has an explicit five-second grace period and a `SIGKILL` fallback instead of an unbounded exit wait.

![The pull request diff shows the bounded Wrangler shutdown path](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-767-after-bounded-shutdown.png)

Tracks #742.