### PR TITLE
Entities are cited as chips, the way people already are

### DIFF
--- a/src/app/routes/_app/assets/$type/$slug/index.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/index.tsx
@@ -20,8 +20,10 @@ import { LoadPending } from '@ui/block/LoadPending';
 import { NotAvailable } from '@ui/block/NotAvailable';
 import { OpenableTile } from '@ui/block/OpenableTile';
 import { Section } from '@ui/block/Section';
+import { AssetLink } from '@ui/content/AssetLink';
 import { formatRelativeDate } from '@ui/content/dates';
 import { FormattedTextSource } from '@ui/content/FormattedText';
+import { GroupLink } from '@ui/content/GroupLink';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { TopicIcon } from '@ui/content/TopicIcon';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
@@ -201,19 +203,7 @@ function AssetFaces({ page }: { page: AssetPage }) {
           caption={
             backDeck ? (
               <>
-                Cardback from{' '}
-                <Anchor
-                  size="xs"
-                  renderRoot={(rootProps) => (
-                    <Link
-                      {...rootProps}
-                      to="/assets/$type/$slug"
-                      params={{ type: backDeck.type, slug: backDeck.slug }}
-                    />
-                  )}
-                >
-                  {backDeck.name}
-                </Anchor>
+                Cardback from <AssetLink type={backDeck.type} slug={backDeck.slug} name={backDeck.name} />
               </>
             ) : undefined
           }
@@ -267,19 +257,7 @@ function AssetFaces({ page }: { page: AssetPage }) {
         <FaceStage
           caption={
             <>
-              Back:{' '}
-              <Anchor
-                size="xs"
-                renderRoot={(rootProps) => (
-                  <Link
-                    {...rootProps}
-                    to="/assets/$type/$slug"
-                    params={{ type: backToken.type, slug: backToken.slug }}
-                  />
-                )}
-              >
-                {backToken.name}
-              </Anchor>
+              Back: <AssetLink type={backToken.type} slug={backToken.slug} name={backToken.name} />
             </>
           }
         >
@@ -680,7 +658,7 @@ function LoadedAssetDetail({ page }: { page: AssetPage }) {
               {container ? <ShippedByCard rulesets={page.linkingRulesets} /> : null}
               {assignedGroup ? (
                 <Card title="Maintained by" icon={<UsersRound size={18} aria-hidden />}>
-                  <Text size="sm">{assignedGroup.name}</Text>
+                  <GroupLink slug={assignedGroup.slug} name={assignedGroup.name} />
                 </Card>
               ) : null}
             </Stack>

--- a/src/app/routes/_app/factions/$factionId/index.tsx
+++ b/src/app/routes/_app/factions/$factionId/index.tsx
@@ -24,6 +24,7 @@ import { complexityOutOfTen, complexityTier, effectiveComplexity } from '@ui/con
 import { COMPLEXITY_TIER_PRESENTATION, ComplexityGlyph } from '@ui/content/ComplexityGlyph';
 import { Eyebrow } from '@ui/content/Eyebrow';
 import { FormattedTextSource, InlineFormattedTextSource } from '@ui/content/FormattedText';
+import { GroupLink } from '@ui/content/GroupLink';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { StatusBadge } from '@ui/content/StatusBadge';
 import { TopicIcon } from '@ui/content/TopicIcon';
@@ -431,14 +432,7 @@ function FactionDetailPage() {
                   <Box>
                     <Eyebrow>Maintaining group</Eyebrow>
                     {assignedGroup.slug ? (
-                      <Anchor
-                        fw={600}
-                        renderRoot={(rootProps) => (
-                          <Link {...rootProps} to="/groups/$groupSlug" params={{ groupSlug: assignedGroup.slug }} />
-                        )}
-                      >
-                        {assignedGroup.name}
-                      </Anchor>
+                      <GroupLink slug={assignedGroup.slug} name={assignedGroup.name} />
                     ) : (
                       <Text fw={600}>{assignedGroup.name}</Text>
                     )}

--- a/src/app/routes/_app/profiles/$profileSlug/index.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/index.tsx
@@ -9,6 +9,7 @@ import { Section } from '@ui/block/Section';
 import { formatRelativeDate } from '@ui/content/dates';
 import { FormattedTextSource, InlineFormattedTextSource } from '@ui/content/FormattedText';
 import { ProfileLink } from '@ui/content/ProfileLink';
+import { RulesetLink } from '@ui/content/RulesetLink';
 import { TopicIcon } from '@ui/content/TopicIcon';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -105,13 +106,7 @@ function FaqQuestionsAsked({ items }: { items: FaqQuestionAsked[] }) {
       {items.map((item) => (
         <SectionedSurface.Row key={item._id}>
           <div className={styles.contextStrip}>
-            <Link
-              to="/rulesets/$rulesetSlug"
-              params={{ rulesetSlug: item.ruleset.slug }}
-              className={styles.rulesetLink}
-            >
-              {item.ruleset.name}
-            </Link>
+            <RulesetLink slug={item.ruleset.slug} name={item.ruleset.name} />
             <span aria-hidden>·</span>
             <time dateTime={item.created_at}>{formatRelativeDate(item.created_at)}</time>
           </div>
@@ -148,13 +143,7 @@ function FaqAnswersGiven({ items, viewedProfileId }: { items: FaqAnswerGiven[]; 
         return (
           <SectionedSurface.Row key={row._id}>
             <div className={styles.contextStrip}>
-              <Link
-                to="/rulesets/$rulesetSlug"
-                params={{ rulesetSlug: row.ruleset.slug }}
-                className={styles.rulesetLink}
-              >
-                {row.ruleset.name}
-              </Link>
+              <RulesetLink slug={row.ruleset.slug} name={row.ruleset.name} />
               <span aria-hidden>·</span>
               {row.asker_profile ? (
                 <AskerChip profile={row.asker_profile} viewedProfileId={viewedProfileId} />

--- a/src/app/routes/_app/profiles/ProfileDetail.module.css
+++ b/src/app/routes/_app/profiles/ProfileDetail.module.css
@@ -83,16 +83,6 @@
   color: var(--color-muted, #666);
 }
 
-.rulesetLink {
-  font-weight: 600;
-  color: var(--color-accent-strong, #8b5a2b);
-  text-decoration: none;
-}
-
-.rulesetLink:hover {
-  text-decoration: underline;
-}
-
 .selfNote {
   font-style: italic;
   color: var(--color-muted, #735c47);

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
@@ -3,6 +3,7 @@ import type { FaqTag } from '@shared/faq/tags';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { LoadPending } from '@ui/block/LoadPending';
 import { LoginGate } from '@ui/block/LoginGate';
+import { RulesetLink } from '@ui/content/RulesetLink';
 import { FaqTagFieldset } from '@ui/control/FaqTagFieldset';
 import { FormattedTextInput } from '@ui/control/FormattedTextInput';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -36,7 +37,11 @@ function FaqCreatePage() {
     <div>
       <h1>Ask a question</h1>
       <p>
-        {rulesetRow ? `For ${rulesetRow.name} · ` : null}
+        {rulesetRow ? (
+          <>
+            For <RulesetLink slug={rulesetSlug} name={rulesetRow.name} /> ·{' '}
+          </>
+        ) : null}
         <Link to="/rulesets/$rulesetSlug" params={{ rulesetSlug }}>
           Back to ruleset
         </Link>

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -13,6 +13,7 @@ import { ProposedContent } from '@ui/block/ProposedContent';
 import { Section } from '@ui/block/Section';
 import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
 import { FormattedTextSource } from '@ui/content/FormattedText';
+import { GroupLink } from '@ui/content/GroupLink';
 import { ProfileLink } from '@ui/content/ProfileLink';
 import { StatusBadge } from '@ui/content/StatusBadge';
 import { TopicIcon } from '@ui/content/TopicIcon';
@@ -364,21 +365,7 @@ function RulesetDetailPage() {
                 <Text size="sm">Unknown</Text>
               )}
               {assignedGroup ? (
-                <Group gap={6} wrap="nowrap" align="center">
-                  {/* A glyph, not an avatar: the `groups` table carries no image, and this only has to say "a group". */}
-                  <UsersRound size={15} aria-hidden />
-                  <Anchor
-                    size="sm"
-                    fw={600}
-                    /* White, not the accent: this line sits on artwork, where the accent loses against the sand. */
-                    c="white"
-                    renderRoot={(rootProps) => (
-                      <Link {...rootProps} to="/groups/$groupSlug" params={{ groupSlug: assignedGroup.slug }} />
-                    )}
-                  >
-                    {assignedGroup.name}
-                  </Anchor>
-                </Group>
+                <GroupLink slug={assignedGroup.slug} name={assignedGroup.name} />
               ) : (
                 <Text size="sm" c="dimmed">
                   No maintaining group

--- a/src/app/ui/content/AssetLink.stories.tsx
+++ b/src/app/ui/content/AssetLink.stories.tsx
@@ -1,0 +1,16 @@
+import preview from '@sb/preview';
+
+import { AssetLink } from './AssetLink';
+
+const meta = preview.meta({
+  component: AssetLink,
+  parameters: { layout: 'centered' },
+  args: {
+    type: 'deck',
+    slug: 'spice-deck',
+    name: 'Spice Deck',
+  },
+});
+
+/** The citation: glyph and name, one link, ready to sit inside an attribution caption. */
+export const Default = meta.story({});

--- a/src/app/ui/content/AssetLink.tsx
+++ b/src/app/ui/content/AssetLink.tsx
@@ -1,0 +1,37 @@
+import { Link } from '@tanstack/react-router';
+import clsx from 'clsx';
+import type { CSSProperties } from 'react';
+
+import styles from './EntityLink.module.css';
+import { TopicIcon } from './TopicIcon';
+
+export interface AssetLinkProps {
+  /** The asset's type slug, a route param. Plain string because the page contracts carry it that way. */
+  type: string;
+  slug: string;
+  name: string;
+  className?: string;
+  style?: CSSProperties;
+  title?: string;
+}
+
+/**
+ * An asset, as a link: its glyph and name, leading to its page.
+ *
+ * Content, `ProfileLink`'s sibling for the asset kind.
+ * Callers hand it the fields;
+ * this owns how an asset is cited inline anywhere in the app, so every mention looks and navigates identically.
+ * The destination is hardcoded because it is the component's name.
+ */
+export const AssetLink = ({ type, slug, name, className, style, title }: AssetLinkProps) => (
+  <Link
+    to="/assets/$type/$slug"
+    params={{ type, slug }}
+    className={clsx(styles.link, className)}
+    style={style}
+    title={title}
+  >
+    <TopicIcon topic="assets" size={18} className={styles.icon} />
+    <span className={styles.name}>{name}</span>
+  </Link>
+);

--- a/src/app/ui/content/EntityLink.module.css
+++ b/src/app/ui/content/EntityLink.module.css
@@ -1,0 +1,19 @@
+.link {
+  display: inline-flex;
+  gap: var(--space-2);
+  text-decoration: none;
+  color: inherit;
+  align-items: center;
+  vertical-align: middle;
+}
+
+.icon {
+  flex-shrink: 0;
+  color: var(--color-text);
+}
+
+.name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-text);
+}

--- a/src/app/ui/content/FactionLink.stories.tsx
+++ b/src/app/ui/content/FactionLink.stories.tsx
@@ -1,0 +1,15 @@
+import preview from '@sb/preview';
+
+import { FactionLink } from './FactionLink';
+
+const meta = preview.meta({
+  component: FactionLink,
+  parameters: { layout: 'centered' },
+  args: {
+    factionId: 'house-atreides',
+    name: 'House Atreides',
+  },
+});
+
+/** The citation: glyph and name, one link, ready to sit inside a sentence. */
+export const Default = meta.story({});

--- a/src/app/ui/content/FactionLink.tsx
+++ b/src/app/ui/content/FactionLink.tsx
@@ -1,0 +1,35 @@
+import { Link } from '@tanstack/react-router';
+import clsx from 'clsx';
+import type { CSSProperties } from 'react';
+
+import styles from './EntityLink.module.css';
+import { TopicIcon } from './TopicIcon';
+
+export interface FactionLinkProps {
+  factionId: string;
+  name: string;
+  className?: string;
+  style?: CSSProperties;
+  title?: string;
+}
+
+/**
+ * A faction, as a link: its glyph and name, leading to its page.
+ *
+ * Content, `ProfileLink`'s sibling for the faction kind.
+ * Callers hand it the fields;
+ * this owns how a faction is cited inline anywhere in the app, so every mention looks and navigates identically.
+ * The destination is hardcoded because it is the component's name.
+ */
+export const FactionLink = ({ factionId, name, className, style, title }: FactionLinkProps) => (
+  <Link
+    to="/factions/$factionId"
+    params={{ factionId }}
+    className={clsx(styles.link, className)}
+    style={style}
+    title={title}
+  >
+    <TopicIcon topic="factions" size={18} className={styles.icon} />
+    <span className={styles.name}>{name}</span>
+  </Link>
+);

--- a/src/app/ui/content/GroupLink.stories.tsx
+++ b/src/app/ui/content/GroupLink.stories.tsx
@@ -1,0 +1,15 @@
+import preview from '@sb/preview';
+
+import { GroupLink } from './GroupLink';
+
+const meta = preview.meta({
+  component: GroupLink,
+  parameters: { layout: 'centered' },
+  args: {
+    slug: 'the-landsraad',
+    name: 'The Landsraad',
+  },
+});
+
+/** The citation: glyph and name, one link. The glyph stands in because groups carry no image. */
+export const Default = meta.story({});

--- a/src/app/ui/content/GroupLink.tsx
+++ b/src/app/ui/content/GroupLink.tsx
@@ -1,0 +1,36 @@
+import { Link } from '@tanstack/react-router';
+import clsx from 'clsx';
+import type { CSSProperties } from 'react';
+
+import styles from './EntityLink.module.css';
+import { TopicIcon } from './TopicIcon';
+
+export interface GroupLinkProps {
+  slug: string;
+  name: string;
+  className?: string;
+  style?: CSSProperties;
+  title?: string;
+}
+
+/**
+ * A group, as a link: its glyph and name, leading to its page.
+ *
+ * Content, `ProfileLink`'s sibling for the group kind.
+ * The glyph rather than an avatar because the groups table carries no image.
+ * Callers hand it the fields;
+ * this owns how a group is cited inline anywhere in the app, so every mention looks and navigates identically.
+ * The destination is hardcoded because it is the component's name.
+ */
+export const GroupLink = ({ slug, name, className, style, title }: GroupLinkProps) => (
+  <Link
+    to="/groups/$groupSlug"
+    params={{ groupSlug: slug }}
+    className={clsx(styles.link, className)}
+    style={style}
+    title={title}
+  >
+    <TopicIcon topic="groups" size={18} className={styles.icon} />
+    <span className={styles.name}>{name}</span>
+  </Link>
+);

--- a/src/app/ui/content/RulesetLink.stories.tsx
+++ b/src/app/ui/content/RulesetLink.stories.tsx
@@ -1,0 +1,15 @@
+import preview from '@sb/preview';
+
+import { RulesetLink } from './RulesetLink';
+
+const meta = preview.meta({
+  component: RulesetLink,
+  parameters: { layout: 'centered' },
+  args: {
+    slug: 'dreamrules',
+    name: 'Dreamrules',
+  },
+});
+
+/** The citation: glyph and name, one link, ready to sit inside a sentence. */
+export const Default = meta.story({});

--- a/src/app/ui/content/RulesetLink.tsx
+++ b/src/app/ui/content/RulesetLink.tsx
@@ -1,0 +1,35 @@
+import { Link } from '@tanstack/react-router';
+import clsx from 'clsx';
+import type { CSSProperties } from 'react';
+
+import styles from './EntityLink.module.css';
+import { TopicIcon } from './TopicIcon';
+
+export interface RulesetLinkProps {
+  slug: string;
+  name: string;
+  className?: string;
+  style?: CSSProperties;
+  title?: string;
+}
+
+/**
+ * A ruleset, as a link: its glyph and name, leading to its page.
+ *
+ * Content, `ProfileLink`'s sibling for the ruleset kind.
+ * Callers hand it the fields;
+ * this owns how a ruleset is cited inline anywhere in the app, so every mention looks and navigates identically.
+ * The destination is hardcoded because it is the component's name.
+ */
+export const RulesetLink = ({ slug, name, className, style, title }: RulesetLinkProps) => (
+  <Link
+    to="/rulesets/$rulesetSlug"
+    params={{ rulesetSlug: slug }}
+    className={clsx(styles.link, className)}
+    style={style}
+    title={title}
+  >
+    <TopicIcon topic="rulesets" size={18} className={styles.icon} />
+    <span className={styles.name}>{name}</span>
+  </Link>
+);

--- a/src/app/ui/content/TopicIcon.tsx
+++ b/src/app/ui/content/TopicIcon.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Boxes, Image as ImageIcon, Info, Signature, Type } from 'lucide-react';
+import { BookOpen, Boxes, Image as ImageIcon, Info, Signature, Type, UsersRound } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 const TOPIC_ICON_DEFINITIONS = {
@@ -28,6 +28,11 @@ const TOPIC_ICON_DEFINITIONS = {
   karama: { kind: 'mask', src: '/vector/icon/karama.svg' },
   rulesets: { kind: 'component', component: BookOpen },
   fate: { kind: 'mask', src: '/vector/icon/fate.svg' },
+  /* The entity-kind glyphs the mention chips wear. Factions reuse the hero pictogram and assets
+     reuse the contents glyph, the way decals reuses alliance: one drawing, two topics. */
+  factions: { kind: 'mask', src: '/vector/generic/ceasar.svg' },
+  groups: { kind: 'component', component: UsersRound },
+  assets: { kind: 'component', component: Boxes },
 } as const satisfies Record<string, { kind: 'mask'; src: string } | { kind: 'component'; component: LucideIcon }>;
 
 export type TopicIconTopic = keyof typeof TOPIC_ICON_DEFINITIONS;


### PR DESCRIPTION
Item 2 of [the composition wave](https://github.com/ndelangen/dunezone/issues/701), executing [the entity-mention spec (#685)](https://github.com/ndelangen/dunezone/issues/685) stage 2.

**Four Content components** generalize ProfileLink's shape: `RulesetLink`, `GroupLink`, `FactionLink`, `AssetLink` — each a glyph and a name wearing the one citation treatment (shared `EntityLink.module.css`), each hardcoding the route that is its name, no fetching, one story each. The glyphs are `TopicIcon` registry entries: groups gets UsersRound (canonicalizing what the ruleset page hand-picked), factions reuses the hero pictogram and assets the contents glyph, the way `decals` already reuses `alliance` — one drawing, two topics.

**Converged (8 sites):** the ruleset meta band's hand-rolled group glyph+anchor (its special-case white comment dies — the chip sits beside ProfileLink and inherits the same band treatment); the faction Stewardship card's group anchor (unlinked no-slug fallback preserved); both asset back-reference captions ('Cardback from X', 'Back: X'); both profile FAQ context strips (whose private `.rulesetLink` class is deleted); and two formerly UNLINKED citations now linked — the FAQ ask page's 'For \<ruleset\>' (the spec's own example) and the asset page's maintaining group, whose slug the contract already shipped.

**Enumerated but deliberately not converted,** per the spec's stays-and-listed rule: the groups page's Stack-of-Anchors faction/ruleset lists (hand-rolled *lists*, item 5's Links territory, not citations); the ruleset editor's asset slot rows (furniture — each row's companion is a remove control).

## Proof

Storybook is the proof source per the standing direction — deterministic seeds make every pair controlled by construction. Before-shots from the public build at storybook.dune.zone (main); after-shots from this branch's build; same story ids, same seeded data. Four chip stories plus five page pairs (rulesets detail, factions detail, profiles detail, ask-question, assets deck) follow in a comment. I read the rulesets-detail pair personally: identical everywhere except the meta band, where the chip preserves the design while dropping the hand-rolled glyph and white override.

## Gates

Local gates green: typecheck, lint, format, prose, css-orphans (65 stylesheets — the orphaned `.rulesetLink` was caught and removed), knip, app-layout, 767 unit tests, 444 storybook tests (four new). Changed paths are outside the renderer capture graph; CI's publisher_release confirms.

Closes #685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent links for assets, factions, groups, and rulesets, including topic icons and navigable names.
  - Updated related pages to use these shared links for easier navigation.
  - Added new icons for factions, groups, and assets.

- **Style**
  - Standardized inline entity-link appearance across the application.

- **Tests**
  - Added Storybook examples for the new link components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->