### PR TITLE
PageLayout owns viewport-wide Rulebook editing content

### DIFF
--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.module.css
@@ -1,8 +1,5 @@
 .editorRoot {
-  --editor-side-space: clamp(1rem, calc((100vw - 64rem) * 1.25 + 1rem), 2.5rem);
   container: rulebook-editor / inline-size;
-  width: min(116rem, calc(100vw - var(--editor-side-space) - var(--editor-side-space)));
-  margin-inline-start: max(calc(50% - 58rem), calc(50% - 50vw + var(--editor-side-space)));
   padding-bottom: 3rem;
 }
 

--- a/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/rulebooks/$rulebookSlug/edit.tsx
@@ -762,7 +762,7 @@ function RulebookEditorPage() {
           </Toolbar.Right>
         </Toolbar>
       </PageLayout.Toolbar>
-      <PageLayout.Content>
+      <PageLayout.Content width="viewport">
         <section className={styles.editorRoot} aria-label="Rulebook editing workspace">
           <RulebookWorkspace result={result} dispatch={dispatch} fit={fit} />
         </section>

--- a/src/app/shell/ShellStoryPage.stories.fixture.tsx
+++ b/src/app/shell/ShellStoryPage.stories.fixture.tsx
@@ -35,11 +35,11 @@ function ShellStoryPage({ headerSize }: { headerSize?: 'default' | 'compact' }) 
     <PageLayout>
       {headerSize && (
         <PageLayout.Header size={headerSize}>
-          <LayoutSlotPlaceholder name="header slot" minHeight={0} />
+          <LayoutSlotPlaceholder name="header slot" tone="header" minHeight={0} />
         </PageLayout.Header>
       )}
       <PageLayout.Content>
-        <LayoutSlotPlaceholder name="children slot" minHeight={1400} />
+        <LayoutSlotPlaceholder name="children slot" tone="primary" minHeight={1400} />
       </PageLayout.Content>
     </PageLayout>
   );

--- a/src/app/ui/layout/AsymmetricSplitLayout.stories.tsx
+++ b/src/app/ui/layout/AsymmetricSplitLayout.stories.tsx
@@ -17,14 +17,14 @@ const meta = preview.meta({
   },
 });
 
