### PR TITLE
Spice cards keep their full-frame background sizing

### DIFF
--- a/scripts/storybook-publication-browser.test.ts
+++ b/scripts/storybook-publication-browser.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { RETRYABLE_BROWSER_CHECK_STATUS, runBrowserCheck } from './storybook-publication-browser';
+import type { BrowserCheckProcess } from './storybook-publication-browser';
+
+function processThatExits(status: number): BrowserCheckProcess {
+  return {
+    exited: Promise.resolve(status),
+    kill: vi.fn(),
+  };
+}
+
+function processThatStopsWhenKilled(): BrowserCheckProcess {
+  let resolveExit: (status: number) => void = () => undefined;
+  return {
+    exited: new Promise((resolve) => {
+      resolveExit = resolve;
+    }),
+    kill: vi.fn(() => resolveExit(143)),
+  };
+}
+
+function processThatStopsAfterSigkill(): BrowserCheckProcess {
+  let resolveExit: (status: number) => void = () => undefined;
+  return {
+    exited: new Promise((resolve) => {
+      resolveExit = resolve;
+    }),
+    kill: vi.fn((signal) => {
+      if (signal === 'SIGKILL') {
+        resolveExit(137);
+      }
+    }),
+  };
+}
+
+describe('Storybook publication browser process', () => {
+  test('kills a timed-out browser check and retries it once', async () => {
+    const timedOut = processThatStopsWhenKilled();
+    const passed = processThatExits(0);
+    const spawn = vi.fn().mockReturnValueOnce(timedOut).mockReturnValueOnce(passed);
+
+    await expect(
+      runBrowserCheck({
+        spawn,
+        timeoutMs: 1,
+        shutdownTimeoutMs: 1,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(timedOut.kill).toHaveBeenCalledOnce();
+  });
+
+  test('retries a navigation timeout reported by the browser child', async () => {
+    const spawn = vi
+      .fn()
+      .mockReturnValueOnce(processThatExits(RETRYABLE_BROWSER_CHECK_STATUS))
+      .mockReturnValueOnce(processThatExits(0));
+
+    await expect(runBrowserCheck({ spawn, timeoutMs: 10, shutdownTimeoutMs: 1 })).resolves.toBeUndefined();
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  test('uses SIGKILL when the browser child ignores normal termination', async () => {
+    const timedOut = processThatStopsAfterSigkill();
+    const spawn = vi.fn().mockReturnValueOnce(timedOut).mockReturnValueOnce(processThatExits(0));
+
+    await expect(runBrowserCheck({ spawn, timeoutMs: 1, shutdownTimeoutMs: 1 })).resolves.toBeUndefined();
+    expect(timedOut.kill).toHaveBeenNthCalledWith(1);
+    expect(timedOut.kill).toHaveBeenNthCalledWith(2, 'SIGKILL');
+  });
+
+  test('fails after two browser children time out', async () => {
+    const spawn = vi
+      .fn()
+      .mockReturnValueOnce(processThatStopsWhenKilled())
+      .mockReturnValueOnce(processThatStopsWhenKilled());
+
+    await expect(runBrowserCheck({ spawn, timeoutMs: 1, shutdownTimeoutMs: 1 })).rejects.toThrow(
+      'Browser publication check exceeded 1ms on 2 attempts.'
+    );
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not retry a publication assertion failure', async () => {
+    const spawn = vi.fn().mockReturnValue(processThatExits(1));
+
+    await expect(runBrowserCheck({ spawn, timeoutMs: 10, shutdownTimeoutMs: 1 })).rejects.toThrow(
+      'Browser publication check exited with status 1.'
+    );
+    expect(spawn).toHaveBeenCalledOnce();
+  });
+});

--- a/scripts/storybook-publication-browser.ts
+++ b/scripts/storybook-publication-browser.ts
@@ -1,0 +1,67 @@
+export const RETRYABLE_BROWSER_CHECK_STATUS = 75;
+
+export type BrowserCheckProcess = {
+  exited: Promise<number>;
+  kill(signal?: number | NodeJS.Signals): void;
+};
+
+type BrowserCheckOutcome = { kind: 'exit'; status: number } | { kind: 'timeout' };
+
+type RunBrowserCheckOptions = {
+  spawn: () => BrowserCheckProcess;
+  timeoutMs: number;
+  shutdownTimeoutMs: number;
+  attempts?: number;
+  onRetry?: (reason: string) => void;
+};
+
+function waitForProcess(process: BrowserCheckProcess, timeoutMs: number): Promise<BrowserCheckOutcome> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve({ kind: 'timeout' }), timeoutMs);
+    process.exited.then((status) => {
+      clearTimeout(timeout);
+      resolve({ kind: 'exit', status });
+    });
+  });
+}
+
+async function stopProcess(process: BrowserCheckProcess, shutdownTimeoutMs: number) {
+  process.kill();
+  if ((await waitForProcess(process, shutdownTimeoutMs)).kind === 'exit') {
+    return;
+  }
+
+  process.kill('SIGKILL');
+  if ((await waitForProcess(process, shutdownTimeoutMs)).kind === 'timeout') {
+    throw new Error('The Storybook browser process did not stop after SIGKILL.');
+  }
+}
+
+export async function runBrowserCheck({
+  spawn,
+  timeoutMs,
+  shutdownTimeoutMs,
+  attempts = 2,
+  onRetry = () => undefined,
+}: RunBrowserCheckOptions) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const process = spawn();
+    const outcome = await waitForProcess(process, timeoutMs);
+    if (outcome.kind === 'timeout') {
+      await stopProcess(process, shutdownTimeoutMs);
+      if (attempt < attempts) {
+        onRetry(`attempt ${attempt} exceeded ${timeoutMs}ms`);
+        continue;
+      }
+      throw new Error(`Browser publication check exceeded ${timeoutMs}ms on ${attempts} attempts.`);
+    }
+    if (outcome.status === 0) {
+      return;
+    }
+    if (outcome.status === RETRYABLE_BROWSER_CHECK_STATUS && attempt < attempts) {
+      onRetry(`attempt ${attempt} reported a navigation timeout`);
+      continue;
+    }
+    throw new Error(`Browser publication check exited with status ${outcome.status}.`);
+  }
+}

