### PR TITLE
Asking a question about a ruleset that is not there lands on a page

### DIFF
--- a/src/app/routes/-rulesets.stories.tsx
+++ b/src/app/routes/-rulesets.stories.tsx
@@ -13,6 +13,13 @@ export const Edit = meta.story({ args: { path: '/rulesets/classicrules/edit' } }
 export const AskQuestion = meta.story({
   args: { path: '/rulesets/classicrules/faq/create' },
 });
+/**
+ * The same page reached through a ruleset slug that names nothing, which is the state the route's own frame exists for.
+ * Its loader throws rather than returning nothing, so without that frame this path falls to the router's default and renders the error unstyled.
+ */
+export const AskQuestionMissingRuleset = meta.story({
+  args: { path: '/rulesets/there-is-no-such-ruleset/faq/create' },
+});
 export const Question = meta.story({
   args: { path: '/rulesets/classicrules/faq/when-does-the-storm-move' },
 });

--- a/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/faq/create.tsx
@@ -1,6 +1,8 @@
 import { Button, Group, Stack } from '@mantine/core';
 import type { FaqTag } from '@shared/faq/tags';
+import type { ErrorComponentProps } from '@tanstack/react-router';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { LoadError } from '@ui/block/LoadError';
 import { LoadPending } from '@ui/block/LoadPending';
 import { LoginGate } from '@ui/block/LoginGate';
 import { RulesetLink } from '@ui/content/RulesetLink';
@@ -13,14 +15,34 @@ import { useState } from 'react';
 import { useAskFaqQuestion } from '@db/faq';
 import { useCurrentProfile } from '@db/profiles';
 import { loadRulesetBySlug, useRulesetBySlug } from '@db/rulesets';
+import { isStaleClientData } from '@app/db/core/clientBoundary';
 import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import styles from './create.module.css';
 
 export const Route = createFileRoute('/_app/rulesets/$rulesetSlug/faq/create')({
   loader: async ({ params }) => ({ ruleset: await loadRulesetBySlug(params.rulesetSlug) }),
+  errorComponent: FaqCreateError,
   component: FaqCreatePage,
 });
+
+/**
+ * The frame for a load that failed, which on this route is most often a slug naming no ruleset: the loader awaits `loadRulesetBySlug` unguarded and the query throws rather than returning nothing.
+ * Without this the reader met the router's default, which is styled only for the stale-client case and otherwise renders the error raw.
+ *
+ * The way back is the catalogue rather than the ruleset, which is where this route's sibling points.
+ * The distinction is which thing is missing: on the question page the ruleset exists and only the question is absent, so "back to ruleset" leads somewhere;
+ * here the ruleset is the thing that is not there, so the same link would offer the reader the page that just failed.
+ */
+function FaqCreateError({ error }: ErrorComponentProps) {
+  return (
+    <PageMessage title="Ask a question" back={<PageMessage.Back to="/rulesets">Back to rulesets</PageMessage.Back>}>
+      <LoadError title="This ruleset could not be loaded" stale={isStaleClientData(error)}>
+        {error.message}
+      </LoadError>
+    </PageMessage>
+  );
+}
 
 function FaqCreatePage() {
   const { rulesetSlug } = Route.useParams();


### PR DESCRIPTION
A miss of mine, found by the item-1 audit on [#701](https://github.com/ndelangen/dunezone/issues/701#issuecomment-5444066429) and fixed here.

`rulesets/$rulesetSlug/faq/create` has the same defect the five `errorComponent` fixes in #730 and #733 addressed. It sits in the same directory as `faq/$questionSlug.tsx`, which slice 3 fixed, and it already imports `PageMessage` and already renders `PageMessage` frames for its pending and signed-out states. I converted its frames and did not notice its loader.

Not in #796 or #797, which cover the asset editor family and the remaining hand-rolled frames. This is a one-route bug fix and it is mine, so it goes on its own rather than riding with someone else's ticket.

## The defect

`loader: async ({ params }) => ({ ruleset: await loadRulesetBySlug(params.rulesetSlug) })`, unguarded, and the query throws rather than returning nothing:

- `src/app/db/rulesets.ts:96-99` calls `api.rulesets.getBySlug`
- `convex/rulesets.ts:94-98` delegates to `loadRulesetPublicBundleBySlug`
- `convex/lib/rulesetDetailPage.ts:51-55` throws `Ruleset with slug ${slug} not found`

With no route-level `errorComponent`, that lands on the router's default. Worth stating precisely, because it is easy to say wrongly: the route is **not** unguarded. `src/app/router.tsx:28` sets `defaultErrorComponent: AppErrorComponent`, which is styled for the stale-client case and otherwise returns TanStack's `ErrorComponent`. So the reader gets the raw block rather than nothing at all, and the fix upgrades a default into a page rather than installing a missing boundary.

## One deliberate difference from its sibling

`faq/$questionSlug.tsx`'s error frame sends the reader back to the ruleset. This one sends them to the catalogue. The distinction is which thing is missing: on the question page the ruleset exists and only the question is absent, so "back to ruleset" leads somewhere real; here the ruleset is the thing that is not there, and the same link would offer the reader the page that just failed.

## Proof, and why the story is not a rubber stamp

The proof is a page story rather than a screenshot pair: `Rulesets/AskQuestionMissingRuleset`, at `/rulesets/there-is-no-such-ruleset/faq/create`. It mounts the real route against the seeded database through the same clone seam every page story uses, so it runs in `storybook:test` in CI from now on.

A story that merely renders proves nothing here, because `AppErrorComponent` renders without throwing too. So I checked that the story actually discriminates, by removing the error component and rendering the same story again with everything else identical:

| | alert body | way back | router's "Something went wrong!" |
|---|---|---|---|
| without `errorComponent` | none | absent | present |
| with it | "This ruleset could not be loaded" | Back to rulesets | absent |

That is the whole claim: the same story, the same seed, the same path, and the only difference is the four lines this PR adds.

## Known and out of scope

The rendered message is the raw `error.message`, which in a dev build carries a long Convex stack. That is the error-message-internals observation already recorded as out of scope during the #730 review, and it applies to every `LoadError` caller rather than to this route. I have not touched it, but the story now makes it visible to whoever picks it up.

## Verified

Local gates on a fresh worktree at `8c2c37d187e`: typecheck, lint, format:check, check:prose, check:app-layout, check:css-orphans, knip, 767 unit tests, 445 storybook tests (444 before; the new story is the extra one). `bun run check` reports no capture-bundle changes.
