### PR TITLE
The live-query result stops carrying a knob nothing turns

### DIFF
--- a/src/app/db/accountDeletion.ts
+++ b/src/app/db/accountDeletion.ts
@@ -8,7 +8,7 @@ import { api } from '../../../convex/_generated/api';
 export type ReplacementProfile = FunctionReturnType<typeof api.accountDeletion.listReplacementProfiles>['page'][number];
 
 export function useAccountDeletionPage(profileSlug: string) {
-  return toLiveQueryResult(useQuery(api.accountDeletion.page, { profileSlug }), true);
+  return toLiveQueryResult(useQuery(api.accountDeletion.page, { profileSlug }));
 }
 
 export function useReplacementProfiles(search: string) {

--- a/src/app/db/assets.ts
+++ b/src/app/db/assets.ts
@@ -15,7 +15,7 @@ export async function loadAssetCataloguePage(): Promise<AssetCataloguePageData> 
 
 export function useAssetCataloguePage(options?: { initialData?: AssetCataloguePageData }) {
   const liveData = useQuery(api.assets.cataloguePage, {});
-  return toLiveQueryResult(liveData, true, () => options?.initialData);
+  return toLiveQueryResult(liveData, () => options?.initialData);
 }
 
 export type AssetsByTypesData = FunctionReturnType<typeof api.assets.listByTypes>;
@@ -26,7 +26,7 @@ export type AssetsByTypesData = FunctionReturnType<typeof api.assets.listByTypes
  */
 export function useAssetsByTypes(types: string[], options?: { initialData?: AssetsByTypesData }) {
   const liveData = useQuery(api.assets.listByTypes, { types });
-  return toLiveQueryResult(liveData, true, () => options?.initialData);
+  return toLiveQueryResult(liveData, () => options?.initialData);
 }
 
 export type AssetBrowsePageData = FunctionReturnType<typeof api.assets.browsePage>;
@@ -39,7 +39,7 @@ export async function loadAssetBrowsePage(type: string): Promise<AssetBrowsePage
 /** The browse route's one page query. Search and sort are URL state applied to what this returns, so neither re-fetches. */
 export function useAssetBrowsePage(type: string, options?: { initialData?: AssetBrowsePageData }) {
   const liveData = useQuery(api.assets.browsePage, { type });
-  return toLiveQueryResult(liveData, true, () => options?.initialData);
+  return toLiveQueryResult(liveData, () => options?.initialData);
 }
 
 /**
@@ -62,7 +62,7 @@ export async function loadAssetPage(type: string, slug: string): Promise<AssetPa
 
 export function useAssetPage(type: string, slug: string, options?: { initialData?: AssetPageData }) {
   const liveData = useQuery(api.assets.getPage, { type, slug });
-  return toLiveQueryResult(liveData, true, () => options?.initialData);
+  return toLiveQueryResult(liveData, () => options?.initialData);
 }
 
 export function useUpdateAsset() {

--- a/src/app/db/core/live.ts
+++ b/src/app/db/core/live.ts
@@ -24,16 +24,24 @@ export type LiveMutationResult<TVariables, TResult> = {
   reset: () => void;
 };
 
+/**
+ * A Convex subscription's value in the shape the pages read.
+ *
+ * Waiting is the only state it reports, because it is the only one it can: a live query that fails throws to the route's catch boundary rather than returning, which is why `isError` and `error` were struck from the result type (#732).
+ * `isPending` and `isLoading` are the same answer under two names, kept because callers read both.
+ *
+ * There is no `enabled` argument and there was never a caller for one: every one of the twenty-two call sites passed the literal `true`, so the flag only ever ANDed with a constant.
+ * A subscription that should not run is not disabled here, it is not mounted, which is the contract Pickers already follow.
+ */
 export function toLiveQueryResult<TData>(
   liveData: TData | undefined,
-  enabled = true,
   initialData?: () => TData | undefined
 ): LiveQueryResult<TData> {
   const data = liveData ?? initialData?.();
   return {
     data,
-    isPending: enabled && liveData === undefined,
-    isLoading: enabled && liveData === undefined,
+    isPending: liveData === undefined,
+    isLoading: liveData === undefined,
   };
 }
 

--- a/src/app/db/factions.ts
+++ b/src/app/db/factions.ts
@@ -165,14 +165,14 @@ export function useFaction(
 ) {
   const liveData = useQuery(api.factions.getBySlug, { slug });
   const normalized = liveData ? toFactionDetailPageData(liveData) : undefined;
-  const result = toLiveQueryResult(normalized, true, () => options?.initialData ?? undefined);
+  const result = toLiveQueryResult(normalized, () => options?.initialData ?? undefined);
   return result;
 }
 
 export function useFactionCataloguePage(options?: { initialData?: FactionCataloguePageData }) {
   const liveData = useQuery(api.factions.cataloguePage, {});
   const normalized = liveData ? toFactionCataloguePageData(liveData) : undefined;
-  return toLiveQueryResult(normalized, true, () => options?.initialData);
+  return toLiveQueryResult(normalized, () => options?.initialData);
 }
 
 /** Normalized row from `api.factions.listForLoadPicker` (group label + owner username resolved server-side). */
@@ -202,7 +202,7 @@ export function useFactionLoadPicker(options?: { initialData?: FactionLoadPicker
         memberGroupIds: liveData.memberGroupIds,
       }
     : undefined;
-  return toLiveQueryResult(normalized, true, () => options?.initialData ?? undefined);
+  return toLiveQueryResult(normalized, () => options?.initialData ?? undefined);
 }
 
 export function useCreateFaction() {
@@ -320,5 +320,5 @@ export async function loadFaction(slug: string): Promise<FactionDetailPageData> 
 /** Factions the viewer owns, for the Group detail page's "add a faction" picker. */
 export function useFactionsOwnedForGroupAssign() {
   const liveData = useQuery(api.factions.listOwnedForGroupAssign, {});
-  return toLiveQueryResult(liveData, true);
+  return toLiveQueryResult(liveData);
 }

--- a/src/app/db/faq.ts
+++ b/src/app/db/faq.ts
@@ -82,7 +82,7 @@ export async function loadFaqQuestionPage(locator: FaqQuestionLocator): Promise<
 
 export function useFaqQuestionPage(locator: FaqQuestionLocator, options?: { initialPage?: FaqQuestionPage }) {
   const livePage = useQuery(api.faq.questionPage, locator);
-  const query = toLiveQueryResult(livePage, true, () => options?.initialPage);
+  const query = toLiveQueryResult(livePage, () => options?.initialPage);
   const questionId = query.data?.question.id;
 
   const editQuestionMutation = useLiveMutation<

--- a/src/app/db/groups.ts
+++ b/src/app/db/groups.ts
@@ -64,7 +64,7 @@ function normalizeGroupDetailFromConvex(raw: GroupDetailPageRaw): GroupDetailPag
 export function useGroupDetailBySlug(slug: string, options?: { initialData?: GroupDetailPageData }) {
   const liveData = useQuery(api.groups.detailBySlug, { slug });
   const normalizedLive = liveData ? normalizeGroupDetailFromConvex(liveData) : undefined;
-  const result = toLiveQueryResult<GroupDetailPageData | undefined>(normalizedLive, true, () => options?.initialData);
+  const result = toLiveQueryResult<GroupDetailPageData | undefined>(normalizedLive, () => options?.initialData);
   return result;
 }
 
@@ -74,7 +74,7 @@ export function useGroupEditBySlug(slug: string, options?: { initialData?: Group
   const editData = normalizedLive
     ? { group: normalizedLive.group, viewerAccess: normalizedLive.viewerAccess }
     : undefined;
-  const result = toLiveQueryResult<GroupEditPageData | undefined>(editData, true, () => options?.initialData);
+  const result = toLiveQueryResult<GroupEditPageData | undefined>(editData, () => options?.initialData);
   return result;
 }
 

--- a/src/app/db/homepage.ts
+++ b/src/app/db/homepage.ts
@@ -14,5 +14,5 @@ export async function loadHomepage(): Promise<HomepageData> {
 
 export function useHomepage(options?: { initialData?: HomepageData }) {
   const liveData = useQuery(api.homepage.get, {});
-  return toLiveQueryResult(liveData, true, () => options?.initialData);
+  return toLiveQueryResult(liveData, () => options?.initialData);
 }

--- a/src/app/db/migrations.ts
+++ b/src/app/db/migrations.ts
@@ -14,7 +14,7 @@ export async function loadAdminMigrationDashboard(ids?: string[]): Promise<Admin
 export function useAdminMigrationDashboard(options?: { initialData?: AdminMigrationDashboardData; ids?: string[] }) {
   const args = options?.ids ? { ids: options.ids } : {};
   const liveData = useQuery(api.migrations.adminDashboard, args) as AdminMigrationDashboardData | undefined;
-  const result = toLiveQueryResult(liveData, true, () => options?.initialData);
+  const result = toLiveQueryResult(liveData, () => options?.initialData);
   return result;
 }
 

--- a/src/app/db/profiles.ts
+++ b/src/app/db/profiles.ts
@@ -52,13 +52,13 @@ export function useProfileBySlug(
 ) {
   const liveData = useQuery(api.profiles.getBySlug, { slug });
   const normalized = liveData ? normalizeProfilePage(liveData) : undefined;
-  const result = toLiveQueryResult(normalized, true, () => options?.initialData);
+  const result = toLiveQueryResult(normalized, () => options?.initialData);
   return result;
 }
 
 export function useProfilesAll(options?: { initialData?: ProfileListEntry[] }) {
   const liveData = useQuery(api.profiles.list, {});
-  const result = toLiveQueryResult(liveData, true, () => options?.initialData ?? undefined);
+  const result = toLiveQueryResult(liveData, () => options?.initialData ?? undefined);
   return {
     ...result,
   };
@@ -91,7 +91,7 @@ export function useCurrentProfile() {
 
   /* Unresolved and signed-out are different states and must stay so: `session.profile` is null for a
      signed-out viewer, and collapsing that to undefined would leave every page reading as pending. */
-  const current = toLiveQueryResult(session === undefined ? undefined : session.profile, true);
+  const current = toLiveQueryResult(session === undefined ? undefined : session.profile);
 
   return {
     ...current,
@@ -101,7 +101,7 @@ export function useCurrentProfile() {
 /** The viewer's Groups, held by the page that offers them rather than by the shell. */
 export function useDefaultGroupPreference() {
   const liveData = useQuery(api.profiles.defaultGroupPreference, {});
-  return toLiveQueryResult(liveData, true);
+  return toLiveQueryResult(liveData);
 }
 
 export function useUpdateCurrentProfile() {

--- a/src/app/db/rulesets.ts
+++ b/src/app/db/rulesets.ts
@@ -106,13 +106,13 @@ export async function loadRulesetDetailPage(slug: string): Promise<RulesetDetail
 export function useRulesetsAll(options?: { initialData?: RulesetEntry[] }) {
   const liveData = useQuery(api.rulesets.list, {});
   const normalized = liveData?.map(toRulesetEntry);
-  return toLiveQueryResult(normalized, true, () => options?.initialData ?? undefined);
+  return toLiveQueryResult(normalized, () => options?.initialData ?? undefined);
 }
 
 export function useRulesetBySlug(slug: string, options?: { initialData?: RulesetPageData }) {
   const liveData = useQuery(api.rulesets.getBySlug, { slug });
   const normalized = liveData ? toRulesetPageData(liveData) : undefined;
-  const result = toLiveQueryResult(normalized, true, () => options?.initialData);
+  const result = toLiveQueryResult(normalized, () => options?.initialData);
   return result;
 }
 
@@ -122,7 +122,7 @@ export function useRulesetDetailPage(slug: string, options?: { initialData?: Rul
   });
   const normalized: RulesetDetailPageData | null | undefined =
     liveData === undefined ? undefined : liveData === null ? null : normalizeRulesetDetailPage(liveData);
-  const result = toLiveQueryResult(normalized, true, () => options?.initialData);
+  const result = toLiveQueryResult(normalized, () => options?.initialData);
   return result;
 }
 
@@ -321,5 +321,5 @@ export function useDeleteRuleset() {
 /** Rulesets the viewer owns, for the Group detail page's "add a ruleset" picker. */
 export function useRulesetsOwnedForGroupAssign() {
   const liveData = useQuery(api.rulesets.listOwnedForGroupAssign, {});
-  return toLiveQueryResult(liveData, true);
+  return toLiveQueryResult(liveData);
 }


### PR DESCRIPTION
Closes [#798](https://github.com/ndelangen/dunezone/issues/798), the vestige [#732](https://github.com/ndelangen/dunezone/issues/732)'s strike left behind.

`toLiveQueryResult`'s `enabled` parameter defaulted to `true` and every call site passed the literal `true`, so the flag only ever ANDed with a constant. Its two uses, `isPending` and `isLoading`, both reduce to `liveData === undefined`.

Same shape as the error channel #732 struck: a contract surface advertising behaviour no caller uses. And in this case there was nothing for it to express even in principle, because a subscription that should not run is not disabled here, it is not mounted. That is already the contract `AGENTS.md` sets for Pickers.

## The count, and a trap in checking it

Twenty-two call sites, all passing the literal.

Worth stating because I got it wrong first: a grep for `toLiveQueryResult(` finds **twenty**, not twenty-two. Two calls in `groups.ts` pass an explicit type argument, so the identifier is followed by `<` rather than `(` and an anchored pattern skips them. The honest check is `grep -rn "toLiveQueryResult"` and then subtracting the nine imports, which gives twenty-two and matches the ticket. I mention it because "confirm by grep that no caller passes anything but the literal" is the ticket's own instruction, and the obvious grep quietly under-reports.

## What changed

- The parameter is gone and the third argument, `initialData`, becomes the second. Both call shapes were rewritten: the plain `toLiveQueryResult(x, true, () => y)` and the type-argument `toLiveQueryResult<T>(x, true, () => y)`.
- `isPending` and `isLoading` are now `liveData === undefined` directly.
- The function gains a JSDoc it did not have, saying why waiting is the only state it reports and why there is no `enabled`. That is the part that stops this coming back: the next person to want a disabled query now meets the answer at the point of use.

No behaviour changes. Every expression this touches was already evaluating to the same value.

## Verified

Local gates on a worktree at `2c13e30996c`: typecheck, lint, format:check, check:prose, check:app-layout, check:css-orphans, knip, 767 unit tests, 445 storybook tests. `bun run check` reports no capture-bundle changes.

No proof images: nothing here renders. The claim is that twenty-two expressions were already constant-folded, and the way to check it is the grep above plus a green typecheck, not a screenshot.
