### PR TITLE
The straggler frames join the vocabulary

### DIFF
--- a/src/app/routes/-site.stories.tsx
+++ b/src/app/routes/-site.stories.tsx
@@ -1,4 +1,5 @@
 import preview from '@sb/preview';
+import { expect, within } from 'storybook/test';
 
 import { pageStoryMeta } from './-storybookConfig';
 
@@ -7,8 +8,39 @@ const meta = preview.meta({
   ...pageStoryMeta,
 });
 
-export const NotFound = meta.story({ args: { path: '/a-page-that-does-not-exist' } });
+/**
+ * The most-reached message in the application, and the last one to wear the shared frame.
+ * The assertions distinguish the frame from what stood here before, which was a bare paragraph and a raw link under a title with no pane.
+ */
+export const NotFound = meta.story({
+  args: { path: '/a-page-that-does-not-exist' },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(page.findByRole('heading', { name: 'Page not found' }, { timeout: 30_000 })).resolves.toBeVisible();
+    await expect(
+      page.findByRole('heading', { name: 'This page does not exist' }, { timeout: 30_000 })
+    ).resolves.toBeVisible();
+    const back = await page.findByRole('link', { name: 'Go back home' }, { timeout: 30_000 });
+    expect(back.closest('main')).toBeNull();
+  },
+});
 export const Icons = meta.story({ args: { path: '/__icons' } });
 export const PublicationJobs = meta.story({ args: { path: '/__jobs' } });
+
+/** The job queue reached by a reader the server does not recognise, which is a login gate rather than an alert inside a dashboard header. */
+export const PublicationJobsSignedOut = meta.story({
+  args: { path: '/__jobs' },
+  parameters: { identity: null },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(page.findByRole('link', { name: 'Log in' }, { timeout: 30_000 })).resolves.toBeVisible();
+    /* The dashboard's own header, with its briefcase and its description, is what the frame replaces. */
+    await expect(
+      page.queryByText(
+        'Inspect the durable work queue and control whether the next scheduled run may pick up pending work.'
+      )
+    ).toBeNull();
+  },
+});
 export const FuturePlans = meta.story({ args: { path: '/future-plans' } });
 export const Privacy = meta.story({ args: { path: '/privacy' } });

--- a/src/app/routes/_app/[_]_jobs.tsx
+++ b/src/app/routes/_app/[_]_jobs.tsx
@@ -1,26 +1,17 @@
-import {
-  Alert,
-  Badge,
-  Center,
-  Code,
-  Group,
-  Loader,
-  Pagination,
-  Select,
-  Stack,
-  Switch,
-  Table,
-  Text,
-} from '@mantine/core';
+import { Alert, Badge, Center, Code, Group, Pagination, Select, Stack, Switch, Table, Text } from '@mantine/core';
 import { createFileRoute } from '@tanstack/react-router';
+import { LoadPending } from '@ui/block/LoadPending';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import { PageTitle } from '@ui/block/PageTitle';
 import { PageLayout } from '@ui/layout/PageLayout';
 import { Surface } from '@ui/surface';
-import { AlertCircle, BriefcaseBusiness } from 'lucide-react';
+import { BriefcaseBusiness } from 'lucide-react';
 import { useState } from 'react';
 
 import { usePublicationJobsPage, useSetPublicationPickupEnabled } from '@db/publications';
 import type { PublicationJobStatus } from '@db/publications';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 const PAGE_SIZE = 25;
 
@@ -41,6 +32,36 @@ function PublicationJobsPage() {
   });
   const pickupMutation = useSetPublicationPickupEnabled();
 
