### PR TITLE
Rulebook outline glyphs distinguish entity kinds

### DIFF
--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
@@ -12,6 +12,7 @@ import type { FormattedTextParseResult } from '@shared/formattedText';
 import { rulebookLayoutCatalogue } from '@shared/rulebooks/contents';
 import type { RulebookBlockDraft, RulebookPageDraft } from '@shared/rulebooks/contents';
 import { createFileRoute } from '@tanstack/react-router';
+import { RulebookEntityGlyph } from '@ui/content/RulebookEntityGlyph';
 import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { IconAction } from '@ui/control/IconAction';
 import { SortableItem } from '@ui/control/SortableItem';
@@ -526,7 +527,7 @@ function RulebookWorkspace({
                                 {...attributes}
                                 {...listeners}
                               >
-                                <PageLayoutIcon layoutId={page.layoutId} />
+                                <RulebookEntityGlyph kind="page" icon={<PageLayoutIcon layoutId={page.layoutId} />} />
                                 <span>{index + 1}</span>
                               </button>
                             </DrilldownTooltip>
@@ -624,7 +625,7 @@ function RulebookWorkspace({
                               {...attributes}
                               {...listeners}
                             >
-                              <BlockKindIcon kind={block.kind} />
+                              <RulebookEntityGlyph kind="block" icon={<BlockKindIcon kind={block.kind} />} />
                             </button>
                           </DrilldownTooltip>
                           <DrilldownLevelChoice

--- a/src/app/ui/content/RulebookEntityGlyph.module.css
+++ b/src/app/ui/content/RulebookEntityGlyph.module.css
@@ -1,0 +1,29 @@
+.root {
+  --entity-accent: var(--mantine-color-yellow-4);
+  position: relative;
+  display: inline-grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  color: inherit;
+}
+
+.root::after {
+  position: absolute;
+  right: -0.125rem;
+  bottom: 0;
+  width: 0.4375rem;
+  height: 0.125rem;
+  background: var(--entity-accent);
+  border-radius: 999px;
+  content: "";
+}
+
+.root[data-kind="slot"] {
+  --entity-accent: var(--mantine-color-teal-4);
+}
+
+.root[data-kind="block"] {
+  --entity-accent: var(--mantine-color-blue-4);
+}

--- a/src/app/ui/content/RulebookEntityGlyph.stories.tsx
+++ b/src/app/ui/content/RulebookEntityGlyph.stories.tsx
@@ -1,0 +1,49 @@
+import { Group, Stack, Text } from '@mantine/core';
+import preview from '@sb/preview';
+import { Surface } from '@ui/surface';
+import { BookOpenText, Columns3, ListTree } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+import { RulebookEntityGlyph } from './RulebookEntityGlyph';
+import type { RulebookEntityKind } from './RulebookEntityGlyph';
+
+const meta = preview.meta({
+  component: RulebookEntityGlyph,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    kind: 'page',
+    icon: <BookOpenText size={18} />,
+  },
+});
+
+export const Default = meta.story({
+  args: {
+    kind: 'page',
+    icon: <BookOpenText size={18} />,
+  },
+});
+
+const examples: readonly { kind: RulebookEntityKind; label: string; icon: ReactNode }[] = [
+  { kind: 'page', label: 'Page', icon: <BookOpenText size={18} /> },
+  { kind: 'slot', label: 'Slot', icon: <Columns3 size={18} /> },
+  { kind: 'block', label: 'Block', icon: <ListTree size={18} /> },
+];
+
+export const EntityKinds = meta.story({
+  render: () => (
+    <Surface padding="lg">
+      <Group gap="xl" style={{ color: 'var(--mantine-color-gray-0)' }}>
+        {examples.map((example) => (
+          <Stack key={example.kind} align="center" gap="xs">
+            <RulebookEntityGlyph kind={example.kind} icon={example.icon} />
+            <Text c="inherit" size="sm">
+              {example.label}
+            </Text>
+          </Stack>
+        ))}
+      </Group>
+    </Surface>
+  ),
+});

--- a/src/app/ui/content/RulebookEntityGlyph.test.tsx
+++ b/src/app/ui/content/RulebookEntityGlyph.test.tsx
@@ -1,0 +1,15 @@
+import { BookOpenText } from 'lucide-react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { RulebookEntityGlyph } from './RulebookEntityGlyph';
+import type { RulebookEntityKind } from './RulebookEntityGlyph';
+
+describe('RulebookEntityGlyph', () => {
+  it.each<RulebookEntityKind>(['page', 'slot', 'block'])('identifies the %s kind for presentation', (kind) => {
+    const markup = renderToStaticMarkup(<RulebookEntityGlyph kind={kind} icon={<BookOpenText size={18} />} />);
+
+    expect(markup).toContain(`data-kind="${kind}"`);
+    expect(markup).toContain('aria-hidden="true"');
+  });
+});

--- a/src/app/ui/content/RulebookEntityGlyph.tsx
+++ b/src/app/ui/content/RulebookEntityGlyph.tsx
@@ -1,0 +1,25 @@
+import clsx from 'clsx';
+import type { ReactNode } from 'react';
+
+import styles from './RulebookEntityGlyph.module.css';
+
+export type RulebookEntityKind = 'page' | 'slot' | 'block';
+
+export interface RulebookEntityGlyphProps {
+  kind: RulebookEntityKind;
+  icon: ReactNode;
+  className?: string;
+}
+
+/*
+ * The decorative glyph for one kind of entity in a Rulebook outline.
+ *
+ * The caller owns the specific icon. This component owns the fixed Page, Slot, and Block accent mapping.
+ */
+export function RulebookEntityGlyph({ kind, icon, className }: RulebookEntityGlyphProps) {
+  return (
+    <span className={clsx(styles.root, className)} data-kind={kind} aria-hidden>
+      {icon}
+    </span>
+  );
+}


### PR DESCRIPTION
Closes #776

Parent: #558

## Summary

- Add one Rulebook entity glyph component with fixed Page, Slot, and Block accent mappings.
- Apply Page and Block glyphs to the existing authoring rail without changing navigation or editing behavior.
- Cover the component with its own story and focused test.

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run check:prose`
- `bun run check:css-orphans`
- `bun run test` (118 files, 758 tests)
- `bun run publisher:release:verify`

## Visual proof

| Before | After |
| --- | --- |
| ![Rulebook rail before entity accents](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-777-rulebook-entity-glyph-before.png) | ![Rulebook rail after entity accents](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-777-rulebook-entity-glyph-after.png) |

The isolated component story shows the complete Page, Slot, and Block vocabulary at its intended scale.

![Page, Slot, and Block entity glyphs](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-777-rulebook-entity-glyph-story.png)