### PR TITLE
PageLayout handles overflow and empty toolbars

### DIFF
--- a/src/app/styles/page.css
+++ b/src/app/styles/page.css
@@ -2,6 +2,7 @@ html {
   background-color: rgba(0, 0, 0);
   min-height: 100vh;
   width: 100vw;
+  scrollbar-gutter: stable both-edges;
   background-image: url("/web/page-large.jpg");
   background-size: cover;
   background-repeat: no-repeat;

--- a/src/app/ui/layout/PageLayout.stories.tsx
+++ b/src/app/ui/layout/PageLayout.stories.tsx
@@ -114,6 +114,15 @@ export const WithToolbar = meta.story({
  * Only the content reaches from one shell gutter to the other.
  */
 export const ViewportContent = meta.story({
+  beforeEach: () => {
+    const documentElement = document.documentElement;
+    const previousScrollbarGutter = documentElement.style.scrollbarGutter;
+    documentElement.style.scrollbarGutter = 'stable both-edges';
+
+    return () => {
+      documentElement.style.scrollbarGutter = previousScrollbarGutter;
+    };
+  },
   render: () => (
     <PageLayout>
       <PageLayout.Header>{headerSlot}</PageLayout.Header>
@@ -121,7 +130,7 @@ export const ViewportContent = meta.story({
         <LayoutSlotPlaceholder name="toolbar slot" tone="toolbar" minHeight={72} />
       </PageLayout.Toolbar>
       <PageLayout.Content width="viewport">
-        <LayoutSlotPlaceholder name="content slot" tone="primary" minHeight={420} />
+        <LayoutSlotPlaceholder name="content slot" tone="primary" minHeight={1200} />
       </PageLayout.Content>
     </PageLayout>
   ),
@@ -136,8 +145,11 @@ export const ViewportContent = meta.story({
 
       const toolbarRect = toolbar?.getBoundingClientRect();
       const contentRect = content?.getBoundingClientRect();
-      const viewportWidth = canvasElement.ownerDocument.documentElement.clientWidth;
+      const documentElement = canvasElement.ownerDocument.documentElement;
+      const viewportWidth = documentElement.clientWidth;
 
+      expect(getComputedStyle(documentElement).scrollbarGutter).toBe('stable both-edges');
+      expect(documentElement.scrollHeight).toBeGreaterThan(documentElement.clientHeight);
       expect(contentRect?.width).toBeCloseTo(viewportWidth - 40, 0);
       expect(contentRect?.width).toBeGreaterThan(toolbarRect?.width ?? Number.POSITIVE_INFINITY);
       expect(contentRect?.left).toBeCloseTo(20, 0);

--- a/src/app/ui/layout/PageLayout.test.tsx
+++ b/src/app/ui/layout/PageLayout.test.tsx
@@ -75,4 +75,18 @@ describe('PageLayout', () => {
       markup.indexOf('data-page-layout-content-width="viewport"')
     );
   });
+
+  it('omits the toolbar wrapper when the toolbar slot contains a Boolean child', () => {
+    const markup = renderToStaticMarkup(
+      <PageLayout>
+        <PageLayout.Toolbar>{false}</PageLayout.Toolbar>
+        <PageLayout.Content>
+          <p>Page content</p>
+        </PageLayout.Content>
+      </PageLayout>
+    );
+
+    expect(markup).not.toContain('data-page-layout-toolbar');
+    expect(markup).toContain('Page content');
+  });
 });

--- a/src/app/ui/layout/PageLayout.tsx
+++ b/src/app/ui/layout/PageLayout.tsx
@@ -77,6 +77,8 @@ function PageLayoutBase({ children }: PropsWithChildren) {
     }
   });
 
+  const hasToolbarContent = Children.toArray(toolbar).length > 0;
+
   return (
     <div
       className={styles.layout}
@@ -91,7 +93,7 @@ function PageLayoutBase({ children }: PropsWithChildren) {
         </div>
       )}
       <main className={styles.content}>
-        {toolbar != null && (
+        {hasToolbarContent && (
           <div className={styles.toolbar} data-page-layout-toolbar>
             {toolbar}
           </div>


### PR DESCRIPTION
Follow-up to #789 for two review comments that arrived after merge.

## What changed

- Reserve symmetric root scrollbar gutters so viewport-width content stays centered when classic scrollbars are present.
- Force overflow in the `ViewportContent` story and assert that the content keeps both 20px gutters.
- Skip the toolbar wrapper when the toolbar slot contains only a Boolean child.
- Cover the empty-toolbar case in the unit suite.

## Review comments

- https://github.com/ndelangen/dunezone/pull/789#discussion_r3870866914
- https://github.com/ndelangen/dunezone/pull/789#discussion_r3870866921

## Runtime proof

The Storybook story forces document overflow. The captured runtime geometry shows the symmetric root policy, content retaining 20px on both sides of the 1440px viewport, and the toolbar staying on the 1200px application measure.

![PageLayout forced-overflow geometry](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-790-runtime-geometry.png)

## Verification

- Linux Chromium geometry check in Docker
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run check:css-orphans`
- `bunx vitest run src/app/ui/layout/PageLayout.test.tsx`
- `bun run storybook:test -- src/app/ui/layout/PageLayout.stories.tsx`
- `bun run publisher:release:verify`