+  /* Early returns rather than a ternary chain inside the content: each of the first three is the
+     whole page rather than one region of it, and rendering them under this page's own header meant
+     a reader who may not see the queue at all still got its briefcase and its description. The
+     header is a statement about a dashboard they are not being shown. */
+  if (result === undefined) {
+    return (
+      <PageMessage size="compact" title="Publication jobs">
+        <LoadPending title="Loading publication jobs">The durable work queue is still loading.</LoadPending>
+      </PageMessage>
+    );
+  }
+
+  if (result.access === 'unauthenticated') {
+    return (
+      <PageMessage size="compact" title="Publication jobs">
+        <LoginGate action="inspect publication jobs" />
+      </PageMessage>
+    );
+  }
+
+  if (result.access === 'not_authorized') {
+    return (
+      <PageMessage size="compact" title="Publication jobs">
+        <NotAvailable title="You cannot view publication jobs">
+          Your account does not have permission to view publication jobs.
+        </NotAvailable>
+      </PageMessage>
+    );
+  }
+
   return (
     <PageLayout>
       <PageLayout.Header size="compact">
@@ -53,169 +74,155 @@ function PublicationJobsPage() {
         </Stack>
       </PageLayout.Header>
       <PageLayout.Content>
-        {result === undefined ? (
-          <Center py="xl">
-            <Loader aria-label="Loading publication jobs" />
-          </Center>
-        ) : result.access === 'unauthenticated' ? (
-          <Alert icon={<AlertCircle size={18} />} title="Sign in required" color="yellow">
-            Sign in with an administrator account to inspect publication jobs.
-          </Alert>
-        ) : result.access === 'not_authorized' ? (
-          <Alert icon={<AlertCircle size={18} />} title="Not authorized" color="red">
-            Your account does not have permission to view publication jobs.
-          </Alert>
-        ) : (
-          <Stack gap="lg">
-            <Surface padding="lg">
-              <Stack gap="lg">
-                <Group justify="space-between" align="flex-start" wrap="wrap">
-                  <div>
-                    <Text fw={700}>Publisher pickup</Text>
-                    <Text size="sm" c="dimmed" maw={620}>
-                      Turning this off only prevents the next cron run from picking up pending jobs. It does not
-                      interrupt work already in progress.
-                    </Text>
-                  </div>
-                  <Switch
-                    size="lg"
-                    checked={result.settings?.publicationPickupEnabled ?? false}
-                    disabled={result.settings === null || pickupMutation.isPending}
-                    label={result.settings?.publicationPickupEnabled ? 'Enabled' : 'Disabled'}
-                    onChange={(event) => pickupMutation.mutate({ enabled: event.currentTarget.checked })}
-                  />
-                </Group>
-
-                {pickupMutation.isError ? (
-                  <Alert color="red" title="Could not update publisher pickup">
-                    {pickupMutation.error?.message}
-                  </Alert>
-                ) : null}
-
-                <Group gap="xl" align="flex-start" wrap="wrap">
-                  <Count label="Pending" value={result.counts.pending} color="yellow" />
-                  <Count label="In progress" value={result.counts.inProgress} color="blue" />
-                  <Count label="Error" value={result.counts.error} color="red" />
-                  <div>
-                    <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
-                      Renderer revisions
-                    </Text>
-                    <Group gap="xs" mt={4}>
-                      {result.settings
-                        ? Object.entries(result.settings.rendererRevisions).map(([type, revision]) => (
-                            <Badge variant="light" key={type}>
-                              {formatAssetType(type)} · {revision}
-                            </Badge>
-                          ))
-                        : 'Not initialized'}
-                    </Group>
-                  </div>
-                </Group>
-              </Stack>
-            </Surface>
-
-            <Surface>
-              <Group p="md" justify="space-between" align="end" wrap="wrap">
-                <Group align="end">
-                  <Select
-                    label="Status"
-                    clearable
-                    placeholder="All statuses"
-                    value={status ?? null}
-                    data={[
-                      { value: 'error', label: 'Error' },
-                      { value: 'in_progress', label: 'In progress' },
-                      { value: 'pending', label: 'Pending' },
-                    ]}
-                    onChange={(value) => {
-                      setStatus((value as PublicationJobStatus | null) ?? undefined);
-                      setPage(1);
-                    }}
-                  />
-                  <Select
-                    label="Asset type"
-                    clearable
-                    placeholder="All asset types"
-                    value={assetType ?? null}
-                    data={Object.keys(result.settings?.rendererRevisions ?? {}).map((value) => ({
-                      value,
-                      label: formatAssetType(value),
-                    }))}
-                    onChange={(value) => {
-                      setAssetType(value ?? undefined);
-                      setPage(1);
-                    }}
-                  />
-                </Group>
-                <Text size="sm" c="dimmed">
-                  {result.total} {result.total === 1 ? 'job' : 'jobs'}
-                </Text>
+        <Stack gap="lg">
+          <Surface padding="lg">
+            <Stack gap="lg">
+              <Group justify="space-between" align="flex-start" wrap="wrap">
+                <div>
+                  <Text fw={700}>Publisher pickup</Text>
+                  <Text size="sm" c="dimmed" maw={620}>
+                    Turning this off only prevents the next cron run from picking up pending jobs. It does not interrupt
+                    work already in progress.
+                  </Text>
+                </div>
+                <Switch
+                  size="lg"
+                  checked={result.settings?.publicationPickupEnabled ?? false}
+                  disabled={result.settings === null || pickupMutation.isPending}
+                  label={result.settings?.publicationPickupEnabled ? 'Enabled' : 'Disabled'}
+                  onChange={(event) => pickupMutation.mutate({ enabled: event.currentTarget.checked })}
+                />
               </Group>
 
-              <Table.ScrollContainer minWidth={980}>
-                <Table striped highlightOnHover verticalSpacing="sm">
-                  <Table.Thead>
-                    <Table.Tr>
-                      <Table.Th>Status</Table.Th>
-                      <Table.Th>Asset</Table.Th>
-                      <Table.Th>Attempts</Table.Th>
-                      <Table.Th>Lease expires</Table.Th>
-                      <Table.Th>Last error</Table.Th>
-                      <Table.Th>Updated</Table.Th>
-                      <Table.Th>Job ID</Table.Th>
-                    </Table.Tr>
-                  </Table.Thead>
-                  <Table.Tbody>
-                    {result.jobs.length > 0 ? (
-                      result.jobs.map((job) => (
-                        <Table.Tr key={job.id}>
-                          <Table.Td>
-                            <JobStatusBadge status={job.status} />
-                          </Table.Td>
-                          <Table.Td>
-                            <Text fw={600}>{formatAssetType(job.assetType)}</Text>
-                            <Code>{job.assetId}</Code>
-                          </Table.Td>
-                          <Table.Td>{job.attemptCounter}</Table.Td>
-                          <Table.Td>{formatDate(job.expiresAt)}</Table.Td>
-                          <Table.Td>
-                            <Text size="sm" c={job.error ? 'red' : 'dimmed'} maw={280} lineClamp={3}>
-                              {job.error ?? '—'}
-                            </Text>
-                          </Table.Td>
-                          <Table.Td>{formatDate(job.updatedAt)}</Table.Td>
-                          <Table.Td>
-                            <Code>{job.id}</Code>
-                          </Table.Td>
-                        </Table.Tr>
-                      ))
-                    ) : (
-                      <Table.Tr>
-                        <Table.Td colSpan={7}>
-                          <Text ta="center" c="dimmed" py="lg">
-                            No publication jobs match these filters.
+              {pickupMutation.isError ? (
+                <Alert color="red" title="Could not update publisher pickup">
+                  {pickupMutation.error?.message}
+                </Alert>
+              ) : null}
+
+              <Group gap="xl" align="flex-start" wrap="wrap">
+                <Count label="Pending" value={result.counts.pending} color="yellow" />
+                <Count label="In progress" value={result.counts.inProgress} color="blue" />
+                <Count label="Error" value={result.counts.error} color="red" />
+                <div>
+                  <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                    Renderer revisions
+                  </Text>
+                  <Group gap="xs" mt={4}>
+                    {result.settings
+                      ? Object.entries(result.settings.rendererRevisions).map(([type, revision]) => (
+                          <Badge variant="light" key={type}>
+                            {formatAssetType(type)} · {revision}
+                          </Badge>
+                        ))
+                      : 'Not initialized'}
+                  </Group>
+                </div>
+              </Group>
+            </Stack>
+          </Surface>
+
+          <Surface>
+            <Group p="md" justify="space-between" align="end" wrap="wrap">
+              <Group align="end">
+                <Select
+                  label="Status"
+                  clearable
+                  placeholder="All statuses"
+                  value={status ?? null}
+                  data={[
+                    { value: 'error', label: 'Error' },
+                    { value: 'in_progress', label: 'In progress' },
+                    { value: 'pending', label: 'Pending' },
+                  ]}
+                  onChange={(value) => {
+                    setStatus((value as PublicationJobStatus | null) ?? undefined);
+                    setPage(1);
+                  }}
+                />
+                <Select
+                  label="Asset type"
+                  clearable
+                  placeholder="All asset types"
+                  value={assetType ?? null}
+                  data={Object.keys(result.settings?.rendererRevisions ?? {}).map((value) => ({
+                    value,
+                    label: formatAssetType(value),
+                  }))}
+                  onChange={(value) => {
+                    setAssetType(value ?? undefined);
+                    setPage(1);
+                  }}
+                />
+              </Group>
+              <Text size="sm" c="dimmed">
+                {result.total} {result.total === 1 ? 'job' : 'jobs'}
+              </Text>
+            </Group>
+
+            <Table.ScrollContainer minWidth={980}>
+              <Table striped highlightOnHover verticalSpacing="sm">
+                <Table.Thead>
+                  <Table.Tr>
+                    <Table.Th>Status</Table.Th>
+                    <Table.Th>Asset</Table.Th>
+                    <Table.Th>Attempts</Table.Th>
+                    <Table.Th>Lease expires</Table.Th>
+                    <Table.Th>Last error</Table.Th>
+                    <Table.Th>Updated</Table.Th>
+                    <Table.Th>Job ID</Table.Th>
+                  </Table.Tr>
+                </Table.Thead>
+                <Table.Tbody>
+                  {result.jobs.length > 0 ? (
+                    result.jobs.map((job) => (
+                      <Table.Tr key={job.id}>
+                        <Table.Td>
+                          <JobStatusBadge status={job.status} />
+                        </Table.Td>
+                        <Table.Td>
+                          <Text fw={600}>{formatAssetType(job.assetType)}</Text>
+                          <Code>{job.assetId}</Code>
+                        </Table.Td>
+                        <Table.Td>{job.attemptCounter}</Table.Td>
+                        <Table.Td>{formatDate(job.expiresAt)}</Table.Td>
+                        <Table.Td>
+                          <Text size="sm" c={job.error ? 'red' : 'dimmed'} maw={280} lineClamp={3}>
+                            {job.error ?? '—'}
                           </Text>
                         </Table.Td>
+                        <Table.Td>{formatDate(job.updatedAt)}</Table.Td>
+                        <Table.Td>
+                          <Code>{job.id}</Code>
+                        </Table.Td>
                       </Table.Tr>
-                    )}
-                  </Table.Tbody>
-                </Table>
-              </Table.ScrollContainer>
-            </Surface>
+                    ))
+                  ) : (
+                    <Table.Tr>
+                      <Table.Td colSpan={7}>
+                        <Text ta="center" c="dimmed" py="lg">
+                          No publication jobs match these filters.
+                        </Text>
+                      </Table.Td>
+                    </Table.Tr>
+                  )}
+                </Table.Tbody>
+              </Table>
+            </Table.ScrollContainer>
+          </Surface>
 
-            {result.total > PAGE_SIZE ? (
-              <Center>
-                <Pagination
-                  value={result.page}
-                  onChange={setPage}
-                  total={Math.ceil(result.total / result.pageSize)}
-                  withEdges
-                  aria-label="Publication job pages"
-                />
-              </Center>
-            ) : null}
-          </Stack>
-        )}
+          {result.total > PAGE_SIZE ? (
+            <Center>
+              <Pagination
+                value={result.page}
+                onChange={setPage}
+                total={Math.ceil(result.total / result.pageSize)}
+                withEdges
+                aria-label="Publication job pages"
+              />
+            </Center>
+          ) : null}
+        </Stack>
       </PageLayout.Content>
     </PageLayout>
   );

--- a/src/app/routes/_app/index.tsx
+++ b/src/app/routes/_app/index.tsx
@@ -1,22 +1,10 @@
-import {
-  Anchor,
-  Avatar,
-  Badge,
-  Box,
-  Button,
-  Group,
-  Loader,
-  SimpleGrid,
-  Stack,
-  Text,
-  Title,
-  Tooltip,
-} from '@mantine/core';
+import { Anchor, Avatar, Badge, Box, Button, Group, SimpleGrid, Stack, Text, Title, Tooltip } from '@mantine/core';
 import { useReducedMotion } from '@mantine/hooks';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { FactionCatalogueSpotlight } from '@ui/block/FactionCatalogueSpotlight';
 import { LoadError } from '@ui/block/LoadError';
+import { LoadPending } from '@ui/block/LoadPending';
 import { PageTitle } from '@ui/block/PageTitle';
 import { Section } from '@ui/block/Section';
 import { formatFactionCatalogueDate } from '@ui/content/dates';
@@ -34,6 +22,7 @@ import { SiBoardgamegeek, SiDiscord } from 'react-icons/si';
 
 import { loadHomepage, useHomepage } from '@db/homepage';
 import { isStaleClientData } from '@app/db/core/clientBoundary';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 import { LeaderToken } from '@game/assets/faction/leader/Leader';
 import { factionTokenFixtures } from '@game/fixtures/factionTokens';
 
@@ -398,37 +387,30 @@ function AnimatedLeaderToken() {
   );
 }
 
