### PR TITLE
The app uses its own Dune Zone favicon

### DIFF
--- a/public/dune-zone-favicon.svg
+++ b/public/dune-zone-favicon.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <title>Dune Zone</title>
+  <defs>
+    <linearGradient id="sky" x1="12" y1="4" x2="52" y2="60" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2B3648" />
+      <stop offset="1" stop-color="#0A0F1A" />
+    </linearGradient>
+    <linearGradient id="sand" x1="16" y1="38" x2="50" y2="62" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F4CF8B" />
+      <stop offset="1" stop-color="#C78346" />
+    </linearGradient>
+    <clipPath id="tile">
+      <rect width="64" height="64" rx="14" />
+    </clipPath>
+  </defs>
+  <g clip-path="url(#tile)">
+    <rect width="64" height="64" fill="url(#sky)" />
+    <circle cx="43" cy="21" r="11" fill="#F8AF40" />
+    <circle cx="47" cy="17" r="10" fill="#141C2B" />
+    <path d="M-4 54C9 41 20 36 31 38c10 2 16 10 37 1v29H-4Z" fill="#A75B2B" />
+    <path d="M-4 58c16-10 28-9 39-4 10 5 20 3 33-5v19H-4Z" fill="url(#sand)" />
+    <path d="M28 50c5 0 8 2 10 5-5-2-9-2-14 0 1-3 2-5 4-5Z" fill="#84220C" />
+  </g>
+</svg>

--- a/src/app/routes/__root.tsx
+++ b/src/app/routes/__root.tsx
@@ -36,6 +36,7 @@ export const Route = createRootRoute({
       },
     ],
     links: [
+      { rel: 'icon', type: 'image/svg+xml', href: '/dune-zone-favicon.svg' },
       // Train 1b (#255): the two LCP images and the primary text faces.
       { rel: 'preload', as: 'image', href: '/web/page-large.jpg', fetchPriority: 'high' },
       { rel: 'preload', as: 'image', href: '/video/band-poster.jpg', fetchPriority: 'high' },

--- a/workers/publisher/renderer-manifest-build.test.ts
+++ b/workers/publisher/renderer-manifest-build.test.ts
@@ -8,6 +8,7 @@ import {
   assertExactSharpVersion,
   computeRendererManifestDigest,
   isRendererManifestAsset,
+  isRendererManifestInputPath,
   RENDERER_RUNTIME_CLOSURE_PATHS,
 } from './renderer-manifest-build';
 import type { RendererManifestEntry } from './renderer-manifest-build';
@@ -139,6 +140,7 @@ describe('current Renderer manifest digest', () => {
   test.each([
     '_shell.html',
     'index.html',
+    'dune-zone-favicon.svg',
     '__storybook/index.html',
     '__storybook/assets/Background.stories-hash.js',
     'public/FactionEditor-hash.js',
@@ -150,6 +152,10 @@ describe('current Renderer manifest digest', () => {
     'obj/troop/atreides.obj',
   ])('excludes application-only or generated release asset %s', (assetPath) => {
     expect(isRendererManifestAsset(assetPath)).toBe(false);
+  });
+
+  test('keeps the application favicon out of Renderer change detection', () => {
+    expect(isRendererManifestInputPath('public/dune-zone-favicon.svg')).toBe(false);
   });
 
   test('keeps application-only chunk changes out of the Renderer identity', () => {

--- a/workers/publisher/renderer-manifest-build.ts
+++ b/workers/publisher/renderer-manifest-build.ts
@@ -144,6 +144,8 @@ export function isRendererManifestAsset(relativePath: string): boolean {
   return (
     normalizedPath !== '_shell.html' &&
     normalizedPath !== 'index.html' &&
+    // The favicon is app chrome; capture never loads it, so it must not reprice sheets.
+    normalizedPath !== 'dune-zone-favicon.svg' &&
     !normalizedPath.startsWith('__storybook/') &&
     !normalizedPath.startsWith('public/') &&
     // Generated image and vector output is identified by ingredients, never by bytes.


### PR DESCRIPTION
## Summary

- Add the selected eclipse and dunes favicon to the main app.
- Keep Storybook on its generated favicon.
- Keep the app-only favicon outside Renderer identity.

## Proof

![The main app uses the eclipse and dunes favicon while Storybook keeps its own favicon.](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-775-favicon-contract.png)

The baseline build from `main` emitted no favicon link. This PR emits `<link rel="icon" type="image/svg+xml" href="/dune-zone-favicon.svg">`. Storybook still emits its own `<link rel="icon" href="./favicon.svg">`.

The publisher release includes the favicon, but the capture renderer never loads it. The narrow regression test keeps the app-only asset out of Renderer hashing and change detection. The generated Renderer manifest remains unchanged.

## Verification

- `bun run test`: 117 files and 757 tests passed
- `bun run build-storybook`
- `bun run verify:storybook-publication`
- `VITE_CONVEX_URL=https://example.convex.cloud bun run check`
- `bun run typecheck`
- `bun run knip`
- `VITE_CONVEX_URL=https://example.convex.cloud bun run publisher:release:verify`
