### PR TITLE
The asset editors speak the message vocabulary instead of a second one

### DIFF
--- a/src/app/routes/-assets.stories.tsx
+++ b/src/app/routes/-assets.stories.tsx
@@ -1,4 +1,5 @@
 import preview from '@sb/preview';
+import { expect, within } from 'storybook/test';
 
 import { pageStoryMeta } from './-storybookConfig';
 
@@ -42,4 +43,46 @@ export const EditEnhanceToken = meta.story({
 });
 export const EditBundle = meta.story({
   args: { path: '/assets/bundle/atreides-tokens/edit' },
+});
+
+/**
+ * The editor reached by a reader who is not signed in.
+ * The assertions are the point rather than the render: this state and the two below all rendered before this frame existed, so a story that only mounts them would go green either way.
+ *
+ * The edit route rather than the create route, because this one asks the server: its gate reads `viewerAccess.viewer.kind`, which the asset query decides from the identity, while the create pages read the profile session, which the story seam leaves unresolved rather than answering "signed out".
+ */
+export const EditDeckSignedOut = meta.story({
+  args: { path: '/assets/deck/house-treachery/edit' },
+  parameters: { identity: null },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(page.findByRole('link', { name: 'Log in' }, { timeout: 30_000 })).resolves.toBeVisible();
+    const back = await page.findByRole('link', { name: 'Back to decks' }, { timeout: 30_000 });
+    await expect(back).toBeVisible();
+    /* The words here did not change, only who owns them: this route's own frame used to put the way
+       back inside the pane, below the sentence, and the shared frame puts it in the band. Asserting
+       the position is what makes this story discriminate rather than pass against either version. */
+    expect(back.closest('main')).toBeNull();
+  },
+});
+
+/** A slug that names no deck. The page keeps its own name in the band and says what is missing in the body. */
+export const EditDeckMissing = meta.story({
+  args: { path: '/assets/deck/there-is-no-such-deck/edit' },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(page.findByRole('heading', { name: 'Edit deck' }, { timeout: 30_000 })).resolves.toBeVisible();
+    await expect(page.findByRole('heading', { name: 'Deck not found' }, { timeout: 30_000 })).resolves.toBeVisible();
+    await expect(page.findByRole('link', { name: 'Back to decks' }, { timeout: 30_000 })).resolves.toBeVisible();
+  },
+});
+
+/** A type the registry knows and nothing can author yet, which is a statement about the roadmap rather than a missing page. */
+export const CreateStormCardNoEditor = meta.story({
+  args: { path: '/assets/card-storm/create' },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(page.findByRole('heading', { name: 'Storm cards' }, { timeout: 30_000 })).resolves.toBeVisible();
+    await expect(page.findByRole('heading', { name: 'No editor yet' }, { timeout: 30_000 })).resolves.toBeVisible();
+  },
 });

--- a/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-bundleEdit.tsx
@@ -1,6 +1,8 @@
-import { Alert, Anchor, Popover, Text } from '@mantine/core';
+import { Alert, Popover } from '@mantine/core';
 import { BundleAsset } from '@shared/assets/schema';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { AddAction } from '@ui/control/ListLengthActions';