-const narrow = <LayoutSlotPlaceholder name="narrow" minHeight={360} />;
+const narrow = <LayoutSlotPlaceholder name="narrow" tone="secondary" minHeight={360} />;
 
 /** Above the container breakpoint: unequal columns, wide leading. */
 export const TwoColumns = meta.story({
   render: () => (
     <AsymmetricSplitLayout>
       <AsymmetricSplitLayout.Wide>
-        <LayoutSlotPlaceholder name="wide" minHeight={360} />
+        <LayoutSlotPlaceholder name="wide" tone="primary" minHeight={360} />
       </AsymmetricSplitLayout.Wide>
       <AsymmetricSplitLayout.Narrow>{narrow}</AsymmetricSplitLayout.Narrow>
     </AsymmetricSplitLayout>
@@ -37,7 +37,7 @@ export const Stacked = meta.story({
   render: () => (
     <AsymmetricSplitLayout>
       <AsymmetricSplitLayout.Wide>
-        <LayoutSlotPlaceholder name="wide" minHeight={360} />
+        <LayoutSlotPlaceholder name="wide" tone="primary" minHeight={360} />
       </AsymmetricSplitLayout.Wide>
       <AsymmetricSplitLayout.Narrow>{narrow}</AsymmetricSplitLayout.Narrow>
     </AsymmetricSplitLayout>
@@ -66,10 +66,10 @@ export const SlimRail = meta.story({
   render: () => (
     <AsymmetricSplitLayout rail="slim">
       <AsymmetricSplitLayout.Wide>
-        <LayoutSlotPlaceholder name="wide" minHeight={280} />
+        <LayoutSlotPlaceholder name="wide" tone="primary" minHeight={280} />
       </AsymmetricSplitLayout.Wide>
       <AsymmetricSplitLayout.Narrow>
-        <LayoutSlotPlaceholder name="narrow" minHeight={280} />
+        <LayoutSlotPlaceholder name="narrow" tone="secondary" minHeight={280} />
       </AsymmetricSplitLayout.Narrow>
     </AsymmetricSplitLayout>
   ),

--- a/src/app/ui/layout/AtlasLayout.stories.tsx
+++ b/src/app/ui/layout/AtlasLayout.stories.tsx
@@ -16,7 +16,7 @@ const meta = preview.meta({
   },
 });
 
-const sidebar = <LayoutSlotPlaceholder name="sidebar" minHeight={240} />;
+const sidebar = <LayoutSlotPlaceholder name="sidebar" tone="secondary" minHeight={240} />;
 
 /** Above the container breakpoint: sidebar beside the content. */
 export const WithSidebar = meta.story({
@@ -24,7 +24,7 @@ export const WithSidebar = meta.story({
     <AtlasLayout>
       <AtlasLayout.Sidebar>{sidebar}</AtlasLayout.Sidebar>
       <AtlasLayout.Content>
-        <LayoutSlotPlaceholder name="children" minHeight={720} />
+        <LayoutSlotPlaceholder name="children" tone="primary" minHeight={720} />
       </AtlasLayout.Content>
     </AtlasLayout>
   ),
@@ -37,7 +37,7 @@ export const Stacked = meta.story({
     <AtlasLayout>
       <AtlasLayout.Sidebar>{sidebar}</AtlasLayout.Sidebar>
       <AtlasLayout.Content>
-        <LayoutSlotPlaceholder name="children" minHeight={720} />
+        <LayoutSlotPlaceholder name="children" tone="primary" minHeight={720} />
       </AtlasLayout.Content>
     </AtlasLayout>
   ),
@@ -50,7 +50,7 @@ export const StickySidebarWhileScrolling = meta.story({
     <AtlasLayout>
       <AtlasLayout.Sidebar>{sidebar}</AtlasLayout.Sidebar>
       <AtlasLayout.Content>
-        <LayoutSlotPlaceholder name="scrolling children" minHeight={1600} />
+        <LayoutSlotPlaceholder name="scrolling children" tone="primary" minHeight={1600} />
       </AtlasLayout.Content>
     </AtlasLayout>
   ),

--- a/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
+++ b/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
@@ -22,13 +22,13 @@ export const ThreeColumns = meta.story({
   render: () => (
     <ColumnsWithRailLayout>
       <ColumnsWithRailLayout.Primary>
-        <LayoutSlotPlaceholder name="primary" minHeight={420} />
+        <LayoutSlotPlaceholder name="primary" tone="primary" minHeight={420} />
       </ColumnsWithRailLayout.Primary>
       <ColumnsWithRailLayout.Secondary>
-        <LayoutSlotPlaceholder name="secondary" minHeight={320} />
+        <LayoutSlotPlaceholder name="secondary" tone="secondary" minHeight={320} />
       </ColumnsWithRailLayout.Secondary>
       <ColumnsWithRailLayout.Rail>
-        <LayoutSlotPlaceholder name="rail" minHeight={240} />
+        <LayoutSlotPlaceholder name="rail" tone="tertiary" minHeight={240} />
       </ColumnsWithRailLayout.Rail>
     </ColumnsWithRailLayout>
   ),
@@ -40,13 +40,13 @@ export const ReadingColumnsStacked = meta.story({
   render: () => (
     <ColumnsWithRailLayout>
       <ColumnsWithRailLayout.Primary>
-        <LayoutSlotPlaceholder name="primary" minHeight={420} />
+        <LayoutSlotPlaceholder name="primary" tone="primary" minHeight={420} />
       </ColumnsWithRailLayout.Primary>
       <ColumnsWithRailLayout.Secondary>
-        <LayoutSlotPlaceholder name="secondary" minHeight={320} />
+        <LayoutSlotPlaceholder name="secondary" tone="secondary" minHeight={320} />
       </ColumnsWithRailLayout.Secondary>
       <ColumnsWithRailLayout.Rail>
-        <LayoutSlotPlaceholder name="rail" minHeight={240} />
+        <LayoutSlotPlaceholder name="rail" tone="tertiary" minHeight={240} />
       </ColumnsWithRailLayout.Rail>
     </ColumnsWithRailLayout>
   ),
@@ -58,13 +58,13 @@ export const Stacked = meta.story({
   render: () => (
     <ColumnsWithRailLayout>
       <ColumnsWithRailLayout.Primary>
-        <LayoutSlotPlaceholder name="primary" minHeight={420} />
+        <LayoutSlotPlaceholder name="primary" tone="primary" minHeight={420} />
       </ColumnsWithRailLayout.Primary>
       <ColumnsWithRailLayout.Secondary>
-        <LayoutSlotPlaceholder name="secondary" minHeight={320} />
+        <LayoutSlotPlaceholder name="secondary" tone="secondary" minHeight={320} />
       </ColumnsWithRailLayout.Secondary>
       <ColumnsWithRailLayout.Rail>
-        <LayoutSlotPlaceholder name="rail" minHeight={240} />
+        <LayoutSlotPlaceholder name="rail" tone="tertiary" minHeight={240} />
       </ColumnsWithRailLayout.Rail>
     </ColumnsWithRailLayout>
   ),
@@ -82,10 +82,10 @@ export const IntrinsicSizingStress = meta.story({
         </Stack>
       </ColumnsWithRailLayout.Primary>
       <ColumnsWithRailLayout.Secondary>
-        <LayoutSlotPlaceholder name="secondary" minHeight={320} />
+        <LayoutSlotPlaceholder name="secondary" tone="secondary" minHeight={320} />
       </ColumnsWithRailLayout.Secondary>
       <ColumnsWithRailLayout.Rail>
-        <LayoutSlotPlaceholder name="rail" minHeight={240} />
+        <LayoutSlotPlaceholder name="rail" tone="tertiary" minHeight={240} />
       </ColumnsWithRailLayout.Rail>
     </ColumnsWithRailLayout>
   ),

--- a/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
+++ b/src/app/ui/layout/ColumnsWithRailLayout.stories.tsx
@@ -17,19 +17,17 @@ const meta = preview.meta({
   },
 });
 
+const primary = <LayoutSlotPlaceholder name="primary" tone="primary" minHeight={420} />;
+const secondary = <LayoutSlotPlaceholder name="secondary" tone="secondary" minHeight={320} />;
+const rail = <LayoutSlotPlaceholder name="rail" tone="tertiary" minHeight={240} />;
+
 /** Widest: three columns, the rail last and narrowest. */
 export const ThreeColumns = meta.story({
   render: () => (
     <ColumnsWithRailLayout>
-      <ColumnsWithRailLayout.Primary>
-        <LayoutSlotPlaceholder name="primary" tone="primary" minHeight={420} />
-      </ColumnsWithRailLayout.Primary>
-      <ColumnsWithRailLayout.Secondary>
-        <LayoutSlotPlaceholder name="secondary" tone="secondary" minHeight={320} />
-      </ColumnsWithRailLayout.Secondary>
-      <ColumnsWithRailLayout.Rail>
-        <LayoutSlotPlaceholder name="rail" tone="tertiary" minHeight={240} />
-      </ColumnsWithRailLayout.Rail>
+      <ColumnsWithRailLayout.Primary>{primary}</ColumnsWithRailLayout.Primary>
+      <ColumnsWithRailLayout.Secondary>{secondary}</ColumnsWithRailLayout.Secondary>
+      <ColumnsWithRailLayout.Rail>{rail}</ColumnsWithRailLayout.Rail>
     </ColumnsWithRailLayout>
   ),
   globals: { viewport: { value: 'appDesktop' } },
@@ -39,15 +37,9 @@ export const ThreeColumns = meta.story({
 export const ReadingColumnsStacked = meta.story({
   render: () => (
     <ColumnsWithRailLayout>
-      <ColumnsWithRailLayout.Primary>
-        <LayoutSlotPlaceholder name="primary" tone="primary" minHeight={420} />
-      </ColumnsWithRailLayout.Primary>
-      <ColumnsWithRailLayout.Secondary>
-        <LayoutSlotPlaceholder name="secondary" tone="secondary" minHeight={320} />
-      </ColumnsWithRailLayout.Secondary>
-      <ColumnsWithRailLayout.Rail>
-        <LayoutSlotPlaceholder name="rail" tone="tertiary" minHeight={240} />
-      </ColumnsWithRailLayout.Rail>
+      <ColumnsWithRailLayout.Primary>{primary}</ColumnsWithRailLayout.Primary>
+      <ColumnsWithRailLayout.Secondary>{secondary}</ColumnsWithRailLayout.Secondary>
+      <ColumnsWithRailLayout.Rail>{rail}</ColumnsWithRailLayout.Rail>
     </ColumnsWithRailLayout>
   ),
   globals: { viewport: { value: 'appConstrained' } },
@@ -57,15 +49,9 @@ export const ReadingColumnsStacked = meta.story({
 export const Stacked = meta.story({
   render: () => (
     <ColumnsWithRailLayout>
-      <ColumnsWithRailLayout.Primary>
-        <LayoutSlotPlaceholder name="primary" tone="primary" minHeight={420} />
-      </ColumnsWithRailLayout.Primary>
-      <ColumnsWithRailLayout.Secondary>
-        <LayoutSlotPlaceholder name="secondary" tone="secondary" minHeight={320} />
-      </ColumnsWithRailLayout.Secondary>
-      <ColumnsWithRailLayout.Rail>
-        <LayoutSlotPlaceholder name="rail" tone="tertiary" minHeight={240} />
-      </ColumnsWithRailLayout.Rail>
+      <ColumnsWithRailLayout.Primary>{primary}</ColumnsWithRailLayout.Primary>
+      <ColumnsWithRailLayout.Secondary>{secondary}</ColumnsWithRailLayout.Secondary>
+      <ColumnsWithRailLayout.Rail>{rail}</ColumnsWithRailLayout.Rail>
     </ColumnsWithRailLayout>
   ),
   globals: { viewport: { value: 'appMobile' } },
@@ -81,12 +67,8 @@ export const IntrinsicSizingStress = meta.story({
           <Image alt="Intrinsic sizing test" mah={320} src="/web/tablet1.jpg" w={1400} />
         </Stack>
       </ColumnsWithRailLayout.Primary>
-      <ColumnsWithRailLayout.Secondary>
-        <LayoutSlotPlaceholder name="secondary" tone="secondary" minHeight={320} />
-      </ColumnsWithRailLayout.Secondary>
-      <ColumnsWithRailLayout.Rail>
-        <LayoutSlotPlaceholder name="rail" tone="tertiary" minHeight={240} />
-      </ColumnsWithRailLayout.Rail>
+      <ColumnsWithRailLayout.Secondary>{secondary}</ColumnsWithRailLayout.Secondary>
+      <ColumnsWithRailLayout.Rail>{rail}</ColumnsWithRailLayout.Rail>
     </ColumnsWithRailLayout>
   ),
   globals: { viewport: { value: 'appDesktop' } },

--- a/src/app/ui/layout/LayoutSlotPlaceholder.stories.fixture.tsx
+++ b/src/app/ui/layout/LayoutSlotPlaceholder.stories.fixture.tsx
@@ -14,11 +14,11 @@ export function LayoutSlotPlaceholder({
   name,
   tone,
   minHeight = 240,
-}: {
+}: Readonly<{
   name: string;
   tone: LayoutSlotPlaceholderTone;
   minHeight?: number;
-}) {
+}>) {
   const color = toneColors[tone];
 
   return (

--- a/src/app/ui/layout/LayoutSlotPlaceholder.stories.fixture.tsx
+++ b/src/app/ui/layout/LayoutSlotPlaceholder.stories.fixture.tsx
@@ -1,15 +1,38 @@
 import { Center, Text } from '@mantine/core';
 
-export function LayoutSlotPlaceholder({ name, minHeight = 240 }: { name: string; minHeight?: number }) {
+type LayoutSlotPlaceholderTone = 'header' | 'primary' | 'secondary' | 'tertiary' | 'toolbar';
+
+const toneColors: Record<LayoutSlotPlaceholderTone, string> = {
+  header: 'blue',
+  toolbar: 'violet',
+  primary: 'teal',
+  secondary: 'orange',
+  tertiary: 'pink',
+};
+
+export function LayoutSlotPlaceholder({
+  name,
+  tone,
+  minHeight = 240,
+}: {
+  name: string;
+  tone: LayoutSlotPlaceholderTone;
+  minHeight?: number;
+}) {
+  const color = toneColors[tone];
+
   return (
     <Center
-      bg="gray.1"
-      c="dimmed"
+      bg={`${color}.1`}
+      c={`${color}.9`}
       h="100%"
       mih={minHeight}
       p="md"
       w="100%"
-      style={{ borderRadius: 'var(--mantine-radius-md)' }}
+      style={{
+        border: `1px solid var(--mantine-color-${color}-3)`,
+        borderRadius: 'var(--mantine-radius-md)',
+      }}
     >
       <Text ta="center" fw={700} size="sm">
         {name}

--- a/src/app/ui/layout/LayoutSlotPlaceholder.stories.fixture.tsx
+++ b/src/app/ui/layout/LayoutSlotPlaceholder.stories.fixture.tsx
@@ -2,7 +2,15 @@ import { Center, Text } from '@mantine/core';
 
 export function LayoutSlotPlaceholder({ name, minHeight = 240 }: { name: string; minHeight?: number }) {
   return (
-    <Center bg="gray.1" c="dimmed" h="100%" mih={minHeight} p="md" style={{ borderRadius: 'var(--mantine-radius-md)' }}>
+    <Center
+      bg="gray.1"
+      c="dimmed"
+      h="100%"
+      mih={minHeight}
+      p="md"
+      w="100%"
+      style={{ borderRadius: 'var(--mantine-radius-md)' }}
+    >
       <Text ta="center" fw={700} size="sm">
         {name}
       </Text>

--- a/src/app/ui/layout/PageLayout.module.css
+++ b/src/app/ui/layout/PageLayout.module.css
@@ -30,6 +30,17 @@
   gap: var(--space-4);
 }
 
+.toolbar,
+.pageContent {
+  width: 100%;
+  min-width: 0;
+}
+
+.pageContent[data-page-layout-content-width="viewport"] {
+  width: calc(100vw - 2 * var(--app-shell-inline-gutter, 20px));
+  margin-inline: calc(50% - 50vw + var(--app-shell-inline-gutter, 20px));
+}
+
 @media (max-width: 900px) {
   .headerContent {
     aspect-ratio: auto;

--- a/src/app/ui/layout/PageLayout.stories.tsx
+++ b/src/app/ui/layout/PageLayout.stories.tsx
@@ -1,5 +1,6 @@
 import preview from '@sb/preview';
-import { Toolbar } from '@ui/surface/Toolbar';
+import type { CSSProperties, ReactNode } from 'react';
+import { expect, waitFor } from 'storybook/test';
 
 import { LayoutSlotPlaceholder } from './LayoutSlotPlaceholder.stories.fixture';
 import { PageLayout } from './PageLayout';
@@ -12,18 +13,21 @@ import { PageLayout } from './PageLayout';
  * that negotiation belongs to
  * `Shell/AppHeader`'s stories, not here.
  */
-function ShellFrame({ children }: { children: React.ReactNode }) {
+function ShellFrame({ children }: { children: ReactNode }) {
   return (
     <div
-      style={{
-        display: 'grid',
-        gridTemplateAreas: '"hero" "content"',
-        gridTemplateColumns: 'minmax(0, 1fr)',
-        gap: 40,
-        padding: 20,
-        maxWidth: 1200,
-        marginInline: 'auto',
-      }}
+      style={
+        {
+          '--app-shell-inline-gutter': '20px',
+          display: 'grid',
+          gridTemplateAreas: '"hero" "content"',
+          gridTemplateColumns: 'minmax(0, 1fr)',
+          gap: 40,
+          padding: 20,
+          maxWidth: 1200,
+          marginInline: 'auto',
+        } as CSSProperties
+      }
     >
       <div
         aria-hidden
@@ -98,24 +102,56 @@ export const NoHeader = meta.story({
 });
 
 /**
- * The toolbar slot adds nothing around what it is given, so anything passed brings its own pane;
- * `Toolbar` is a surface and does.
+ * The toolbar slot adds nothing around what it is given.
  */
 export const WithToolbar = meta.story({
   render: () => (
     <PageLayout>
       <PageLayout.Header>{headerSlot}</PageLayout.Header>
       <PageLayout.Toolbar>
-        <Toolbar>
-          <Toolbar.Left>
-            <LayoutSlotPlaceholder name="toolbar controls" minHeight={0} />
-          </Toolbar.Left>
-        </Toolbar>
+        <LayoutSlotPlaceholder name="toolbar slot" minHeight={72} />
       </PageLayout.Toolbar>
       <PageLayout.Content>{contentSlot}</PageLayout.Content>
     </PageLayout>
   ),
   globals: { viewport: { value: 'appDesktop' } },
+});
+
+/**
+ * The header and toolbar keep the shell's normal measure.
+ * Only the content reaches from one shell gutter to the other.
+ */
+export const ViewportContent = meta.story({
+  render: () => (
+    <PageLayout>
+      <PageLayout.Header>{headerSlot}</PageLayout.Header>
+      <PageLayout.Toolbar>
+        <LayoutSlotPlaceholder name="toolbar slot" minHeight={72} />
+      </PageLayout.Toolbar>
+      <PageLayout.Content width="viewport">
+        <LayoutSlotPlaceholder name="content slot" minHeight={420} />
+      </PageLayout.Content>
+    </PageLayout>
+  ),
+  globals: { viewport: { value: 'appLarge' } },
+  play: async ({ canvasElement }) => {
+    const toolbar = canvasElement.querySelector<HTMLElement>('[data-page-layout-toolbar]');
+    const content = canvasElement.querySelector<HTMLElement>('[data-page-layout-content]');
+
+    await waitFor(() => {
+      expect(toolbar).not.toBeNull();
+      expect(content).not.toBeNull();
+
+      const toolbarRect = toolbar?.getBoundingClientRect();
+      const contentRect = content?.getBoundingClientRect();
+      const viewportWidth = canvasElement.ownerDocument.documentElement.clientWidth;
+
+      expect(contentRect?.width).toBeCloseTo(viewportWidth - 40, 0);
+      expect(contentRect?.width).toBeGreaterThan(toolbarRect?.width ?? Number.POSITIVE_INFINITY);
+      expect(contentRect?.left).toBeCloseTo(20, 0);
+      expect(contentRect?.right).toBeCloseTo(viewportWidth - 20, 0);
+    });
+  },
 });
 
 export const Mobile = meta.story({

--- a/src/app/ui/layout/PageLayout.stories.tsx
+++ b/src/app/ui/layout/PageLayout.stories.tsx
@@ -55,8 +55,8 @@ const meta = preview.meta({
   ],
 });
 
-const headerSlot = <LayoutSlotPlaceholder name="header slot" minHeight={0} />;
-const contentSlot = <LayoutSlotPlaceholder name="children slot" minHeight={320} />;
+const headerSlot = <LayoutSlotPlaceholder name="header slot" tone="header" minHeight={0} />;
+const contentSlot = <LayoutSlotPlaceholder name="children slot" tone="primary" minHeight={320} />;
 
 /** The header sits in the band's row, aligned to its lower edge. */
 export const WithHeader = meta.story({
@@ -101,7 +101,7 @@ export const WithToolbar = meta.story({
     <PageLayout>
       <PageLayout.Header>{headerSlot}</PageLayout.Header>
       <PageLayout.Toolbar>
-        <LayoutSlotPlaceholder name="toolbar slot" minHeight={72} />
+        <LayoutSlotPlaceholder name="toolbar slot" tone="toolbar" minHeight={72} />
       </PageLayout.Toolbar>
       <PageLayout.Content>{contentSlot}</PageLayout.Content>
     </PageLayout>
@@ -118,10 +118,10 @@ export const ViewportContent = meta.story({
     <PageLayout>
       <PageLayout.Header>{headerSlot}</PageLayout.Header>
       <PageLayout.Toolbar>
-        <LayoutSlotPlaceholder name="toolbar slot" minHeight={72} />
+        <LayoutSlotPlaceholder name="toolbar slot" tone="toolbar" minHeight={72} />
       </PageLayout.Toolbar>
       <PageLayout.Content width="viewport">
-        <LayoutSlotPlaceholder name="content slot" minHeight={420} />
+        <LayoutSlotPlaceholder name="content slot" tone="primary" minHeight={420} />
       </PageLayout.Content>
     </PageLayout>
   ),

--- a/src/app/ui/layout/PageLayout.stories.tsx
+++ b/src/app/ui/layout/PageLayout.stories.tsx
@@ -13,7 +13,7 @@ import { PageLayout } from './PageLayout';
  * that negotiation belongs to
  * `Shell/AppHeader`'s stories, not here.
  */
-function ShellFrame({ children }: { children: ReactNode }) {
+function ShellFrame({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <div
       style={

--- a/src/app/ui/layout/PageLayout.stories.tsx
+++ b/src/app/ui/layout/PageLayout.stories.tsx
@@ -29,15 +29,7 @@ function ShellFrame({ children }: { children: ReactNode }) {
         } as CSSProperties
       }
     >
-      <div
-        aria-hidden
-        style={{
-          gridArea: 'hero',
-          minHeight: 180,
-          borderRadius: 6,
-          background: 'linear-gradient(180deg, rgba(120,90,50,0.55), rgba(40,30,20,0.75))',
-        }}
-      />
+      <div aria-hidden style={{ gridArea: 'hero', minHeight: 180 }} />
       {children}
     </div>
   );
@@ -50,7 +42,7 @@ const meta = preview.meta({
     docs: {
       description: {
         component:
-          "The frame every terminal route composes: a header that overlays the shell's artwork band, an optional toolbar, and the content. It claims grid areas from its parent rather than creating any, so these stories supply a stand-in frame — the band behind the header here is a placeholder, not the real one.",
+          "The frame every terminal route composes: a header that overlays the shell's artwork band, an optional toolbar, and the content. It claims grid areas from its parent rather than creating any, so these stories reserve unpainted shell grid rows without imitating the application artwork.",
       },
     },
   },

--- a/src/app/ui/layout/PageLayout.test.tsx
+++ b/src/app/ui/layout/PageLayout.test.tsx
@@ -56,4 +56,23 @@ describe('PageLayout', () => {
     expect(markup).toContain('<main');
     expect(markup).toContain('Minimal content');
   });
+
+  it('lets content opt into the viewport measure without widening the toolbar', () => {
+    const markup = renderToStaticMarkup(
+      <PageLayout>
+        <PageLayout.Toolbar>
+          <div>Page tools</div>
+        </PageLayout.Toolbar>
+        <PageLayout.Content width="viewport">
+          <p>Wide content</p>
+        </PageLayout.Content>
+      </PageLayout>
+    );
+
+    expect(markup).toContain('data-page-layout-toolbar="true"');
+    expect(markup).toContain('data-page-layout-content-width="viewport"');
+    expect(markup.indexOf('data-page-layout-toolbar')).toBeLessThan(
+      markup.indexOf('data-page-layout-content-width="viewport"')
+    );
+  });
 });

--- a/src/app/ui/layout/PageLayout.tsx
+++ b/src/app/ui/layout/PageLayout.tsx
@@ -10,6 +10,9 @@ import styles from './PageLayout.module.css';
  */
 export type PageHeaderSize = 'default' | 'compact' | 'hero';
 
+/** How much horizontal room the page content may claim. */
+export type PageContentWidth = 'default' | 'viewport';
+
 const InsidePageHeader = createContext(false);
 
 /**
@@ -30,7 +33,7 @@ function Toolbar(_: PropsWithChildren): null {
   return null;
 }
 
-function Content(_: PropsWithChildren): null {
+function Content(_: PropsWithChildren<{ width?: PageContentWidth }>): null {
   return null;
 }
 
@@ -42,7 +45,7 @@ function Content(_: PropsWithChildren): null {
  *
  * Slots: `Header` (omit it to mark the page intentionally compact;
  * `size="compact"` shrinks the band, and `size="hero"` declares a page whose title takes the display treatment), `Toolbar`, and
- * `Content`.
+ * `Content` (`width="viewport"` lets the content use the viewport between the shell gutters).
  */
 function PageLayoutBase({ children }: PropsWithChildren) {
   let hasHeader = false;
@@ -50,6 +53,7 @@ function PageLayoutBase({ children }: PropsWithChildren) {
   let headerSize: PageHeaderSize = 'default';
   let toolbar: ReactNode = null;
   let content: ReactNode = null;
+  let contentWidth: PageContentWidth = 'default';
 
   Children.forEach(children, (child) => {
     if (!isValidElement(child)) {
@@ -67,7 +71,9 @@ function PageLayoutBase({ children }: PropsWithChildren) {
       return;
     }
     if (child.type === Content) {
-      content = (child.props as PropsWithChildren).children;
+      const props = child.props as PropsWithChildren<{ width?: PageContentWidth }>;
+      content = props.children;
+      contentWidth = props.width ?? 'default';
     }
   });
 
@@ -85,8 +91,18 @@ function PageLayoutBase({ children }: PropsWithChildren) {
         </div>
       )}
       <main className={styles.content}>
-        {toolbar}
-        {content}
+        {toolbar != null && (
+          <div className={styles.toolbar} data-page-layout-toolbar>
+            {toolbar}
+          </div>
+        )}
+        <div
+          className={styles.pageContent}
+          data-page-layout-content
+          data-page-layout-content-width={contentWidth}
+        >
+          {content}
+        </div>
       </main>
     </div>
   );

--- a/src/app/ui/layout/PageLayout.tsx
+++ b/src/app/ui/layout/PageLayout.tsx
@@ -11,7 +11,7 @@ import styles from './PageLayout.module.css';
 export type PageHeaderSize = 'default' | 'compact' | 'hero';
 
 /** How much horizontal room the page content may claim. */
-export type PageContentWidth = 'default' | 'viewport';
+type PageContentWidth = 'default' | 'viewport';
 
 const InsidePageHeader = createContext(false);
 

--- a/src/app/ui/layout/PageLayout.tsx
+++ b/src/app/ui/layout/PageLayout.tsx
@@ -96,11 +96,7 @@ function PageLayoutBase({ children }: PropsWithChildren) {
             {toolbar}
           </div>
         )}
-        <div
-          className={styles.pageContent}
-          data-page-layout-content
-          data-page-layout-content-width={contentWidth}
-        >
+        <div className={styles.pageContent} data-page-layout-content data-page-layout-content-width={contentWidth}>
           {content}
         </div>
       </main>

--- a/src/app/ui/layout/TriptychLayout.stories.tsx
+++ b/src/app/ui/layout/TriptychLayout.stories.tsx
@@ -20,13 +20,13 @@ function Triptych() {
   return (
     <TriptychLayout>
       <TriptychLayout.Left>
-        <LayoutSlotPlaceholder name="left" minHeight={320} />
+        <LayoutSlotPlaceholder name="left" tone="secondary" minHeight={320} />
       </TriptychLayout.Left>
       <TriptychLayout.Center>
-        <LayoutSlotPlaceholder name="center" minHeight={320} />
+        <LayoutSlotPlaceholder name="center" tone="primary" minHeight={320} />
       </TriptychLayout.Center>
       <TriptychLayout.Right>
-        <LayoutSlotPlaceholder name="right" minHeight={320} />
+        <LayoutSlotPlaceholder name="right" tone="tertiary" minHeight={320} />
       </TriptychLayout.Right>
     </TriptychLayout>
   );

--- a/src/app/ui/layout/WorkbenchLayout.stories.tsx
+++ b/src/app/ui/layout/WorkbenchLayout.stories.tsx
@@ -20,8 +20,8 @@ const meta = preview.meta({
 export const ReadingColumn = meta.story({
   render: () => (
     <WorkbenchLayout>
-      <LayoutSlotPlaceholder name="toolbar" minHeight={56} />
-      <LayoutSlotPlaceholder name="editor" minHeight={360} />
+      <LayoutSlotPlaceholder name="toolbar" tone="toolbar" minHeight={56} />
+      <LayoutSlotPlaceholder name="editor" tone="primary" minHeight={360} />
     </WorkbenchLayout>
   ),
 });
@@ -32,10 +32,10 @@ export const ChaptersBesideRail = meta.story({
     <WorkbenchLayout gap="sm">
       <WorkbenchLayout.Workbench>
         <WorkbenchLayout.Chapters>
-          <LayoutSlotPlaceholder name="chapters" minHeight={480} />
+          <LayoutSlotPlaceholder name="chapters" tone="secondary" minHeight={480} />
         </WorkbenchLayout.Chapters>
         <WorkbenchLayout.Rail>
-          <LayoutSlotPlaceholder name="rail" minHeight={240} />
+          <LayoutSlotPlaceholder name="rail" tone="tertiary" minHeight={240} />
         </WorkbenchLayout.Rail>
       </WorkbenchLayout.Workbench>
     </WorkbenchLayout>


### PR DESCRIPTION
## Summary

- add an explicit viewport width option to the PageLayout content slot while the toolbar keeps the normal page measure
- let the Rulebook editor fill that slot and remove its route-owned viewport breakout
- give shared layout-story placeholders stable role hues so shallow and adjacent slots remain legible

Part of #558.

## Validation

- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run check:css-orphans`
- `bunx vitest run src/app/ui/layout/PageLayout.test.tsx`
- `bun run storybook:test -- src/app/shell src/app/ui/layout`
- `bun run publisher:release:verify`

## Proof

Both editor captures use the same route, state, and 1440 x 1000 viewport. On `main`, the route performs its own breakout and the workspace spans x=40 to x=1400, or 1360px. In this branch, PageLayout owns the viewport slot. The workspace spans x=20 to x=1420, or 1400px, while the toolbar remains on the 1200px page measure.

| Before | After |
| --- | --- |
| <img src="https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-789-page-layout-viewport-before.png" width="680" alt="Rulebook editor on main with route-owned viewport breakout"> | <img src="https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-789-page-layout-viewport-after.png" width="680" alt="Rulebook editor with PageLayout-owned viewport content"> |

The isolated story keeps the Header and Toolbar at the normal measure and lets only Content reach the shell gutters. Stable role hues make each supplied slot visible without imitating application content.

<img src="https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-789-page-layout-viewport-story.png" width="720" alt="PageLayout viewport content story with blue Header, violet Toolbar, and teal Content placeholders">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Page content can now expand to the full viewport width while keeping toolbars constrained.
  * Rulebook editing content now uses the available viewport width for a more spacious layout.

* **Improvements**
  * Updated layout previews with clearer visual distinctions between headers, primary content, secondary areas, rails, and toolbars.
  * Added coverage to verify viewport-width content behavior and layout spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->