### PR TITLE
The browser retry seam separates attempts from orchestration

### DIFF
--- a/scripts/storybook-publication-browser.test.ts
+++ b/scripts/storybook-publication-browser.test.ts
@@ -10,43 +10,31 @@ function processThatExits(status: number): BrowserCheckProcess {
   };
 }
 
-function processThatStopsWhenKilled(): BrowserCheckProcess {
+function processThatStopsOn(signal?: NodeJS.Signals): BrowserCheckProcess {
   let resolveExit: (status: number) => void = () => undefined;
   return {
     exited: new Promise((resolve) => {
       resolveExit = resolve;
     }),
-    kill: vi.fn(() => resolveExit(143)),
-  };
-}
-
-function processThatStopsAfterSigkill(): BrowserCheckProcess {
-  let resolveExit: (status: number) => void = () => undefined;
-  return {
-    exited: new Promise((resolve) => {
-      resolveExit = resolve;
-    }),
-    kill: vi.fn((signal) => {
-      if (signal === 'SIGKILL') {
-        resolveExit(137);
+    kill: vi.fn((receivedSignal) => {
+      if (receivedSignal === signal) {
+        resolveExit(signal === 'SIGKILL' ? 137 : 143);
       }
     }),
   };
 }
 
+function check(spawn: () => BrowserCheckProcess, timeoutMs = 10) {
+  return runBrowserCheck({ spawn, timeoutMs, shutdownTimeoutMs: 1 });
+}
+
 describe('Storybook publication browser process', () => {
   test('kills a timed-out browser check and retries it once', async () => {
-    const timedOut = processThatStopsWhenKilled();
+    const timedOut = processThatStopsOn();
     const passed = processThatExits(0);
     const spawn = vi.fn().mockReturnValueOnce(timedOut).mockReturnValueOnce(passed);
 
-    await expect(
-      runBrowserCheck({
-        spawn,
-        timeoutMs: 1,
-        shutdownTimeoutMs: 1,
-      })
-    ).resolves.toBeUndefined();
+    await expect(check(spawn, 1)).resolves.toBeUndefined();
 
     expect(spawn).toHaveBeenCalledTimes(2);
     expect(timedOut.kill).toHaveBeenCalledOnce();
@@ -58,37 +46,30 @@ describe('Storybook publication browser process', () => {
       .mockReturnValueOnce(processThatExits(RETRYABLE_BROWSER_CHECK_STATUS))
       .mockReturnValueOnce(processThatExits(0));
 
-    await expect(runBrowserCheck({ spawn, timeoutMs: 10, shutdownTimeoutMs: 1 })).resolves.toBeUndefined();
+    await expect(check(spawn)).resolves.toBeUndefined();
     expect(spawn).toHaveBeenCalledTimes(2);
   });
 
   test('uses SIGKILL when the browser child ignores normal termination', async () => {
-    const timedOut = processThatStopsAfterSigkill();
+    const timedOut = processThatStopsOn('SIGKILL');
     const spawn = vi.fn().mockReturnValueOnce(timedOut).mockReturnValueOnce(processThatExits(0));
 
-    await expect(runBrowserCheck({ spawn, timeoutMs: 1, shutdownTimeoutMs: 1 })).resolves.toBeUndefined();
+    await expect(check(spawn, 1)).resolves.toBeUndefined();
     expect(timedOut.kill).toHaveBeenNthCalledWith(1);
     expect(timedOut.kill).toHaveBeenNthCalledWith(2, 'SIGKILL');
   });
 
   test('fails after two browser children time out', async () => {
-    const spawn = vi
-      .fn()
-      .mockReturnValueOnce(processThatStopsWhenKilled())
-      .mockReturnValueOnce(processThatStopsWhenKilled());
+    const spawn = vi.fn().mockReturnValueOnce(processThatStopsOn()).mockReturnValueOnce(processThatStopsOn());
 
-    await expect(runBrowserCheck({ spawn, timeoutMs: 1, shutdownTimeoutMs: 1 })).rejects.toThrow(
-      'Browser publication check exceeded 1ms on 2 attempts.'
-    );
+    await expect(check(spawn, 1)).rejects.toThrow('Browser publication check exceeded 1ms on 2 attempts.');
     expect(spawn).toHaveBeenCalledTimes(2);
   });
 
   test('does not retry a publication assertion failure', async () => {
     const spawn = vi.fn().mockReturnValue(processThatExits(1));
 
-    await expect(runBrowserCheck({ spawn, timeoutMs: 10, shutdownTimeoutMs: 1 })).rejects.toThrow(
-      'Browser publication check exited with status 1.'
-    );
+    await expect(check(spawn)).rejects.toThrow('Browser publication check exited with status 1.');
     expect(spawn).toHaveBeenCalledOnce();
   });
 });

--- a/scripts/storybook-publication-browser.ts
+++ b/scripts/storybook-publication-browser.ts
@@ -7,6 +7,11 @@ export type BrowserCheckProcess = {
 
 type BrowserCheckOutcome = { kind: 'exit'; status: number } | { kind: 'timeout' };
 
+type BrowserCheckAttempt =
+  | { kind: 'passed' }
+  | { kind: 'retry'; reason: string; exhaustedMessage: string }
+  | { kind: 'failed'; status: number };
+
 type RunBrowserCheckOptions = {
   spawn: () => BrowserCheckProcess;
   timeoutMs: number;
@@ -37,6 +42,34 @@ async function stopProcess(process: BrowserCheckProcess, shutdownTimeoutMs: numb
   }
 }
 
+async function runBrowserCheckAttempt(
+  spawn: () => BrowserCheckProcess,
+  timeoutMs: number,
+  shutdownTimeoutMs: number
+): Promise<BrowserCheckAttempt> {
+  const process = spawn();
+  const outcome = await waitForProcess(process, timeoutMs);
+  if (outcome.kind === 'timeout') {
+    await stopProcess(process, shutdownTimeoutMs);
+    return {
+      kind: 'retry',
+      reason: `exceeded ${timeoutMs}ms`,
+      exhaustedMessage: `Browser publication check exceeded ${timeoutMs}ms`,
+    };
+  }
+  if (outcome.status === 0) {
+    return { kind: 'passed' };
+  }
+  if (outcome.status === RETRYABLE_BROWSER_CHECK_STATUS) {
+    return {
+      kind: 'retry',
+      reason: 'reported a navigation timeout',
+      exhaustedMessage: 'Browser publication check reported a navigation timeout',
+    };
+  }
+  return { kind: 'failed', status: outcome.status };
+}
+
 export async function runBrowserCheck({
   spawn,
   timeoutMs,
@@ -45,23 +78,16 @@ export async function runBrowserCheck({
   onRetry = () => undefined,
 }: RunBrowserCheckOptions) {
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const process = spawn();
-    const outcome = await waitForProcess(process, timeoutMs);
-    if (outcome.kind === 'timeout') {
-      await stopProcess(process, shutdownTimeoutMs);
-      if (attempt < attempts) {
-        onRetry(`attempt ${attempt} exceeded ${timeoutMs}ms`);
-        continue;
-      }
-      throw new Error(`Browser publication check exceeded ${timeoutMs}ms on ${attempts} attempts.`);
-    }
-    if (outcome.status === 0) {
+    const result = await runBrowserCheckAttempt(spawn, timeoutMs, shutdownTimeoutMs);
+    if (result.kind === 'passed') {
       return;
     }
-    if (outcome.status === RETRYABLE_BROWSER_CHECK_STATUS && attempt < attempts) {
-      onRetry(`attempt ${attempt} reported a navigation timeout`);
-      continue;
+    if (result.kind === 'failed') {
+      throw new Error(`Browser publication check exited with status ${result.status}.`);
     }
-    throw new Error(`Browser publication check exited with status ${outcome.status}.`);
+    if (attempt === attempts) {
+      throw new Error(`${result.exhaustedMessage} on ${attempts} attempts.`);
+    }
+    onRetry(`attempt ${attempt} ${result.reason}`);
   }
 }


### PR DESCRIPTION
## Summary

- separate one browser-check attempt from the retry coordinator
- consolidate the killable subprocess fixtures used by the regression suite

## Context

This is a behavior-preserving follow-up to #787. That PR merged after its full CI and Storybook gates passed. CodeScene then identified avoidable branching in `runBrowserCheck` and duplicated subprocess setup in its new unit tests.

## Validation

- `bun run test -- scripts/storybook-publication-browser.test.ts` (5 passed)
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run verify:storybook-publication`
- `VITE_CONVEX_URL=https://storybook.invalid bun run publisher:release:verify`
