### PR TITLE
Page stories use the responsive canvas by default

### DIFF
--- a/scripts/verify-storybook-publication.ts
+++ b/scripts/verify-storybook-publication.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
 import { chromium } from 'playwright';
+import type { Page } from 'playwright';
 
 const repositoryRoot = path.resolve(import.meta.dir, '..');
 const artifactDirectory = path.join(repositoryRoot, 'storybook-static');
@@ -9,6 +10,7 @@ const wranglerConfig = path.join(repositoryRoot, 'workers/storybook/wrangler.jso
 const port = 6842;
 const origin = `http://127.0.0.1:${port}`;
 const PROCESS_SHUTDOWN_TIMEOUT_MS = 5000;
+const PAGE_CLEAR_TIMEOUT_MS = 5000;
 const NETWORK_PROBE_TIMEOUT_MS = 5000;
 
 function progress(message: string) {
@@ -254,8 +256,9 @@ async function verifyNonRootPath() {
     },
   });
   const browser = await chromium.launch({ headless: true });
+  let page: Page | undefined;
   try {
-    const page = await browser.newPage();
+    page = await browser.newPage();
     const externalRequests: string[] = [];
     page.on('request', (request) => {
       if (new URL(request.url()).origin !== nonRootOrigin) {
@@ -270,9 +273,21 @@ async function verifyNonRootPath() {
       externalRequests.length === 0,
       `Non-root Storybook requested an external URL: ${externalRequests.join(', ')}`
     );
+    progress('The non-root story rendered.');
   } finally {
-    await browser.close();
-    server.stop(true);
+    progress('Clearing the non-root story before Chromium shutdown.');
+    if (page && !page.isClosed()) {
+      await page
+        .goto('about:blank', { waitUntil: 'commit', timeout: PAGE_CLEAR_TIMEOUT_MS })
+        .catch((error) => progress(`The non-root story did not clear: ${String(error)}`));
+    }
+    progress('Stopping non-root Chromium.');
+    try {
+      await browser.close();
+    } finally {
+      progress('Stopping the non-root static server.');
+      server.stop(true);
+    }
   }
 }
 

--- a/src/app/routes/-admin.stories.tsx
+++ b/src/app/routes/-admin.stories.tsx
@@ -1,14 +1,10 @@
 import preview from '@sb/preview';
 
-import { StorybookPage } from './-storybook';
-import { pageStoryArgs, pageStoryGlobals, pageStoryParameters } from './-storybookConfig';
+import { pageStoryMeta } from './-storybookConfig';
 
 const meta = preview.meta({
   title: 'Admin',
-  component: StorybookPage,
-  args: pageStoryArgs,
-  parameters: pageStoryParameters,
-  globals: pageStoryGlobals,
+  ...pageStoryMeta,
 });
 
 export const Migrations = meta.story({ args: { path: '/admin/migrations' } });

--- a/src/app/routes/-assets.stories.tsx
+++ b/src/app/routes/-assets.stories.tsx
@@ -1,14 +1,10 @@
 import preview from '@sb/preview';
 
-import { StorybookPage } from './-storybook';
-import { pageStoryArgs, pageStoryGlobals, pageStoryParameters } from './-storybookConfig';
+import { pageStoryMeta } from './-storybookConfig';
 
 const meta = preview.meta({
   title: 'Assets',
-  component: StorybookPage,
-  args: pageStoryArgs,
-  parameters: pageStoryParameters,
-  globals: pageStoryGlobals,
+  ...pageStoryMeta,
 });
 
 export const Catalogue = meta.story({ args: { path: '/assets' } });

--- a/src/app/routes/-auth.stories.tsx
+++ b/src/app/routes/-auth.stories.tsx
@@ -1,14 +1,10 @@
 import preview from '@sb/preview';
 
-import { StorybookPage } from './-storybook';
-import { pageStoryArgs, pageStoryGlobals, pageStoryParameters } from './-storybookConfig';
+import { pageStoryMeta } from './-storybookConfig';
 
 const meta = preview.meta({
   title: 'Auth',
-  component: StorybookPage,
-  args: pageStoryArgs,
-  parameters: pageStoryParameters,
-  globals: pageStoryGlobals,
+  ...pageStoryMeta,
 });
 
 export const Login = meta.story({

--- a/src/app/routes/-factions.stories.tsx
+++ b/src/app/routes/-factions.stories.tsx
@@ -1,14 +1,10 @@
 import preview from '@sb/preview';
 
-import { StorybookPage } from './-storybook';
-import { pageStoryArgs, pageStoryGlobals, pageStoryParameters } from './-storybookConfig';
+import { pageStoryMeta } from './-storybookConfig';
 
 const meta = preview.meta({
   title: 'Factions',
-  component: StorybookPage,
-  args: pageStoryArgs,
-  parameters: pageStoryParameters,
-  globals: pageStoryGlobals,
+  ...pageStoryMeta,
 });
 
 export const Catalogue = meta.story({ args: { path: '/factions' } });

--- a/src/app/routes/-groups.stories.tsx
+++ b/src/app/routes/-groups.stories.tsx
@@ -1,14 +1,10 @@
 import preview from '@sb/preview';
 
-import { StorybookPage } from './-storybook';
-import { pageStoryArgs, pageStoryGlobals, pageStoryParameters } from './-storybookConfig';
+import { pageStoryMeta } from './-storybookConfig';
 
 const meta = preview.meta({
   title: 'Groups',
-  component: StorybookPage,
-  args: pageStoryArgs,
-  parameters: pageStoryParameters,
-  globals: pageStoryGlobals,
+  ...pageStoryMeta,
 });
 
 export const Detail = meta.story({

--- a/src/app/routes/-home.stories.tsx
+++ b/src/app/routes/-home.stories.tsx
@@ -1,14 +1,10 @@
 import preview from '@sb/preview';
 
-import { StorybookPage } from './-storybook';
-import { pageStoryArgs, pageStoryGlobals, pageStoryParameters } from './-storybookConfig';
+import { pageStoryMeta } from './-storybookConfig';
 
 const meta = preview.meta({
   title: 'Home',
-  component: StorybookPage,
-  args: pageStoryArgs,
-  parameters: pageStoryParameters,
-  globals: pageStoryGlobals,
+  ...pageStoryMeta,
 });
 
 export const Default = meta.story({

--- a/src/app/routes/-preview.stories.tsx
+++ b/src/app/routes/-preview.stories.tsx
@@ -1,14 +1,10 @@
 import preview from '@sb/preview';
 
-import { StorybookPage } from './-storybook';
-import { pageStoryArgs, pageStoryGlobals, pageStoryParameters } from './-storybookConfig';
+import { pageStoryMeta } from './-storybookConfig';
 
 const meta = preview.meta({
   title: 'Preview',
-  component: StorybookPage,
-  args: pageStoryArgs,
-  parameters: pageStoryParameters,
-  globals: pageStoryGlobals,
+  ...pageStoryMeta,
 });
 
 export const FactionSheet = meta.story({

--- a/src/app/routes/-profiles.stories.tsx
+++ b/src/app/routes/-profiles.stories.tsx
@@ -1,15 +1,11 @@
 import preview from '@sb/preview';
 import { userEvent, within } from 'storybook/test';
 
-import { StorybookPage } from './-storybook';
-import { pageStoryArgs, pageStoryGlobals, pageStoryParameters } from './-storybookConfig';
+import { pageStoryMeta } from './-storybookConfig';
 
 const meta = preview.meta({
   title: 'Profiles',
-  component: StorybookPage,
-  args: pageStoryArgs,
-  parameters: pageStoryParameters,
-  globals: pageStoryGlobals,
+  ...pageStoryMeta,
 });
 
 export const Directory = meta.story({ args: { path: '/profiles' } });

--- a/src/app/routes/-rulesets.stories.tsx
+++ b/src/app/routes/-rulesets.stories.tsx
@@ -1,14 +1,10 @@
 import preview from '@sb/preview';
 
-import { StorybookPage } from './-storybook';
-import { pageStoryArgs, pageStoryGlobals, pageStoryParameters } from './-storybookConfig';
+import { pageStoryMeta } from './-storybookConfig';
 
 const meta = preview.meta({
   title: 'Rulesets',
-  component: StorybookPage,
-  args: pageStoryArgs,
-  parameters: pageStoryParameters,
-  globals: pageStoryGlobals,
+  ...pageStoryMeta,
 });
 
 export const Directory = meta.story({ args: { path: '/rulesets' } });

--- a/src/app/routes/-site.stories.tsx
+++ b/src/app/routes/-site.stories.tsx
@@ -1,14 +1,10 @@
 import preview from '@sb/preview';
 
-import { StorybookPage } from './-storybook';
-import { pageStoryArgs, pageStoryGlobals, pageStoryParameters } from './-storybookConfig';
+import { pageStoryMeta } from './-storybookConfig';
 
 const meta = preview.meta({
   title: 'Site',
-  component: StorybookPage,
-  args: pageStoryArgs,
-  parameters: pageStoryParameters,
-  globals: pageStoryGlobals,
+  ...pageStoryMeta,
 });
 
 export const NotFound = meta.story({ args: { path: '/a-page-that-does-not-exist' } });

--- a/src/app/routes/-storybookConfig.ts
+++ b/src/app/routes/-storybookConfig.ts
@@ -1,9 +1,13 @@
 import { db } from '@db/storybook';
 
-export const pageStoryArgs = { path: '/' };
-export const pageStoryParameters = {
-  controls: { disable: true },
-  layout: 'fullscreen',
-  database: db((baseline) => baseline),
+import { StorybookPage } from './-storybook';
+
+export const pageStoryMeta = {
+  component: StorybookPage,
+  args: { path: '/' },
+  parameters: {
+    controls: { disable: true },
+    layout: 'fullscreen',
+    database: db((baseline) => baseline),
+  },
 };
-export const pageStoryGlobals = { viewport: { value: 'appDesktop' } };

--- a/src/app/routes/_app/rulesets/-create.stories.tsx
+++ b/src/app/routes/_app/rulesets/-create.stories.tsx
@@ -107,7 +107,6 @@ const meta = preview.meta({
     layout: 'fullscreen',
     database: db((baseline) => baseline),
   },
-  globals: { viewport: { value: 'appDesktop' } },
 });
 
 async function createThroughPage(canvasElement: HTMLElement) {


### PR DESCRIPTION
## Summary

- let page stories follow the responsive Storybook canvas by default
- remove the inherited `appDesktop` viewport from grouped and older page stories
- keep the grouped page-story component, args, and parameters in one shared meta object
- keep explicit fixed viewports where dimensions are part of the story, including printable sheets and the wide authoring variant
- clear the non-root publication probe before Chromium shutdown so its browser-local worker cannot hold CI open

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run storybook:test -- src/app/routes/-home.stories.tsx src/app/routes/_app/rulesets/-create.stories.tsx src/app/routes/-preview.stories.tsx`
- `CI=true VITE_CONVEX_URL=https://storybook.invalid bun run build-storybook`
- `bun run verify:storybook-publication`
- `VITE_CONVEX_URL=https://storybook.invalid bun run publisher:release:verify`

## Visual proof

Before, the Home page story forced the disabled `App desktop` viewport and exposed fixed 1200 by 900 dimensions. After, the story fills the available canvas and the viewport menu remains available for deliberate checks at named widths.

| Before | After |
| --- | --- |
| ![Home page story forced to the fixed App desktop viewport](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-772-before-fixed-page-viewport.png) | ![Home page story filling the responsive canvas with viewport presets available](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-772-after-responsive-page-viewport.png) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized page stories around shared Storybook configuration.
  * Simplified story metadata across Admin, Assets, Auth, Factions, Groups, Home, Preview, Profiles, Rulesets, and Site pages.
* **Style**
  * Removed the dedicated desktop viewport override from the Rulesets creation story.
  * Preserved existing story content while improving consistency and reducing duplicated configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