+/*
+ * No way back on either: the landing page is the top of every branch, so a link here would point at
+ * the page the reader is already on.
+ *
+ * These were half-converted before, which is the failure mode the widget's own doc warns about: the
+ * error frame used the body and not the frame, so its alert sat straight on the page background
+ * while every other caller's sat on a pane, and the pending frame used neither, hand-rolling a
+ * `Surface` whose missing padding prop resolved to none against the frame's xl.
+ */
 function HomepagePending() {
   return (
-    <PageLayout>
-      <PageLayout.Header size="hero">
-        <PageTitle title="Make Dune your own" />
-      </PageLayout.Header>
-      <PageLayout.Content>
-        <Surface>
-          <Stack align="center" gap="sm">
-            <Loader size="sm" />
-            <Title order={2}>Setting the table</Title>
-            <Text c="dimmed">The latest work from the community is loading.</Text>
-          </Stack>
-        </Surface>
-      </PageLayout.Content>
-    </PageLayout>
+    <PageMessage size="hero" title="Make Dune your own">
+      <LoadPending title="Setting the table">The latest work from the community is loading.</LoadPending>
+    </PageMessage>
   );
 }
 
 function HomepageError({ error }: ErrorComponentProps) {
   return (
-    <PageLayout>
-      <PageLayout.Header size="hero">
-        <PageTitle title="Make Dune your own" />
-      </PageLayout.Header>
-      <PageLayout.Content>
-        <LoadError title="The homepage could not be loaded" stale={isStaleClientData(error)}>
-          {error.message}
-        </LoadError>
-      </PageLayout.Content>
-    </PageLayout>
+    <PageMessage size="hero" title="Make Dune your own">
+      <LoadError title="The homepage could not be loaded" stale={isStaleClientData(error)}>
+        {error.message}
+      </LoadError>
+    </PageMessage>
   );
 }
 

