### PR TITLE
The Rulebook editor uses the accepted drill-down catalogue

### DIFF
--- a/e2e/rulebook-editor-route.spec.ts
+++ b/e2e/rulebook-editor-route.spec.ts
@@ -5,165 +5,135 @@ test.use({ storageState: { cookies: [], origins: [] } });
 
 const editorPath = '/rulesets/local-rules/rulebooks/starter/edit';
 
-test('the local Rulebook editor keeps its preview synchronized', async ({ page }) => {
+test('collapsed icons select Blocks directly and formatted edits reach the preview', async ({ page }) => {
   await page.goto(editorPath);
 
-  const preview = page.getByRole('region', { name: 'Rulebook page preview' });
-  await expect(preview).toBeVisible();
+  const preview = page.getByRole('article', { name: 'Rulebook page preview' });
+  await expect(preview).toContainText('Movement sequence');
 
-  await page.getByRole('button', { name: /Edit Page 1/ }).click();
-  await page.getByRole('textbox', { name: 'Text block' }).fill('A browser-local Rulebook revision.');
+  await page.getByRole('button', { name: /Storm marker\. Asset figure/ }).click();
+  await expect(page.getByRole('textbox', { name: 'Title' })).toHaveValue('Storm marker');
+  await page.getByRole('textbox', { name: 'Title' }).fill('Storm sector marker');
+  await expect(preview).toContainText('Storm sector marker');
 
-  await expect(preview).toContainText('A browser-local Rulebook revision.');
-
-  await page.getByRole('textbox', { name: 'Text block' }).fill('An *unfinished draft');
+  const content = page.getByRole('textbox', { name: 'Content' });
+  await content.fill('An *unfinished draft');
   await expect(page.getByText('Line 1, column 4: Bold starts here but has no closing *.')).toBeVisible();
-  await expect(page.getByText('Suggestion: Add * after the words you want formatted, or remove this *.')).toBeVisible();
   await expect(preview).toContainText('An *unfinished draft');
+
+  await content.fill('A **formatted** marker rule.');
+  await expect(preview.getByText('formatted')).toHaveJSProperty('tagName', 'STRONG');
+  await expect(page.getByRole('button', { name: 'Save' })).toBeEnabled();
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByRole('button', { name: 'Saved' })).toBeDisabled();
 });
 
-test('the fit toggle changes Page size while the document owns vertical scrolling', async ({ page }) => {
+test('Page and Block add menus expose only layout-compatible choices', async ({ page }) => {
+  await page.goto(editorPath);
+
+  await page.getByRole('button', { name: 'Open pages' }).click();
+  const addPage = page.getByRole('button', { name: 'Add page' });
+  await expect(addPage).toBeVisible();
+  await expect.poll(async () => (await addPage.boundingBox())?.width ?? 0).toBeGreaterThan(150);
+  await addPage.click();
+  const pageMenu = page.getByRole('menu', { name: 'Add page' });
+  await expect(pageMenu.getByRole('menuitem')).toHaveCount(3);
+  await pageMenu.getByRole('menuitem', { name: 'Visual reference' }).click();
+
+  const preview = page.getByRole('article', { name: 'Rulebook page preview' });
+  await expect(preview).toContainText('Visual reference / 04');
+  await expect(page.getByRole('textbox', { name: 'Title' })).toHaveValue('Selected Asset');
+
+  await page.getByRole('button', { name: 'Add block' }).click();
+  const blockMenu = page.getByRole('menu', { name: 'Add block' });
+  await expect(blockMenu.getByRole('menuitem', { name: 'Asset figure' })).toBeVisible();
+  await expect(blockMenu.getByRole('menuitem', { name: 'Worked example' })).toBeVisible();
+  await expect(blockMenu.getByRole('menuitem', { name: 'Rule group' })).toHaveCount(0);
+  await blockMenu.getByRole('menuitem', { name: 'Worked example' }).click();
+  await expect(page.getByRole('textbox', { name: 'Title' })).toHaveValue('Worked example');
+  await expect(preview).toContainText('Explain one example step by step.');
+});
+
+test('Page and Block icon rails reorder their current draft', async ({ page }) => {
+  await page.goto(editorPath);
+
+  const drag = async (source: ReturnType<typeof page.getByRole>, target: ReturnType<typeof page.getByRole>) => {
+    const sourceBox = await source.boundingBox();
+    const targetBox = await target.boundingBox();
+    if (!sourceBox || !targetBox) {
+      throw new Error('A sortable icon has no rendered bounds.');
+    }
+    await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2, { steps: 10 });
+    await page.mouse.up();
+  };
+
+  await drag(
+    page.getByRole('button', { name: /Welcome to Arrakis\. Page 1/ }),
+    page.getByRole('button', { name: /Movement\. Page 2/ })
+  );
+  await expect(page.getByRole('button', { name: /Movement\. Page 1/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Welcome to Arrakis\. Page 2/ })).toBeVisible();
+
+  const blocks = page.getByRole('region', { name: 'Blocks panel' });
+  await drag(
+    blocks.getByRole('button', { name: /Storm marker\. Asset figure/ }),
+    blocks.getByRole('button', { name: /Movement sequence\. Rule group/ })
+  );
+  const blockButtons = blocks.getByRole('button', { name: /Drag to reorder or click to select/ });
+  await expect.poll(() => blockButtons.first().getAttribute('aria-label')).toContain('Storm marker');
+  const blockLabels = await blockButtons.evaluateAll((buttons) =>
+    buttons.map((button) => button.getAttribute('aria-label'))
+  );
+  expect(blockLabels[0]).toContain('Storm marker');
+});
+
+test('the A4 preview and Sidebar stay aligned without nested scroll traps', async ({ page }) => {
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto(editorPath);
 
-  const controlsRegion = page.getByRole('region', { name: 'Rulebook controls' });
-  const previewRegion = page.getByRole('region', { name: 'Rulebook page preview' });
-  const previewPage = page.getByRole('article', { name: 'Preview of Page 1' });
-  await expect(previewPage).toBeVisible();
-
-  const fitHeightBox = await previewPage.boundingBox();
+  const sidebar = page.getByRole('complementary', { name: 'Rulebook outline and controls' });
+  const preview = page.getByRole('article', { name: 'Rulebook page preview' });
+  const fitHeightBox = await preview.boundingBox();
+  const sidebarBox = await sidebar.boundingBox();
   expect(fitHeightBox).not.toBeNull();
-  if (!fitHeightBox) {
-    throw new Error('The fit-height preview has no rendered bounds.');
+  expect(sidebarBox).not.toBeNull();
+  if (!fitHeightBox || !sidebarBox) {
+    throw new Error('The Rulebook editor surfaces have no rendered bounds.');
   }
-  expect(fitHeightBox.width).toBeGreaterThan(0);
   expect(fitHeightBox.width / fitHeightBox.height).toBeCloseTo(210 / 297, 2);
+  expect(Math.abs(sidebarBox.y - fitHeightBox.y)).toBeLessThanOrEqual(1);
+  expect(sidebarBox.height).toBeGreaterThanOrEqual(fitHeightBox.height - 1);
+  expect(fitHeightBox.y + fitHeightBox.height).toBeLessThanOrEqual(901);
+  expect(await sidebar.evaluate((element) => getComputedStyle(element).overflowY)).not.toMatch(/auto|scroll/);
 
-  for (const region of [controlsRegion, previewRegion]) {
-    await expect
-      .poll(() => region.evaluate((element) => element.scrollHeight - element.clientHeight))
-      .toBeLessThanOrEqual(1);
-  }
-
-  const controlsBox = await controlsRegion.boundingBox();
-  expect(controlsBox).not.toBeNull();
-  if (!controlsBox) {
-    throw new Error('The Rulebook controls have no rendered bounds.');
-  }
-  await page.mouse.move(controlsBox.x + 20, controlsBox.y + 20);
-
-  let previousPageY = fitHeightBox.y;
-  let previousWindowY = await page.evaluate(() => window.scrollY);
-  let stickyPageY: number | undefined;
+  let pinnedY: number | undefined;
+  let previousY = fitHeightBox.y;
   for (let step = 0; step < 30; step += 1) {
-    await page.mouse.wheel(0, 20);
-    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(previousWindowY);
-    const candidateBox = await previewPage.boundingBox();
-    expect(candidateBox).not.toBeNull();
-    if (!candidateBox) {
-      throw new Error('The fit-height preview lost its rendered bounds while scrolling.');
+    await page.mouse.wheel(0, 30);
+    const box = await preview.boundingBox();
+    if (!box) {
+      throw new Error('The A4 preview lost its rendered bounds while scrolling.');
     }
-    if (Math.abs(candidateBox.y - previousPageY) <= 1) {
-      stickyPageY = candidateBox.y;
+    if (Math.abs(box.y - previousY) <= 1) {
+      pinnedY = box.y;
       break;
     }
-    previousPageY = candidateBox.y;
-    previousWindowY = await page.evaluate(() => window.scrollY);
+    previousY = box.y;
   }
-  expect(stickyPageY).toBeDefined();
-  expect(await controlsRegion.evaluate((element) => element.scrollTop)).toBe(0);
-  expect(await previewRegion.evaluate((element) => element.scrollTop)).toBe(0);
+  expect(pinnedY).toBeDefined();
+  expect(await sidebar.evaluate((element) => element.scrollTop)).toBe(0);
 
-  const stickyFitHeightBox = await previewPage.boundingBox();
-  expect(stickyFitHeightBox).not.toBeNull();
-  if (!stickyFitHeightBox) {
-    throw new Error('The sticky fit-height preview has no rendered bounds.');
-  }
-  expect(stickyFitHeightBox.y).toBeCloseTo(stickyPageY ?? Number.NaN, 0);
-  expect(stickyFitHeightBox.y).toBeGreaterThanOrEqual(-1);
-  expect(stickyFitHeightBox.y + stickyFitHeightBox.height).toBeLessThanOrEqual(901);
-
-  await page.mouse.move(stickyFitHeightBox.x + stickyFitHeightBox.width / 2, stickyFitHeightBox.y + 20);
-  const beforePinnedWheel = await page.evaluate(() => window.scrollY);
-  await page.mouse.wheel(0, 20);
-  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(beforePinnedWheel);
-  const pinnedFitHeightBox = await previewPage.boundingBox();
-  expect(pinnedFitHeightBox).not.toBeNull();
-  if (!pinnedFitHeightBox) {
-    throw new Error('The pinned fit-height preview has no rendered bounds.');
-  }
-  expect(Math.abs(pinnedFitHeightBox.y - stickyFitHeightBox.y)).toBeLessThanOrEqual(1);
-  expect(await controlsRegion.evaluate((element) => element.scrollTop)).toBe(0);
-  expect(await previewRegion.evaluate((element) => element.scrollTop)).toBe(0);
-
-  await page.getByRole('button', { name: 'Switch preview to fit width' }).click();
-  await expect(page.getByRole('button', { name: 'Switch preview to fit height' })).toBeVisible();
-  await page.evaluate(() => window.scrollTo(0, 0));
-  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
-
-  const fitWidthBox = await previewPage.boundingBox();
+  await page.getByRole('button', { name: 'Fit width' }).click();
+  await expect(page.getByRole('button', { name: 'Fit height' })).toBeVisible();
+  const fitWidthBox = await preview.boundingBox();
   expect(fitWidthBox).not.toBeNull();
   if (!fitWidthBox) {
-    throw new Error('The fit-width preview has no rendered bounds.');
+    throw new Error('The fit-width A4 preview has no rendered bounds.');
   }
-  expect(fitWidthBox.width).toBeGreaterThan(0);
-  expect(fitWidthBox.width / fitHeightBox.width).toBeGreaterThanOrEqual(1.3);
-
-  const fitWidthRegionBox = await previewRegion.boundingBox();
-  expect(fitWidthRegionBox).not.toBeNull();
-  if (!fitWidthRegionBox) {
-    throw new Error('The fit-width preview region has no rendered bounds.');
-  }
-  await page.mouse.move(fitWidthRegionBox.x + fitWidthRegionBox.width / 2, fitWidthRegionBox.y + 20);
-  const beforeFitWidthWheel = await page.evaluate(() => window.scrollY);
-  await page.mouse.wheel(0, 40);
-  await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(beforeFitWidthWheel);
-  const afterFitWidthWheel = await page.evaluate(() => window.scrollY);
-  const scrolledFitWidthBox = await previewPage.boundingBox();
-  expect(scrolledFitWidthBox).not.toBeNull();
-  if (!scrolledFitWidthBox) {
-    throw new Error('The scrolled fit-width preview has no rendered bounds.');
-  }
-  expect(
-    Math.abs(fitWidthBox.y - scrolledFitWidthBox.y - (afterFitWidthWheel - beforeFitWidthWheel))
-  ).toBeLessThanOrEqual(1);
-  expect(await controlsRegion.evaluate((element) => element.scrollTop)).toBe(0);
-  expect(await previewRegion.evaluate((element) => element.scrollTop)).toBe(0);
-});
-
-test('a repeated text item can be added, edited, previewed, and removed', async ({ page }) => {
-  await page.goto(editorPath);
-  await page.getByRole('button', { name: /Page 2/ }).click();
-
-  await expect(page.getByRole('article', { name: 'Preview of Page 2' })).toBeVisible();
-  await expect(page.getByRole('button', { name: /Edit Page 2/ })).toHaveAttribute('aria-expanded', 'true');
-
-  const preview = page.getByRole('region', { name: 'Rulebook page preview' });
-  const items = page.getByRole('textbox', { name: /^repeated text block, item \d+$/ });
-  await expect(items.first()).toBeVisible();
-  const originalCount = await items.count();
-  await page.getByRole('button', { name: 'Add item to repeated text block' }).click();
-
-  await expect(items).toHaveCount(originalCount + 1);
-  const addedItem = page.getByRole('textbox', {
-    name: `repeated text block, item ${originalCount + 1}`,
-  });
-  await addedItem.fill('An *unfinished draft');
-  await expect(page.getByText('Line 1, column 4: Bold starts here but has no closing *.')).toBeVisible();
-  await expect(page.getByText('Suggestion: Add * after the words you want formatted, or remove this *.')).toBeVisible();
-
-  await addedItem.fill('A newly repeated browser-local rule.');
-  await expect(preview).toContainText('A newly repeated browser-local rule.');
-
-  const removeItem = page.getByRole('button', {
-    name: `Remove item ${originalCount + 1} from repeated text block`,
-  });
-  await removeItem.hover();
-  await page.mouse.down();
-  await page.waitForTimeout(5200);
-  await page.mouse.up();
-  await expect(items).toHaveCount(originalCount);
-  await expect(preview).not.toContainText('A newly repeated browser-local rule.');
+  expect(fitWidthBox.width / fitWidthBox.height).toBeCloseTo(210 / 297, 2);
+  expect(fitWidthBox.width).toBeGreaterThan(fitHeightBox.width);
 });
 
 test('only the narrow editor workspace scrolls horizontally', async ({ page }) => {
@@ -172,23 +142,6 @@ test('only the narrow editor workspace scrolls horizontally', async ({ page }) =
 
   const workspace = page.getByRole('region', { name: 'Rulebook editor and preview' });
   await expect(workspace).toBeVisible();
-  const editingSection = page.getByRole('region', { name: 'Rulebook editing workspace' });
-  const controls = page.getByRole('region', { name: 'Rulebook controls' });
-  const preview = page.getByRole('region', { name: 'Rulebook page preview' });
-  const [editingSectionBox, controlsBox, previewBox] = await Promise.all([
-    editingSection.boundingBox(),
-    controls.boundingBox(),
-    preview.boundingBox(),
-  ]);
-  expect(editingSectionBox).not.toBeNull();
-  expect(controlsBox).not.toBeNull();
-  expect(previewBox).not.toBeNull();
-  if (!editingSectionBox || !controlsBox || !previewBox) {
-    throw new Error('The narrow Rulebook workspace has no rendered bounds.');
-  }
-  const contentBottom = Math.max(controlsBox.y + controlsBox.height, previewBox.y + previewBox.height);
-  const sectionBottom = editingSectionBox.y + editingSectionBox.height;
-  expect(sectionBottom - contentBottom).toBeLessThan(350);
   await expect.poll(() => workspace.evaluate((element) => element.scrollWidth > element.clientWidth)).toBe(true);
   await expect
     .poll(() =>
@@ -200,29 +153,7 @@ test('only the narrow editor workspace scrolls horizontally', async ({ page }) =
     )
     .toBe(true);
 
-  const viewportWidth = page.viewportSize()?.width ?? 0;
-  for (const landmark of [page.getByRole('banner'), page.getByRole('contentinfo')]) {
-    const box = await landmark.boundingBox();
-    expect(box).not.toBeNull();
-    if (box) {
-      expect(box.x).toBeGreaterThanOrEqual(0);
-      expect(box.x + box.width).toBeLessThanOrEqual(viewportWidth);
-    }
-  }
-  await expect(page.getByText('Starter state', { exact: true })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Switch preview to fit width' })).toBeVisible();
-
   await workspace.focus();
-  await expect(workspace).toBeFocused();
   await page.keyboard.press('ArrowRight');
   await expect.poll(() => workspace.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0);
-
-  const previewPage = page.getByRole('article', { name: 'Preview of Page 1' });
-  const fitHeightBox = await previewPage.boundingBox();
-  expect(fitHeightBox).not.toBeNull();
-  await page.getByRole('button', { name: 'Switch preview to fit width' }).click();
-  await expect(page.getByRole('button', { name: 'Switch preview to fit height' })).toBeVisible();
-  await expect
-    .poll(async () => Math.round((await previewPage.boundingBox())?.width ?? 0))
-    .not.toBe(Math.round(fitHeightBox?.width ?? 0));
 });

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
@@ -1,233 +1,545 @@
-.prototypeRoot {
-  --prototype-side-space: clamp(1rem, calc((100vw - 64rem) * 1.25 + 1rem), 2.5rem);
-  container: rulebook-editor-prototype / inline-size;
-  width: min(116rem, calc(100vw - var(--prototype-side-space) - var(--prototype-side-space)));
-  margin-inline-start: max(calc(50% - 58rem), calc(50% - 50vw + var(--prototype-side-space)));
-  padding-bottom: 5rem;
+.editorRoot {
+  --editor-side-space: clamp(1rem, calc((100vw - 64rem) * 1.25 + 1rem), 2.5rem);
+  container: rulebook-editor / inline-size;
+  width: min(116rem, calc(100vw - var(--editor-side-space) - var(--editor-side-space)));
+  margin-inline-start: max(calc(50% - 58rem), calc(50% - 50vw + var(--editor-side-space)));
+  padding-bottom: 3rem;
+}
+
+.workspaceViewport {
+  position: relative;
+  min-width: 0;
+}
+
+.stickyFrame {
+  --sticky-top: calc(var(--app-shell-header-offset, 0px) + 0.75rem);
+  --frame-height: min(52rem, calc(100dvh - var(--app-shell-header-offset, 0px) - 13rem));
+  --page-width: calc(var(--frame-height) * 210 / 297);
+  position: sticky;
+  z-index: 3;
+  top: var(--sticky-top);
+  display: grid;
+  gap: var(--mantine-spacing-lg);
+  align-items: stretch;
+  min-height: var(--frame-height);
+}
+
+.workspaceViewport[data-fit="height"] .stickyFrame {
+  grid-template-columns:
+    minmax(23rem, 1fr)
+    minmax(0, min(var(--page-width), calc(100% - 23rem - var(--mantine-spacing-lg))));
+}
+
+.workspaceViewport[data-fit="width"] .stickyFrame {
+  grid-template-columns: minmax(23rem, 0.85fr) minmax(28rem, 1.15fr);
 }
 
 .stickyRunway {
   display: none;
 }
 
-.workspaceSticky[data-fit="height"][data-mode="navigate"] + .stickyRunway {
+.workspaceViewport[data-fit="height"] .stickyRunway {
   display: block;
-  height: 100dvh;
+  height: 65dvh;
 }
 
-.mobileStatus {
-  display: none;
-}
-
-.workspaceSticky {
-  --workspace-top: calc(var(--app-shell-header-offset, 0px) + 0.75rem);
-  --preview-caption-space: 2rem;
-  --available-page-height: min(52rem, calc(100dvh - var(--app-shell-header-offset, 0px) - 2rem));
-  --height-page-width: calc((var(--available-page-height) - var(--preview-caption-space)) * 210 / 297);
-  --workspace-gap: var(--mantine-spacing-xl);
+.drilldownSidebar {
+  display: flex;
   min-width: 0;
-}
-
-.workspaceSticky[data-fit="height"][data-mode="navigate"] {
-  position: sticky;
-  z-index: 1;
-  top: var(--workspace-top);
-}
-
-.workspaceViewport {
-  width: 100%;
-  max-width: 100%;
-  min-width: 0;
-  overflow: visible;
-}
-
-.workspace {
-  display: grid;
-  gap: var(--workspace-gap);
-  align-items: stretch;
-}
-
-.workspace[data-fit="height"] {
-  grid-template-columns: minmax(0, 1fr) min(var(--height-page-width), 50cqi);
-}
-
-.workspace[data-fit="width"] {
-  align-items: start;
-  grid-template-columns:
-    minmax(0, 1fr)
-    min(calc(var(--height-page-width) * 1.45), calc(100cqi - 18rem - var(--workspace-gap)));
-}
-
-.outlineRail,
-.previewRail {
-  min-width: 0;
-}
-
-.outlineRail {
   min-height: 100%;
+  overflow: hidden;
 }
 
-.outlineContent {
-  padding: var(--mantine-spacing-lg);
+.pagesLevel,
+.blocksLevel,
+.controlsPanel {
+  flex-basis: 0;
+  flex-grow: 0;
+  flex-shrink: 1;
+  transition:
+    flex-basis 360ms cubic-bezier(0.22, 1, 0.36, 1),
+    flex-grow 360ms cubic-bezier(0.22, 1, 0.36, 1),
+    gap 360ms cubic-bezier(0.22, 1, 0.36, 1),
+    padding 360ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 180ms ease,
+    visibility 0ms linear;
 }
 
-.outlineAccordion {
-  background: transparent;
+.drilldownSidebarPages .pagesLevel,
+.drilldownSidebarBlocks .blocksLevel,
+.drilldownSidebarControls .controlsPanel {
+  flex-grow: 1;
 }
 
-.outlineAccordion :global(.mantine-Accordion-item),
-.outlineAccordion :global(.mantine-Accordion-control),
-.outlineAccordion :global(.mantine-Accordion-panel),
-.outlineAccordion :global(.mantine-Accordion-content) {
-  background: transparent;
-  box-shadow: none;
+.drilldownSidebarBlocks .pagesLevel,
+.drilldownSidebarControls .pagesLevel,
+.drilldownSidebarControls .blocksLevel {
+  flex-basis: 3rem;
+  flex-shrink: 0;
 }
 
-.outlineAccordion :global(.mantine-Accordion-item) {
-  border-color: var(--mantine-color-default-border);
-}
-
-.outlineAccordion :global(.mantine-Accordion-content) {
-  padding-inline: 0;
-  padding-block-end: var(--mantine-spacing-xl);
-}
-
-.sectionLabel {
-  letter-spacing: 0.12em;
-}
-
-.pageChoice {
-  width: 100%;
-  min-height: 3rem;
-  padding-inline: var(--mantine-spacing-sm);
-  color: var(--mantine-color-text);
-  border-inline-start: 3px solid transparent;
-  border-radius: 0;
-}
-
-.pageChoice :global(.mantine-Button-label) {
+.drilldownLevel {
+  box-sizing: border-box;
+  position: relative;
   display: grid;
-  grid-template-columns: 2.25rem minmax(7rem, 1fr) auto;
-  width: 100%;
+  grid-template-rows: auto minmax(2rem, 1fr) auto;
+  gap: var(--mantine-spacing-md);
+  min-width: 0;
+  padding: var(--mantine-spacing-lg);
+  color: var(--mantine-color-text);
+  border-inline-end: 1px solid var(--mantine-color-default-border);
+  overflow: hidden;
 }
 
-.pageChoice[aria-current="page"] {
-  border-inline-start-color: var(--mantine-primary-color-filled);
+.drilldownLevel + .drilldownLevel {
+  background: var(--mantine-color-body);
 }
 
-.pageChoiceNumber {
-  color: var(--mantine-color-dimmed);
-  font-variant-numeric: tabular-nums;
-  text-align: start;
+.levelCollapsed {
+  grid-template-rows: 0 minmax(2rem, 1fr) auto;
+  gap: 0;
+  padding: 0.45rem 0 0.5rem;
+  background: var(--mantine-color-default-hover);
 }
 
-.pageChoiceName {
-  text-align: start;
+.levelHidden {
+  gap: 0;
+  padding: 0;
+  opacity: 0;
+  border-inline-end: 0;
+  visibility: hidden;
+  pointer-events: none;
 }
 
-.previewRail {
-  width: 100%;
+.levelHeading {
+  display: flex;
+  gap: var(--mantine-spacing-sm);
+  align-items: center;
+  justify-content: space-between;
+  min-width: 0;
+  max-height: 5rem;
+  padding-bottom: var(--mantine-spacing-sm);
+  overflow: hidden;
+  border-bottom: 1px solid var(--mantine-color-default-border);
+  opacity: 1;
+  transition:
+    max-height 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    padding 260ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 140ms ease;
 }
 
-.previewFigure {
+.levelCollapsed .levelHeading,
+.levelHidden .levelHeading {
+  max-height: 0;
+  padding-bottom: 0;
+  opacity: 0;
+}
+
+.levelList {
+  position: relative;
+  z-index: 1;
   display: grid;
   gap: var(--mantine-spacing-xs);
-  width: 100%;
-  margin: 0;
+  align-content: start;
+  min-height: 0;
 }
 
-.previewViewport {
-  container: rulebook-page-preview / inline-size;
+.levelItem {
   display: grid;
-  place-items: start center;
-  width: 100%;
+  grid-template-columns: 2.25rem minmax(0, 1fr);
+  gap: var(--mantine-spacing-sm);
+  align-items: center;
+  min-width: 0;
+  min-height: 3.75rem;
+  padding: 0.35rem;
+  background: var(--mantine-color-body);
+  border: 1px solid var(--mantine-color-default-border);
+  border-radius: var(--mantine-radius-sm);
+  transition:
+    gap 360ms cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.levelItem:has(.levelIcon[aria-current]) {
+  background: var(--mantine-color-default-hover);
+  box-shadow: inset 3px 0 var(--mantine-primary-color-filled);
+}
+
+.levelCollapsed .levelItem {
+  grid-template-columns: 2.25rem 0;
+  gap: 0;
+  width: 2.25rem;
+  min-height: 2.25rem;
+  padding: 0;
+  justify-self: center;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+  pointer-events: auto;
+}
+
+.levelCollapsed .levelList {
+  pointer-events: none;
+}
+
+.levelIcon,
+.levelChoice,
+.levelLabel {
+  display: grid;
+  min-width: 0;
+  padding: 0;
+  color: var(--mantine-color-text);
+  font: inherit;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+}
+
+.levelIcon {
+  position: relative;
+  place-items: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: var(--mantine-radius-sm);
+  cursor: grab;
+}
+
+.levelCollapsed .levelIcon:hover,
+.levelCollapsed .levelIcon:focus-visible {
+  color: var(--mantine-primary-color-filled);
+  background: var(--mantine-color-default-hover);
+  outline: 2px solid var(--mantine-primary-color-filled);
+  outline-offset: -2px;
+}
+
+.drilldownLevel:not(.levelCollapsed) .levelItem:hover,
+.drilldownLevel:not(.levelCollapsed) .levelItem:focus-within {
+  color: var(--mantine-primary-color-filled);
+  background: var(--mantine-color-default-hover);
+  outline: 2px solid var(--mantine-primary-color-filled);
+  outline-offset: -2px;
+}
+
+.levelIcon[aria-current] {
+  color: var(--mantine-primary-color-filled);
+  background: var(--mantine-color-default-hover);
+}
+
+.levelCollapsed .levelIcon[aria-current] {
+  color: var(--mantine-color-text);
+  background: color-mix(in srgb, var(--mantine-primary-color-filled) 18%, var(--mantine-color-body));
+  box-shadow: inset 0 0 0 1px var(--mantine-primary-color-filled);
+}
+
+.levelIcon:active {
+  cursor: grabbing;
+}
+
+.levelIcon > span {
+  position: absolute;
+  right: 0.1rem;
+  bottom: 0;
+  padding-inline: 0.12rem;
+  color: currentColor;
+  background: var(--mantine-color-body);
+  border-radius: 0.15rem;
+  font-size: 0.55rem;
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.levelChoice {
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--mantine-spacing-xs);
+  align-items: center;
+  height: 100%;
+  padding: var(--mantine-spacing-sm);
+  overflow: hidden;
+  text-align: start;
+  opacity: 1;
+  transition: opacity 180ms ease 100ms;
+}
+
+.levelChoice strong {
+  overflow: hidden;
+  min-width: 0;
+  font-size: var(--mantine-font-size-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.levelCollapsed .levelChoice,
+.levelHidden .levelChoice {
+  opacity: 0;
+  pointer-events: none;
+  transition-delay: 0ms;
+}
+
+.levelFooter {
+  display: grid;
+  gap: var(--mantine-spacing-sm);
+  min-width: 0;
+  padding-top: var(--mantine-spacing-md);
+  border-top: 1px solid var(--mantine-color-default-border);
+}
+
+.levelFooter[data-empty="true"] {
+  padding-top: 0;
+  border-top: 0;
+}
+
+.levelLabel {
+  place-items: end center;
+  max-height: 0;
+  min-height: 0;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.levelCollapsed .levelFooter {
+  align-self: end;
+  gap: 1rem;
+  padding: 0 0.375rem;
+  border-top: 0;
+}
+
+.levelCollapsed .levelLabel {
+  position: absolute;
+  z-index: 0;
+  inset: 0;
+  place-items: end center;
+  max-height: none;
+  padding-bottom: calc(2.25rem + 1.75rem);
+  opacity: 1;
+  pointer-events: auto;
+  transition-delay: 180ms;
+}
+
+.levelLabel:hover,
+.levelLabel:focus-visible {
+  color: var(--mantine-primary-color-filled);
+  background: color-mix(in srgb, var(--mantine-primary-color-filled) 6%, transparent);
+  outline: 0;
+}
+
+.levelLabel span {
+  font-size: var(--mantine-font-size-sm);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+
+.addSlot {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  place-items: center;
   min-width: 0;
 }
 
-.pagePreview {
+.expandedAdd {
+  width: 100%;
+}
+
+.collapsedAdd {
+  flex: 0 0 auto;
+}
+
+.controlsPanel {
+  box-sizing: border-box;
+  display: grid;
+  grid-template-rows: auto auto;
+  gap: var(--mantine-spacing-md);
+  align-content: start;
+  min-width: 0;
+  padding: var(--mantine-spacing-lg);
+  opacity: 1;
+}
+
+.controlsHidden {
+  gap: 0;
+  padding: 0;
+  overflow: hidden;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.controlsHeading {
+  display: flex;
+  gap: var(--mantine-spacing-sm);
+  align-items: center;
+  min-width: 0;
+  padding-bottom: var(--mantine-spacing-sm);
+  border-bottom: 1px solid var(--mantine-color-default-border);
+}
+
+.controlsHeading > svg {
+  flex: 0 0 auto;
+  color: var(--mantine-primary-color-filled);
+}
+
+.controlsHeading > :global(.mantine-Text-root) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.editorControls {
+  min-width: 0;
+  padding-inline-end: 1px;
+}
+
+.documentPage {
   box-sizing: border-box;
   container-type: inline-size;
   position: relative;
+  align-self: start;
+  justify-self: center;
   width: 100%;
   aspect-ratio: 210 / 297;
   overflow: hidden;
-  contain: paint;
-  color: #282218;
+  color: #2d271e;
   background: linear-gradient(90deg, rgb(66 45 16 / 4%), transparent 12%, transparent 88%, rgb(66 45 16 / 4%)), #f4ecd9;
   border: 1px solid rgb(75 56 29 / 32%);
+  border-radius: var(--mantine-radius-md);
   box-shadow: 0 0.7rem 1.8rem rgb(41 27 8 / 22%);
+  font-family: Caladea, Georgia, serif;
 }
 
-.pagePreview::before {
+.workspaceViewport[data-fit="height"] .documentPage {
+  width: min(var(--page-width), 100%);
+}
+
+.documentPage::before {
   position: absolute;
-  z-index: 1;
+  z-index: 2;
   inset: 3cqi;
   border: 1px solid rgb(117 88 43 / 20%);
   content: "";
   pointer-events: none;
 }
 
-.previewViewport[data-fit="height"] .pagePreview,
-.previewViewport[data-fit="width"] .pagePreview {
-  width: 100%;
-}
-
-.pageFolio {
-  padding: 6cqi 8cqi 2cqi;
+.documentFolio {
+  padding: 6cqi 8cqi 1.5cqi;
   color: #765d35;
-  font-family: var(--mantine-font-family-headings);
-  font-size: clamp(0.35rem, 4cqi, 0.86rem);
+  font-family: Lato, Arial, sans-serif;
+  font-size: 2.1cqi;
   font-weight: 700;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
-.previewSlot {
-  min-width: 0;
-  padding: 2cqi 8cqi 8cqi;
-}
-
-.previewColumns {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  min-height: 0;
-}
-
-.previewColumns .previewSlot:first-child {
-  border-inline-end: 1px solid rgb(75 56 29 / 20%);
-}
-
-.previewBlock,
-.repeatedText {
-  font-family: var(--mantine-font-family);
-  font-size: clamp(0.34rem, 3.2cqi, 0.76rem);
-  line-height: 1.45;
-}
-
-.previewBlock + .previewBlock,
-.previewBlock + .repeatedText,
-.repeatedText + .previewBlock {
-  margin-top: 4cqi;
-}
-
-.previewBlock p,
-.repeatedText p {
-  margin: 0 0 2.5cqi;
-}
-
-.previewBlock ul,
-.repeatedText ul {
-  margin: 0 0 2.5cqi;
-  padding-inline-start: 5cqi;
-}
-
-.repeatedText {
+.documentPage > h1 {
   margin: 0;
-  padding-inline-start: 6cqi;
+  padding: 1.5cqi 8cqi 3cqi;
+  color: #3b2b18;
+  font-size: 7.2cqi;
+  line-height: 1;
 }
 
-.repeatedText > li + li {
-  margin-top: 2.5cqi;
+.previewBlocks {
+  display: grid;
+  gap: 3cqi;
+  padding: 1cqi 8cqi 8cqi;
+}
+
+.previewBlocks > [data-selected="true"] {
+  position: relative;
+  background-color: rgb(117 88 43 / 7%);
+}
+
+.previewBlocks > [data-selected="true"]::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -3.5cqi;
+  width: 0.7cqi;
+  background: var(--mantine-primary-color-filled);
+  border-radius: 999px;
+  content: "";
+  pointer-events: none;
+}
+
+.previewRuleGroup {
+  padding: 3cqi 0 4cqi;
+  border-bottom: 1px solid rgb(117 88 43 / 30%);
+}
+
+.previewRuleGroup > span {
+  color: #8b6634;
+  font-family: Lato, Arial, sans-serif;
+  font-size: 2cqi;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.previewRuleGroup h2 {
+  margin: 1cqi 0 0.5cqi;
+  font-size: 3.2cqi;
+}
+
+.previewRuleGroup p,
+.previewRuleGroup ul,
+.previewAssetBlock p,
+.previewAssetBlock ul,
+.previewCallout p,
+.previewCallout ul {
+  margin: 0;
+  font-size: 2.45cqi;
+  line-height: 1.4;
+}
+
+.previewAssetBlock {
+  display: grid;
+  grid-template-columns: 18cqi minmax(0, 1fr);
+  gap: 3cqi;
+  align-items: center;
+  padding: 3cqi;
+  background: rgb(139 102 52 / 8%);
+  border: 1px solid rgb(139 102 52 / 24%);
+}
+
+.assetImagePlaceholder {
+  display: grid;
+  place-items: center;
+  min-height: 14cqi;
+  padding: 3cqi;
+  color: rgb(70 55 35 / 72%);
+  background: linear-gradient(135deg, transparent 49%, rgb(117 88 43 / 18%) 50%, transparent 51%), rgb(117 88 43 / 9%);
+  border: 1px dashed rgb(117 88 43 / 45%);
+  font-family: Lato, Arial, sans-serif;
+  font-size: 2.2cqi;
+  text-align: center;
+}
+
+.assetImagePlaceholder svg {
+  width: 5cqi;
+  height: 5cqi;
+  margin-bottom: 1cqi;
+}
+
+.previewCallout {
+  display: grid;
+  gap: 1cqi;
+  margin-top: 4cqi;
+  padding: 3cqi;
+  color: #4c351d;
+  background: rgb(139 102 52 / 12%);
+  border-inline-start: 0.8cqi solid #8b6634;
+}
+
+.previewCallout strong {
+  font-family: Lato, Arial, sans-serif;
+  font-size: 2.1cqi;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .underline {
@@ -245,87 +557,31 @@
   white-space: pre-wrap;
 }
 
-@container rulebook-editor-prototype (max-width: 72rem) {
-  .workspaceSticky {
-    --workspace-gap: var(--mantine-spacing-lg);
-  }
-
-  .outlineContent {
-    padding: var(--mantine-spacing-md);
-  }
-
-  .outlineAccordion :global(.mantine-Accordion-content) {
-    padding-block-end: var(--mantine-spacing-md);
-  }
-
-  .pageChoiceAnchor {
-    display: none;
-  }
-}
-
-@container rulebook-editor-prototype (max-width: 45rem) {
-  .workspaceSticky[data-fit="height"][data-mode="navigate"] + .stickyRunway {
-    display: none;
-  }
-
-  .workspaceSticky {
-    --workspace-gap: var(--mantine-spacing-sm);
-  }
-
-  .workspaceSticky[data-fit="height"][data-mode="navigate"] {
-    position: relative;
-    top: auto;
-  }
-
+@container rulebook-editor (max-width: 50rem) {
   .workspaceViewport {
     overflow-x: auto;
     overscroll-behavior-inline: contain;
   }
 
-  .workspace[data-fit="height"] {
-    grid-template-columns: 17rem 25rem;
-    min-width: calc(42rem + var(--workspace-gap));
+  .stickyFrame {
+    position: relative;
+    top: auto;
+    grid-template-columns: 24rem 28rem !important;
+    min-width: calc(52rem + var(--mantine-spacing-lg));
   }
 
-  .workspace[data-fit="width"] {
-    grid-template-columns: 17rem 34.5rem;
-    min-width: calc(51.5rem + var(--workspace-gap));
-  }
-
-  .outlineContent {
-    padding: var(--mantine-spacing-sm);
-  }
-
-  .outlineAccordion :global(.mantine-Accordion-control) {
-    padding-inline: var(--mantine-spacing-xs);
-  }
-
-  .outlineAccordion :global(.mantine-Accordion-content) {
-    padding-block-end: var(--mantine-spacing-sm);
-  }
-
-  .pageChoice {
-    min-height: 2.5rem;
-    padding-inline: var(--mantine-spacing-xs);
-  }
-
-  .pageChoice :global(.mantine-Button-label) {
-    grid-template-columns: 1.75rem minmax(0, 1fr);
+  .stickyRunway {
+    display: none !important;
   }
 }
 
-@media (max-width: 48rem) {
-  .desktopStatus {
-    display: none;
-  }
-
-  .mobileStatus {
-    display: block;
-  }
-}
-
-@media (max-width: 24rem) {
-  .mobileStatus {
-    display: none;
+@media (prefers-reduced-motion: reduce) {
+  .pagesLevel,
+  .blocksLevel,
+  .controlsPanel,
+  .levelHeading,
+  .levelItem,
+  .levelChoice {
+    transition-duration: 0ms;
   }
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
@@ -1,29 +1,61 @@
-import { Accordion, Alert, Badge, Box, Button, Group, Stack, Text } from '@mantine/core';
+import { closestCenter, DndContext, KeyboardSensor, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import type { DragEndEvent } from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { ActionIcon, Alert, Badge, Box, Button, Group, Menu, Stack, Text, TextInput, Tooltip } from '@mantine/core';
 import { parseFormattedText } from '@shared/formattedText';
 import type { FormattedTextParseResult } from '@shared/formattedText';
-import type { RulebookBlockDraft, RulebookContentsDraftV1, RulebookPageDraft } from '@shared/rulebooks/contents';
+import { rulebookLayoutCatalogue } from '@shared/rulebooks/contents';
+import type { RulebookBlockDraft, RulebookPageDraft } from '@shared/rulebooks/contents';
 import { createFileRoute } from '@tanstack/react-router';
-import { PageTitle } from '@ui/block/PageTitle';
-import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { FormattedTextInput } from '@ui/control/FormattedTextInput';
-import { AddAction } from '@ui/control/ListLengthActions';
+import { IconAction } from '@ui/control/IconAction';
+import { SortableItem } from '@ui/control/SortableItem';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
 import { Toolbar } from '@ui/surface/Toolbar';
-import { BookOpenText, Minus } from 'lucide-react';
+import { BookOpenText, ChevronDown, CircleHelp, FileImage, ListTree, MessageSquareQuote, Plus } from 'lucide-react';
 import { Fragment, useState } from 'react';
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 import styles from './edit.module.css';
 import { createRulebookEditorStateManager } from './edit/-rulebookEditorState';
 import type { RulebookEditorResult, RulebookEditorStateManager } from './edit/-rulebookEditorState';
-import { createCleanRulebookEditorInput } from './edit/-rulebookEditorState.fixtures';
+import { createEditorialRulebookEditorInput } from './edit/-rulebookEditorState.fixtures';
 
-type EditorMode = 'navigate' | 'edit';
 type PreviewFit = 'height' | 'width';
+type DrilldownDepth = 'pages' | 'blocks' | 'controls';
 type ReadyResult = Extract<RulebookEditorResult, { status: 'ready' }>;
+type EditorialPage = Extract<RulebookPageDraft, { layoutId: 'chapter-opener' | 'rules-page' | 'visual-reference' }>;
+type EditorialBlock = Extract<RulebookBlockDraft, { kind: 'rule-group' | 'worked-example' | 'asset-figure' }>;
+type PageLayoutId = EditorialPage['layoutId'];
+type BlockKind = EditorialBlock['kind'];
 type FormattedBlock = FormattedTextParseResult['blocks'][number];
 type FormattedInline = Extract<FormattedBlock, { kind: 'paragraph' }>['children'][number];
+
+const pageLayoutNames: Record<PageLayoutId, string> = {
+  'chapter-opener': 'Chapter opener',
+  'rules-page': 'Rules page',
+  'visual-reference': 'Visual reference',
+};
+
+const blockKindNames: Record<BlockKind, string> = {
+  'rule-group': 'Rule group',
+  'worked-example': 'Worked example',
+  'asset-figure': 'Asset figure',
+};
+
+const pageLayoutIds = ['chapter-opener', 'rules-page', 'visual-reference'] as const;
+const drilldownDepthClassNames: Record<DrilldownDepth, string> = {
+  pages: styles.drilldownSidebarPages,
+  blocks: styles.drilldownSidebarBlocks,
+  controls: styles.drilldownSidebarControls,
+};
+
 export const Route = createFileRoute('/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit')({
   component: RulebookEditorPage,
 });
@@ -72,283 +104,612 @@ function FormattedTextPreview({ value }: { value: string }) {
   );
 }
 
-function PreviewBlock({ block }: { block: RulebookBlockDraft }) {
-  if (block.kind === 'text') {
-    return (
-      <div className={styles.previewBlock}>
-        <FormattedTextPreview value={block.text} />
-      </div>
-    );
+function PageLayoutIcon({ layoutId, size = 18 }: Readonly<{ layoutId: PageLayoutId; size?: number }>) {
+  if (layoutId === 'chapter-opener') {
+    return <BookOpenText size={size} aria-hidden />;
   }
-  return (
-    <ol className={styles.repeatedText}>
-      {block.itemOrder.map((itemId) => (
-        <li key={itemId}>
-          <FormattedTextPreview value={block.itemsById[itemId]?.text ?? ''} />
-        </li>
-      ))}
-    </ol>
-  );
+  if (layoutId === 'visual-reference') {
+    return <FileImage size={size} aria-hidden />;
+  }
+  return <ListTree size={size} aria-hidden />;
 }
 
-function PreviewSlot({
-  blockIds,
-  draft,
-  label,
-}: {
-  blockIds: readonly string[];
-  draft: RulebookContentsDraftV1;
-  label?: string;
-}) {
+function BlockKindIcon({ kind, size = 18 }: Readonly<{ kind: BlockKind; size?: number }>) {
+  if (kind === 'rule-group') {
+    return <ListTree size={size} aria-hidden />;
+  }
+  if (kind === 'worked-example') {
+    return <MessageSquareQuote size={size} aria-hidden />;
+  }
+  return <FileImage size={size} aria-hidden />;
+}
+
+function AssetImagePlaceholder({ label }: Readonly<{ label: string }>) {
   return (
-    <div className={styles.previewSlot} role={label ? 'group' : undefined} aria-label={label}>
-      {blockIds.map((blockId) => {
-        const block = draft.blocksById[blockId];
-        return block ? <PreviewBlock key={blockId} block={block} /> : null;
-      })}
+    <div className={styles.assetImagePlaceholder}>
+      <FileImage aria-hidden />
+      <span>{label}</span>
     </div>
   );
 }
 
 function RulebookPagePreview({
   page,
+  blocks,
   pageNumber,
-  draft,
-  fit,
-}: {
-  page: RulebookPageDraft;
+  selectedBlockId,
+}: Readonly<{
+  page: EditorialPage;
+  blocks: readonly EditorialBlock[];
   pageNumber: number;
-  draft: RulebookContentsDraftV1;
-  fit: PreviewFit;
-}) {
+  selectedBlockId?: string;
+}>) {
   return (
-    <Box component="figure" className={styles.previewFigure}>
-      <div className={styles.previewViewport} data-fit={fit}>
-        <article className={styles.pagePreview} aria-label={`Preview of Page ${pageNumber}`}>
-          <div className={styles.pageFolio}>Page {pageNumber}</div>
-          {page.layoutId === 'single-column' ? (
-            <PreviewSlot blockIds={page.slots.body} draft={draft} />
-          ) : (
-            <div className={styles.previewColumns}>
-              <PreviewSlot blockIds={page.slots.left} draft={draft} label="Left page column" />
-              <PreviewSlot blockIds={page.slots.right} draft={draft} label="Right page column" />
-            </div>
-          )}
-        </article>
+    <article className={styles.documentPage} aria-label="Rulebook page preview">
+      <div className={styles.documentFolio}>
+        {pageLayoutNames[page.layoutId]} / {String(pageNumber).padStart(2, '0')}
       </div>
-      <Text component="figcaption" size="xs" c="dimmed" ta="center">
-        A4 preview. Content beyond the page edge is cropped.
+      <h1>{page.title}</h1>
+      <div className={styles.previewBlocks}>
+        {blocks.map((block) => {
+          const selected = block.id === selectedBlockId;
+          if (block.kind === 'asset-figure') {
+            return (
+              <section className={styles.previewAssetBlock} data-selected={selected} key={block.id}>
+                <AssetImagePlaceholder label={block.title} />
+                <FormattedTextPreview value={block.text} />
+              </section>
+            );
+          }
+          if (block.kind === 'worked-example') {
+            return (
+              <aside className={styles.previewCallout} data-selected={selected} key={block.id}>
+                <strong>{block.title}</strong>
+                <FormattedTextPreview value={block.text} />
+              </aside>
+            );
+          }
+          return (
+            <section className={styles.previewRuleGroup} data-selected={selected} key={block.id}>
+              <span>{blockKindNames[block.kind]}</span>
+              <h2>{block.title}</h2>
+              <FormattedTextPreview value={block.text} />
+            </section>
+          );
+        })}
+      </div>
+    </article>
+  );
+}
+
+function DrilldownTooltip({
+  title,
+  details,
+  children,
+}: Readonly<{
+  title: string;
+  details: readonly string[];
+  children: ReactElement;
+}>) {
+  return (
+    <Tooltip
+      label={
+        <Stack gap={1}>
+          <Text size="xs" fw={700}>
+            {title}
+          </Text>
+          {details.map((detail) => (
+            <Text size="xs" key={detail}>
+              {detail}
+            </Text>
+          ))}
+        </Stack>
+      }
+      position="right"
+      openDelay={250}
+      withArrow
+      multiline
+      maw={260}
+    >
+      {children}
+    </Tooltip>
+  );
+}
+
+function DrilldownLevelChoice({
+  title,
+  metadata,
+  active,
+  tabIndex,
+  onClick,
+}: Readonly<{
+  title: string;
+  metadata: string;
+  active: boolean;
+  tabIndex: number;
+  onClick: () => void;
+}>) {
+  return (
+    <button
+      type="button"
+      className={styles.levelChoice}
+      aria-current={active ? 'true' : undefined}
+      tabIndex={tabIndex}
+      onClick={onClick}
+    >
+      <strong>{title}</strong>
+      <Badge color="gray" variant="outline" size="sm">
+        {metadata}
+      </Badge>
+    </button>
+  );
+}
+
+function AddMenu<T extends string>({
+  label,
+  menuLabel,
+  choices,
+  collapsed,
+  onPick,
+}: Readonly<{
+  label: string;
+  menuLabel: string;
+  choices: readonly { value: T; label: string; icon: ReactNode }[];
+  collapsed: boolean;
+  onPick: (value: T) => void;
+}>) {
+  return (
+    <Menu position={collapsed ? 'right-end' : 'bottom-start'} withArrow>
+      <Menu.Target>
+        {collapsed ? (
+          <ActionIcon className={styles.collapsedAdd} aria-label={label} color="confirm" variant="light" size="sm">
+            <Plus size={15} aria-hidden />
+          </ActionIcon>
+        ) : (
+          <Button
+            className={styles.expandedAdd}
+            color="confirm"
+            size="sm"
+            leftSection={<Plus size={15} aria-hidden />}
+            rightSection={<ChevronDown size={14} aria-hidden />}
+            fullWidth
+          >
+            {label}
+          </Button>
+        )}
+      </Menu.Target>
+      <Menu.Dropdown>
+        <Menu.Label>{menuLabel}</Menu.Label>
+        {choices.map((choice) => (
+          <Menu.Item key={choice.value} leftSection={choice.icon} onClick={() => onPick(choice.value)}>
+            {choice.label}
+          </Menu.Item>
+        ))}
+      </Menu.Dropdown>
+    </Menu>
+  );
+}
+
+function createPage(layoutId: PageLayoutId, id: string, anchor: string): EditorialPage {
+  let title = 'New rules page';
+  if (layoutId === 'chapter-opener') {
+    title = 'New chapter';
+  } else if (layoutId === 'visual-reference') {
+    title = 'New reference';
+  }
+  return { id, anchor, title, layoutId, slots: { body: [] } } as EditorialPage;
+}
+
+function createBlock(kind: BlockKind, id: string): EditorialBlock {
+  if (kind === 'rule-group') {
+    return { id, kind, title: 'Untitled rule group', text: 'Replace this starter content with the rule text.' };
+  }
+  if (kind === 'worked-example') {
+    return { id, kind, title: 'Worked example', text: 'Explain one example step by step.' };
+  }
+  return { id, kind, title: 'Selected Asset', text: 'Add a short caption for this figure.' };
+}
+
+function defaultBlockKind(layoutId: PageLayoutId): BlockKind {
+  return layoutId === 'rules-page' ? 'rule-group' : 'asset-figure';
+}
+
+function acceptedBlockKinds(layoutId: PageLayoutId): readonly BlockKind[] {
+  const layout = rulebookLayoutCatalogue.find((candidate) => candidate.id === layoutId);
+  return (layout?.slots[0]?.acceptedBlockKinds ?? []) as readonly BlockKind[];
+}
+
+function destinationForIndex(ids: readonly string[], index: number) {
+  return { afterId: ids[index - 1] ?? null, beforeId: ids[index + 1] ?? null };
+}
+
+function EditorControls({
+  block,
+  dispatch,
+}: Readonly<{
+  block?: EditorialBlock;
+  dispatch: RulebookEditorStateManager['dispatch'];
+}>) {
+  if (!block) {
+    return (
+      <Text size="sm" c="dimmed">
+        Select a block to edit it.
       </Text>
+    );
+  }
+  const target = { kind: 'block' as const, blockId: block.id };
+  return (
+    <Stack gap="md" className={styles.editorControls}>
+      <TextInput
+        label="Title"
+        value={block.title}
+        onChange={(event) => dispatch({ kind: 'set', target, field: 'title', value: event.currentTarget.value })}
+      />
+      <FormattedTextInput
+        label="Content"
+        value={block.text}
+        autosize
+        minRows={6}
+        onChange={(value) => dispatch({ kind: 'set', target, field: 'text', value })}
+      />
+    </Stack>
+  );
+}
+
+function RulebookWorkspace({
+  result,
+  dispatch,
+  fit,
+}: Readonly<{
+  result: ReadyResult;
+  dispatch: RulebookEditorStateManager['dispatch'];
+  fit: PreviewFit;
+}>) {
+  const [depth, setDepth] = useState<DrilldownDepth>('controls');
+  const [activePageId, setActivePageId] = useState(result.draft.pageOrder[1] ?? result.draft.pageOrder[0]);
+  const activePage = result.draft.pagesById[activePageId ?? ''] as EditorialPage | undefined;
+  const blockIds = activePage?.slots.body ?? [];
+  const blocks = blockIds.flatMap((id) => {
+    const block = result.draft.blocksById[id];
+    return block && block.kind !== 'text' && block.kind !== 'repeated-text' ? [block] : [];
+  });
+  const [selectedBlockId, setSelectedBlockId] = useState<string | undefined>(blocks[0]?.id);
+  const selectedBlock = blocks.find((block) => block.id === selectedBlockId) ?? blocks[0];
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  if (!activePage) {
+    return <Alert color="yellow">The editor has no page to display.</Alert>;
+  }
+
+  const pageNumber = result.draft.pageOrder.indexOf(activePage.id) + 1;
+  const selectPageInstantly = (pageId: string) => {
+    const page = result.draft.pagesById[pageId] as EditorialPage | undefined;
+    setActivePageId(pageId);
+    setSelectedBlockId(page?.slots.body[0]);
+  };
+  const openPage = (pageId: string) => {
+    selectPageInstantly(pageId);
+    setDepth('blocks');
+  };
+  const openBlock = (blockId: string) => {
+    setSelectedBlockId(blockId);
+    setDepth('controls');
+  };
+  const addPage = (layoutId: PageLayoutId) => {
+    const suffix = globalThis.crypto.randomUUID();
+    const pageId = `page-${suffix}`;
+    const blockId = `block-${globalThis.crypto.randomUUID()}`;
+    const page = createPage(layoutId, pageId, `new-${layoutId}-${suffix.slice(0, 8)}`);
+    const block = createBlock(defaultBlockKind(layoutId), blockId);
+    dispatch({
+      kind: 'create',
+      entity: { kind: 'page', page },
+      placement: {
+        container: { kind: 'page-order' },
+        afterId: result.draft.pageOrder.at(-1) ?? null,
+        beforeId: null,
+      },
+    });
+    dispatch({
+      kind: 'create',
+      entity: { kind: 'block', block },
+      placement: { container: { kind: 'page-slot', pageId, slotId: 'body' }, afterId: null, beforeId: null },
+    });
+    setActivePageId(pageId);
+    setSelectedBlockId(blockId);
+    setDepth('controls');
+  };
+  const addBlock = (kind: BlockKind) => {
+    const blockId = `block-${globalThis.crypto.randomUUID()}`;
+    dispatch({
+      kind: 'create',
+      entity: { kind: 'block', block: createBlock(kind, blockId) },
+      placement: {
+        container: { kind: 'page-slot', pageId: activePage.id, slotId: 'body' },
+        afterId: blockIds.at(-1) ?? null,
+        beforeId: null,
+      },
+    });
+    setSelectedBlockId(blockId);
+    setDepth('controls');
+  };
+  const onPageDragEnd = ({ active, over }: DragEndEvent) => {
+    const sourceIndex = result.draft.pageOrder.indexOf(String(active.id));
+    const targetIndex = over ? result.draft.pageOrder.indexOf(String(over.id)) : -1;
+    if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) {
+      return;
+    }
+    const order = arrayMove(result.draft.pageOrder, sourceIndex, targetIndex);
+    const index = order.indexOf(String(active.id));
+    dispatch({
+      kind: 'place',
+      target: { kind: 'page', pageId: String(active.id) },
+      destination: { container: { kind: 'page-order' }, ...destinationForIndex(order, index) },
+    });
+  };
+  const onBlockDragEnd = ({ active, over }: DragEndEvent) => {
+    const sourceIndex = blockIds.indexOf(String(active.id));
+    const targetIndex = over ? blockIds.indexOf(String(over.id)) : -1;
+    if (sourceIndex < 0 || targetIndex < 0 || sourceIndex === targetIndex) {
+      return;
+    }
+    const order = arrayMove(blockIds, sourceIndex, targetIndex);
+    const index = order.indexOf(String(active.id));
+    dispatch({
+      kind: 'place',
+      target: { kind: 'block', blockId: String(active.id) },
+      destination: {
+        container: { kind: 'page-slot', pageId: activePage.id, slotId: 'body' },
+        ...destinationForIndex(order, index),
+      },
+    });
+  };
+
+  return (
+    <Box
+      className={styles.workspaceViewport}
+      data-fit={fit}
+      role="region"
+      aria-label="Rulebook editor and preview"
+      tabIndex={0}
+    >
+      <div className={styles.stickyFrame}>
+        <Surface
+          padding="none"
+          as="aside"
+          aria-label="Rulebook outline and controls"
+          className={`${styles.drilldownSidebar} ${drilldownDepthClassNames[depth]}`}
+        >
+          <section
+            className={`${styles.drilldownLevel} ${styles.pagesLevel} ${depth === 'pages' ? '' : styles.levelCollapsed}`}
+            aria-label="Pages panel"
+          >
+            <div className={styles.levelHeading}>
+              <Text fw={700}>Pages</Text>
+              <IconAction
+                label="About page ordering"
+                tooltip="Drag a page icon to reorder pages. Choose a page to open its blocks."
+                icon={<CircleHelp size={15} aria-hidden />}
+                size="sm"
+                variant="subtle"
+              />
+            </div>
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onPageDragEnd}>
+              <SortableContext items={result.draft.pageOrder} strategy={verticalListSortingStrategy}>
+                <div className={styles.levelList}>
+                  {result.draft.pageOrder.map((pageId, index) => {
+                    const page = result.draft.pagesById[pageId] as EditorialPage | undefined;
+                    if (!page) {
+                      return null;
+                    }
+                    return (
+                      <SortableItem className={styles.levelItem} id={page.id} key={page.id}>
+                        {({ setActivatorNodeRef, attributes, listeners }) => (
+                          <>
+                            <DrilldownTooltip
+                              title={page.title}
+                              details={[
+                                `Page ${index + 1} · ${pageLayoutNames[page.layoutId]}`,
+                                `${page.slots.body.length} ${page.slots.body.length === 1 ? 'block' : 'blocks'}`,
+                              ]}
+                            >
+                              <button
+                                type="button"
+                                ref={setActivatorNodeRef}
+                                className={styles.levelIcon}
+                                aria-current={page.id === activePage.id ? 'page' : undefined}
+                                aria-label={`${page.title}. Page ${index + 1}. Drag to reorder or click to select.`}
+                                onClick={() => (depth === 'pages' ? openPage(page.id) : selectPageInstantly(page.id))}
+                                {...attributes}
+                                {...listeners}
+                              >
+                                <PageLayoutIcon layoutId={page.layoutId} />
+                                <span>{index + 1}</span>
+                              </button>
+                            </DrilldownTooltip>
+                            <DrilldownLevelChoice
+                              title={page.title}
+                              metadata={pageLayoutNames[page.layoutId]}
+                              active={page.id === activePage.id}
+                              tabIndex={depth === 'pages' ? 0 : -1}
+                              onClick={() => openPage(page.id)}
+                            />
+                          </>
+                        )}
+                      </SortableItem>
+                    );
+                  })}
+                </div>
+              </SortableContext>
+            </DndContext>
+            <div className={styles.levelFooter}>
+              <button
+                type="button"
+                className={styles.levelLabel}
+                aria-label="Open pages"
+                tabIndex={depth === 'pages' ? -1 : 0}
+                onClick={() => setDepth('pages')}
+              >
+                <span>Pages</span>
+              </button>
+              <div className={styles.addSlot}>
+                <AddMenu
+                  label="Add page"
+                  menuLabel="Choose a page layout"
+                  choices={pageLayoutIds.map((layoutId) => ({
+                    value: layoutId,
+                    label: pageLayoutNames[layoutId],
+                    icon: <PageLayoutIcon layoutId={layoutId} />,
+                  }))}
+                  collapsed={depth !== 'pages'}
+                  onPick={addPage}
+                />
+              </div>
+            </div>
+          </section>
+          <section
+            className={`${styles.drilldownLevel} ${styles.blocksLevel} ${depth === 'controls' ? styles.levelCollapsed : ''} ${depth === 'pages' ? styles.levelHidden : ''}`}
+            aria-label="Blocks panel"
+            aria-hidden={depth === 'pages'}
+            inert={depth === 'pages'}
+          >
+            <div className={styles.levelHeading}>
+              <Text fw={700} truncate>
+                {activePage.title}
+              </Text>
+              <Group gap={4} wrap="nowrap">
+                {depth === 'blocks' ? (
+                  <AddMenu
+                    label="Add block"
+                    menuLabel="Choose a block type"
+                    choices={acceptedBlockKinds(activePage.layoutId).map((kind) => ({
+                      value: kind,
+                      label: blockKindNames[kind],
+                      icon: <BlockKindIcon kind={kind} />,
+                    }))}
+                    collapsed
+                    onPick={addBlock}
+                  />
+                ) : null}
+                <IconAction
+                  label="About block ordering"
+                  tooltip="Drag a block icon to reorder blocks. Choose a block to edit it."
+                  icon={<CircleHelp size={15} aria-hidden />}
+                  size="sm"
+                  variant="subtle"
+                />
+              </Group>
+            </div>
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onBlockDragEnd}>
+              <SortableContext items={blockIds} strategy={verticalListSortingStrategy}>
+                <div className={styles.levelList}>
+                  {blocks.map((block) => (
+                    <SortableItem className={styles.levelItem} id={block.id} key={block.id}>
+                      {({ setActivatorNodeRef, attributes, listeners }) => (
+                        <>
+                          <DrilldownTooltip
+                            title={block.title}
+                            details={[blockKindNames[block.kind], activePage.title]}
+                          >
+                            <button
+                              type="button"
+                              ref={setActivatorNodeRef}
+                              className={styles.levelIcon}
+                              aria-current={block.id === selectedBlock?.id ? 'true' : undefined}
+                              aria-label={`${block.title}. ${blockKindNames[block.kind]}. Drag to reorder or click to select.`}
+                              onClick={() => (depth === 'blocks' ? openBlock(block.id) : setSelectedBlockId(block.id))}
+                              {...attributes}
+                              {...listeners}
+                            >
+                              <BlockKindIcon kind={block.kind} />
+                            </button>
+                          </DrilldownTooltip>
+                          <DrilldownLevelChoice
+                            title={block.title}
+                            metadata={blockKindNames[block.kind]}
+                            active={block.id === selectedBlock?.id}
+                            tabIndex={depth === 'blocks' ? 0 : -1}
+                            onClick={() => openBlock(block.id)}
+                          />
+                        </>
+                      )}
+                    </SortableItem>
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+            <div className={styles.levelFooter} data-empty={depth === 'blocks'}>
+              <button
+                type="button"
+                className={styles.levelLabel}
+                aria-label="Open blocks"
+                tabIndex={depth === 'controls' ? 0 : -1}
+                onClick={() => setDepth('blocks')}
+              >
+                <span>Blocks</span>
+              </button>
+              {depth === 'controls' ? (
+                <div className={styles.addSlot}>
+                  <AddMenu
+                    label="Add block"
+                    menuLabel="Choose a block type"
+                    choices={acceptedBlockKinds(activePage.layoutId).map((kind) => ({
+                      value: kind,
+                      label: blockKindNames[kind],
+                      icon: <BlockKindIcon kind={kind} />,
+                    }))}
+                    collapsed
+                    onPick={addBlock}
+                  />
+                </div>
+              ) : null}
+            </div>
+          </section>
+          <section
+            className={`${styles.controlsPanel} ${depth === 'controls' ? '' : styles.controlsHidden}`}
+            aria-label="Controls panel"
+            aria-hidden={depth !== 'controls'}
+            inert={depth !== 'controls'}
+          >
+            <div className={styles.controlsHeading}>
+              {selectedBlock ? <BlockKindIcon kind={selectedBlock.kind} size={20} /> : null}
+              <Text fw={700}>{selectedBlock?.title ?? 'Select a block'}</Text>
+            </div>
+            <EditorControls block={selectedBlock} dispatch={dispatch} />
+          </section>
+        </Surface>
+        <RulebookPagePreview
+          page={activePage}
+          blocks={blocks}
+          pageNumber={pageNumber}
+          selectedBlockId={selectedBlock?.id}
+        />
+      </div>
+      <div className={styles.stickyRunway} aria-hidden />
     </Box>
   );
 }
 
-function createRepeatedTextItemId(): string {
-  return `item-${globalThis.crypto.randomUUID()}`;
-}
-
-function PageTextEditors({
-  page,
-  result,
-  dispatch,
-}: {
-  page: RulebookPageDraft;
-  result: ReadyResult;
-  dispatch: RulebookEditorStateManager['dispatch'];
-}) {
-  const blockIds = Object.values(page.slots).flat();
-  const repeatedBlockIds = blockIds.filter((blockId) => result.draft.blocksById[blockId]?.kind === 'repeated-text');
-  return (
-    <Stack gap="lg">
-      {blockIds.map((blockId) => {
-        const block = result.draft.blocksById[blockId];
-        if (!block) {
-          return null;
-        }
-        if (block.kind === 'text') {
-          const target = { kind: 'block' as const, blockId };
-          return (
-            <FormattedTextInput
-              key={blockId}
-              label="Text block"
-              value={block.text}
-              autosize
-              minRows={6}
-              onChange={(value) => dispatch({ kind: 'set', target, field: 'text', value })}
-            />
-          );
-        }
-        const repeatedBlockNumber = repeatedBlockIds.indexOf(blockId) + 1;
-        const repeatedBlockLabel =
-          repeatedBlockIds.length === 1 ? 'repeated text block' : `repeated text block ${repeatedBlockNumber}`;
-        return (
-          <Stack key={blockId} gap="sm">
-            <Group justify="space-between" align="center" wrap="nowrap">
-              <Text fw={700}>Repeated text block</Text>
-              <AddAction
-                label={`Add item to ${repeatedBlockLabel}`}
-                onClick={() => {
-                  const itemId = createRepeatedTextItemId();
-                  dispatch({
-                    kind: 'create',
-                    entity: { kind: 'item', blockId, item: { id: itemId, text: '' } },
-                    placement: {
-                      container: { kind: 'item-order', blockId },
-                      afterId: block.itemOrder.at(-1) ?? null,
-                      beforeId: null,
-                    },
-                  });
-                }}
-              />
-            </Group>
-            {block.itemOrder.length === 0 ? (
-              <Text size="sm" c="dimmed">
-                This block has no items.
-              </Text>
-            ) : (
-              block.itemOrder.map((itemId, index) => {
-                const item = block.itemsById[itemId];
-                if (!item) {
-                  return null;
-                }
-                const target = { kind: 'item' as const, blockId, itemId };
-                return (
-                  <Group key={itemId} align="flex-start" wrap="nowrap">
-                    <FormattedTextInput
-                      label={`Item ${index + 1}`}
-                      aria-label={`${repeatedBlockLabel}, item ${index + 1}`}
-                      value={item.text}
-                      autosize
-                      minRows={4}
-                      style={{ flex: 1 }}
-                      onChange={(value) => dispatch({ kind: 'set', target, field: 'text', value })}
-                    />
-                    <ConfirmDeleteAction
-                      label={`Remove item ${index + 1} from ${repeatedBlockLabel}`}
-                      verb="remove"
-                      pending={false}
-                      size="sm"
-                      icon={<Minus size={15} aria-hidden />}
-                      onConfirm={() => dispatch({ kind: 'delete', root: target })}
-                    />
-                  </Group>
-                );
-              })
-            )}
-          </Stack>
-        );
-      })}
-    </Stack>
-  );
-}
-
-type RulebookWorkspaceProps = {
-  page: RulebookPageDraft;
-  pageId: string;
-  pageNumber: number;
-  result: ReadyResult;
-  dispatch: RulebookEditorStateManager['dispatch'];
-  mode: EditorMode;
-  fit: PreviewFit;
-  setMode: (mode: EditorMode) => void;
-  selectPage: (pageId: string) => void;
-};
-
-function PageOutline({ result, pageId, selectPage }: Pick<RulebookWorkspaceProps, 'result' | 'pageId' | 'selectPage'>) {
-  return (
-    <Stack component="nav" aria-label="Rulebook pages" gap="xs">
-      <Text size="xs" fw={700} tt="uppercase" c="dimmed" className={styles.sectionLabel}>
-        Contents
-      </Text>
-      {result.draft.pageOrder.map((candidateId, index) => {
-        const candidate = result.draft.pagesById[candidateId];
-        return candidate ? (
-          <Button
-            key={candidateId}
-            className={styles.pageChoice}
-            variant={candidateId === pageId ? 'light' : 'subtle'}
-            color="gray"
-            justify="space-between"
-            aria-current={candidateId === pageId ? 'page' : undefined}
-            onClick={() => selectPage(candidateId)}
-          >
-            <span className={styles.pageChoiceNumber}>{String(index + 1).padStart(2, '0')}</span>
-            <span className={styles.pageChoiceName}>Page {index + 1}</span>
-            <Text component="span" size="xs" inherit opacity={0.62}>
-              <span className={styles.pageChoiceAnchor}>{candidate.anchor}</span>
-            </Text>
-          </Button>
-        ) : null;
-      })}
-    </Stack>
-  );
-}
-
-function PreviewRail({ page, pageNumber, result, fit }: RulebookWorkspaceProps) {
-  return (
-    <section className={styles.previewRail} aria-label="Rulebook page preview">
-      <RulebookPagePreview page={page} pageNumber={pageNumber} draft={result.draft} fit={fit} />
-    </section>
-  );
-}
-
-function RulebookWorkspace(props: RulebookWorkspaceProps) {
-  return (
-    <div className={styles.workspace} data-fit={props.fit}>
-      <Surface className={styles.outlineRail} padding="none" as="section" aria-label="Rulebook controls">
-        <div className={styles.outlineContent}>
-          <Accordion
-            value={props.mode}
-            onChange={(value) => value && props.setMode(value as EditorMode)}
-            className={styles.outlineAccordion}
-          >
-            <Accordion.Item value="navigate">
-              <Accordion.Control>
-                <Text fw={700}>Navigate</Text>
-                <Text size="xs" c="dimmed">
-                  Page {props.pageNumber} of {props.result.draft.pageOrder.length}
-                </Text>
-              </Accordion.Control>
-              <Accordion.Panel>
-                <PageOutline result={props.result} pageId={props.pageId} selectPage={props.selectPage} />
-              </Accordion.Panel>
-            </Accordion.Item>
-            <Accordion.Item value="edit">
-              <Accordion.Control>
-                <Text fw={700}>Edit Page {props.pageNumber}</Text>
-                <Text size="xs" c="dimmed">
-                  Text and repeated text
-                </Text>
-              </Accordion.Control>
-              <Accordion.Panel>
-                <PageTextEditors page={props.page} result={props.result} dispatch={props.dispatch} />
-              </Accordion.Panel>
-            </Accordion.Item>
-          </Accordion>
-        </div>
-      </Surface>
-      <PreviewRail {...props} />
-    </div>
-  );
-}
-
 function RulebookEditorPage() {
-  const { rulesetSlug, rulebookSlug } = Route.useParams();
-  const [manager] = useState(() => createRulebookEditorStateManager(createCleanRulebookEditorInput()));
+  const [manager] = useState(() => createRulebookEditorStateManager(createEditorialRulebookEditorInput()));
   const [result, setResult] = useState<RulebookEditorResult>(() => manager.result);
-  const [activePageId, setActivePageId] = useState(() =>
-    manager.result.status === 'ready' ? manager.result.draft.pageOrder[0] : undefined
-  );
-  const [mode, setMode] = useState<EditorMode>('navigate');
   const [fit, setFit] = useState<PreviewFit>('height');
+  const [saveLabel, setSaveLabel] = useState('Save');
+  const dispatch: RulebookEditorStateManager['dispatch'] = (action) => {
+    const next = manager.dispatch(action);
+    setResult(next);
+    setSaveLabel('Save');
+    return next;
+  };
+
   if (result.status !== 'ready') {
     return (
       <PageLayout>
-        <PageLayout.Header size="compact">
-          <PageTitle title="Rulebook editor unavailable" />
-        </PageLayout.Header>
         <PageLayout.Content>
-          <Alert color="red" role="alert" title="This starter session could not open">
+          <Alert color="red" role="alert" title="This Rulebook could not open">
             {result.message}
           </Alert>
         </PageLayout.Content>
@@ -356,94 +717,55 @@ function RulebookEditorPage() {
     );
   }
 
-  const pageId = activePageId ?? result.draft.pageOrder[0];
-  const page = pageId ? result.draft.pagesById[pageId] : undefined;
-  const pageNumber = pageId ? result.draft.pageOrder.indexOf(pageId) + 1 : 0;
   const hasLocalChanges =
     result.rebasedPatch.creates.length > 0 ||
     result.rebasedPatch.deletes.length > 0 ||
     result.rebasedPatch.sets.length > 0 ||
     result.rebasedPatch.placements.length > 0 ||
     result.rebasedPatch.restorations.length > 0;
-  const dispatch: RulebookEditorStateManager['dispatch'] = (action) => {
-    const next = manager.dispatch(action);
-    setResult(next);
-    return next;
+  const save = () => {
+    const saving = manager.dispatch({ kind: 'begin-save' });
+    if (saving.status !== 'ready' || !saving.saveRequest) {
+      setResult(saving);
+      return;
+    }
+    const saved = manager.dispatch({
+      kind: 'save-succeeded',
+      saved: { revision: `local-${Date.now()}`, contents: saving.saveRequest.contents },
+    });
+    setResult(saved);
+    setSaveLabel('Saved');
   };
 
   return (
     <PageLayout>
-      <PageLayout.Header size="compact">
-        <Group gap="sm" wrap="nowrap">
-          <BookOpenText size={24} aria-hidden />
-          <div>
-            <PageTitle title="Rulebook workspace" />
-            <Text size="xs" c="dimmed">
-              {rulesetSlug} / {rulebookSlug}
-            </Text>
-          </div>
-        </Group>
-      </PageLayout.Header>
       <PageLayout.Toolbar>
         <Toolbar>
           <Toolbar.Left>
-            <Group gap="xs" wrap="nowrap">
-              <Badge variant="light" color={hasLocalChanges ? 'yellow' : 'gray'}>
-                {hasLocalChanges ? 'Local changes' : 'Starter state'}
-              </Badge>
-              <Text className={styles.desktopStatus} size="xs" c="dimmed">
-                Browser-only starter state. Nothing is loaded from or saved to the database.
-              </Text>
-              <Text className={styles.mobileStatus} size="xs" c="dimmed">
-                Local only.
-              </Text>
-            </Group>
+            <Badge variant="light" color={hasLocalChanges ? 'yellow' : 'gray'}>
+              {hasLocalChanges ? 'Local changes' : 'Saved draft'}
+            </Badge>
           </Toolbar.Left>
           <Toolbar.Right>
-            <Button
-              size="xs"
-              variant="default"
-              aria-label={`Switch preview to fit ${fit === 'height' ? 'width' : 'height'}`}
-              onClick={() => setFit((current) => (current === 'height' ? 'width' : 'height'))}
-            >
-              Fit {fit === 'height' ? 'width' : 'height'}
-            </Button>
+            <Group gap="xs" wrap="nowrap">
+              <Button
+                size="xs"
+                variant="default"
+                onClick={() => setFit((value) => (value === 'height' ? 'width' : 'height'))}
+              >
+                Fit {fit === 'height' ? 'width' : 'height'}
+              </Button>
+              <Button size="xs" color="confirm" disabled={!result.canSave} onClick={save}>
+                {saveLabel}
+              </Button>
+            </Group>
           </Toolbar.Right>
         </Toolbar>
       </PageLayout.Toolbar>
       <PageLayout.Content>
-        {page ? (
-          <section className={styles.prototypeRoot} aria-label="Rulebook editing workspace">
-            <div className={styles.workspaceSticky} data-fit={fit} data-mode={mode}>
-              <Box
-                className={styles.workspaceViewport}
-                role="region"
-                aria-label="Rulebook editor and preview"
-                tabIndex={0}
-              >
-                <RulebookWorkspace
-                  page={page}
-                  pageId={pageId}
-                  pageNumber={pageNumber}
-                  result={result}
-                  dispatch={dispatch}
-                  mode={mode}
-                  fit={fit}
-                  setMode={setMode}
-                  selectPage={(candidateId) => {
-                    setActivePageId(candidateId);
-                    setMode('edit');
-                  }}
-                />
-              </Box>
-            </div>
-            <div className={styles.stickyRunway} aria-hidden="true" />
-          </section>
-        ) : (
-          <Alert color="yellow" role="status" title="No page selected">
-            The local starter session has no Page to edit.
-          </Alert>
-        )}
+        <section className={styles.editorRoot} aria-label="Rulebook editing workspace">
+          <RulebookWorkspace result={result} dispatch={dispatch} fit={fit} />
+        </section>
       </PageLayout.Content>
     </PageLayout>
   );

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit/-rulebookEditorState.fixtures.ts
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit/-rulebookEditorState.fixtures.ts
@@ -1,6 +1,6 @@
 import { normalizeFormattedText } from '@shared/formattedText';
 import type { RulebookContentsV1 } from '@shared/rulebooks/contents';
-import { createRulebookStarterContents } from '@shared/rulebooks/fixtures';
+import { createRulebookEditorialStarterContents, createRulebookStarterContents } from '@shared/rulebooks/fixtures';
 
 import { createRulebookEditorStateManager } from './-rulebookEditorState';
 import type { RulebookEditorInput, RulebookEditPatchV1 } from './-rulebookEditorState';
@@ -38,6 +38,16 @@ export function createCleanRulebookEditorInput(): RulebookEditorInput {
     baseline,
     latest: structuredClone(baseline),
     patch: structuredClone(EMPTY_PATCH),
+    resolutionLedger: [],
+  };
+}
+
+export function createEditorialRulebookEditorInput(): RulebookEditorInput {
+  const baseline = { revision: 'editorial-revision-1', contents: createRulebookEditorialStarterContents() };
+  return {
+    baseline,
+    latest: structuredClone(baseline),
+    patch: { ...structuredClone(EMPTY_PATCH), baselineRevision: baseline.revision },
     resolutionLedger: [],
   };
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit/-rulebookEditorState.test.ts
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit/-rulebookEditorState.test.ts
@@ -1,6 +1,6 @@
 import { rulebookContentsV1Schema } from '@shared/rulebooks/contents';
 import type { RulebookContentsDraftV1, RulebookContentsV1 } from '@shared/rulebooks/contents';
-import { createRulebookStarterContents } from '@shared/rulebooks/fixtures';
+import { createRulebookEditorialStarterContents, createRulebookStarterContents } from '@shared/rulebooks/fixtures';
 import { describe, expect, it } from 'vitest';
 
 import { createRulebookEditorStateManager } from './-rulebookEditorState';
@@ -8,6 +8,7 @@ import type { RulebookEditorResult, RulebookEditorStateManager } from './-rulebo
 import {
   createCleanRebaseInput,
   createCleanRulebookEditorInput,
+  createEditorialRulebookEditorInput,
   createFieldConflictInput,
   createRulebookSavedRevision,
   createStaleSaveInput,
@@ -115,9 +116,54 @@ describe('Rulebook Contents V1', () => {
     singleColumnPage(invalidCardinality, 'page-introduction').slots.body.push('block-introduction');
     expect(rulebookContentsV1Schema.safeParse(invalidCardinality).success).toBe(false);
   });
+
+  it('enforces the editorial Page layout Block catalogue', () => {
+    const contents = createRulebookEditorialStarterContents();
+    expect(rulebookContentsV1Schema.safeParse(contents).success).toBe(true);
+
+    const markers = contents.pagesById['page-markers'];
+    const movement = contents.pagesById['page-movement'];
+    if (markers?.layoutId !== 'visual-reference' || movement?.layoutId !== 'rules-page') {
+      throw new Error('The editorial fixture must retain its accepted Page layouts');
+    }
+    markers.slots.body.push('block-movement-sequence');
+    movement.slots.body = movement.slots.body.filter((blockId) => blockId !== 'block-movement-sequence');
+    expect(rulebookContentsV1Schema.safeParse(contents).success).toBe(false);
+  });
 });
 
 describe('Rulebook editor state manager', () => {
+  it('tracks editorial titles and formatted content as Saveable field intents', () => {
+    const manager = createRulebookEditorStateManager(createEditorialRulebookEditorInput());
+    manager.dispatch({
+      kind: 'set',
+      target: { kind: 'page', pageId: 'page-movement' },
+      field: 'title',
+      value: 'Movement phase',
+    });
+    const result = manager.dispatch({
+      kind: 'set',
+      target: { kind: 'block', blockId: 'block-movement-sequence' },
+      field: 'text',
+      value: 'Choose a force, then **move it**.',
+    });
+    expect(result.status).toBe('ready');
+    if (result.status !== 'ready') {
+      return;
+    }
+    expect(result.draft.pagesById['page-movement']).toMatchObject({ title: 'Movement phase' });
+    expect(result.draft.blocksById['block-movement-sequence']).toMatchObject({
+      text: 'Choose a force, then **move it**.',
+    });
+    expect(result.rebasedPatch.sets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ field: 'title', target: { kind: 'page', pageId: 'page-movement' } }),
+        expect.objectContaining({ field: 'text', target: { kind: 'block', blockId: 'block-movement-sequence' } }),
+      ])
+    );
+    expect(result.canSave).toBe(true);
+  });
+
   it('fails closed for an unknown schema version', () => {
     const input = createCleanRulebookEditorInput();
     const manager = createRulebookEditorStateManager({

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit/-rulebookEditorState.ts
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit/-rulebookEditorState.ts
@@ -97,16 +97,19 @@ type RulebookDeleteIntent = z.infer<typeof deleteIntentSchema>;
 
 const setIntentSchema = z.union([
   z.strictObject({ kind: z.literal('set'), target: pageRefSchema, field: z.literal('anchor'), value: z.string() }),
+  z.strictObject({ kind: z.literal('set'), target: pageRefSchema, field: z.literal('title'), value: z.string() }),
   z.strictObject({
     kind: z.literal('set'),
     target: blockRefSchema,
     field: z.literal('anchor'),
     value: z.string().optional(),
   }),
+  z.strictObject({ kind: z.literal('set'), target: blockRefSchema, field: z.literal('title'), value: z.string() }),
   z.strictObject({ kind: z.literal('set'), target: blockRefSchema, field: z.literal('text'), value: z.string() }),
   z.strictObject({ kind: z.literal('set'), target: itemRefSchema, field: z.literal('text'), value: z.string() }),
 ]);
 type RulebookSetIntent = z.infer<typeof setIntentSchema>;
+type RulebookFieldName = RulebookSetIntent['field'];
 
 const placeIntentSchema = z.strictObject({
   kind: z.literal('place'),
@@ -273,7 +276,7 @@ export type RulebookEditPatchV1 = z.infer<typeof rulebookEditPatchV1Schema>;
 
 type RulebookFieldDiagnostic = {
   readonly target?: RulebookEntityRef;
-  readonly field?: 'anchor' | 'text' | 'structure';
+  readonly field?: RulebookFieldName | 'structure';
   readonly code: string;
   readonly message: string;
   readonly line?: number;
@@ -289,7 +292,7 @@ type RulebookIncompatibilityBase = {
 type RulebookFieldIncompatibility = RulebookIncompatibilityBase & {
   readonly kind: 'field';
   readonly target: RulebookEntityRef;
-  readonly field: 'anchor' | 'text';
+  readonly field: RulebookFieldName;
   readonly baselineValue?: string;
   readonly latestValue?: string;
   readonly localValue?: string;
@@ -452,7 +455,7 @@ function immutableLayoutError(
 
 type FieldRecord = {
   target: RulebookEntityRef;
-  field: 'anchor' | 'text';
+  field: RulebookFieldName;
   value?: string;
 };
 
@@ -539,10 +542,7 @@ function stableFingerprint(value: unknown): string {
 }
 
 function pageSlotEntries(page: RulebookPageDraft): Array<[RulebookSlotId, string[]]> {
-  if (page.layoutId === rulebookLayoutCatalogue[0].id) {
-    return rulebookLayoutCatalogue[0].slots.map(({ id }) => [id, page.slots[id]]);
-  }
-  return rulebookLayoutCatalogue[1].slots.map(({ id }) => [id, page.slots[id]]);
+  return Object.entries(page.slots) as Array<[RulebookSlotId, string[]]>;
 }
 
 function allEntityRefs(contents: RulebookContentsDraftV1): RulebookEntityRef[] {
@@ -877,13 +877,63 @@ function restoreSnapshot(
   }
 }
 
+function setPageField(
+  page: RulebookContentsDraftV1['pagesById'][string],
+  field: RulebookFieldName,
+  value: string | undefined
+): void {
+  if (field === 'anchor' && value !== undefined) {
+    page.anchor = value;
+    return;
+  }
+  if (field === 'title' && value !== undefined && 'title' in page) {
+    page.title = value;
+    return;
+  }
+  throw new Error('That field does not belong to this Page layout');
+}
+
+function setBlockField(
+  block: RulebookContentsDraftV1['blocksById'][string],
+  field: RulebookFieldName,
+  value: string | undefined
+): void {
+  if (field === 'anchor') {
+    block.anchor = value;
+    return;
+  }
+  if (field === 'title' && value !== undefined && 'title' in block) {
+    block.title = value;
+    return;
+  }
+  if (field === 'text' && value !== undefined && block.kind !== 'repeated-text') {
+    block.text = value;
+    return;
+  }
+  throw new Error('That field does not belong to this Block kind');
+}
+
+function setItemField(
+  contents: RulebookContentsDraftV1,
+  target: Extract<RulebookEntityRef, { kind: 'item' }>,
+  field: RulebookFieldName,
+  value: string | undefined
+): void {
+  const block = contents.blocksById[target.blockId];
+  const item = block?.kind === 'repeated-text' ? block.itemsById[target.itemId] : undefined;
+  if (!item || field !== 'text' || value === undefined) {
+    throw new Error('The repeated-item field target is not available');
+  }
+  item.text = value;
+}
+
 function setField(contents: RulebookContentsDraftV1, intent: RulebookSetIntent): void {
   if (intent.target.kind === 'page') {
     const page = contents.pagesById[intent.target.pageId];
-    if (!page || intent.field !== 'anchor') {
+    if (!page) {
       throw new Error('The Page field target is not available');
     }
-    page.anchor = intent.value ?? '';
+    setPageField(page, intent.field, intent.value);
     return;
   }
   if (intent.target.kind === 'block') {
@@ -891,50 +941,60 @@ function setField(contents: RulebookContentsDraftV1, intent: RulebookSetIntent):
     if (!block) {
       throw new Error('The Block field target is not available');
     }
-    if (intent.field === 'anchor') {
-      block.anchor = intent.value;
-      return;
-    }
-    if (intent.field === 'text' && block.kind === 'text') {
-      block.text = intent.value;
-      return;
-    }
-    throw new Error('That field does not belong to this Block kind');
+    setBlockField(block, intent.field, intent.value);
+    return;
   }
-  const block = contents.blocksById[intent.target.blockId];
-  if (block?.kind !== 'repeated-text' || intent.field !== 'text' || !block.itemsById[intent.target.itemId]) {
-    throw new Error('The repeated-item field target is not available');
+  setItemField(contents, intent.target, intent.field, intent.value);
+}
+
+function anchorFieldIntent(target: RulebookEntityRef, value: string | undefined): RulebookSetIntent {
+  if (target.kind === 'page') {
+    if (value === undefined) {
+      throw new Error('A Page anchor resolution needs a value');
+    }
+    return { kind: 'set', target, field: 'anchor', value };
   }
-  block.itemsById[intent.target.itemId]!.text = intent.value;
+  if (target.kind === 'block') {
+    return { kind: 'set', target, field: 'anchor', value };
+  }
+  throw new Error('A repeated item cannot own an anchor');
+}
+
+function titleFieldIntent(target: RulebookEntityRef, value: string | undefined): RulebookSetIntent {
+  if (value === undefined || target.kind === 'item') {
+    throw new Error('A title resolution needs a Page or Block value');
+  }
+  if (target.kind === 'page') {
+    return { kind: 'set', target, field: 'title', value };
+  }
+  return { kind: 'set', target, field: 'title', value };
+}
+
+function textFieldIntent(target: RulebookEntityRef, value: string | undefined): RulebookSetIntent {
+  if (value === undefined) {
+    throw new Error('A text resolution needs a value');
+  }
+  if (target.kind === 'page') {
+    throw new Error('A Page cannot own editable text');
+  }
+  if (target.kind === 'block') {
+    return { kind: 'set', target, field: 'text', value };
+  }
+  return { kind: 'set', target, field: 'text', value };
 }
 
 function fieldIntent(
   target: RulebookEntityRef,
-  field: 'anchor' | 'text',
+  field: RulebookFieldName,
   value: string | undefined
 ): RulebookSetIntent {
   if (field === 'anchor') {
-    if (target.kind === 'page') {
-      if (value === undefined) {
-        throw new Error('A Page anchor resolution needs a value');
-      }
-      return { kind: 'set', target, field, value };
-    }
-    if (target.kind === 'block') {
-      return { kind: 'set', target, field, value };
-    }
-    throw new Error('A repeated item cannot own an anchor');
+    return anchorFieldIntent(target, value);
   }
-  if (value === undefined) {
-    throw new Error('A text resolution needs a value');
+  if (field === 'title') {
+    return titleFieldIntent(target, value);
   }
-  if (target.kind === 'block') {
-    return { kind: 'set', target, field, value };
-  }
-  if (target.kind === 'item') {
-    return { kind: 'set', target, field, value };
-  }
-  throw new Error('A Page cannot own editable text');
+  return textFieldIntent(target, value);
 }
 
 function resolveGap(
@@ -1210,10 +1270,16 @@ function fieldRecords(contents: RulebookContentsDraftV1): FieldRecord[] {
   const records: FieldRecord[] = [];
   for (const page of Object.values(contents.pagesById)) {
     records.push({ target: { kind: 'page', pageId: page.id }, field: 'anchor', value: page.anchor });
+    if ('title' in page) {
+      records.push({ target: { kind: 'page', pageId: page.id }, field: 'title', value: page.title });
+    }
   }
   for (const block of Object.values(contents.blocksById)) {
     records.push({ target: { kind: 'block', blockId: block.id }, field: 'anchor', value: block.anchor });
-    if (block.kind === 'text') {
+    if ('title' in block) {
+      records.push({ target: { kind: 'block', blockId: block.id }, field: 'title', value: block.title });
+    }
+    if (block.kind !== 'repeated-text') {
       records.push({ target: { kind: 'block', blockId: block.id }, field: 'text', value: block.text });
     } else {
       for (const item of Object.values(block.itemsById)) {
@@ -1232,7 +1298,7 @@ function fieldKey(record: Pick<FieldRecord, 'target' | 'field'>): string {
   return `${entityRefKey(record.target)}:${record.field}`;
 }
 
-function comparableFieldValue(field: 'anchor' | 'text', value: string | undefined): string | undefined {
+function comparableFieldValue(field: RulebookFieldName, value: string | undefined): string | undefined {
   if (field !== 'text' || value === undefined) {
     return value;
   }
@@ -1240,7 +1306,7 @@ function comparableFieldValue(field: 'anchor' | 'text', value: string | undefine
   return normalized.ok ? normalized.value : value;
 }
 
-function fieldsEqual(field: 'anchor' | 'text', left: string | undefined, right: string | undefined): boolean {
+function fieldsEqual(field: RulebookFieldName, left: string | undefined, right: string | undefined): boolean {
   return comparableFieldValue(field, left) === comparableFieldValue(field, right);
 }
 
@@ -1458,7 +1524,7 @@ function validateDraft(draft: RulebookContentsDraftV1): {
       }
     }
     const textFields =
-      block.kind === 'text'
+      block.kind !== 'repeated-text'
         ? [{ target: { kind: 'block' as const, blockId: block.id }, value: block.text }]
         : Object.values(block.itemsById).map((item) => ({
             target: { kind: 'item' as const, blockId: block.id, itemId: item.id },
@@ -1479,8 +1545,9 @@ function validateDraft(draft: RulebookContentsDraftV1): {
           }))
         );
       } else if (textField.target.kind === 'block') {
-        (candidate.blocksById[textField.target.blockId] as Extract<RulebookBlockDraft, { kind: 'text' }>).text =
-          normalized.value;
+        (
+          candidate.blocksById[textField.target.blockId] as Exclude<RulebookBlockDraft, { kind: 'repeated-text' }>
+        ).text = normalized.value;
       } else {
         const repeated = candidate.blocksById[textField.target.blockId] as Extract<
           RulebookBlockDraft,
@@ -1536,7 +1603,7 @@ function validateDraft(draft: RulebookContentsDraftV1): {
         occupiedAnchors.add(block.anchor);
       }
     }
-    if (block.kind === 'text') {
+    if (block.kind !== 'repeated-text') {
       if (!normalizeFormattedText(block.text).ok) {
         block.text = '';
       }
@@ -1660,7 +1727,7 @@ function placementChanged(
 
 function fieldIncompatibility(
   target: RulebookEntityRef,
-  field: 'anchor' | 'text',
+  field: RulebookFieldName,
   baselineValue: string | undefined,
   latestValue: string | undefined,
   localValue: string | undefined
@@ -2034,7 +2101,7 @@ function reconcile(state: ReadyState): Reconciliation {
     if (
       incompatibility.kind === 'field' &&
       ((incompatibility.field === 'anchor' && outcome.kind === 'anchor') ||
-        (incompatibility.field === 'text' && outcome.kind === 'text'))
+        ((incompatibility.field === 'title' || incompatibility.field === 'text') && outcome.kind === 'text'))
     ) {
       setField(comparisonDraft, fieldIntent(incompatibility.target, incompatibility.field, outcome.value));
     } else if (incompatibility.kind === 'anchor' && outcome.kind === 'anchor') {
@@ -2140,7 +2207,7 @@ function outcomeFits(
 ): boolean {
   const outcome = approval.outcome;
   if (incompatibility.kind === 'field') {
-    if (incompatibility.field === 'text') {
+    if (incompatibility.field === 'title' || incompatibility.field === 'text') {
       return outcome.kind === 'text' && typeof outcome.value === 'string';
     }
     return outcome.kind === 'anchor' && (incompatibility.target.kind === 'block' || typeof outcome.value === 'string');

--- a/src/shared/rulebooks/contents.ts
+++ b/src/shared/rulebooks/contents.ts
@@ -2,21 +2,45 @@ import { normalizeFormattedText } from '@shared/formattedText';
 import type { NormalizedFormattedText } from '@shared/formattedText';
 import { z } from 'zod';
 
-const rulebookBlockKinds = ['text', 'repeated-text'] as const;
+const rulebookBlockKinds = ['text', 'repeated-text', 'rule-group', 'worked-example', 'asset-figure'] as const;
+type RulebookBlockKind = (typeof rulebookBlockKinds)[number];
 
-const unboundedBootstrapSlot = {
-  acceptedBlockKinds: rulebookBlockKinds,
+const legacyBlockKinds = ['text', 'repeated-text'] as const satisfies readonly RulebookBlockKind[];
+const editorialBlockKinds = [
+  'rule-group',
+  'worked-example',
+  'asset-figure',
+] as const satisfies readonly RulebookBlockKind[];
+
+const unboundedLegacySlot = {
+  acceptedBlockKinds: legacyBlockKinds,
   cardinality: { minimum: 0, maximum: null },
 } as const;
 
+const editorialSlot = <const Accepted extends readonly (typeof editorialBlockKinds)[number][]>(
+  acceptedBlockKinds: Accepted
+) => ({ acceptedBlockKinds, cardinality: { minimum: 0, maximum: null } }) as const;
+
 export const rulebookLayoutCatalogue = [
-  { id: 'single-column', slots: [{ id: 'body', ...unboundedBootstrapSlot }] },
+  { id: 'single-column', slots: [{ id: 'body', ...unboundedLegacySlot }] },
   {
     id: 'two-columns',
     slots: [
-      { id: 'left', ...unboundedBootstrapSlot },
-      { id: 'right', ...unboundedBootstrapSlot },
+      { id: 'left', ...unboundedLegacySlot },
+      { id: 'right', ...unboundedLegacySlot },
     ],
+  },
+  {
+    id: 'chapter-opener',
+    slots: [{ id: 'body', ...editorialSlot(['asset-figure', 'rule-group']) }],
+  },
+  {
+    id: 'rules-page',
+    slots: [{ id: 'body', ...editorialSlot(editorialBlockKinds) }],
+  },
+  {
+    id: 'visual-reference',
+    slots: [{ id: 'body', ...editorialSlot(['asset-figure', 'worked-example']) }],
   },
 ] as const;
 
@@ -62,7 +86,27 @@ const repeatedTextBlockSchema = z.strictObject({
   itemsById: z.record(rulebookItemIdSchema, repeatedTextItemSchema),
 });
 
-const rulebookBlockSchema = z.discriminatedUnion('kind', [textBlockSchema, repeatedTextBlockSchema]);
+function editorialBlockSchema<const Kind extends (typeof editorialBlockKinds)[number]>(kind: Kind) {
+  return z.strictObject({
+    id: rulebookBlockIdSchema,
+    kind: z.literal(kind),
+    anchor: rulebookAnchorSchema.optional(),
+    title: z.string(),
+    text: normalizedFormattedTextSchema,
+  });
+}
+
+const ruleGroupBlockSchema = editorialBlockSchema('rule-group');
+const workedExampleBlockSchema = editorialBlockSchema('worked-example');
+const assetFigureBlockSchema = editorialBlockSchema('asset-figure');
+
+const rulebookBlockSchema = z.discriminatedUnion('kind', [
+  textBlockSchema,
+  repeatedTextBlockSchema,
+  ruleGroupBlockSchema,
+  workedExampleBlockSchema,
+  assetFigureBlockSchema,
+]);
 
 function slotSchema<const Slots extends readonly { readonly id: string }[]>(slotDefinitions: Slots) {
   const slots = Object.fromEntries(slotDefinitions.map(({ id }) => [id, z.array(rulebookBlockIdSchema)])) as {
@@ -84,7 +128,28 @@ const twoColumnsPageSchema = z.strictObject({
   slots: slotSchema(rulebookLayoutCatalogue[1].slots),
 });
 
-const rulebookPageSchema = z.discriminatedUnion('layoutId', [singleColumnPageSchema, twoColumnsPageSchema]);
+function editorialPageSchema<const Index extends 2 | 3 | 4>(index: Index) {
+  const layout = rulebookLayoutCatalogue[index];
+  return z.strictObject({
+    id: rulebookPageIdSchema,
+    anchor: rulebookAnchorSchema,
+    title: z.string(),
+    layoutId: z.literal(layout.id),
+    slots: slotSchema(layout.slots),
+  });
+}
+
+const chapterOpenerPageSchema = editorialPageSchema(2);
+const rulesPageSchema = editorialPageSchema(3);
+const visualReferencePageSchema = editorialPageSchema(4);
+
+const rulebookPageSchema = z.discriminatedUnion('layoutId', [
+  singleColumnPageSchema,
+  twoColumnsPageSchema,
+  chapterOpenerPageSchema,
+  rulesPageSchema,
+  visualReferencePageSchema,
+]);
 
 function duplicateValues(values: readonly string[]): readonly string[] {
   const seen = new Set<string>();
@@ -262,13 +327,31 @@ const repeatedTextBlockDraftSchema = repeatedTextBlockSchema.extend({
   anchor: z.string().optional(),
   itemsById: z.record(rulebookItemIdSchema, repeatedTextItemDraftSchema),
 });
+const ruleGroupBlockDraftSchema = ruleGroupBlockSchema.extend({ anchor: z.string().optional(), text: z.string() });
+const workedExampleBlockDraftSchema = workedExampleBlockSchema.extend({
+  anchor: z.string().optional(),
+  text: z.string(),
+});
+const assetFigureBlockDraftSchema = assetFigureBlockSchema.extend({
+  anchor: z.string().optional(),
+  text: z.string(),
+});
 
 /** Runtime structure authority for editor operation payloads whose direct fields may contain raw text. */
 export const rulebookDraftEntitySchemas = {
   page: z.discriminatedUnion('layoutId', [
     singleColumnPageSchema.extend({ anchor: z.string() }),
     twoColumnsPageSchema.extend({ anchor: z.string() }),
+    chapterOpenerPageSchema.extend({ anchor: z.string() }),
+    rulesPageSchema.extend({ anchor: z.string() }),
+    visualReferencePageSchema.extend({ anchor: z.string() }),
   ]),
-  block: z.discriminatedUnion('kind', [textBlockDraftSchema, repeatedTextBlockDraftSchema]),
+  block: z.discriminatedUnion('kind', [
+    textBlockDraftSchema,
+    repeatedTextBlockDraftSchema,
+    ruleGroupBlockDraftSchema,
+    workedExampleBlockDraftSchema,
+    assetFigureBlockDraftSchema,
+  ]),
   item: repeatedTextItemDraftSchema,
 } as const;

--- a/src/shared/rulebooks/fixtures.ts
+++ b/src/shared/rulebooks/fixtures.ts
@@ -44,7 +44,72 @@ const starter = rulebookContentsV1Schema.parse({
   },
 });
 
+const editorialStarter = rulebookContentsV1Schema.parse({
+  schemaVersion: 1,
+  pageOrder: ['page-welcome', 'page-movement', 'page-markers'],
+  pagesById: {
+    'page-welcome': {
+      id: 'page-welcome',
+      anchor: 'welcome-to-arrakis',
+      title: 'Welcome to Arrakis',
+      layoutId: 'chapter-opener',
+      slots: { body: ['block-arrakis-hero'] },
+    },
+    'page-movement': {
+      id: 'page-movement',
+      anchor: 'movement',
+      title: 'Movement',
+      layoutId: 'rules-page',
+      slots: { body: ['block-movement-sequence', 'block-storm-marker'] },
+    },
+    'page-markers': {
+      id: 'page-markers',
+      anchor: 'markers-and-tokens',
+      title: 'Markers and tokens',
+      layoutId: 'visual-reference',
+      slots: { body: ['block-token-reference', 'block-marker-example'] },
+    },
+  },
+  blocksById: {
+    'block-arrakis-hero': {
+      id: 'block-arrakis-hero',
+      kind: 'asset-figure',
+      title: 'Arrakis hero image',
+      text: 'A selected Asset with a short caption.',
+    },
+    'block-movement-sequence': {
+      id: 'block-movement-sequence',
+      kind: 'rule-group',
+      title: 'Movement sequence',
+      text: 'Choose a force, choose an adjacent destination, then resolve the move.',
+    },
+    'block-storm-marker': {
+      id: 'block-storm-marker',
+      kind: 'asset-figure',
+      title: 'Storm marker',
+      text: 'The storm closes the boundary between its two sectors.',
+    },
+    'block-token-reference': {
+      id: 'block-token-reference',
+      kind: 'asset-figure',
+      title: 'Token reference',
+      text: 'Identify the markers used during play.',
+    },
+    'block-marker-example': {
+      id: 'block-marker-example',
+      kind: 'worked-example',
+      title: 'Marker placement',
+      text: 'Place each marker beside the rule it helps explain.',
+    },
+  },
+});
+
 /** The accepted two-Page bootstrap Contents, cloned for each editor or story scenario. */
 export function createRulebookStarterContents(): RulebookContentsV1 {
   return structuredClone(starter);
+}
+
+/** The accepted editorial catalogue fixture, cloned for editor and contract scenarios. */
+export function createRulebookEditorialStarterContents(): RulebookContentsV1 {
+  return structuredClone(editorialStarter);
 }


### PR DESCRIPTION
## Summary

- replace the comparison prototype with the accepted 4A Rulebook editor
- add typed editorial page layouts and block kinds to the shared Rulebook catalogue
- keep page and block navigation, editing controls, and the A4 preview visible together
- make collapsed page and block icons sortable, directly selectable, and backed by typed add menus
- preserve formatted inline text in the preview and keep Save local to the fixture-backed draft

## Verification

- `bun run test` (755 tests)
- `bun run typecheck`
- `bun run lint`
- `bun run check:prose`
- `npx playwright test e2e/rulebook-editor-route.spec.ts --project=userA` (6 tests)
- `VITE_CONVEX_URL=https://exuberant-finch-263.eu-west-1.convex.cloud bun run publisher:release:verify`

## Visual proof

Both captures use the same 1280 x 720 viewport and the same Rulebook editor route.

| Before | After |
| --- | --- |
| ![Rulebook editor before](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-774-rulebook-editor-before.jpg) | ![Rulebook editor after](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-774-rulebook-editor-after.jpg) |

Closes #773

Parent map: #558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a redesigned rulebook editor with chapter, rules, and visual-reference pages.
  - Added editable page and block titles, formatted content previews, and support for rule groups, worked examples, and visual assets.
  - Added page and block creation, drag-and-drop reordering, drill-down navigation, compatible menus, and local save-state handling.
  - Improved responsive workspace behavior, including A4 sizing, sidebar alignment, fit-width mode, and keyboard-accessible horizontal scrolling.

- **Bug Fixes**
  - Improved preview updates and editor layout behavior across workspace sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->