### PR TITLE
The footer opens the public Storybook

### DIFF
--- a/src/app/shell/AppFooter.tsx
+++ b/src/app/shell/AppFooter.tsx
@@ -98,7 +98,7 @@ const SITE_ACCENT = 'var(--color-accent)';
    build, or an external site (opened in a new tab). */
 const footerLinks = [
   {
-    href: '/__storybook/',
+    href: 'https://storybook.dune.zone',
     icon: StorybookMark,
     size: BRAND_GLYPH,
     tint: STORYBOOK_CORAL,

--- a/src/app/shell/AppRoot.test.tsx
+++ b/src/app/shell/AppRoot.test.tsx
@@ -144,7 +144,7 @@ describe('AppRoot page header', () => {
         label: link.getAttribute('aria-label'),
       }))
     ).toEqual([
-      { href: '/__storybook/', label: 'Component library' },
+      { href: 'https://storybook.dune.zone', label: 'Component library' },
       { href: 'https://github.com/ndelangen/dunezone', label: 'Source code' },
       { href: '/privacy', label: 'Privacy policy' },
       {
@@ -157,6 +157,9 @@ describe('AppRoot page header', () => {
         label: 'Dune forums on BoardGameGeek',
       },
     ]);
+    const componentLibrary = container.querySelector('footer a[aria-label="Component library"]');
+    expect(componentLibrary?.getAttribute('target')).toBe('_blank');
+    expect(componentLibrary?.getAttribute('rel')).toBe('noopener noreferrer');
     expect(container.querySelector('footer [role="radiogroup"]')).toBeNull();
 
     act(() => root.unmount());


### PR DESCRIPTION
## Summary

- point the footer's Component library link at `https://storybook.dune.zone`
- preserve the icon and label while treating the separate host as an external link
- verify the exact destination, new-tab target, and relationship attributes in the shell test

## Validation

- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run check:prose`
- `CI=true VITE_CONVEX_URL=https://storybook.invalid bun run build-storybook`
- `VITE_CONVEX_URL=https://storybook.invalid bun run publisher:release:verify`

## Visual proof

The footer keeps its existing presentation. The public baseline emitted `/__storybook/`; the local
static result emits `https://storybook.dune.zone` with external-link attributes.

| Before | After |
| --- | --- |
| ![Public footer story before the destination change](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-771-before-footer-settled.png) | ![Local static footer story after the destination change](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-771-after-footer-settled-v2.png) |

The destination is the meaningful change. The old production path rendered a blank page. The new
link opens the public Storybook catalogue.

| Before | After |
| --- | --- |
| ![Blank page at the old same-origin Storybook path](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-771-before-destination.png) | ![Public Storybook catalogue at the new destination](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-771-after-destination.png) |

Closes #750