--- a/src/app/routes/_app/profiles/$profileSlug/-delete.test.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/-delete.test.tsx
@@ -21,6 +21,12 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     ...actual,
     createFileRoute: () => (options: unknown) => ({ options, useParams: () => ({ profileSlug: 'source' }) }),
     Link: ({ children, to }: { children?: ReactNode; to: string }) => <a href={to}>{children}</a>,
+    /* `PageMessage.Back` is built with `createLink`, whose `useLinkProps` reads router context and
+       throws without a `RouterProvider`. Mocking it to the same plain anchor `Link` already gets
+       keeps this a unit test of the page rather than of the router. */
+    createLink:
+      () =>
+      ({ children, to }: { children?: ReactNode; to: string }) => <a href={to}>{children}</a>,
   };
 });
 
@@ -154,7 +160,9 @@ describe('account deletion page', () => {
   });
 
   it.each([
-    [{ kind: 'denied', reason: 'signed_out' }, 'Account deletion is unavailable'],
+    /* The marker moved with the words: a signed-out reader now gets the login gate rather than the
+       sentence that used to serve both denial reasons, so "Log in" is what identifies this state. */
+    [{ kind: 'denied', reason: 'signed_out' }, 'Log in'],
     [
       {
         kind: 'pending',

--- a/src/app/routes/_app/profiles/$profileSlug/delete.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/delete.tsx
@@ -1,6 +1,10 @@
-import { Alert, Anchor, Button, Checkbox, Group, List, Loader, Popover, Stack, Text, Title } from '@mantine/core';
+import { Alert, Button, Checkbox, Group, List, Popover, Stack, Text, Title } from '@mantine/core';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { FormError } from '@ui/block/FormError';
+import { LoadError } from '@ui/block/LoadError';
+import { LoadPending } from '@ui/block/LoadPending';
+import { LoginGate } from '@ui/block/LoginGate';
+import { NotAvailable } from '@ui/block/NotAvailable';
 import { ConfirmDeleteButton } from '@ui/control/ConfirmDeleteButton';
 import { IconAction } from '@ui/control/IconAction';
 import { PageLayout } from '@ui/layout/PageLayout';
@@ -12,6 +16,7 @@ import { useState } from 'react';
 import { useAccountDeletionPage, useConfirmAccountDeletion } from '@db/accountDeletion';
 import type { ReplacementProfile } from '@db/accountDeletion';
 import { ProfilePicker } from '@app/pickers/ProfilePicker';
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 const kindLabels = { group: 'Groups', faction: 'Factions', ruleset: 'Rulesets' } as const;
 
@@ -42,70 +47,67 @@ function AccountDeletionPage() {
     </Toolbar>
   );
 
+  const backToSettings = (
+    <PageMessage.Back to="/profiles/$profileSlug/edit" params={{ profileSlug }}>
+      Back to profile settings
+    </PageMessage.Back>
+  );
+
   if (page.isPending) {
     return (
-      <PageLayout>
-        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Loader aria-label="Loading account deletion" />
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Delete account" back={backToSettings}>
+        <LoadPending title="Loading">Checking what deleting this account would affect.</LoadPending>
+      </PageMessage>
     );
   }
 
   const data = page.data;
-  if (!data || data.kind === 'denied') {
+  /* The server already tells these two apart, sending `reason: 'signed_out'` or `'wrong_profile'`;
+     this page used to collapse both into one sentence that offered a login link to a reader who was
+     already logged in. The vocabulary makes keeping the distinction cheaper than losing it. */
+  if (!data || (data.kind === 'denied' && data.reason === 'signed_out')) {
     return (
-      <PageLayout>
-        <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Stack gap="sm">
-              <Title order={1}>Account deletion is unavailable</Title>
-              <Text>You must be signed in to the profile named in this address.</Text>
-              <Anchor component={Link} to="/auth/login">
-                Log in
-              </Anchor>
-            </Stack>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Delete account" back={backToSettings}>
+        <LoginGate action="delete your account" />
+      </PageMessage>
+    );
+  }
+
+  if (data.kind === 'denied') {
+    return (
+      <PageMessage title="Delete account" back={backToSettings}>
+        <NotAvailable title="This is not your account">
+          You must be signed in to the profile named in this address.
+        </NotAvailable>
+      </PageMessage>
     );
   }
 
   if (data.kind === 'pending') {
+    const failed = data.operation?.state === 'failed';
     return (
-      <PageLayout>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Alert color={data.operation?.state === 'failed' ? 'red' : 'blue'} title="Account deletion is in progress">
-              {data.operation?.state === 'failed'
-                ? (data.operation.error ?? 'The operation needs administrative repair before it can continue.')
-                : `Current phase: ${data.operation?.phase ?? 'starting'}. This page updates automatically.`}
-            </Alert>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Delete account" back={backToSettings}>
+        {failed ? (
+          <LoadError title="Account deletion did not finish" stale={false}>
+            {data.operation?.error ?? 'The operation needs administrative repair before it can continue.'}
+          </LoadError>
+        ) : (
+          <LoadPending title="Account deletion is in progress">
+            {`Current phase: ${data.operation?.phase ?? 'starting'}. This page updates automatically.`}
+          </LoadPending>
+        )}
+      </PageMessage>
     );
   }
 
   if (data.kind === 'deleted') {
+    /* The one state here with no block: a finished action is neither absent, pending nor failed, and
+       the four bodies are all ways of saying a page has nothing to show. The frame still carries the
+       name and the way out, which is what it was missing before. */
     return (
-      <PageLayout>
-        <PageLayout.Content>
-          <Surface padding="xl">
-            <Stack gap="md">
-              <Title order={1}>Account deleted</Title>
-              <Text>Your account and direct ownership have been disposed according to your choice.</Text>
-              <Anchor component={Link} to="/">
-                Return to Dune Zone
-              </Anchor>
-            </Stack>
-          </Surface>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Account deleted" back={<PageMessage.Back to="/">Return to Dune Zone</PageMessage.Back>}>
+        <Text>Your account and direct ownership have been disposed according to your choice.</Text>
+      </PageMessage>
     );
   }
 

--- a/src/app/shell/AppNotFound.tsx
+++ b/src/app/shell/AppNotFound.tsx
@@ -1,21 +1,25 @@
-import { Link } from '@tanstack/react-router';
-import { PageTitle } from '@ui/block/PageTitle';
-import { PageLayout } from '@ui/layout/PageLayout';
+import { NotAvailable } from '@ui/block/NotAvailable';
+
+import { PageMessage } from '@app/widgets/page-message/PageMessage';
 
 import { ApplicationChrome } from './ApplicationChrome';
 
+/**
+ * The not-there page for the whole `_app` subtree, mounted as its `notFoundComponent` and thrown into directly by the catch-all route.
+ * It is the most-reached message in the application and was the last one not wearing the shared frame: a bare paragraph and a raw link under a title, with no pane.
+ *
+ * This is the first place the shell installs a widget rather than only the kit.
+ * The dependency runs the legal way, since the kit is imported by the shell, by widgets and by routes and never the reverse, and the alternative was worse: keeping the hand-rolled frame and swapping only the words would leave the page half-converted, which is the state this component's own body is here to remove elsewhere.
+ * The chrome stays this component's, because a `notFoundComponent` mounts outside the layout that would otherwise supply it.
+ */
 export function AppNotFound() {
   return (
     <ApplicationChrome>
-      <PageLayout>
-        <PageLayout.Header>
-          <PageTitle title="404 - Page Not Found" />
-        </PageLayout.Header>
-        <PageLayout.Content>
-          <p>The page you're looking for doesn't exist.</p>
-          <Link to="/">Go back home</Link>
-        </PageLayout.Content>
-      </PageLayout>
+      <PageMessage title="Page not found" back={<PageMessage.Back to="/">Go back home</PageMessage.Back>}>
+        <NotAvailable title="This page does not exist">
+          The address may be mistyped, or whatever lived here has since been removed.
+        </NotAvailable>
+      </PageMessage>
     </ApplicationChrome>
   );
 }

--- a/src/app/widgets/page-message/PageMessage.tsx
+++ b/src/app/widgets/page-message/PageMessage.tsx
@@ -35,6 +35,9 @@ export interface PageMessageProps {
  * The message never says which state it is showing;
  * the caller has already decided that by choosing which block to hand it.
  *
+ * Testing contract: `PageMessage.Back` is built with `createLink`, whose `useLinkProps` reads router context and throws outside a `RouterProvider`, so a unit test rendering one of these frames must supply a router or mock `createLink` alongside `Link`.
+ * It surfaces as `Cannot read properties of null (reading 'isServer')` rather than as a failed assertion, which is why it is written down here rather than left to be rediscovered.
+ *
  * It exists because about seventeen sites framed these messages themselves, and the frames drifted apart while nobody was comparing them: some centred the header and some did not, some offered a way back inside the pane and some in a toolbar and some not at all, and the pane came at two paddings depending on which page you had reached.
  */
 export function PageMessage({ title, size = 'default', back, children }: PageMessageProps) {


### PR DESCRIPTION
Closes [#797](https://github.com/ndelangen/dunezone/issues/797). The four sites the item-1 audit left, converted rather than exempted.

## The account deletion page

Four hand-rolled whole-page frames and no header band in any of them, so the page lost its own name in every state and its way back appeared and disappeared depending on which one you landed in.

The interesting part is its denied branch. It read `!data || data.kind === 'denied'` and answered both with one sentence plus a login link, so a reader who was already signed in as the wrong person was invited to log in. The server has always told the two apart, sending `reason: 'signed_out'` or `reason: 'wrong_profile'` (`convex/accountDeletion.ts:139` and `:143`), and the page discarded it. They are now a `LoginGate` and a `NotAvailable`.

Its in-progress state was one `Alert` whose colour flipped to red on failure under an unchanged "in progress" title. Those are two states, and they are now `LoadPending` (`status`, polite) and `LoadError` (`alert`, assertive) with a title that says the operation did not finish.

The finished state is the one thing here with no block: a completed action is neither absent, pending nor failed, and all four bodies are ways of saying a page has nothing to show. It keeps a bare sentence, and gains the name and the way out it never had.

## The homepage

Half-converted, which is the failure mode the widget's own doc names. `HomepageError` used the body and not the frame, so its alert sat directly on the page background while every other caller's sat on a pane. `HomepagePending` used neither and hand-rolled a `Surface` with no `padding` prop, which resolves to `none` against the frame's `xl`.

## The publication jobs dashboard

Its first three states were arms of a ternary inside the content, so a reader who may not see the queue at all still got the dashboard's briefcase, its title and its description above the refusal. They are early returns now, and the header is reserved for the page that actually shows a queue.

## AppNotFound, converted rather than exempted

The ticket allows recording why a site stays, and flags that this one "may argue it IS the frame". I converted it, and the argument is that it is not a frame but a page: the most-reached message in the application, rendering a bare `<p>` and a raw `<Link>` under a title with no pane.

**This is the first place the shell installs a widget rather than only the kit,** and that deserves your eye. The dependency runs the legal direction: `.oxlintrc.json` restricts only `src/app/ui` from reaching into shell, widgets and routes, and its own message says the kit is imported by the shell, by widgets and by routes and never the reverse. The alternative was to keep the hand-rolled frame and swap only the words, which is precisely the half-conversion this same PR removes from the homepage. If you would rather the shell stayed widget-free, the fallback is to leave `AppNotFound` as it is and record it as an exemption; I did not want to pick that quietly.

Its title also changes, from "404 - Page Not Found" to "Page not found" in the band with "This page does not exist" as the body's heading. That is the same title split the asset editors needed: the frame title was carrying the state rather than naming the page.

## Proof

Two page stories, both with assertions rather than a bare mount, and both checked against a full revert.

| story | asserts | with the conversion | against unconverted main |
|---|---|---|---|
| `Site/NotFound` | "Page not found" in the band, "This page does not exist" as the body heading, and the way back **not inside `main`** | pass | **fail** |
| `Site/PublicationJobsSignedOut` | the "Log in" link, **and that the dashboard's description is absent** | pass | **fail** |

The A/B was run by reverting all five changed source files to `real-origin/main` with the stories left in place, not by reasoning about what would happen.

**Two sites are not story-covered, and I would rather say so than imply otherwise.** The homepage's pending and error frames need a staged loader or a thrown one, and I did not add stories that stage them. The account deletion page has no page story; it does have a unit suite (`-delete.test.tsx`) that covers three of its lifecycle states and the fail-closed case, which I kept passing and did not weaken.

## One thing this surfaced about the widget

`PageMessage.Back` is built with `createLink`, whose `useLinkProps` reads router context and throws outside a `RouterProvider`. The delete page's unit test mocked `Link` but not `createLink`, so converting the page broke four tests with `Cannot read properties of null (reading 'isServer')` rather than an assertion failure. The fix is one line in that file's existing router mock, and it is worth knowing generally: **any unit test that renders a `PageMessage` frame must mock `createLink` or provide a router.** The four tests then failed honestly, on the one marker my copy change had invalidated, and that marker moved with the words.

## Verified

Local gates on a fresh worktree at `2c13e30996c`: typecheck, lint, format:check, check:prose, check:app-layout, check:css-orphans, knip, 767 unit tests, 446 storybook tests. `bun run check` reports no capture-bundle changes.
