### PR TITLE
The identity band becomes a Block, and five pages wear it

### DIFF
--- a/src/app/routes/_app/assets/$type/$slug/index.module.css
+++ b/src/app/routes/_app/assets/$type/$slug/index.module.css
@@ -1,25 +1,9 @@
-/* The identity band follows the faction and ruleset detail pages: media in its own column, text sharing one left edge. */
-.pageHead {
-  width: min(100%, 64rem);
-  min-width: 0;
-}
-
-/* The media column: the asset's own face, small, beside the title. */
-.pageHeadMedia {
-  flex-shrink: 0;
-  width: 4.5rem;
+/* The asset's own face filling the band's media box, keeping its card-corner clip. */
+.pageHeadFace {
+  width: 100%;
+  height: 100%;
   border-radius: var(--mantine-radius-sm);
   overflow: hidden;
-}
-
-.pageHeadText {
-  min-width: 0;
-}
-
-/* The band renders data-scheme-paper, so the title takes the band's own text colour rather than the page scheme's. */
-.assetTitle {
-  overflow-wrap: anywhere;
-  color: var(--color-text, var(--mantine-color-dark-8));
 }
 
 /* The face at reading size: large enough that a card's rules text is legible, short of becoming a poster. */

--- a/src/app/routes/_app/assets/$type/$slug/index.tsx
+++ b/src/app/routes/_app/assets/$type/$slug/index.tsx
@@ -9,7 +9,7 @@
  * Its slug stays reserved so the address survives, but the page renders the same body a slug that never existed would get, matching the ruleset detail page.
  * That is deliberately not a claim that nothing was ever here, and nothing of the deleted row reaches the client to leak.
  */
-import { Alert, Anchor, Group, Stack, Text, Title } from '@mantine/core';
+import { Alert, Group, Stack, Text } from '@mantine/core';
 import { ASSET_TYPES, holdsDeckMembership, isAssetType } from '@shared/assets/types';
 import { RULESET_ASSET_SLOTS } from '@shared/rulesets/assetSlots';
 import type { RulesetAssetSlot } from '@shared/rulesets/assetSlots';
@@ -19,6 +19,7 @@ import { LoadError } from '@ui/block/LoadError';
 import { LoadPending } from '@ui/block/LoadPending';
 import { NotAvailable } from '@ui/block/NotAvailable';
 import { OpenableTile } from '@ui/block/OpenableTile';
+import { PageIdentity } from '@ui/block/PageIdentity';
 import { Section } from '@ui/block/Section';
 import { AssetLink } from '@ui/content/AssetLink';
 import { formatRelativeDate } from '@ui/content/dates';
@@ -491,60 +492,55 @@ function LoadedAssetDetail({ page }: { page: AssetPage }) {
     <PageLayout>
       <PageLayout.Header size="compact">
         {/* The identity pattern the faction and ruleset detail pages use: the media sits in its own column, so the breadcrumb, the title and the meta line share one left edge. */}
-        <Group wrap="nowrap" align="center" gap="lg" className={styles.pageHead}>
-          <div className={styles.pageHeadMedia} role="img" aria-label={`${asset.name} face`}>
-            <AssetFace type={asset.type} data={asset.data} name={asset.name} />
-          </div>
-          <Stack gap={6} className={styles.pageHeadText}>
-            <Group gap="xs" wrap="wrap">
-              <Anchor
-                size="sm"
-                fw={600}
-                renderRoot={(rootProps) => <Link {...rootProps} to="/assets/$type" params={{ type: asset.type }} />}
-              >
-                {collectionLabel}
-              </Anchor>
-            </Group>
-            <Title order={1} className={styles.assetTitle}>
-              {asset.name}
-            </Title>
-            <Group gap="xs" wrap="wrap">
-              <Text size="sm" c="dimmed">
-                Made by
-              </Text>
-              {asset.owner ? <ProfileLink {...asset.owner} /> : <Text size="sm">Unknown</Text>}
-              {/* The band carries the page's statistics, the ruleset band's pattern (Norbert, 2026-08-21). */}
-              <Stats
-                orientation="row"
-                items={[
-                  {
-                    key: 'created',
-                    icon: <CalendarPlus size={17} aria-hidden />,
-                    value: formatRelativeDate(asset.created_at),
-                    label: `Created ${formatRelativeDate(asset.created_at)}`,
-                  },
-                  {
-                    key: 'updated',
-                    icon: <History size={17} aria-hidden />,
-                    value: formatRelativeDate(asset.updated_at),
-                    label: `Updated ${formatRelativeDate(asset.updated_at)}`,
-                  },
-                  /* Only for types a deck can hold; the payload already carries the list for the In-decks section. */
-                  ...(holdsDeckMembership(asset.type)
-                    ? [
-                        {
-                          key: 'decks',
-                          icon: <Layers3 size={17} aria-hidden />,
-                          value: inDecks.length,
-                          label: `In ${inDecks.length} ${inDecks.length === 1 ? 'deck' : 'decks'}`,
-                        },
-                      ]
-                    : []),
-                ]}
-              />
-            </Group>
-          </Stack>
-        </Group>
+        <PageIdentity
+          title={asset.name}
+          media={
+            <div role="img" aria-label={`${asset.name} face`} className={styles.pageHeadFace}>
+              <AssetFace type={asset.type} data={asset.data} name={asset.name} />
+            </div>
+          }
+          breadcrumb={
+            <PageIdentity.Breadcrumb to="/assets/$type" params={{ type: asset.type }}>
+              {collectionLabel}
+            </PageIdentity.Breadcrumb>
+          }
+        >
+          <Group gap="xs" wrap="wrap">
+            <Text size="sm" c="dimmed">
+              Made by
+            </Text>
+            {asset.owner ? <ProfileLink {...asset.owner} /> : <Text size="sm">Unknown</Text>}
+            {/* The band carries the page's statistics, the ruleset band's pattern (Norbert, 2026-08-21). */}
+            <Stats
+              orientation="row"
+              items={[
+                {
+                  key: 'created',
+                  icon: <CalendarPlus size={17} aria-hidden />,
+                  value: formatRelativeDate(asset.created_at),
+                  label: `Created ${formatRelativeDate(asset.created_at)}`,
+                },
+                {
+                  key: 'updated',
+                  icon: <History size={17} aria-hidden />,
+                  value: formatRelativeDate(asset.updated_at),
+                  label: `Updated ${formatRelativeDate(asset.updated_at)}`,
+                },
+                /* Only for types a deck can hold; the payload already carries the list for the In-decks section. */
+                ...(holdsDeckMembership(asset.type)
+                  ? [
+                      {
+                        key: 'decks',
+                        icon: <Layers3 size={17} aria-hidden />,
+                        value: inDecks.length,
+                        label: `In ${inDecks.length} ${inDecks.length === 1 ? 'deck' : 'decks'}`,
+                      },
+                    ]
+                  : []),
+              ]}
+            />
+          </Group>
+        </PageIdentity>
       </PageLayout.Header>
 
       <PageLayout.Toolbar>

--- a/src/app/routes/_app/factions/$factionId/index.tsx
+++ b/src/app/routes/_app/factions/$factionId/index.tsx
@@ -18,6 +18,7 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import type { ErrorComponentProps } from '@tanstack/react-router';
 import { LoadError } from '@ui/block/LoadError';
 import { LoadPending } from '@ui/block/LoadPending';
+import { PageIdentity } from '@ui/block/PageIdentity';
 import { Section } from '@ui/block/Section';
 import { factionAssetPublishingCopy } from '@ui/content/assetPublishingStatus';
 import { complexityOutOfTen, complexityTier, effectiveComplexity } from '@ui/content/complexity';
@@ -137,27 +138,22 @@ function FactionDetailPage() {
   return (
     <PageLayout>
       <PageLayout.Header size="compact">
-        <Group wrap="nowrap" align="center" gap="lg" className={styles.pageHead}>
-          <div className={styles.factionSymbol} role="img" aria-label={`${data.name} symbol`}>
-            <FactionToken logo={data.logo} background={data.background} />
-          </div>
-          <Stack gap={6} className={styles.pageHeadText}>
-            <Group gap="xs" wrap="wrap">
-              <Anchor size="sm" fw={600} renderRoot={(rootProps) => <Link {...rootProps} to="/factions" />}>
-                Factions
-              </Anchor>
-            </Group>
-            <Title order={1} className={styles.factionTitle}>
-              {data.name}
-            </Title>
-            <Group gap="xs" wrap="wrap">
-              <Text size="sm" c="dimmed">
-                Maintained by
-              </Text>
-              {owner ? <ProfileLink {...owner} /> : <Text size="sm">Unknown</Text>}
-            </Group>
-          </Stack>
-        </Group>
+        <PageIdentity
+          title={data.name}
+          media={
+            <div className={styles.factionSymbol} role="img" aria-label={`${data.name} symbol`}>
+              <FactionToken logo={data.logo} background={data.background} />
+            </div>
+          }
+          breadcrumb={<PageIdentity.Breadcrumb to="/factions">Factions</PageIdentity.Breadcrumb>}
+        >
+          <Group gap="xs" wrap="wrap">
+            <Text size="sm" c="dimmed">
+              Maintained by
+            </Text>
+            {owner ? <ProfileLink {...owner} /> : <Text size="sm">Unknown</Text>}
+          </Group>
+        </PageIdentity>
       </PageLayout.Header>
       <PageLayout.Toolbar>
         <Toolbar>

--- a/src/app/routes/_app/factions/FactionDetail.module.css
+++ b/src/app/routes/_app/factions/FactionDetail.module.css
@@ -1,7 +1,7 @@
 .factionSymbol {
   position: relative;
   width: 100%;
-  height: 100%;
+  aspect-ratio: 1;
 }
 
 .factionSymbol,

--- a/src/app/routes/_app/factions/FactionDetail.module.css
+++ b/src/app/routes/_app/factions/FactionDetail.module.css
@@ -1,15 +1,7 @@
-.pageHead {
-  width: min(100%, 48rem);
-  min-width: 0;
-  margin: 0 auto;
-  padding-inline: var(--mantine-spacing-sm);
-}
-
 .factionSymbol {
   position: relative;
-  flex: 0 0 5.5rem;
-  width: 5.5rem;
-  height: 5.5rem;
+  width: 100%;
+  height: 100%;
 }
 
 .factionSymbol,
@@ -28,16 +20,6 @@
 .loreHeroToken > * {
   position: absolute;
   inset: 0;
-}
-
-.pageHeadText {
-  min-width: 0;
-  color: var(--color-text, var(--mantine-color-dark-8));
-}
-
-.factionTitle {
-  overflow-wrap: anywhere;
-  color: var(--color-text, var(--mantine-color-dark-8));
 }
 
 .horizontalLane {
@@ -102,35 +84,10 @@
 }
 
 @media (max-width: 48em) {
-  .pageHead {
-    align-items: flex-start;
-    gap: var(--mantine-spacing-md);
-  }
-
-  .factionSymbol {
-    flex-basis: 4.75rem;
-    width: 4.75rem;
-    height: 4.75rem;
-  }
-
-  .factionTitle {
-    font-size: 1.35rem;
-  }
-
   .loreHeroToken {
     width: min(100%, 12rem);
   }
 }
 
 @media (max-width: 30em) {
-  .pageHead {
-    padding-inline: 0;
-    gap: var(--mantine-spacing-sm);
-  }
-
-  .factionSymbol {
-    flex-basis: 3.75rem;
-    width: 3.75rem;
-    height: 3.75rem;
-  }
 }

--- a/src/app/routes/_app/profiles/$profileSlug/index.tsx
+++ b/src/app/routes/_app/profiles/$profileSlug/index.tsx
@@ -4,6 +4,7 @@ import type { ErrorComponentProps } from '@tanstack/react-router';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { LoadError } from '@ui/block/LoadError';
 import { NotAvailable } from '@ui/block/NotAvailable';
+import { PageIdentity } from '@ui/block/PageIdentity';
 import { ProposedContent } from '@ui/block/ProposedContent';
 import { Section } from '@ui/block/Section';
 import { formatRelativeDate } from '@ui/content/dates';
@@ -265,20 +266,21 @@ function ProfileDetailPage() {
   return (
     <PageLayout>
       <PageLayout.Header size="compact">
-        <div className={styles.identityRow}>
-          {page.profile.avatar_url ? (
-            <img src={page.profile.avatar_url} alt={page.profile.username ?? 'Avatar'} className={styles.avatar} />
-          ) : (
-            <span className={styles.avatarPlaceholder}>{initials}</span>
-          )}
-          <Stack gap="xs">
-            <h1 className={styles.displayName}>{page.profile.username ?? 'Unknown'}</h1>
-            {isSelf && <p className={styles.selfHint}>This is you!</p>}
-            <p className={styles.profileSummary}>
-              <strong>Proposed bio:</strong> A short introduction describing this contributor's interests and work.
-            </p>
-          </Stack>
-        </div>
+        <PageIdentity
+          title={page.profile.username ?? 'Unknown'}
+          media={
+            page.profile.avatar_url ? (
+              <img src={page.profile.avatar_url} alt={page.profile.username ?? 'Avatar'} className={styles.avatar} />
+            ) : (
+              <span className={styles.avatarPlaceholder}>{initials}</span>
+            )
+          }
+        >
+          {isSelf && <p className={styles.selfHint}>This is you!</p>}
+          <p className={styles.profileSummary}>
+            <strong>Proposed bio:</strong> A short introduction describing this contributor's interests and work.
+          </p>
+        </PageIdentity>
       </PageLayout.Header>
       <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
       <PageLayout.Content>

--- a/src/app/routes/_app/profiles/ProfileDetail.module.css
+++ b/src/app/routes/_app/profiles/ProfileDetail.module.css
@@ -1,13 +1,6 @@
-.identityRow {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  min-width: 0;
-}
-
 .avatar {
-  width: 72px;
-  height: 72px;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   object-fit: cover;
   display: block;
@@ -16,8 +9,8 @@
 }
 
 .avatarPlaceholder {
-  width: 72px;
-  height: 72px;
+  width: 100%;
+  height: 100%;
   border-radius: 50%;
   background: color-mix(in srgb, var(--panel-border, #b8ad9b) 40%, transparent);
   display: flex;
@@ -26,14 +19,6 @@
   font-size: 1rem;
   font-weight: 600;
   flex-shrink: 0;
-  color: var(--color-text, #2e2927);
-}
-
-.displayName {
-  margin: 0;
-  font-size: 1.35rem;
-  font-weight: 700;
-  line-height: 1.2;
   color: var(--color-text, #2e2927);
 }
 

--- a/src/app/routes/_app/profiles/ProfileDetail.module.css
+++ b/src/app/routes/_app/profiles/ProfileDetail.module.css
@@ -1,6 +1,7 @@
 .avatar {
   width: 100%;
-  height: 100%;
+  aspect-ratio: 1;
+  height: auto;
   border-radius: 50%;
   object-fit: cover;
   display: block;
@@ -10,7 +11,8 @@
 
 .avatarPlaceholder {
   width: 100%;
-  height: 100%;
+  aspect-ratio: 1;
+  height: auto;
   border-radius: 50%;
   background: color-mix(in srgb, var(--panel-border, #b8ad9b) 40%, transparent);
   display: flex;

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.module.css
@@ -1,18 +1,9 @@
-.pageHead {
-  min-width: 0;
-  width: 100%;
-  max-width: 42rem;
-  margin: 0 auto;
-  padding-inline: var(--mantine-spacing-sm);
-}
-
 /* The cover's box must carry a size of its own: the image inside stretches to 100% of it, so an
-   unsized box hands layout to the image's intrinsic pixels, which overflow the header and squeeze
-   the title to wrapping (the regression behind the cover drawing over the nav). */
+   unsized box hands layout to the image's intrinsic pixels (the regression behind the cover once
+   drawing over the nav). The band's media column owns the outer size now; this fills and clips. */
 .rulesetHeadCover {
-  width: 5.5rem;
-  height: 5.5rem;
-  flex: 0 0 5.5rem;
+  width: 100%;
+  height: 100%;
   overflow: hidden;
 }
 
@@ -20,14 +11,4 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-}
-
-.pageHeadText {
-  min-width: 0;
-  text-align: left;
-}
-
-.rulesetTitle {
-  overflow-wrap: anywhere;
-  color: var(--color-text, var(--mantine-color-dark-8));
 }

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.module.css
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.module.css
@@ -3,7 +3,7 @@
    drawing over the nav). The band's media column owns the outer size now; this fills and clips. */
 .rulesetHeadCover {
   width: 100%;
-  height: 100%;
+  aspect-ratio: 1;
   overflow: hidden;
 }
 

--- a/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/edit.tsx
@@ -8,6 +8,7 @@ import { FormError } from '@ui/block/FormError';
 import { LoadPending } from '@ui/block/LoadPending';
 import { LoginGate } from '@ui/block/LoginGate';
 import { NotAvailable } from '@ui/block/NotAvailable';
+import { PageIdentity } from '@ui/block/PageIdentity';
 import { rulesetAboutHint } from '@ui/content/rulesetAboutHint';
 import { SlugRenameNotice } from '@ui/content/SlugRenameNotice';
 import { FormattedTextInput } from '@ui/control/FormattedTextInput';
@@ -239,32 +240,30 @@ function RulesetEditPage() {
   }
 
   /* Built here rather than above the guards: every path that lacked a ruleset now returns a
-     `PageMessage` before this point, so the band and the toolbar no longer need a shape for the
-     case where there is nothing to name. The band itself is unchanged, and stays #451's to revisit. */
+     `PageMessage` before this point, so the band no longer needs a shape for the case where there
+     is nothing to name. */
   const header = (
-    <Group wrap="nowrap" align="center" gap="lg" className={styles.pageHead}>
-      <Surface className={styles.rulesetHeadCover}>
-        {r.coverUrl ? (
-          <Image
-            src={r.coverUrl}
-            fallbackSrc="/image/background/card-large.jpg"
-            alt={`Cover for ${r.name}`}
-            className={styles.coverImage}
-          />
-        ) : (
-          <Center h="100%">
-            <Text size="xs" c="dimmed" ta="center">
-              No cover
-            </Text>
-          </Center>
-        )}
-      </Surface>
-      <Stack gap={6} className={styles.pageHeadText}>
-        <Title order={1} className={styles.rulesetTitle}>
-          Edit {r.name}
-        </Title>
-      </Stack>
-    </Group>
+    <PageIdentity
+      title={`Edit ${r.name}`}
+      media={
+        <Surface className={styles.rulesetHeadCover}>
+          {r.coverUrl ? (
+            <Image
+              src={r.coverUrl}
+              fallbackSrc="/image/background/card-large.jpg"
+              alt={`Cover for ${r.name}`}
+              className={styles.coverImage}
+            />
+          ) : (
+            <Center h="100%">
+              <Text size="xs" c="dimmed" ta="center">
+                No cover
+              </Text>
+            </Center>
+          )}
+        </Surface>
+      }
+    />
   );
   const toolbar = (
     <Surface padding="sm">
@@ -293,7 +292,8 @@ function RulesetEditPage() {
 
   return (
     <PageLayout>
-      <PageLayout.Header>{header}</PageLayout.Header>
+      {/* Compact like every other identity band; the tall default was this page's private anomaly. */}
+      <PageLayout.Header size="compact">{header}</PageLayout.Header>
       <PageLayout.Toolbar>{toolbar}</PageLayout.Toolbar>
       <PageLayout.Content>
         <Stack gap="lg">

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -1,4 +1,4 @@
-import { Alert, Anchor, Avatar, Group, Menu, Popover, Select, Stack, Text, TextInput, Title } from '@mantine/core';
+import { Alert, Avatar, Group, Menu, Popover, Select, Stack, Text, TextInput } from '@mantine/core';
 import { FAQ_TAG_VALUES } from '@shared/faq/tags';
 import type { FaqTag } from '@shared/faq/tags';
 import { isRouteNoticeCode } from '@shared/routeNotices';
@@ -9,6 +9,7 @@ import { FactionCard } from '@ui/block/FactionCard';
 import { LoadError } from '@ui/block/LoadError';
 import { LoadPending } from '@ui/block/LoadPending';
 import { NotAvailable } from '@ui/block/NotAvailable';
+import { PageIdentity } from '@ui/block/PageIdentity';
 import { ProposedContent } from '@ui/block/ProposedContent';
 import { Section } from '@ui/block/Section';
 import { FAQ_TAG_LABELS } from '@ui/content/faqTagLabels';
@@ -327,13 +328,9 @@ function RulesetDetailPage() {
   return (
     <PageLayout>
       <PageLayout.Header size="compact">
-        {/*
-          The identity pattern the faction and profile detail pages already use: the media sits in its own column, so
-          the breadcrumb, the title and the meta line all share one left edge instead of the title starting indented.
-        */}
-        <Group wrap="nowrap" align="center" gap="md" className={styles.pageHead}>
-          {/* The media matches the text block's height rather than a fixed size, so the band reads as one unit. */}
-          <div className={styles.pageHeadMedia}>
+        <PageIdentity
+          title={r.name}
+          media={
             <Avatar
               src={r.coverThumbUrl}
               alt={`Cover for ${r.name}`}
@@ -342,40 +339,34 @@ function RulesetDetailPage() {
               size="100%"
               color="dune"
             />
-          </div>
-          <Stack gap={4} className={styles.pageHeadText}>
-            <Anchor size="sm" fw={600} renderRoot={(rootProps) => <Link {...rootProps} to="/rulesets" />}>
-              Rulesets
-            </Anchor>
-            <Title order={1} className={styles.rulesetTitle}>
-              {r.name}
-            </Title>
-            {/*
+          }
+          breadcrumb={<PageIdentity.Breadcrumb to="/rulesets">Rulesets</PageIdentity.Breadcrumb>}
+        >
+          {/*
             One line carrying everything the old "At a glance" and "Stewardship" cards said.
             The sizes are level on purpose: this row centres its children, and a 12px label among 14-16px text reads as
             misaligned even when every box is perfectly centred.
           */}
-            <Group gap="sm" wrap="wrap" align="center">
+          <Group gap="sm" wrap="wrap" align="center">
+            <Text size="sm" c="dimmed">
+              Maintained by
+            </Text>
+            {page.owner ? (
+              <ProfileLink slug={page.owner.slug} username={page.owner.username} avatar_url={page.owner.avatar_url} />
+            ) : (
+              <Text size="sm">Unknown</Text>
+            )}
+            {assignedGroup ? (
+              <GroupLink slug={assignedGroup.slug} name={assignedGroup.name} />
+            ) : (
               <Text size="sm" c="dimmed">
-                Maintained by
+                No maintaining group
               </Text>
-              {page.owner ? (
-                <ProfileLink slug={page.owner.slug} username={page.owner.username} avatar_url={page.owner.avatar_url} />
-              ) : (
-                <Text size="sm">Unknown</Text>
-              )}
-              {assignedGroup ? (
-                <GroupLink slug={assignedGroup.slug} name={assignedGroup.name} />
-              ) : (
-                <Text size="sm" c="dimmed">
-                  No maintaining group
-                </Text>
-              )}
-              {membershipBadge ? <StatusBadge tone={membershipBadge.tone}>{membershipBadge.label}</StatusBadge> : null}
-              <Stats items={headerStats} orientation="row" />
-            </Group>
-          </Stack>
-        </Group>
+            )}
+            {membershipBadge ? <StatusBadge tone={membershipBadge.tone}>{membershipBadge.label}</StatusBadge> : null}
+            <Stats items={headerStats} orientation="row" />
+          </Group>
+        </PageIdentity>
       </PageLayout.Header>
       <PageLayout.Toolbar>
         <Toolbar>

--- a/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
+++ b/src/app/routes/_app/rulesets/$rulesetSlug/index.tsx
@@ -338,6 +338,7 @@ function RulesetDetailPage() {
               radius="md"
               size="100%"
               color="dune"
+              className={styles.coverAvatar}
             />
           }
           breadcrumb={<PageIdentity.Breadcrumb to="/rulesets">Rulesets</PageIdentity.Breadcrumb>}

--- a/src/app/routes/_app/rulesets/RulesetDetail.module.css
+++ b/src/app/routes/_app/rulesets/RulesetDetail.module.css
@@ -1,34 +1,3 @@
-.pageHead {
-  width: min(100%, 48rem);
-  min-width: 0;
-  margin: 0 auto;
-  padding-inline: var(--mantine-spacing-sm);
-  color: var(--color-text, var(--mantine-color-dark-8));
-}
-
-/* The text column beside the media: everything in it shares this left edge. */
-.pageHeadText {
-  min-width: 0;
-}
-
-/*
- * A fixed square per breakpoint, sized to the three lines of text beside it, the same approach and
- * the same steps as the faction detail page's symbol rule.
- * Deliberately not computed from the text: `align-self: stretch` with an `aspect-ratio` is circular, since the square's
- * width would come from the row height while the row height comes from its tallest item, and the media grows without
- * bound. Matching by design is what the pattern already does.
- */
-.pageHeadMedia {
-  flex: 0 0 6rem;
-  width: 6rem;
-  height: 6rem;
-}
-
-.rulesetTitle {
-  overflow-wrap: anywhere;
-  color: var(--color-text, var(--mantine-color-dark-8));
-}
-
 .faqFilterWrapper {
   border-radius: var(--mantine-radius-md);
   box-shadow: var(--mantine-shadow-sm);
@@ -51,29 +20,4 @@
   border-radius: 0 var(--mantine-radius-md) var(--mantine-radius-md) 0;
   font-size: var(--mantine-font-size-xs);
   font-weight: 700;
-}
-
-/* The band's own gaps come from the header's `Stack`; only the title size and the edge padding change with width. */
-@media (max-width: 48em) {
-  .pageHeadMedia {
-    flex-basis: 4.75rem;
-    width: 4.75rem;
-    height: 4.75rem;
-  }
-
-  .rulesetTitle {
-    font-size: 1.35rem;
-  }
-}
-
-@media (max-width: 30em) {
-  .pageHead {
-    padding-inline: 0;
-  }
-
-  .pageHeadMedia {
-    flex-basis: 3.75rem;
-    width: 3.75rem;
-    height: 3.75rem;
-  }
 }

--- a/src/app/routes/_app/rulesets/RulesetDetail.module.css
+++ b/src/app/routes/_app/rulesets/RulesetDetail.module.css
@@ -1,3 +1,10 @@
+/* The band's media column is width-only; the cover badge declares its own square. */
+.coverAvatar {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1;
+}
+
 .faqFilterWrapper {
   border-radius: var(--mantine-radius-md);
   box-shadow: var(--mantine-shadow-sm);

--- a/src/app/ui/block/PageIdentity.module.css
+++ b/src/app/ui/block/PageIdentity.module.css
@@ -1,0 +1,52 @@
+.band {
+  width: min(100%, 48rem);
+  min-width: 0;
+  margin: 0 auto;
+  padding-inline: var(--mantine-spacing-sm);
+}
+
+/*
+ * A fixed square per breakpoint, sized to the three lines of text beside it.
+ * Deliberately not computed from the text: stretching with an aspect ratio is circular, since the
+ * square's width would come from the row height while the row height comes from its tallest item.
+ * Matching by design is what the hand-rolled bands already did.
+ */
+.media {
+  flex: 0 0 6rem;
+  width: 6rem;
+  height: 6rem;
+}
+
+/* Everything in the text column shares this left edge. */
+.text {
+  min-width: 0;
+  text-align: left;
+}
+
+.text h1 {
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 48em) {
+  .media {
+    flex-basis: 4.75rem;
+    width: 4.75rem;
+    height: 4.75rem;
+  }
+
+  .text h1 {
+    font-size: 1.35rem;
+  }
+}
+
+@media (max-width: 30em) {
+  .band {
+    padding-inline: 0;
+  }
+
+  .media {
+    flex-basis: 3.75rem;
+    width: 3.75rem;
+    height: 3.75rem;
+  }
+}

--- a/src/app/ui/block/PageIdentity.module.css
+++ b/src/app/ui/block/PageIdentity.module.css
@@ -6,15 +6,13 @@
 }
 
 /*
- * A fixed square per breakpoint, sized to the three lines of text beside it.
- * Deliberately not computed from the text: stretching with an aspect ratio is circular, since the
- * square's width would come from the row height while the row height comes from its tallest item.
- * Matching by design is what the hand-rolled bands already did.
+ * A fixed width per breakpoint, sized to the three lines of text beside it.
+ * Width only: square media declares its own aspect ratio, and non-square media (a portrait card
+ * face) keeps its natural height instead of being cropped to a square it never had.
  */
 .media {
   flex: 0 0 6rem;
   width: 6rem;
-  height: 6rem;
 }
 
 /* Everything in the text column shares this left edge. */
@@ -31,7 +29,6 @@
   .media {
     flex-basis: 4.75rem;
     width: 4.75rem;
-    height: 4.75rem;
   }
 
   .text h1 {
@@ -47,6 +44,5 @@
   .media {
     flex-basis: 3.75rem;
     width: 3.75rem;
-    height: 3.75rem;
   }
 }

--- a/src/app/ui/block/PageIdentity.stories.tsx
+++ b/src/app/ui/block/PageIdentity.stories.tsx
@@ -1,13 +1,12 @@
-import preview from '@sb/preview';
 import { Avatar, Text } from '@mantine/core';
+import preview from '@sb/preview';
 
 import { PageLayout } from '../layout/PageLayout';
 import { PageIdentity } from './PageIdentity';
 import type { PageIdentityProps } from './PageIdentity';
 
 /**
- * The band's ink and treatment come from the header's scheme-pinned paper, so each story mounts the
- * real `PageLayout` and declares a compact header the way the five band pages do.
+ * The band's ink and treatment come from the header's scheme-pinned paper, so each story mounts the real `PageLayout` and declares a compact header the way the five band pages do.
  */
 function InHeader(props: PageIdentityProps) {
   return (

--- a/src/app/ui/block/PageIdentity.stories.tsx
+++ b/src/app/ui/block/PageIdentity.stories.tsx
@@ -1,0 +1,48 @@
+import preview from '@sb/preview';
+import { Avatar, Text } from '@mantine/core';
+
+import { PageLayout } from '../layout/PageLayout';
+import { PageIdentity } from './PageIdentity';
+import type { PageIdentityProps } from './PageIdentity';
+
+/**
+ * The band's ink and treatment come from the header's scheme-pinned paper, so each story mounts the
+ * real `PageLayout` and declares a compact header the way the five band pages do.
+ */
+function InHeader(props: PageIdentityProps) {
+  return (
+    <PageLayout>
+      <PageLayout.Header size="compact">
+        <PageIdentity {...props} />
+      </PageLayout.Header>
+      <PageLayout.Content>
+        <span />
+      </PageLayout.Content>
+    </PageLayout>
+  );
+}
+
+const meta = preview.meta({
+  component: PageIdentity,
+  parameters: { layout: 'fullscreen' },
+  render: (args: PageIdentityProps) => <InHeader {...args} />,
+  args: {
+    title: 'ClassicRules',
+    media: <Avatar name="ClassicRules" radius="md" size="100%" color="dune" />,
+    breadcrumb: <PageIdentity.Breadcrumb to="/rulesets">Rulesets</PageIdentity.Breadcrumb>,
+    children: <Text size="sm">Maintained by the Arrakeen Rules Council</Text>,
+  },
+});
+
+/** The full band: media, breadcrumb, name, and a meta line, in the pinned paper ink. */
+export const Default = meta.story({});
+
+/** A page with no identity media: the text column keeps its edge and the name leads. */
+export const WithoutMedia = meta.story({
+  args: { media: undefined },
+});
+
+/** The top of a branch has no way up, so the name sits first in the column. */
+export const WithoutBreadcrumb = meta.story({
+  args: { breadcrumb: undefined },
+});

--- a/src/app/ui/block/PageIdentity.tsx
+++ b/src/app/ui/block/PageIdentity.tsx
@@ -3,8 +3,8 @@ import { createLink } from '@tanstack/react-router';
 import { forwardRef } from 'react';
 import type { ComponentPropsWithoutRef, ReactNode } from 'react';
 
-import { PageTitle } from './PageTitle';
 import styles from './PageIdentity.module.css';
+import { PageTitle } from './PageTitle';
 
 const BreadcrumbAnchor = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
   function BreadcrumbAnchor(props, ref) {

--- a/src/app/ui/block/PageIdentity.tsx
+++ b/src/app/ui/block/PageIdentity.tsx
@@ -1,0 +1,52 @@
+import { Anchor, Group, Stack } from '@mantine/core';
+import { createLink } from '@tanstack/react-router';
+import { forwardRef } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+
+import { PageTitle } from './PageTitle';
+import styles from './PageIdentity.module.css';
+
+const BreadcrumbAnchor = forwardRef<HTMLAnchorElement, ComponentPropsWithoutRef<'a'>>(
+  function BreadcrumbAnchor(props, ref) {
+    return <Anchor ref={ref} size="sm" fw={600} {...props} />;
+  }
+);
+
+export interface PageIdentityProps {
+  /** The page's name. Rendered through `PageTitle`, so the level and face rules hold here too. */
+  title: string;
+  /**
+   * The identity media beside the name: a faction token, a cover, an avatar.
+   * The caller keeps its own clip and treatment;
+   * this owns only the column's size scale, matched to the text block the way the pattern always did by design.
+   */
+  media?: ReactNode;
+  /** The way up one level, as a `PageIdentity.Breadcrumb`. Above the name, where the collection label reads as context. */
+  breadcrumb?: ReactNode;
+  /** The meta line under the name: maintainers, badges, stats, or a profile's hint and summary. */
+  children?: ReactNode;
+}
+
+/**
+ * The identity band: who or what this page is about, worn in the header.
+ *
+ * Media beside name, breadcrumb above, meta below, one row geometry and one media scale.
+ * The ink is deliberately not set here: the header content is scheme-pinned paper, and that pinning dictates every colour in the band (Norbert, 2026-08-27), so the band's parts wear the pinned treatment instead of opting out of it.
+ *
+ * It exists because five detail and editor pages composed this band by hand with three media scales, four row widths, and five private copies of the ink override, and the drift between them is what this Block erases.
+ */
+export function PageIdentity({ title, media, breadcrumb, children }: PageIdentityProps) {
+  return (
+    <Group wrap="nowrap" align="center" gap="lg" className={styles.band}>
+      {media === undefined ? null : <div className={styles.media}>{media}</div>}
+      <Stack gap={6} className={styles.text}>
+        {breadcrumb}
+        <PageTitle title={title} />
+        {children}
+      </Stack>
+    </Group>
+  );
+}
+
+/** The way up one level, taking the same route props as the router's own `Link`, the `PageMessage.Back` idiom. */
+PageIdentity.Breadcrumb = createLink(BreadcrumbAnchor);


### PR DESCRIPTION
Item 3 of [the composition wave](https://github.com/ndelangen/dunezone/issues/701), executing [the identity-band territory (#451)](https://github.com/ndelangen/dunezone/issues/451) on Norbert's two decisions: **the band is a Block** (`PageIdentity` in `ui/block`), and **the band's content is fixed to the light theme** — the header's scheme-pinned paper dictates every colour, so the Block sets no ink of its own and the five per-page `--color-text` overrides die.

**The Block**: media beside name, breadcrumb above (a createLink sub-component, the `PageMessage.Back` idiom), meta as children, the h1 through `PageTitle` so the level and face rules hold. It owns the row geometry (48rem), one media scale (6→4.75→3.75rem), and the title's wrap and sub-48em step. Each page keeps what is genuinely its own: the faction its circle clip and drop shadow, the asset its card-corner clip, the profile its initials placeholder, the editor its cover pane.

**Unifications riding the convergence, each a visible change flagged for veto:**
- The **ruleset editor** adopts `size="compact"` (its tall band was the anomaly) and its title takes the paper ink — the form now starts above the fold.
- The **asset band** joins the shared scale: 64rem row → 48rem, 4.5rem face → the 6rem step.
- The **profile** h1 gains the canonical title face (was a raw 1.35rem bold) and its avatar fills the shared box (72px → the 6rem step).
- All five titles go from the dark override to the pinned paper ink, in both schemes.

Net −165 lines across the five routes' markup and CSS.

## Proof

Twenty story captures: five pages × before/after × both schemes (before = the public Storybook, main's build; after = this branch; deterministic seeds, so every pair is controlled). Embedded in a comment. I read the editor and profile pairs personally: the compact adoption, the ink change, and the face treatment land exactly as decided, with everything outside the band identical.

## Gates

typecheck, lint, format, prose, css-orphans (66 stylesheets), app-layout, knip, 767 unit tests, 448 storybook tests (three new Block stories). Changed paths are outside the renderer capture graph; CI's publisher_release confirms.

Closes #451