--- a/scripts/verify-storybook-publication.ts
+++ b/scripts/verify-storybook-publication.ts
@@ -1,8 +1,10 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 
-import { chromium } from 'playwright';
-import type { Page } from 'playwright';
+import { chromium, errors } from 'playwright';
+import type { Browser, Page } from 'playwright';
+
+import { RETRYABLE_BROWSER_CHECK_STATUS, runBrowserCheck } from './storybook-publication-browser';
 
 const repositoryRoot = path.resolve(import.meta.dir, '..');
 const artifactDirectory = path.join(repositoryRoot, 'storybook-static');
@@ -12,6 +14,8 @@ const origin = `http://127.0.0.1:${port}`;
 const PROCESS_SHUTDOWN_TIMEOUT_MS = 5000;
 const PAGE_CLEAR_TIMEOUT_MS = 5000;
 const NETWORK_PROBE_TIMEOUT_MS = 5000;
+const BROWSER_CHECK_TIMEOUT_MS = 180_000;
+const BROWSER_CHECK_CHILD = 'STORYBOOK_PUBLICATION_BROWSER_CHECK_CHILD';
 
 function progress(message: string) {
   console.log(`[storybook-publication] ${message}`);
@@ -167,78 +171,74 @@ async function verifyHeaders(workerPath: string) {
   assertWorkerCsp(worker.headers.get('Content-Security-Policy'));
 }
 
-async function verifyBrowser(workerPath: string) {
-  const browser = await chromium.launch({ headless: true });
-  try {
-    const page = await browser.newPage();
-    const externalRequests: string[] = [];
-    const consoleErrors: string[] = [];
-    page.on('request', (request) => {
-      const url = new URL(request.url());
-      if (url.protocol === 'http:' && url.origin !== origin) {
-        externalRequests.push(request.url());
-      }
-      if (url.protocol === 'https:') {
-        externalRequests.push(request.url());
-      }
-    });
-    page.on('console', (message) => {
-      if (message.type() === 'error') {
-        consoleErrors.push(message.text());
-      }
-    });
+async function verifyBrowser(browser: Browser, workerPath: string) {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  const externalRequests: string[] = [];
+  const consoleErrors: string[] = [];
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (url.protocol === 'http:' && url.origin !== origin) {
+      externalRequests.push(request.url());
+    }
+    if (url.protocol === 'https:') {
+      externalRequests.push(request.url());
+    }
+  });
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
 
-    await page.goto(`${origin}/iframe.html?id=pages-rulesets-create--authenticated&viewMode=story`, {
-      waitUntil: 'networkidle',
-    });
-    await page.getByRole('heading', { name: 'Create ruleset' }).waitFor({ timeout: 45_000 });
-    await page.waitForTimeout(1000);
-    invariant(externalRequests.length === 0, `Storybook requested an external URL: ${externalRequests.join(', ')}`);
-    invariant(consoleErrors.length === 0, `Storybook logged browser errors: ${consoleErrors.join('\n')}`);
+  await page.goto(`${origin}/iframe.html?id=pages-rulesets-create--authenticated&viewMode=story`, {
+    waitUntil: 'networkidle',
+  });
+  await page.getByRole('heading', { name: 'Create ruleset' }).waitFor({ timeout: 45_000 });
+  await page.waitForTimeout(1000);
+  invariant(externalRequests.length === 0, `Storybook requested an external URL: ${externalRequests.join(', ')}`);
+  invariant(consoleErrors.length === 0, `Storybook logged browser errors: ${consoleErrors.join('\n')}`);
 
-    const networkResult = await page.evaluate(async (timeoutMs) => {
-      const controller = new AbortController();
-      const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
-      try {
-        await fetch('https://example.com', { signal: controller.signal });
-        return 'connected';
-      } catch (error) {
-        return error instanceof Error ? error.message : String(error);
-      } finally {
+  const networkResult = await page.evaluate(async (timeoutMs) => {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      await fetch('https://example.com', { signal: controller.signal });
+      return 'connected';
+    } catch (error) {
+      return error instanceof Error ? error.message : String(error);
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  }, NETWORK_PROBE_TIMEOUT_MS);
+  invariant(networkResult !== 'connected', 'The Storybook document connected to an external origin.');
+
+  const subworkerResult = await page.evaluate(async (url) => {
+    return await new Promise<string>((resolve, reject) => {
+      const worker = new Worker(url, { type: 'module' });
+      const timeout = window.setTimeout(() => reject(new Error('The subworker probe timed out.')), 15_000);
+      worker.addEventListener('message', (event: MessageEvent<{ id: number; result?: unknown }>) => {
+        if (event.data.id !== 1) {
+          return;
+        }
         window.clearTimeout(timeout);
-      }
-    }, NETWORK_PROBE_TIMEOUT_MS);
-    invariant(networkResult !== 'connected', 'The Storybook document connected to an external origin.');
-
-    const subworkerResult = await page.evaluate(async (url) => {
-      return await new Promise<string>((resolve, reject) => {
-        const worker = new Worker(url, { type: 'module' });
-        const timeout = window.setTimeout(() => reject(new Error('The subworker probe timed out.')), 15_000);
-        worker.addEventListener('message', (event: MessageEvent<{ id: number; result?: unknown }>) => {
-          if (event.data.id !== 1) {
-            return;
-          }
-          window.clearTimeout(timeout);
-          worker.terminate();
-          resolve(String(event.data.result));
-        });
-        worker.addEventListener('error', (event) => reject(new Error(event.message)));
-        worker.postMessage({ id: 1, operation: 'subworkerProbe' });
+        worker.terminate();
+        resolve(String(event.data.result));
       });
-    }, `${origin}${workerPath}`);
-    invariant(
-      subworkerResult !== 'The Convex Storybook worker started a subworker.',
-      'The Convex Storybook worker started a subworker despite its CSP.'
-    );
-  } finally {
-    await browser.close();
-  }
+      worker.addEventListener('error', (event) => reject(new Error(event.message)));
+      worker.postMessage({ id: 1, operation: 'subworkerProbe' });
+    });
+  }, `${origin}${workerPath}`);
+  invariant(
+    subworkerResult !== 'The Convex Storybook worker started a subworker.',
+    'The Convex Storybook worker started a subworker despite its CSP.'
+  );
+  await context.close();
 }
 
-async function verifyNonRootPath() {
-  const nonRootOrigin = 'http://127.0.0.1:6843';
+function startNonRootServer() {
   const prefix = '/catalogue/';
-  const server = Bun.serve({
+  return Bun.serve({
     hostname: '127.0.0.1',
     port: 6843,
     fetch(request) {
@@ -255,82 +255,108 @@ async function verifyNonRootPath() {
       return file.exists().then((exists) => (exists ? new Response(file) : new Response('Not found', { status: 404 })));
     },
   });
+}
+
+async function verifyNonRootPath(browser: Browser) {
+  const nonRootOrigin = 'http://127.0.0.1:6843';
+  const prefix = '/catalogue/';
+  const context = await browser.newContext();
+  const page: Page = await context.newPage();
+  const externalRequests: string[] = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).origin !== nonRootOrigin) {
+      externalRequests.push(request.url());
+    }
+  });
+  await page.goto(`${nonRootOrigin}${prefix}iframe.html?id=pages-rulesets-create--authenticated&viewMode=story`, {
+    waitUntil: 'networkidle',
+  });
+  await page.getByRole('heading', { name: 'Create ruleset' }).waitFor({ timeout: 45_000 });
+  invariant(
+    externalRequests.length === 0,
+    `Non-root Storybook requested an external URL: ${externalRequests.join(', ')}`
+  );
+  progress('The non-root story rendered.');
+  progress('Clearing the non-root story before context shutdown.');
+  await page.goto('about:blank', { waitUntil: 'commit', timeout: PAGE_CLEAR_TIMEOUT_MS });
+  progress('Closing the non-root browser context.');
+  await context.close();
+}
+
+async function runBrowserChecks() {
   const browser = await chromium.launch({ headless: true });
-  let page: Page | undefined;
   try {
-    page = await browser.newPage();
-    const externalRequests: string[] = [];
-    page.on('request', (request) => {
-      if (new URL(request.url()).origin !== nonRootOrigin) {
-        externalRequests.push(request.url());
-      }
+    const workerPath = inspectArtifact();
+    progress('Checking the published story in Chromium.');
+    await verifyBrowser(browser, workerPath);
+    progress('Checking publication from a non-root path.');
+    await verifyNonRootPath(browser);
+  } catch (error) {
+    /* The parent owns the servers and kills this disposable child when Chromium stops answering. */
+    console.error(error);
+    process.exit(error instanceof errors.TimeoutError ? RETRYABLE_BROWSER_CHECK_STATUS : 1);
+  }
+  await browser.close();
+}
+
+async function verifyPublication() {
+  progress('Building the static Storybook.');
+  await run([process.execPath, 'run', 'build-storybook'], buildEnvironment());
+  const workerPath = inspectArtifact();
+  progress('Checking the publication worker bundle.');
+  await run([process.execPath, 'x', 'wrangler', 'deploy', '--dry-run', '--config', wranglerConfig], buildEnvironment());
+
+  const nonRootServer = startNonRootServer();
+  const wrangler = Bun.spawn(
+    [
+      process.execPath,
+      'x',
+      'wrangler',
+      'dev',
+      '--local',
+      '--ip',
+      '127.0.0.1',
+      '--port',
+      String(port),
+      '--config',
+      wranglerConfig,
+    ],
+    {
+      cwd: repositoryRoot,
+      env: buildEnvironment(),
+      stderr: 'inherit',
+      stdout: 'inherit',
+    }
+  );
+  try {
+    progress('Waiting for the publication worker.');
+    await waitForServer(wrangler);
+    progress('Checking publication headers.');
+    await verifyHeaders(workerPath);
+    await runBrowserCheck({
+      spawn: () =>
+        Bun.spawn([process.execPath, path.join(repositoryRoot, 'scripts/verify-storybook-publication.ts')], {
+          cwd: repositoryRoot,
+          env: { ...buildEnvironment(), [BROWSER_CHECK_CHILD]: 'true' },
+          stderr: 'inherit',
+          stdout: 'inherit',
+        }),
+      timeoutMs: BROWSER_CHECK_TIMEOUT_MS,
+      shutdownTimeoutMs: PROCESS_SHUTDOWN_TIMEOUT_MS,
+      onRetry: (reason) => progress(`Retrying the browser publication check because ${reason}.`),
     });
-    await page.goto(`${nonRootOrigin}${prefix}iframe.html?id=pages-rulesets-create--authenticated&viewMode=story`, {
-      waitUntil: 'networkidle',
-    });
-    await page.getByRole('heading', { name: 'Create ruleset' }).waitFor({ timeout: 45_000 });
-    invariant(
-      externalRequests.length === 0,
-      `Non-root Storybook requested an external URL: ${externalRequests.join(', ')}`
-    );
-    progress('The non-root story rendered.');
   } finally {
-    progress('Clearing the non-root story before Chromium shutdown.');
-    if (page && !page.isClosed()) {
-      await page
-        .goto('about:blank', { waitUntil: 'commit', timeout: PAGE_CLEAR_TIMEOUT_MS })
-        .catch((error) => progress(`The non-root story did not clear: ${String(error)}`));
-    }
-    progress('Stopping non-root Chromium.');
-    try {
-      await browser.close();
-    } finally {
-      progress('Stopping the non-root static server.');
-      server.stop(true);
-    }
+    progress('Stopping the non-root static server.');
+    nonRootServer.stop(true);
+    progress('Stopping the publication worker.');
+    await stopProcess(wrangler);
   }
+
+  console.log(JSON.stringify({ ok: true, workerPath, origin }));
 }
 
-progress('Building the static Storybook.');
-await run([process.execPath, 'run', 'build-storybook'], buildEnvironment());
-const workerPath = inspectArtifact();
-progress('Checking the publication worker bundle.');
-await run([process.execPath, 'x', 'wrangler', 'deploy', '--dry-run', '--config', wranglerConfig], buildEnvironment());
-
-const wrangler = Bun.spawn(
-  [
-    process.execPath,
-    'x',
-    'wrangler',
-    'dev',
-    '--local',
-    '--ip',
-    '127.0.0.1',
-    '--port',
-    String(port),
-    '--config',
-    wranglerConfig,
-  ],
-  {
-    cwd: repositoryRoot,
-    env: buildEnvironment(),
-    stderr: 'inherit',
-    stdout: 'inherit',
-  }
-);
-try {
-  progress('Waiting for the publication worker.');
-  await waitForServer(wrangler);
-  progress('Checking publication headers.');
-  await verifyHeaders(workerPath);
-  progress('Checking the published story in Chromium.');
-  await verifyBrowser(workerPath);
-} finally {
-  progress('Stopping the publication worker.');
-  await stopProcess(wrangler);
+if (process.env[BROWSER_CHECK_CHILD] === 'true') {
+  await runBrowserChecks();
+} else {
+  await verifyPublication();
 }
-
-progress('Checking publication from a non-root path.');
-await verifyNonRootPath();
-
-console.log(JSON.stringify({ ok: true, workerPath, origin }));

--- a/src/game/assets/card/Spice.module.css
+++ b/src/game/assets/card/Spice.module.css
@@ -1,5 +1,5 @@
 .shape {
-  background: url("/image/card/base-full-large.webp");
+  background-image: url("/image/card/base-full-large.webp");
 }
 
 .logo {

--- a/src/game/assets/card/Spice.stories.ts
+++ b/src/game/assets/card/Spice.stories.ts
@@ -1,4 +1,5 @@
 import preview from '@sb/preview';
+import { expect } from 'storybook/test';
 
 import { SpiceCard } from './Spice';
 
@@ -18,6 +19,14 @@ export const Arsunt = meta.story({
     icon: 'spice-mine',
     highlights: ['arsunt'],
     amount: 3,
+  },
+  play: async ({ canvasElement }) => {
+    const shape = Array.from(canvasElement.querySelectorAll<HTMLElement>('div')).find((element) =>
+      getComputedStyle(element).backgroundImage.includes('/image/card/base-full-large.webp')
+    );
+
+    expect(shape).toBeDefined();
+    expect(getComputedStyle(shape as HTMLElement).backgroundSize).toBe('100% 100%');
   },
 });
 


### PR DESCRIPTION
## Summary

- preserve the base card's full-frame background sizing when the Spice renderer swaps textures
- add a rendered Storybook assertion for the Arsunt card's computed background size
- contain the publication verifier's Playwright work in a bounded, retryable browser process

## Causes

### Spice card

The Spice stylesheet used the `background` shorthand. That reset the base card's `background-size: 100% 100%` to `auto`, so the generated 640x898 texture tiled across the 900x1263 renderer.

### Storybook CI timeout

The failed Storybook job completed the root publication check. The non-root story then hit Playwright's 30-second `networkidle` navigation timeout. Its cleanup navigation to `about:blank` also timed out, after which the unbounded `browser.close()` call never returned. GitHub cancelled the job at its 15-minute limit.

This was not a Storybook build-size timeout. A stress loop reproduced Chromium becoming unresponsive after repeated fresh launches of the authenticated story, while 50 isolated contexts in one Chromium process passed. The heavy story makes the lifecycle fault easier to trigger, but the CI defect was trusting an unresponsive browser to close itself.

## CI fix

- keep both local servers in the parent process, outside Playwright's failure boundary
- run the root and non-root checks in isolated contexts inside one disposable Chromium child
- give the child a hard deadline, then terminate it and retry once when navigation or cleanup wedges
- fail publication assertions immediately instead of retrying them
- cover normal termination, forced termination, retry, exhaustion, and assertion failure in a focused unit suite

## Validation

- `bun run storybook:test -- src/game/assets/card/Spice.stories.ts` (26 passed)
- `bun run storybook:test --coverage.enabled=true --reporter=default --reporter=junit --outputFile.junit=test-results/vitest-storybook.junit.xml` (439 passed)
- `bun run test` (762 passed)
- `bun run typecheck`
- `bun run verify:images` (1,108 generated files verified)
- `bun run verify:storybook-publication` (passed twice, then 8 consecutive stress-loop runs)
- `VITE_CONVEX_URL=https://storybook.invalid bun run check`
- `VITE_CONVEX_URL=https://storybook.invalid bun run publisher:release:verify`

## Visual proof

Before, production renders the 640x898 card texture at its intrinsic size, so it repeats inside the 900x1263 card. After, one texture fills the renderer while the map, type icon, text, and amount keep their existing geometry. Both captures use the Arsunt story at 1117x1199.

| Before | After |
| --- | --- |
| ![The production Arsunt Spice card with its frame texture tiled across the renderer](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-787-before-arsunt-spice-card.jpg) | ![The fixed Arsunt Spice card with one frame texture filling the renderer](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-787-after-arsunt-spice-card.jpg) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved card background image handling while preserving the existing visual appearance.
  * Improved Storybook publication verification by automatically retrying transient browser timeouts and ensuring stalled checks are stopped cleanly.

* **Tests**
  * Added Storybook coverage to verify cards render with the expected background image and full-size scaling.
  * Added automated coverage for browser-check retries, timeout handling, process termination, and publication failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
