### PR TITLE
The generated server bindings return to their pinned exact state

### DIFF
--- a/convex/_generated/server.d.ts
+++ b/convex/_generated/server.d.ts
@@ -22,6 +22,17 @@ import {
 import type { DataModel } from "./dataModel.js";
 
 /**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+type Env = {
+  readonly CONVEX_CLOUD_URL: string;
+  readonly CONVEX_SITE_URL: string;
+};
+
+/**
  * Define a query in this Convex app's public API.
  *
  * This function will be allowed to read your Convex database and will be accessible from the client.
@@ -94,6 +105,14 @@ export declare const internalAction: ActionBuilder<DataModel, "internal">;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export declare const httpAction: HttpActionBuilder;
+
+/**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+export declare const env: Env;
 
 /**
  * A set of services for use within Convex query functions.

--- a/convex/_generated/server.js
+++ b/convex/_generated/server.js
@@ -91,3 +91,11 @@ export const internalAction = internalActionGeneric;
  * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
  */
 export const httpAction = httpActionGeneric;
+
+/**
+ * Typesafe environment variables.
+ *
+ * This includes platform-provided env vars and any variables declared in
+ * `convex.config.ts`.
+ */
+export const env = process.env;


### PR DESCRIPTION
Unblocks the deploy pipeline. The cover-rehost branch (#799) ran its Convex codegen under a version that drops the typed `env` export, and its `convex/_generated/server.d.ts` and `server.js` rode into main in that state — a drift the adversarial review flagged as out-of-scope at the time. The deploy job's own **Deploy Convex** step, pinned at 1.45, regenerates the export, and the worker preflight's exact-checkout assertion then finds a dirtied tree and refuses: `Tracked source changed after checkout; refusing to deploy`. Every deploy-main run since the merge has failed on exactly this ([the run Norbert linked](https://github.com/ndelangen/dunezone/actions/runs/33115257949/job/98676003579)).

This restores the two files to the state the pin demands (#765's contract), taken **from history rather than from running codegen** — running `convex codegen` locally deploys to whatever `.env.local` names, which is this evening's other lesson. The `api.d.ts`/`api.js` additions for the rehost module are legitimate codegen and stay untouched.

After merge: rerun `deploy-main` — with the ingest secret now set, the deploy should complete, the worker picks up its bucket binding and base-URL var, the audit drift gate clears repo-wide, and #806's audit reruns green.

Gates: typecheck, lint, 790 tests. Generated-contract files only; no behavior.