@@ -38,8 +40,8 @@ export function BundleEditPage({ slug, loaderData }: { slug: string; loaderData:
 
   if (data === null) {
     return (
-      <AssetEditorMessage title="Bundle not found" type="bundle">
-        <Text>No bundle lives at this address.</Text>
+      <AssetEditorMessage title="Edit bundle" type="bundle">
+        <NotAvailable title="Bundle not found">No bundle lives at this address.</NotAvailable>
       </AssetEditorMessage>
     );
   }
@@ -47,9 +49,7 @@ export function BundleEditPage({ slug, loaderData }: { slug: string; loaderData:
   if (data.viewerAccess.viewer.kind === 'anonymous') {
     return (
       <AssetEditorMessage title={`Edit ${data.asset.name}`} type="bundle">
-        <Text>
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to edit bundles.
-        </Text>
+        <LoginGate action="edit bundles" />
       </AssetEditorMessage>
     );
   }
@@ -57,11 +57,11 @@ export function BundleEditPage({ slug, loaderData }: { slug: string; loaderData:
   if (!data.viewerAccess.capabilities.edit) {
     return (
       <AssetEditorMessage title={`Edit ${data.asset.name}`} type="bundle">
-        <Text>
+        <NotAvailable title="You cannot edit this bundle">
           {data.viewerAccess.assignedGroup
             ? 'Only the bundle owner or an active member of its group can edit this bundle.'
             : 'Only the bundle owner can edit this bundle.'}
-        </Text>
+        </NotAvailable>
       </AssetEditorMessage>
     );
   }
@@ -70,7 +70,7 @@ export function BundleEditPage({ slug, loaderData }: { slug: string; loaderData:
   if (!parsed.success) {
     return (
       <DriftedAssetPage asset={data.asset} noun="bundle" canDelete={data.viewerAccess.capabilities.delete}>
-        <Text>This bundle's stored data no longer matches the bundle schema, so it cannot be edited here.</Text>
+        {`This bundle's stored data no longer matches the bundle schema, so it cannot be edited here.`}
       </DriftedAssetPage>
     );
   }

--- a/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-deckEdit.tsx
@@ -1,7 +1,9 @@
-import { Alert, Anchor, Popover, Text } from '@mantine/core';
+import { Alert, Popover } from '@mantine/core';
 import { DeckAsset } from '@shared/assets/schema';
 import { ASSET_TYPE_KEYS, ASSET_TYPES } from '@shared/assets/types';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
@@ -47,8 +49,8 @@ export function DeckEditPage({ slug, loaderData }: { slug: string; loaderData: A
 
   if (data === null) {
     return (
-      <AssetEditorMessage title="Deck not found" type="deck">
-        <Text>No deck lives at this address.</Text>
+      <AssetEditorMessage title="Edit deck" type="deck">
+        <NotAvailable title="Deck not found">No deck lives at this address.</NotAvailable>
       </AssetEditorMessage>
     );
   }
@@ -56,9 +58,7 @@ export function DeckEditPage({ slug, loaderData }: { slug: string; loaderData: A
   if (data.viewerAccess.viewer.kind === 'anonymous') {
     return (
       <AssetEditorMessage title={`Edit ${data.asset.name}`} type="deck">
-        <Text>
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to edit decks.
-        </Text>
+        <LoginGate action="edit decks" />
       </AssetEditorMessage>
     );
   }
@@ -66,11 +66,11 @@ export function DeckEditPage({ slug, loaderData }: { slug: string; loaderData: A
   if (!data.viewerAccess.capabilities.edit) {
     return (
       <AssetEditorMessage title={`Edit ${data.asset.name}`} type="deck">
-        <Text>
+        <NotAvailable title="You cannot edit this deck">
           {data.viewerAccess.assignedGroup
             ? 'Only the deck owner or an active member of its group can edit this deck.'
             : 'Only the deck owner can edit this deck.'}
-        </Text>
+        </NotAvailable>
       </AssetEditorMessage>
     );
   }
@@ -79,7 +79,7 @@ export function DeckEditPage({ slug, loaderData }: { slug: string; loaderData: A
   if (!parsed.success) {
     return (
       <DriftedAssetPage asset={data.asset} noun="deck" canDelete={data.viewerAccess.capabilities.delete}>
-        <Text>This deck's stored data no longer matches the deck schema, so it cannot be edited here.</Text>
+        {`This deck's stored data no longer matches the deck schema, so it cannot be edited here.`}
       </DriftedAssetPage>
     );
   }

--- a/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-rectangleEdit.tsx
@@ -1,6 +1,8 @@
-import { Alert, Anchor, Button, Group, Popover, Stack, Text } from '@mantine/core';
+import { Alert, Button, Group, Popover, Stack, Text } from '@mantine/core';
 import { RectangleTokenAsset } from '@shared/assets/schema';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -51,8 +53,8 @@ export function RectangleEditPage({
 
   if (data === null) {
     return (
-      <AssetEditorMessage title="Token not found" type={type}>
-        <Text>No {label} token lives at this address.</Text>
+      <AssetEditorMessage title="Edit token" type={type}>
+        <NotAvailable title="Token not found">{`No ${label} token lives at this address.`}</NotAvailable>
       </AssetEditorMessage>
     );
   }
@@ -60,9 +62,7 @@ export function RectangleEditPage({
   if (data.viewerAccess.viewer.kind === 'anonymous') {
     return (
       <AssetEditorMessage title={`Edit ${data.asset.name}`} type={type}>
-        <Text>
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to edit tokens.
-        </Text>
+        <LoginGate action="edit tokens" />
       </AssetEditorMessage>
     );
   }
@@ -70,11 +70,11 @@ export function RectangleEditPage({
   if (!data.viewerAccess.capabilities.edit) {
     return (
       <AssetEditorMessage title={`Edit ${data.asset.name}`} type={type}>
-        <Text>
+        <NotAvailable title="You cannot edit this token">
           {data.viewerAccess.assignedGroup
             ? 'Only the token owner or an active member of its group can edit this token.'
             : 'Only the token owner can edit this token.'}
-        </Text>
+        </NotAvailable>
       </AssetEditorMessage>
     );
   }
@@ -83,7 +83,7 @@ export function RectangleEditPage({
   if (!parsed.success) {
     return (
       <DriftedAssetPage asset={data.asset} noun="token" canDelete={data.viewerAccess.capabilities.delete}>
-        <Text>This token's stored data no longer matches the token schema, so it cannot be edited here.</Text>
+        {`This token's stored data no longer matches the token schema, so it cannot be edited here.`}
       </DriftedAssetPage>
     );
   }

--- a/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-tokenEdit.tsx
@@ -1,7 +1,9 @@
-import { Alert, Anchor, Button, Group, Popover, Stack, Text } from '@mantine/core';
+import { Alert, Button, Group, Popover, Stack, Text } from '@mantine/core';
 import { TokenAsset } from '@shared/assets/schema';
 import { ASSET_TYPES, isAssetType } from '@shared/assets/types';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -36,8 +38,8 @@ export function TokenEditPage({ type, slug, loaderData }: { type: string; slug: 
 
   if (data === null) {
     return (
-      <AssetEditorMessage title="Token not found" type={type}>
-        <Text>No {label} token lives at this address.</Text>
+      <AssetEditorMessage title="Edit token" type={type}>
+        <NotAvailable title="Token not found">{`No ${label} token lives at this address.`}</NotAvailable>
       </AssetEditorMessage>
     );
   }
@@ -45,9 +47,7 @@ export function TokenEditPage({ type, slug, loaderData }: { type: string; slug: 
   if (data.viewerAccess.viewer.kind === 'anonymous') {
     return (
       <AssetEditorMessage title={`Edit ${data.asset.name}`} type={type}>
-        <Text>
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to edit tokens.
-        </Text>
+        <LoginGate action="edit tokens" />
       </AssetEditorMessage>
     );
   }
@@ -55,11 +55,11 @@ export function TokenEditPage({ type, slug, loaderData }: { type: string; slug: 
   if (!data.viewerAccess.capabilities.edit) {
     return (
       <AssetEditorMessage title={`Edit ${data.asset.name}`} type={type}>
-        <Text>
+        <NotAvailable title="You cannot edit this token">
           {data.viewerAccess.assignedGroup
             ? 'Only the token owner or an active member of its group can edit this token.'
             : 'Only the token owner can edit this token.'}
-        </Text>
+        </NotAvailable>
       </AssetEditorMessage>
     );
   }
@@ -68,7 +68,7 @@ export function TokenEditPage({ type, slug, loaderData }: { type: string; slug: 
   if (!parsed.success) {
     return (
       <DriftedAssetPage asset={data.asset} noun="token" canDelete={data.viewerAccess.capabilities.delete}>
-        <Text>This token's stored data no longer matches the token schema, so it cannot be edited here.</Text>
+        {`This token's stored data no longer matches the token schema, so it cannot be edited here.`}
       </DriftedAssetPage>
     );
   }

--- a/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/edit/-treacheryEdit.tsx
@@ -1,5 +1,7 @@
-import { Alert, Anchor, Text } from '@mantine/core';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Alert } from '@mantine/core';
+import { useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -33,8 +35,8 @@ export function TreacheryEditPage({ slug, loaderData }: { slug: string; loaderDa
 
   if (data === null) {
     return (
-      <AssetEditorMessage type="card-treachery" title="Card not found">
-        <Text>No treachery card lives at this address.</Text>
+      <AssetEditorMessage type="card-treachery" title="Edit card">
+        <NotAvailable title="Card not found">No treachery card lives at this address.</NotAvailable>
       </AssetEditorMessage>
     );
   }
@@ -42,9 +44,7 @@ export function TreacheryEditPage({ slug, loaderData }: { slug: string; loaderDa
   if (data.viewerAccess.viewer.kind === 'anonymous') {
     return (
       <AssetEditorMessage type="card-treachery" title={`Edit ${data.asset.name}`}>
-        <Text>
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to edit cards.
-        </Text>
+        <LoginGate action="edit cards" />
       </AssetEditorMessage>
     );
   }
@@ -52,11 +52,11 @@ export function TreacheryEditPage({ slug, loaderData }: { slug: string; loaderDa
   if (!data.viewerAccess.capabilities.edit) {
     return (
       <AssetEditorMessage type="card-treachery" title={`Edit ${data.asset.name}`}>
-        <Text>
+        <NotAvailable title="You cannot edit this card">
           {data.viewerAccess.assignedGroup
             ? 'Only the card owner or an active member of its group can edit this card.'
             : 'Only the card owner can edit this card.'}
-        </Text>
+        </NotAvailable>
       </AssetEditorMessage>
     );
   }
@@ -65,7 +65,7 @@ export function TreacheryEditPage({ slug, loaderData }: { slug: string; loaderDa
   if (!parsed.success) {
     return (
       <DriftedAssetPage asset={data.asset} noun="card" canDelete={data.viewerAccess.capabilities.delete}>
-        <Text>This card's stored data no longer matches the treachery card schema, so it cannot be edited here.</Text>
+        {`This card's stored data no longer matches the treachery card schema, so it cannot be edited here.`}
       </DriftedAssetPage>
     );
   }

--- a/src/app/routes/_app/assets/$type/create/-bundleCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-bundleCreate.tsx
@@ -1,5 +1,6 @@
-import { Anchor, Text } from '@mantine/core';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Text } from '@mantine/core';
+import { useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
@@ -56,10 +57,7 @@ export function BundleCreatePage() {
   if (profile.data === null) {
     return (
       <AssetEditorMessage title="New bundle" type="bundle">
-        <Text>
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to create
-          bundles.
-        </Text>
+        <LoginGate action="create bundles" />
       </AssetEditorMessage>
     );
   }

--- a/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-deckCreate.tsx
@@ -1,5 +1,6 @@
-import { Alert, Anchor, Text } from '@mantine/core';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Alert, Text } from '@mantine/core';
+import { useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
@@ -63,9 +64,7 @@ export function DeckCreatePage() {
   if (profile.data === null) {
     return (
       <AssetEditorMessage title="New deck" type="deck">
-        <Text>
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to create decks.
-        </Text>
+        <LoginGate action="create decks" />
       </AssetEditorMessage>
     );
   }

--- a/src/app/routes/_app/assets/$type/create/-rectangleCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-rectangleCreate.tsx
@@ -1,5 +1,6 @@
-import { Alert, Anchor, Text } from '@mantine/core';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Alert, Text } from '@mantine/core';
+import { useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
@@ -63,9 +64,7 @@ export function RectangleCreatePage() {
   if (profile.data === null) {
     return (
       <AssetEditorMessage title="New enhance token" type={TYPE}>
-        <Text>
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to create tokens.
-        </Text>
+        <LoginGate action="create tokens" />
       </AssetEditorMessage>
     );
   }

--- a/src/app/routes/_app/assets/$type/create/-tokenCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-tokenCreate.tsx
@@ -1,6 +1,7 @@
-import { Alert, Anchor, Text } from '@mantine/core';
+import { Alert, Text } from '@mantine/core';
 import { ASSET_TYPES, isAssetType } from '@shared/assets/types';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
@@ -61,9 +62,7 @@ export function TokenCreatePage({ type }: { type: string }) {
   if (profile.data === null) {
     return (
       <AssetEditorMessage title={`New ${label} token`} type={type}>
-        <Text>
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to create tokens.
-        </Text>
+        <LoginGate action="create tokens" />
       </AssetEditorMessage>
     );
   }

--- a/src/app/routes/_app/assets/$type/create/-treacheryCreate.tsx
+++ b/src/app/routes/_app/assets/$type/create/-treacheryCreate.tsx
@@ -1,5 +1,5 @@
-import { Anchor, Text } from '@mantine/core';
-import { Link, useNavigate } from '@tanstack/react-router';
+import { useNavigate } from '@tanstack/react-router';
+import { LoginGate } from '@ui/block/LoginGate';
 import type { AuthoringSaveState } from '@ui/content/assetPublishingStatus';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { WorkbenchLayout } from '@ui/layout/WorkbenchLayout';
@@ -56,9 +56,7 @@ export function TreacheryCreatePage() {
   if (profile.data === null) {
     return (
       <AssetEditorMessage title="New treachery card" type="card-treachery">
-        <Text>
-          <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/auth/login" />}>Log in</Anchor> to create cards.
-        </Text>
+        <LoginGate action="create cards" />
       </AssetEditorMessage>
     );
   }

--- a/src/app/routes/_app/assets/-assetEditorStates.tsx
+++ b/src/app/routes/_app/assets/-assetEditorStates.tsx
@@ -1,12 +1,10 @@
-import { Alert, Anchor, Group, Stack, Text } from '@mantine/core';
+import { Alert, Group, Text } from '@mantine/core';
 import { ASSET_TYPES, isAssetType } from '@shared/assets/types';
-import { Link, useNavigate } from '@tanstack/react-router';
-import { PageTitle } from '@ui/block/PageTitle';
+import { useNavigate } from '@tanstack/react-router';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import { AssignOptions, AssignPopover } from '@ui/control/AssignPopover';
 import { ConfirmDeleteAction } from '@ui/control/ConfirmDeleteAction';
 import { IconAction } from '@ui/control/IconAction';
-import { PageLayout } from '@ui/layout/PageLayout';
-import { Surface } from '@ui/surface';
 import { UserRoundMinus, UsersRound } from 'lucide-react';
 import { useState } from 'react';
 import type { ReactNode } from 'react';
@@ -17,10 +15,14 @@ import { mutationErrorMessage } from '@app/db/core/mutationError';
 import { AssetNameInput } from '@app/pickers/AssetNameInput';
 import { nameConflictComplaint } from '@app/pickers/UniqueNameInput';
 import type { NameConflict } from '@app/pickers/UniqueNameInput';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 /**
- * The states an asset editor route reaches instead of an editor: no such asset, not signed in, not allowed, no editor built yet.
- * Shared by the create and edit routes because both reach most of them, and a message that differs between the two would read as a bug rather than a distinction.
+ * The words `PageMessage` wears on an asset editor route, and the destination its way back points at.
+ *
+ * It used to be the frame itself, built independently of the widget and predating it: its own `PageLayout`, its own compact header, its own `Surface`, its own anchor below the words.
+ * The frame is `PageMessage`'s now, so what is left here is the part that is genuinely this feature's: a known type goes back to its own browse page and anything else to the landing, which is a fact about the asset registry rather than about message frames.
+ * `AssetDetailMessage` on the detail route is the same shape for the same reason, so the two siblings now differ only in which browse page they name.
  */
 export function AssetEditorMessage({
   title,
@@ -33,25 +35,21 @@ export function AssetEditorMessage({
   children: ReactNode;
 }) {
   return (
-    <PageLayout>
-      <PageLayout.Header size="compact">
-        <PageTitle title={title} />
-      </PageLayout.Header>
-      <PageLayout.Content>
-        <Surface padding="xl">
-          <Stack gap="sm">
-            {children}
-            {isAssetType(type) ? (
-              <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/assets/$type" params={{ type }} />}>
-                Back to {ASSET_TYPES[type].label.toLowerCase()}
-              </Anchor>
-            ) : (
-              <Anchor renderRoot={(rootProps) => <Link {...rootProps} to="/assets" />}>Back to assets</Anchor>
-            )}
-          </Stack>
-        </Surface>
-      </PageLayout.Content>
-    </PageLayout>
+    <PageMessage
+      size="compact"
+      title={title}
+      back={
+        isAssetType(type) ? (
+          <PageMessage.Back to="/assets/$type" params={{ type }}>
+            Back to {ASSET_TYPES[type].label.toLowerCase()}
+          </PageMessage.Back>
+        ) : (
+          <PageMessage.Back to="/assets">Back to assets</PageMessage.Back>
+        )
+      }
+    >
+      {children}
+    </PageMessage>
   );
 }
 
@@ -78,8 +76,10 @@ export function useAssetDeletion(asset: Pick<NonNullable<AssetPageData>['asset']
 /**
  * An asset whose stored data no longer satisfies its type's schema, reachable whenever a schema tightens ahead of a backfill.
  * The editor cannot open it, but deletion never reads the data, so the owner keeps the one action that still applies rather than needing the database to be rid of it.
- * The message stays the caller's, because each editor names its own schema;
- * the delete affordance is what every drifted asset shares.
+ * The message stays the caller's, because each editor names its own schema, and they are not interchangeable: four of the five say "the token schema" or "the deck schema" after their own noun, while the treachery editor says "the treachery card schema" after "card".
+ * The delete affordance is what every drifted asset shares.
+ *
+ * This is the one state here that is not one of the four bodies, because it ends in an action rather than in words: the heading and sentence are a `NotAvailable`, and the offer to delete sits beside it in the same slot.
  */
 export function DriftedAssetPage({
   asset,
@@ -88,16 +88,17 @@ export function DriftedAssetPage({
   children,
 }: {
   asset: NonNullable<AssetPageData>['asset'];
-  /** The word on the delete control: "Delete card", "Delete token". */
+  /** The word on the delete control and in the heading: "Delete card", "This card cannot be edited". */
   noun: string;
   canDelete: boolean;
-  children: ReactNode;
+  /** Why this one cannot open, naming the schema the editor actually parses against. */
+  children: string;
 }) {
   const deletion = useAssetDeletion(asset);
 
   return (
     <AssetEditorMessage title={`Edit ${asset.name}`} type={asset.type}>
-      {children}
+      <NotAvailable title={`This ${noun} cannot be edited`}>{children}</NotAvailable>
       {canDelete ? (
         <>
           <Text size="sm" c="dimmed">
@@ -124,8 +125,10 @@ export function DriftedAssetPage({
 export function NoEditorYet({ type }: { type: string }) {
   const label = isAssetType(type) ? ASSET_TYPES[type].label.toLowerCase() : 'assets of this type';
   return (
-    <AssetEditorMessage title="No editor yet" type={type}>
-      <Text>There is no editor for {label} yet. This type is on the roadmap and cannot hold assets so far.</Text>
+    <AssetEditorMessage title={isAssetType(type) ? ASSET_TYPES[type].label : 'Assets'} type={type}>
+      <NotAvailable title="No editor yet">
+        {`There is no editor for ${label} yet. This type is on the roadmap and cannot hold assets so far.`}
+      </NotAvailable>
     </AssetEditorMessage>
   );
 }


### PR DESCRIPTION
Closes [#796](https://github.com/ndelangen/dunezone/issues/796), the largest population the item-1 audit found.

`AssetEditorMessage` was a second page-message frame, built independently and predating the widget: its own `PageLayout`, its own compact header, its own `Surface`, its own anchor below the words. Twenty-two render sites across eleven files, plus `DriftedAssetPage` and `NoEditorYet` routing through it, and every body a bare `Text`.

## What moved and what stayed

**The frame is `PageMessage`'s.** What stays in `-assetEditorStates.tsx` is the part that is genuinely this feature's: a known asset type goes back to its own browse page and anything else to the landing. That is a fact about the registry rather than about message frames, and `AssetDetailMessage` on the detail route has been exactly this shape since #726, so the two siblings now differ only in which browse page they name.

I kept the name rather than deleting it, which is a deviation from the ticket's wording ("retiring AssetEditorMessage"). The duplicate *frame* is what is retired; the type-to-destination logic would otherwise be spelled at twenty-two call sites. If you would rather see the identifier go, it is a rename plus twenty-two touches and I will do it.

**The bodies became the four blocks.** Ten hand-rolled login sentences are `LoginGate`, five not-found and five denied states are `NotAvailable`, and the way back moved from inside the pane to the band.

**Two states needed a title split.** The frame title was carrying the state rather than the page: an editor whose asset is missing announced itself as "Deck not found" and had no page name at all. It now says "Edit deck" in the band with "Deck not found" as the body's heading, which is the same split `AssetDetailMessage` uses. `NoEditorYet` reads the same way, with the type's own label in the band.

**The drifted-asset state stays bespoke**, and deliberately: it ends in an action rather than in words, so its heading and sentence are a `NotAvailable` and the offer to delete sits beside it in the same slot. Its message stays the caller's, because that JSDoc claim turned out to still be load-bearing for exactly one caller: four editors say "the token schema" or "the deck schema" after their own noun, and the treachery editor says "the treachery card schema" after "card". I checked before collapsing it, and did not collapse it.

## Proof, with the discrimination the protocol now asks for

Three new page stories, each with `play` assertions rather than a bare mount, following the `SignedOut` precedent in `rulesets/-create.stories.tsx`.

| story | asserts |
|---|---|
| `Assets/EditDeckSignedOut` | the "Log in" link, the way back, **and that the way back is not inside `main`** |
| `Assets/EditDeckMissing` | "Edit deck" in the band **and** "Deck not found" as the body heading |
| `Assets/CreateStormCardNoEditor` | "Storm cards" in the band **and** "No editor yet" as the body heading |

And the A/B, run by reverting every converted file to `real-origin/main` and leaving the three stories in place:

| | with the conversion | against unconverted main |
|---|---|---|
| `EditDeckSignedOut` | pass | **fail** |
| `EditDeckMissing` | pass | **fail** |
| `CreateStormCardNoEditor` | pass | **fail** |

The signed-out story is the one that needed thought. Its words do not change: that route already used a themed anchor, so nothing visible differs except where the way back sits. Asserting the position is what makes it discriminate instead of passing against either version; without that line it was a story that would have gone green on main.

![Signed out on a deck editor](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-796-edit-deck-signedout.png)

![A slug naming no deck](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-796-edit-deck-missing.png)

![A type with no editor yet](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-796-create-storm-noeditor.png)

## Two things found on the way, neither fixed here

**The create pages' signed-out state is not story-reachable.** I tried `CreateDeckSignedOut` first and it rendered the full deck editor, Save button and all, to an anonymous viewer. That is not an app bug: `useCurrentProfile` documents at `src/app/db/profiles.ts:93` that `session.profile` is `null` for a signed-out viewer, and the create gates read `profile.data === null`, which fires correctly in production. In Storybook, `identity: null` leaves `profiles.session` unresolved rather than answering "signed out", so a strict `=== null` gate never fires. Routes that gate on `!profile.data?.x` show the gate in both cases, which is why the ruleset create story works.

Two consequences worth someone's attention, neither mine to take here: the story seam cannot currently express "signed out" for anything reading the profile session, and the app has two gate spellings that differ during the pending window, so an anonymous visitor briefly sees the deck editor and never the ruleset one. I used the edit route instead, whose gate reads `viewerAccess.viewer.kind` and is decided server-side.

**One storybook run failed under load.** Running `storybook:test` concurrently with the unit tests and typecheck, `EditDeckSignedOut` timed out once. Three subsequent runs alone passed 448/448. My three stories each mount a full route with 30s waits, matching the existing precedent's timeout, so this is contention rather than a defect, but three more heavy page stories is a real addition to that suite's cost and I would rather say so than have CI discover it.

## Verified

Rebased onto `2c13e30996c` and re-run there, not on the pre-rebase tree. Local gates: typecheck, lint, format:check, check:prose, check:app-layout, check:css-orphans, knip, 767 unit tests, 448 storybook tests. `bun run check` reports no capture-bundle changes.
