### PR TITLE
The ruleset editor's cover gets its sized box back

### DIFF
--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.module.css
@@ -6,6 +6,16 @@
   padding-inline: var(--mantine-spacing-sm);
 }
 
+/* The cover's box must carry a size of its own: the image inside stretches to 100% of it, so an
+   unsized box hands layout to the image's intrinsic pixels, which overflow the header and squeeze
+   the title to wrapping (the regression behind the cover drawing over the nav). */
+.rulesetHeadCover {
+  width: 5.5rem;
+  height: 5.5rem;
+  flex: 0 0 5.5rem;
+  overflow: hidden;
+}
+
 .coverImage {
   width: 100%;
   height: 100%;

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
@@ -205,7 +205,7 @@ function RulesetEditPage() {
      case where there is nothing to name. The band itself is unchanged, and stays #451's to revisit. */
   const header = (
     <Group wrap="nowrap" align="center" gap="lg" className={styles.pageHead}>
-      <Surface>
+      <Surface className={styles.rulesetHeadCover}>
         {r.image_cover ? (
           <Image
             src={r.image_cover}


### PR DESCRIPTION
Spot fix for the live defect recorded on [the identity-band territory (#451)](https://github.com/ndelangen/dunezone/issues/451): on main, a ruleset editor with a cover draws that cover across the nav and past the header's lower edge, title wrapped to three lines around it.

**Traced, not guessed** (full trace on #451): the Paper→Surface kit extraction (b582517cb59) dropped the cover's className, and the follow-up cleanup (2a47d08c478) deleted the then-orphaned size rule instead of restoring the wiring — since then the image's width/height:100% resolve against an unsized parent and it lays out at intrinsic size (~640x892), with no clipping ancestor (the header's clipped band is a sibling, not a parent). This restores the sized box: 5.5rem square, clipped, flex-fixed, with the constraint stated in a comment so the next cleanup knows why the class exists.

## Proof

Measured on the deterministic edit story (probe walks up from the cover placeholder looking for any constrained ancestor):

| | box found | size | flex-basis | overflow |
|---|---|---|---|---|
| before (public Storybook = main) | none within six levels — probe escaped to a page-level 1200x1485 box | — | auto | visible |
| after (this branch) | the immediate Surface | **88x88** | **88px** | **hidden** |

The seeded story carries no cover image, so the intrinsic-size spill itself is shown by the archived real-world shot from #730's proof ([the before image there](https://github.com/ndelangen/dunezone/pull/730#issuecomment-5407187855), `pr-730-ruleset-edit-signedout-cover-before.png`): the cover over the nav is this defect. Story after-shot follows in a comment.

This is the minimal fix; the band extraction (#451, decisions pending) supersedes this CSS when it lands.

## Gates

Local gates green: typecheck, lint, format, css-orphans (64 stylesheets), prose, 764 unit tests. Route CSS is outside the renderer capture graph; CI's publisher_release confirms.