### PR TITLE
Nested tabs provide connected two-level navigation

### DIFF
--- a/src/app/ui/surface/NestedTabs.module.css
+++ b/src/app/ui/surface/NestedTabs.module.css
@@ -239,7 +239,7 @@
   flex-direction: column;
   align-items: center;
   gap: 0.35rem;
-  padding: 0.4rem 0.25rem;
+  padding: 0.4rem 0.25rem 0.75rem;
 }
 
 .levelLabel {

--- a/src/app/ui/surface/NestedTabs.module.css
+++ b/src/app/ui/surface/NestedTabs.module.css
@@ -280,6 +280,8 @@
   line-height: 1;
   text-overflow: ellipsis;
   text-transform: none;
+  cursor: default;
+  user-select: none;
   white-space: nowrap;
   writing-mode: vertical-rl;
   transform: rotate(180deg);

--- a/src/app/ui/surface/NestedTabs.module.css
+++ b/src/app/ui/surface/NestedTabs.module.css
@@ -21,7 +21,6 @@
   align-items: stretch;
   width: 100%;
   min-width: 0;
-  min-height: 38rem;
   overflow: visible;
   isolation: isolate;
 }
@@ -96,8 +95,8 @@
 .level {
   position: relative;
   z-index: 3;
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   min-width: 0;
   min-height: 0;
   background: transparent;
@@ -120,10 +119,9 @@
 }
 
 .levelItems {
+  flex: 0 0 auto;
   min-height: 0;
   padding: 0.4rem 0.25rem;
-  overflow: auto;
-  scrollbar-width: thin;
 }
 
 .itemSlot {
@@ -240,6 +238,7 @@
   flex-direction: column;
   align-items: center;
   gap: 0.35rem;
+  margin-block-start: auto;
   padding: 0.4rem 0.25rem 0.75rem;
 }
 
@@ -267,7 +266,7 @@
   z-index: 4;
   min-width: 0;
   padding: clamp(var(--mantine-spacing-sm), 2cqi, var(--mantine-spacing-md));
-  overflow: auto;
+  overflow: visible;
   background: transparent;
 }
 
@@ -276,10 +275,6 @@
     --nested-tabs-level-width: 3.1rem;
     --nested-tabs-item-size: 2.4rem;
     --nested-tabs-gap: 0.25rem;
-  }
-
-  .root {
-    min-height: 32rem;
   }
 
   .levelItems {

--- a/src/app/ui/surface/NestedTabs.module.css
+++ b/src/app/ui/surface/NestedTabs.module.css
@@ -190,43 +190,32 @@
   flex: 0 0 auto;
   justify-items: center;
   width: 100%;
-  padding: 0.25rem 0.15rem 0.35rem;
-}
-
-.group::before,
-.group::after {
-  position: absolute;
-  inset-inline: 0.35rem;
-  height: 1px;
-  background: color-mix(in srgb, currentColor 18%, transparent);
-  content: "";
-  transition: background-color var(--transition-fast);
-}
-
-.group::before {
-  inset-block-start: 0;
-}
-
-.group::after {
-  inset-block-end: 0;
-}
-
-.group[data-contains-active-item="true"]::before,
-.group[data-contains-active-item="true"]::after {
-  background: color-mix(in srgb, currentColor 32%, transparent);
+  padding: 0.15rem 0.15rem 0.35rem;
 }
 
 .groupAdornment {
-  position: relative;
-  z-index: 1;
   display: grid;
-  width: 1.8rem;
-  height: 1.8rem;
-  margin-block-end: 0.15rem;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0.25rem;
+  align-items: center;
+  width: calc(100% - 0.4rem);
+  min-height: 1.25rem;
+  margin-block-end: 0.2rem;
   color: currentColor;
   opacity: 0.58;
-  place-items: center;
   transition: opacity var(--transition-fast);
+}
+
+.groupAdornment::before,
+.groupAdornment::after {
+  height: 1px;
+  background: currentColor;
+  content: "";
+}
+
+.groupAdornment > * {
+  width: 0.95rem;
+  height: 0.95rem;
 }
 
 .group[data-contains-active-item="true"] .groupAdornment {
@@ -313,8 +302,6 @@
 
 @media (prefers-reduced-motion: reduce) {
   .item,
-  .group::before,
-  .group::after,
   .groupAdornment {
     transition: none;
   }

--- a/src/app/ui/surface/NestedTabs.module.css
+++ b/src/app/ui/surface/NestedTabs.module.css
@@ -95,10 +95,11 @@
 .level {
   position: relative;
   z-index: 3;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
   min-width: 0;
   min-height: 0;
+  contain: size;
   background: transparent;
 }
 
@@ -119,9 +120,10 @@
 }
 
 .levelItems {
-  flex: 0 0 auto;
   min-height: 0;
   padding: 0.4rem 0.25rem;
+  overflow: auto;
+  scrollbar-width: thin;
 }
 
 .itemSlot {
@@ -238,7 +240,6 @@
   flex-direction: column;
   align-items: center;
   gap: 0.35rem;
-  margin-block-start: auto;
   padding: 0.4rem 0.25rem 0.75rem;
 }
 

--- a/src/app/ui/surface/NestedTabs.module.css
+++ b/src/app/ui/surface/NestedTabs.module.css
@@ -188,24 +188,32 @@
   position: relative;
   display: grid;
   flex: 0 0 auto;
-  isolation: isolate;
   justify-items: center;
   width: 100%;
   padding: 0.25rem 0.15rem 0.35rem;
 }
 
-.group::before {
+.group::before,
+.group::after {
   position: absolute;
-  z-index: -1;
-  inset: 0 0.1rem;
-  background: color-mix(in srgb, currentColor 10%, transparent);
-  border-radius: calc(var(--nested-tabs-radius) + 0.1rem);
+  inset-inline: 0.35rem;
+  height: 1px;
+  background: color-mix(in srgb, currentColor 18%, transparent);
   content: "";
   transition: background-color var(--transition-fast);
 }
 
-.group[data-contains-active-item="true"]::before {
-  background: color-mix(in srgb, currentColor 18%, transparent);
+.group::before {
+  inset-block-start: 0;
+}
+
+.group::after {
+  inset-block-end: 0;
+}
+
+.group[data-contains-active-item="true"]::before,
+.group[data-contains-active-item="true"]::after {
+  background: color-mix(in srgb, currentColor 32%, transparent);
 }
 
 .groupAdornment {
@@ -306,6 +314,7 @@
 @media (prefers-reduced-motion: reduce) {
   .item,
   .group::before,
+  .group::after,
   .groupAdornment {
     transition: none;
   }

--- a/src/app/ui/surface/NestedTabs.module.css
+++ b/src/app/ui/surface/NestedTabs.module.css
@@ -188,9 +188,24 @@
   position: relative;
   display: grid;
   flex: 0 0 auto;
+  isolation: isolate;
   justify-items: center;
   width: 100%;
-  padding-block: 0.25rem;
+  padding: 0.25rem 0.15rem 0.35rem;
+}
+
+.group::before {
+  position: absolute;
+  z-index: -1;
+  inset: 0 0.1rem;
+  background: color-mix(in srgb, currentColor 10%, transparent);
+  border-radius: calc(var(--nested-tabs-radius) + 0.1rem);
+  content: "";
+  transition: background-color var(--transition-fast);
+}
+
+.group[data-contains-active-item="true"]::before {
+  background: color-mix(in srgb, currentColor 18%, transparent);
 }
 
 .groupAdornment {
@@ -219,19 +234,8 @@
 }
 
 .groupItems {
-  position: relative;
   width: 100%;
   padding-block: 0.15rem;
-}
-
-.groupItems::before {
-  position: absolute;
-  inset-block: 0;
-  inset-inline-start: 0.18rem;
-  width: 1px;
-  background: currentColor;
-  content: "";
-  opacity: 0.2;
 }
 
 .levelFooter {
@@ -301,6 +305,7 @@
 
 @media (prefers-reduced-motion: reduce) {
   .item,
+  .group::before,
   .groupAdornment {
     transition: none;
   }

--- a/src/app/ui/surface/NestedTabs.module.css
+++ b/src/app/ui/surface/NestedTabs.module.css
@@ -140,9 +140,9 @@
   color: currentColor;
   text-decoration: none;
   background: transparent;
-  border: 1px solid currentColor;
+  border: 0;
   border-radius: calc(var(--nested-tabs-radius) + 0.15rem);
-  opacity: 0.44;
+  opacity: 0.58;
   cursor: pointer;
   place-items: center;
   transition:
@@ -154,7 +154,6 @@
 .item[data-path-state="active"],
 .item[data-path-state="ancestor"] {
   background: transparent;
-  border-color: transparent;
   opacity: 1;
 }
 
@@ -202,7 +201,7 @@
   height: 1.8rem;
   margin-block-end: 0.15rem;
   color: currentColor;
-  opacity: 0.44;
+  opacity: 0.58;
   place-items: center;
   transition: opacity var(--transition-fast);
 }

--- a/src/app/ui/surface/NestedTabs.module.css
+++ b/src/app/ui/surface/NestedTabs.module.css
@@ -1,0 +1,312 @@
+.host {
+  --nested-tabs-level-width: 3.5rem;
+  --nested-tabs-item-size: 2.65rem;
+  --nested-tabs-gap: 0.3rem;
+  --nested-tabs-radius: var(--mantine-radius-md);
+  --nested-tabs-level-one-bg: var(--glass-surface-0);
+  --nested-tabs-level-two-bg: var(--glass-surface-1);
+  --nested-tabs-panel-bg: var(--glass-surface-2);
+
+  container: nested-tabs / inline-size;
+  display: block;
+  width: 100%;
+  min-width: 0;
+  color: var(--color-text);
+}
+
+.root {
+  position: relative;
+  display: grid;
+  grid-template-columns: var(--nested-tabs-level-width) var(--nested-tabs-level-width) minmax(0, 1fr);
+  align-items: stretch;
+  width: 100%;
+  min-width: 0;
+  min-height: 38rem;
+  overflow: visible;
+  isolation: isolate;
+}
+
+.baseSurface {
+  position: absolute;
+  z-index: 0;
+  inset-block: 0;
+  inset-inline-start: 0;
+  width: var(--nested-tabs-level-width);
+  background: var(--nested-tabs-level-one-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--nested-tabs-radius) 0 0 var(--nested-tabs-radius);
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(var(--glass-blur-md));
+  pointer-events: none;
+}
+
+.surfaceLayer {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  display: block;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.surfaceLayer[data-nested-tabs-surface="panel"] {
+  z-index: 2;
+}
+
+.definitions {
+  position: absolute;
+}
+
+.geometryShadow,
+.geometryContour {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  pointer-events: none;
+}
+
+.geometryShadow {
+  z-index: 0;
+  fill: #000;
+}
+
+.glassSurface {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  background: var(--nested-tabs-level-two-bg);
+  backdrop-filter: blur(var(--glass-blur-md));
+}
+
+.surfaceLayer[data-nested-tabs-surface="panel"] .glassSurface {
+  background: var(--nested-tabs-panel-bg);
+}
+
+.geometryContour {
+  z-index: 2;
+  fill: none;
+  stroke: var(--panel-border);
+  stroke-width: 1;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+
+.level {
+  position: relative;
+  z-index: 3;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  min-width: 0;
+  min-height: 0;
+  background: transparent;
+}
+
+.level[data-nested-tabs-level="2"] {
+  z-index: 4;
+}
+
+.levelItems,
+.groupItems {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--nested-tabs-gap);
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.levelItems {
+  min-height: 0;
+  padding: 0.4rem 0.25rem;
+  overflow: auto;
+  scrollbar-width: thin;
+}
+
+.itemSlot {
+  display: contents;
+}
+
+.item {
+  position: relative;
+  display: grid;
+  flex: 0 0 var(--nested-tabs-item-size);
+  width: var(--nested-tabs-item-size);
+  height: var(--nested-tabs-item-size);
+  padding: 0;
+  color: currentColor;
+  text-decoration: none;
+  background: transparent;
+  border: 1px solid currentColor;
+  border-radius: calc(var(--nested-tabs-radius) + 0.15rem);
+  opacity: 0.44;
+  cursor: pointer;
+  place-items: center;
+  transition:
+    opacity var(--transition-fast),
+    background-color var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.item[data-path-state="active"],
+.item[data-path-state="ancestor"] {
+  background: transparent;
+  border-color: transparent;
+  opacity: 1;
+}
+
+.item:hover,
+.item:focus-visible {
+  opacity: 1;
+}
+
+.item:hover {
+  transform: translateY(-1px);
+}
+
+.item:focus-visible {
+  outline: 3px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.itemIcon {
+  display: grid;
+  width: 1.4rem;
+  height: 1.4rem;
+  color: currentColor;
+  place-items: center;
+}
+
+.itemIcon > * {
+  max-width: 100%;
+  max-height: 100%;
+}
+
+.group {
+  position: relative;
+  display: grid;
+  flex: 0 0 auto;
+  justify-items: center;
+  width: 100%;
+  padding-block: 0.25rem;
+}
+
+.groupAdornment {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  width: 1.8rem;
+  height: 1.8rem;
+  margin-block-end: 0.15rem;
+  color: currentColor;
+  opacity: 0.44;
+  place-items: center;
+  transition: opacity var(--transition-fast);
+}
+
+.group[data-contains-active-item="true"] .groupAdornment {
+  opacity: 1;
+}
+
+.groupMarker {
+  display: block;
+  width: 0.65rem;
+  height: 0.65rem;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+}
+
+.groupItems {
+  position: relative;
+  width: 100%;
+  padding-block: 0.15rem;
+}
+
+.groupItems::before {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 0.18rem;
+  width: 1px;
+  background: currentColor;
+  content: "";
+  opacity: 0.2;
+}
+
+.levelFooter {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.25rem;
+}
+
+.levelLabel {
+  max-height: 9rem;
+  overflow: hidden;
+  font-size: var(--mantine-font-size-md);
+  font-weight: 800;
+  line-height: 1;
+  text-overflow: ellipsis;
+  text-transform: none;
+  white-space: nowrap;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+}
+
+.levelTools {
+  display: grid;
+  min-height: 2rem;
+  place-items: center;
+}
+
+.contentPanel {
+  position: relative;
+  z-index: 4;
+  min-width: 0;
+  padding: clamp(var(--mantine-spacing-sm), 2cqi, var(--mantine-spacing-md));
+  overflow: auto;
+  background: transparent;
+}
+
+@container nested-tabs (max-width: 34rem) {
+  .host {
+    --nested-tabs-level-width: 3.1rem;
+    --nested-tabs-item-size: 2.4rem;
+    --nested-tabs-gap: 0.25rem;
+  }
+
+  .root {
+    min-height: 32rem;
+  }
+
+  .levelItems {
+    padding-inline: 0.2rem;
+  }
+
+  .itemIcon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  .levelLabel {
+    font-size: var(--mantine-font-size-sm);
+  }
+
+  .contentPanel {
+    padding: var(--mantine-spacing-xs);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .item,
+  .groupAdornment {
+    transition: none;
+  }
+
+  .item:hover {
+    transform: none;
+  }
+}

--- a/src/app/ui/surface/NestedTabs.module.css
+++ b/src/app/ui/surface/NestedTabs.module.css
@@ -120,10 +120,39 @@
 }
 
 .levelItems {
+  --nested-tabs-scroll-fade: 1.35rem;
+
   min-height: 0;
   padding: 0.4rem 0.25rem;
   overflow: auto;
   scrollbar-width: thin;
+}
+
+.levelItems[data-scroll-before] {
+  -webkit-mask-image: linear-gradient(to bottom, transparent, #000 var(--nested-tabs-scroll-fade), #000 100%);
+  mask-image: linear-gradient(to bottom, transparent, #000 var(--nested-tabs-scroll-fade), #000 100%);
+}
+
+.levelItems[data-scroll-after] {
+  -webkit-mask-image: linear-gradient(to bottom, #000 0, #000 calc(100% - var(--nested-tabs-scroll-fade)), transparent);
+  mask-image: linear-gradient(to bottom, #000 0, #000 calc(100% - var(--nested-tabs-scroll-fade)), transparent);
+}
+
+.levelItems[data-scroll-before][data-scroll-after] {
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    #000 var(--nested-tabs-scroll-fade),
+    #000 calc(100% - var(--nested-tabs-scroll-fade)),
+    transparent
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    transparent,
+    #000 var(--nested-tabs-scroll-fade),
+    #000 calc(100% - var(--nested-tabs-scroll-fade)),
+    transparent
+  );
 }
 
 .itemSlot {

--- a/src/app/ui/surface/NestedTabs.module.css
+++ b/src/app/ui/surface/NestedTabs.module.css
@@ -124,8 +124,32 @@
 
   min-height: 0;
   padding: 0.4rem 0.25rem;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-color: transparent transparent;
   scrollbar-width: thin;
+}
+
+.levelItems[data-scrolling] {
+  scrollbar-color: color-mix(in srgb, currentColor 38%, transparent) transparent;
+}
+
+.levelItems::-webkit-scrollbar {
+  width: 0.3rem;
+  height: 0;
+}
+
+.levelItems::-webkit-scrollbar-track,
+.levelItems::-webkit-scrollbar-thumb {
+  background: transparent;
+}
+
+.levelItems::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+}
+
+.levelItems[data-scrolling]::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, currentColor 38%, transparent);
 }
 
 .levelItems[data-scroll-before] {

--- a/src/app/ui/surface/NestedTabs.stories.module.css
+++ b/src/app/ui/surface/NestedTabs.stories.module.css
@@ -35,11 +35,6 @@
   opacity: 0.58;
 }
 
-.withoutGroupEmphasis [data-contains-active-item="true"]::before,
-.withoutGroupEmphasis [data-contains-active-item="true"]::after {
-  background: color-mix(in srgb, currentColor 18%, transparent);
-}
-
 .fixedHeight {
   height: 42rem;
 }

--- a/src/app/ui/surface/NestedTabs.stories.module.css
+++ b/src/app/ui/surface/NestedTabs.stories.module.css
@@ -1,0 +1,126 @@
+.stage {
+  box-sizing: border-box;
+  width: min(72rem, 100%);
+  margin-inline: auto;
+  padding: var(--mantine-spacing-xl);
+}
+
+.comparison {
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(28rem, 1fr));
+  gap: var(--mantine-spacing-xl);
+  align-items: start;
+  width: min(76rem, 100%);
+  padding: var(--mantine-spacing-xl);
+  overflow-x: auto;
+}
+
+.comparisonCase {
+  display: grid;
+  gap: var(--mantine-spacing-sm);
+}
+
+.caseLabel {
+  margin: 0;
+  font-weight: 700;
+}
+
+.panel {
+  display: grid;
+  gap: var(--mantine-spacing-xl);
+}
+
+.withoutGroupEmphasis [data-contains-active-item="true"] > :first-child {
+  opacity: 0.44;
+}
+
+.fixedHeight {
+  height: 42rem;
+}
+
+.fixedHeight > div {
+  height: 100%;
+  min-height: 0;
+}
+
+.reducedMotion [data-nested-tabs-item],
+.reducedMotion [data-nested-tabs-item]::after {
+  transition: none;
+}
+
+.dragRegions {
+  display: grid;
+  gap: var(--mantine-spacing-lg);
+}
+
+.dragRegion {
+  display: grid;
+  gap: var(--mantine-spacing-xs);
+  min-height: 7rem;
+  padding: var(--mantine-spacing-md);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--mantine-radius-md);
+  transition:
+    border-color var(--transition-fast),
+    opacity var(--transition-fast);
+}
+
+.dragRegion[data-drop-state="valid"] {
+  border-color: var(--color-confirm);
+}
+
+.dragRegion[data-drop-state="invalid"] {
+  border-color: var(--color-danger);
+  opacity: 0.62;
+}
+
+.sortableBlocks {
+  display: grid;
+  gap: var(--mantine-spacing-xs);
+}
+
+.sortableBlock {
+  display: flex;
+  align-items: center;
+  gap: var(--mantine-spacing-sm);
+  padding: var(--mantine-spacing-sm);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--mantine-radius-sm);
+  background: var(--nested-tabs-panel-bg, transparent);
+}
+
+.sortableBlockContent {
+  flex: 1;
+  min-width: 0;
+}
+
+.emptyTarget {
+  min-height: 3.75rem;
+  border: 1px dashed color-mix(in srgb, currentColor 32%, transparent);
+  border-radius: var(--mantine-radius-sm);
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dragRegion {
+    transition: none;
+  }
+}
+
+@media (max-width: 34rem) {
+  .stage {
+    padding: var(--mantine-spacing-md);
+  }
+}

--- a/src/app/ui/surface/NestedTabs.stories.module.css
+++ b/src/app/ui/surface/NestedTabs.stories.module.css
@@ -32,7 +32,11 @@
 }
 
 .withoutGroupEmphasis [data-contains-active-item="true"] > :first-child {
-  opacity: 0.44;
+  opacity: 0.58;
+}
+
+.withoutGroupEmphasis [data-contains-active-item="true"]::before {
+  background: color-mix(in srgb, currentColor 10%, transparent);
 }
 
 .fixedHeight {

--- a/src/app/ui/surface/NestedTabs.stories.module.css
+++ b/src/app/ui/surface/NestedTabs.stories.module.css
@@ -5,15 +5,6 @@
   padding: var(--mantine-spacing-xl);
 }
 
-.fixedHeight {
-  height: 42rem;
-}
-
-.fixedHeight > div {
-  height: 100%;
-  min-height: 0;
-}
-
 @media (max-width: 34rem) {
   .stage {
     padding: var(--mantine-spacing-md);

--- a/src/app/ui/surface/NestedTabs.stories.module.css
+++ b/src/app/ui/surface/NestedTabs.stories.module.css
@@ -35,8 +35,9 @@
   opacity: 0.58;
 }
 
-.withoutGroupEmphasis [data-contains-active-item="true"]::before {
-  background: color-mix(in srgb, currentColor 10%, transparent);
+.withoutGroupEmphasis [data-contains-active-item="true"]::before,
+.withoutGroupEmphasis [data-contains-active-item="true"]::after {
+  background: color-mix(in srgb, currentColor 18%, transparent);
 }
 
 .fixedHeight {

--- a/src/app/ui/surface/NestedTabs.stories.module.css
+++ b/src/app/ui/surface/NestedTabs.stories.module.css
@@ -5,36 +5,6 @@
   padding: var(--mantine-spacing-xl);
 }
 
-.comparison {
-  box-sizing: border-box;
-  display: grid;
-  grid-template-columns: repeat(2, minmax(28rem, 1fr));
-  gap: var(--mantine-spacing-xl);
-  align-items: start;
-  width: min(76rem, 100%);
-  padding: var(--mantine-spacing-xl);
-  overflow-x: auto;
-}
-
-.comparisonCase {
-  display: grid;
-  gap: var(--mantine-spacing-sm);
-}
-
-.caseLabel {
-  margin: 0;
-  font-weight: 700;
-}
-
-.panel {
-  display: grid;
-  gap: var(--mantine-spacing-xl);
-}
-
-.withoutGroupEmphasis [data-contains-active-item="true"] > :first-child {
-  opacity: 0.58;
-}
-
 .fixedHeight {
   height: 42rem;
 }
@@ -42,81 +12,6 @@
 .fixedHeight > div {
   height: 100%;
   min-height: 0;
-}
-
-.reducedMotion [data-nested-tabs-item],
-.reducedMotion [data-nested-tabs-item]::after {
-  transition: none;
-}
-
-.dragRegions {
-  display: grid;
-  gap: var(--mantine-spacing-lg);
-}
-
-.dragRegion {
-  display: grid;
-  gap: var(--mantine-spacing-xs);
-  min-height: 7rem;
-  padding: var(--mantine-spacing-md);
-  border: 1px solid var(--panel-border);
-  border-radius: var(--mantine-radius-md);
-  transition:
-    border-color var(--transition-fast),
-    opacity var(--transition-fast);
-}
-
-.dragRegion[data-drop-state="valid"] {
-  border-color: var(--color-confirm);
-}
-
-.dragRegion[data-drop-state="invalid"] {
-  border-color: var(--color-danger);
-  opacity: 0.62;
-}
-
-.sortableBlocks {
-  display: grid;
-  gap: var(--mantine-spacing-xs);
-}
-
-.sortableBlock {
-  display: flex;
-  align-items: center;
-  gap: var(--mantine-spacing-sm);
-  padding: var(--mantine-spacing-sm);
-  border: 1px solid var(--panel-border);
-  border-radius: var(--mantine-radius-sm);
-  background: var(--nested-tabs-panel-bg, transparent);
-}
-
-.sortableBlockContent {
-  flex: 1;
-  min-width: 0;
-}
-
-.emptyTarget {
-  min-height: 3.75rem;
-  border: 1px dashed color-mix(in srgb, currentColor 32%, transparent);
-  border-radius: var(--mantine-radius-sm);
-}
-
-.visuallyHidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .dragRegion {
-    transition: none;
-  }
 }
 
 @media (max-width: 34rem) {

--- a/src/app/ui/surface/NestedTabs.stories.tsx
+++ b/src/app/ui/surface/NestedTabs.stories.tsx
@@ -185,7 +185,7 @@ function ManyRootItemsFixture() {
   const [activePath, setActivePath] = useState<NestedTabsPath>(['root-2', NESTED_ONE]);
   const activeRoot = activePath[0] ?? 'root-2';
   return (
-    <NestedTabs activePath={activePath} ariaLabel="Overflowing nested navigation" className={styles.fixedHeight}>
+    <NestedTabs activePath={activePath} ariaLabel="Nested navigation with many root items">
       <NestedTabs.Level label="Root level">
         {Array.from({ length: 20 }, (_, index) => {
           const id = `root-${index + 1}`;
@@ -237,7 +237,10 @@ export const ManyRootItems = meta.story({
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const rootLevel = canvas.getByRole('navigation', { name: 'Root level' });
+    const rootItems = rootLevel.querySelector('ul');
     await expect(rootLevel.querySelectorAll('[data-nested-tabs-item]')).toHaveLength(20);
+    await expect(rootItems).not.toBeNull();
+    await expect(rootItems?.scrollHeight).toBe(rootItems?.clientHeight);
   },
 });
 

--- a/src/app/ui/surface/NestedTabs.stories.tsx
+++ b/src/app/ui/surface/NestedTabs.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import type { Key, MouseEvent, ReactNode } from 'react';
-import { expect, within } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 
 import { NestedTabs } from './NestedTabs';
 import type { NestedTabsPath } from './NestedTabs';
@@ -182,8 +182,8 @@ export const GroupedItemActive = meta.story({
 });
 
 function ManyRootItemsFixture() {
-  const [activePath, setActivePath] = useState<NestedTabsPath>(['root-2', NESTED_ONE]);
-  const activeRoot = activePath[0] ?? 'root-2';
+  const [activePath, setActivePath] = useState<NestedTabsPath>(['root-19', NESTED_ONE]);
+  const activeRoot = activePath[0] ?? 'root-19';
   return (
     <NestedTabs activePath={activePath} ariaLabel="Nested navigation with many root items">
       <NestedTabs.Level label="Root level">
@@ -240,7 +240,11 @@ export const ManyRootItems = meta.story({
     const rootItems = rootLevel.querySelector('ul');
     await expect(rootLevel.querySelectorAll('[data-nested-tabs-item]')).toHaveLength(20);
     await expect(rootItems).not.toBeNull();
-    await expect(rootItems?.scrollHeight).toBe(rootItems?.clientHeight);
+    await expect(rootItems?.scrollHeight).toBeGreaterThan(rootItems?.clientHeight ?? 0);
+    await expect(rootItems?.scrollTop).toBeGreaterThan(0);
+    await userEvent.click(canvas.getByRole('link', { name: 'Root item 20' }));
+    await expect(canvas.getByRole('link', { name: 'Root item 20' })).toHaveAttribute('data-path-state', 'ancestor');
+    await expect(canvas.getByRole('link', { name: 'Nested item A' })).toHaveAttribute('aria-current', 'page');
   },
 });
 

--- a/src/app/ui/surface/NestedTabs.stories.tsx
+++ b/src/app/ui/surface/NestedTabs.stories.tsx
@@ -1,4 +1,6 @@
 import preview from '@sb/preview';
+import { NestedTabs } from '@ui/surface';
+import type { NestedTabsPath } from '@ui/surface';
 import {
   Circle,
   FileText,
@@ -16,8 +18,6 @@ import { useState } from 'react';
 import type { Key, MouseEvent, ReactNode } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 
-import { NestedTabs } from './NestedTabs';
-import type { NestedTabsPath } from './NestedTabs';
 import styles from './NestedTabs.stories.module.css';
 import { SurfaceFiller } from './SurfaceFiller.stories.fixture';
 

--- a/src/app/ui/surface/NestedTabs.stories.tsx
+++ b/src/app/ui/surface/NestedTabs.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import type { Key, MouseEvent, ReactNode } from 'react';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { NestedTabs } from './NestedTabs';
 import type { NestedTabsPath } from './NestedTabs';
@@ -159,8 +159,10 @@ export const NestedItemActive = meta.story({
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const storyDocument = within(canvasElement.ownerDocument.body);
     const levels = canvas.getAllByRole('navigation');
-    await expect(canvas.getByRole('link', { name: 'Root item B' })).toHaveAttribute('data-path-state', 'ancestor');
+    const rootItemB = canvas.getByRole('link', { name: 'Root item B' });
+    await expect(rootItemB).toHaveAttribute('data-path-state', 'ancestor');
     await expect(canvas.getByRole('link', { name: 'Nested item A' })).toHaveAttribute('aria-current', 'page');
     await expect(canvas.queryByRole('tab')).not.toBeInTheDocument();
     for (const level of levels) {
@@ -168,6 +170,12 @@ export const NestedItemActive = meta.story({
       await expect(items).not.toBeNull();
       await expect(getComputedStyle(items as HTMLElement).overflowX).toBe('hidden');
     }
+    await userEvent.hover(rootItemB);
+    await waitFor(() => expect(storyDocument.getByRole('tooltip')).toHaveTextContent('Root item B'));
+    levels[0]?.querySelector(':scope > ul')?.dispatchEvent(new Event('scroll'));
+    await waitFor(() => expect(storyDocument.queryByRole('tooltip')).not.toBeInTheDocument());
+    await new Promise<void>((resolve) => window.setTimeout(resolve, 700));
+    await expect(storyDocument.queryByRole('tooltip')).not.toBeInTheDocument();
   },
 });
 

--- a/src/app/ui/surface/NestedTabs.stories.tsx
+++ b/src/app/ui/surface/NestedTabs.stories.tsx
@@ -1,0 +1,601 @@
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { ActionIcon } from '@mantine/core';
+import preview from '@sb/preview';
+import {
+  Circle,
+  FileText,
+  Hexagon,
+  Image,
+  List,
+  Plus,
+  Rows3,
+  Settings2,
+  SlidersHorizontal,
+  Square,
+  Triangle,
+  Type,
+} from 'lucide-react';
+import { useState } from 'react';
+import type { Key, MouseEvent, ReactNode } from 'react';
+import { expect, userEvent, within } from 'storybook/test';
+
+import { SortableItem } from '../control/SortableItem';
+import { SortableReorderHandle } from '../control/SortableReorderHandle';
+import { NestedTabs } from './NestedTabs';
+import type { NestedTabsPath } from './NestedTabs';
+import styles from './NestedTabs.stories.module.css';
+import { SurfaceFiller } from './SurfaceFiller.stories.fixture';
+
+const PAGE_ONE = 'p-a7';
+const PAGE_TWO = 'p-k4';
+const PAGE_THREE = 'p-r9';
+
+const DETAILS = 'details';
+const CONTROL_SEO = 'c-n3';
+const CONTROL_RULES = 'c-t8';
+const BLOCK_INTRO = 'b-h2';
+const BLOCK_IMAGE = 'b-q5';
+const BLOCK_LIST = 'b-w7';
+
+interface PathItemProps {
+  key?: Key;
+  path: NestedTabsPath;
+  label: string;
+  icon: ReactNode;
+  onNavigate: (path: NestedTabsPath) => void;
+}
+
+function pathItem({ key, path, label, icon, onNavigate }: PathItemProps) {
+  return (
+    <NestedTabs.Item
+      key={key}
+      as="a"
+      href={`#${path.join('/')}`}
+      path={path}
+      label={label}
+      icon={icon}
+      onClick={(event: MouseEvent<HTMLAnchorElement>) => {
+        event.preventDefault();
+        onNavigate(path.length === 1 ? [path[0] ?? PAGE_ONE, DETAILS] : path);
+      }}
+    />
+  );
+}
+
+function pageLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }) {
+  return (
+    <NestedTabs.Level label="Pages">
+      {pathItem({ path: [PAGE_ONE], label: 'Cover layout', icon: <Triangle />, onNavigate })}
+      {pathItem({ path: [PAGE_TWO], label: 'Article layout', icon: <Hexagon />, onNavigate })}
+      {pathItem({ path: [PAGE_THREE], label: 'Reference layout', icon: <Square />, onNavigate })}
+      <NestedTabs.Tools>
+        <ActionIcon variant="subtle" aria-label="Add page">
+          <Plus aria-hidden />
+        </ActionIcon>
+      </NestedTabs.Tools>
+    </NestedTabs.Level>
+  );
+}
+
+function detailLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }) {
+  return (
+    <NestedTabs.Level label="Page">
+      {pathItem({ path: [PAGE_TWO, DETAILS], label: 'Page details', icon: <FileText />, onNavigate })}
+      {pathItem({
+        path: [PAGE_TWO, CONTROL_SEO],
+        label: 'Search and sharing',
+        icon: <SlidersHorizontal />,
+        onNavigate,
+      })}
+      {pathItem({
+        path: [PAGE_TWO, CONTROL_RULES],
+        label: 'Rule presentation',
+        icon: <Settings2 />,
+        onNavigate,
+      })}
+      <NestedTabs.Group label="Opening region" icon={<Rows3 />}>
+        {pathItem({
+          path: [PAGE_TWO, BLOCK_INTRO],
+          label: 'Introduction block',
+          icon: <Type />,
+          onNavigate,
+        })}
+        {pathItem({
+          path: [PAGE_TWO, BLOCK_IMAGE],
+          label: 'Illustration block',
+          icon: <Image />,
+          onNavigate,
+        })}
+      </NestedTabs.Group>
+      <NestedTabs.Group label="Reference region" icon={<List />}>
+        {pathItem({
+          path: [PAGE_TWO, BLOCK_LIST],
+          label: 'Reference list block',
+          icon: <List />,
+          onNavigate,
+        })}
+      </NestedTabs.Group>
+    </NestedTabs.Level>
+  );
+}
+
+function PanelFixture() {
+  return <SurfaceFiller height={420} />;
+}
+
+function HierarchyFixture({
+  initialPath,
+  className,
+  tools = true,
+}: {
+  initialPath: NestedTabsPath;
+  className?: string;
+  tools?: boolean;
+}) {
+  const [activePath, setActivePath] = useState<NestedTabsPath>(initialPath);
+  return (
+    <NestedTabs activePath={activePath} ariaLabel="Rulebook editor" className={className}>
+      {tools ? (
+        pageLevel({ onNavigate: setActivePath })
+      ) : (
+        <NestedTabs.Level label="Pages">
+          {pathItem({ path: [PAGE_ONE], label: 'Cover layout', icon: <Triangle />, onNavigate: setActivePath })}
+          {pathItem({ path: [PAGE_TWO], label: 'Article layout', icon: <Hexagon />, onNavigate: setActivePath })}
+          {pathItem({ path: [PAGE_THREE], label: 'Reference layout', icon: <Square />, onNavigate: setActivePath })}
+        </NestedTabs.Level>
+      )}
+      {detailLevel({ onNavigate: setActivePath })}
+      <NestedTabs.ContentPanel aria-label="Editor controls">
+        <PanelFixture />
+      </NestedTabs.ContentPanel>
+    </NestedTabs>
+  );
+}
+
+type DemoBlockKind = 'text' | 'image' | 'list';
+type DemoRegionId = 'opening' | 'aside' | 'references' | 'notes';
+
+interface DemoBlock {
+  id: string;
+  label: string;
+  kind: DemoBlockKind;
+}
+
+interface DemoRegionDefinition {
+  id: DemoRegionId;
+  label: string;
+  accepts: readonly DemoBlockKind[];
+  capacity: number;
+}
+
+const demoRegions: readonly DemoRegionDefinition[] = [
+  {
+    id: 'opening',
+    label: 'Opening region',
+    accepts: ['text', 'image'],
+    capacity: 4,
+  },
+  { id: 'notes', label: 'Notes region', accepts: ['text'], capacity: 2 },
+  { id: 'aside', label: 'Aside region', accepts: ['image'], capacity: 1 },
+  {
+    id: 'references',
+    label: 'Reference region',
+    accepts: ['list'],
+    capacity: 3,
+  },
+];
+
+const initialRegionBlocks: Record<DemoRegionId, DemoBlock[]> = {
+  opening: [
+    { id: BLOCK_INTRO, label: 'Introduction block', kind: 'text' },
+    { id: BLOCK_IMAGE, label: 'Illustration block', kind: 'image' },
+  ],
+  aside: [{ id: 'b-z4', label: 'Aside illustration', kind: 'image' }],
+  references: [{ id: BLOCK_LIST, label: 'Reference list block', kind: 'list' }],
+  notes: [],
+};
+
+function blockIcon(kind: DemoBlockKind) {
+  if (kind === 'image') {
+    return <Image />;
+  }
+  if (kind === 'list') {
+    return <List />;
+  }
+  return <Type />;
+}
+
+function findBlockRegion(regions: Record<DemoRegionId, DemoBlock[]>, blockId: string): DemoRegionId | undefined {
+  return demoRegions.find((region) => regions[region.id].some((block) => block.id === blockId))?.id;
+}
+
+function canRegionAccept(
+  definition: DemoRegionDefinition,
+  blocks: readonly DemoBlock[],
+  block: DemoBlock,
+  sourceRegion: DemoRegionId
+) {
+  const keepsSameCount = sourceRegion === definition.id;
+  return definition.accepts.includes(block.kind) && (keepsSameCount || blocks.length < definition.capacity);
+}
+
+function sortingDetailLevel({
+  regions,
+  onNavigate,
+}: {
+  regions: Record<DemoRegionId, DemoBlock[]>;
+  onNavigate: PathItemProps['onNavigate'];
+}) {
+  return (
+    <NestedTabs.Level label="Page">
+      {pathItem({ path: [PAGE_TWO, DETAILS], label: 'Page details', icon: <FileText />, onNavigate })}
+      {pathItem({
+        path: [PAGE_TWO, CONTROL_RULES],
+        label: 'Rule presentation',
+        icon: <Settings2 />,
+        onNavigate,
+      })}
+      {demoRegions.map((region) => (
+        <NestedTabs.Group key={region.id} label={region.label} icon={<Rows3 />}>
+          {regions[region.id].map((block) =>
+            pathItem({
+              key: block.id,
+              path: [PAGE_TWO, block.id],
+              label: block.label,
+              icon: blockIcon(block.kind),
+              onNavigate,
+            })
+          )}
+        </NestedTabs.Group>
+      ))}
+    </NestedTabs.Level>
+  );
+}
+
+function SortableBlockCard({ block }: { block: DemoBlock }) {
+  return (
+    <SortableItem id={block.id}>
+      {({ setActivatorNodeRef, attributes, listeners }) => (
+        <div className={styles.sortableBlock} data-block-id={block.id}>
+          <SortableReorderHandle
+            label={`Reorder ${block.label}`}
+            setActivatorNodeRef={setActivatorNodeRef}
+            attributes={attributes}
+            listeners={listeners}
+          />
+          <SurfaceFiller className={styles.sortableBlockContent} height={32} />
+        </div>
+      )}
+    </SortableItem>
+  );
+}
+
+function SortableRegion({
+  definition,
+  blocks,
+  activeBlock,
+  sourceRegion,
+}: {
+  definition: DemoRegionDefinition;
+  blocks: DemoBlock[];
+  activeBlock: DemoBlock | null;
+  sourceRegion: DemoRegionId | undefined;
+}) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `region:${definition.id}`,
+  });
+  const canAccept =
+    activeBlock && sourceRegion ? canRegionAccept(definition, blocks, activeBlock, sourceRegion) : undefined;
+  const dropState =
+    activeBlock && (isOver || definition.id !== sourceRegion) ? (canAccept ? 'valid' : 'invalid') : undefined;
+
+  return (
+    <section
+      ref={setNodeRef}
+      className={styles.dragRegion}
+      data-region={definition.id}
+      data-drop-state={dropState}
+      aria-label={definition.label}
+    >
+      <SortableContext items={blocks.map((block) => block.id)} strategy={verticalListSortingStrategy}>
+        <div className={styles.sortableBlocks}>
+          {blocks.map((block) => (
+            <SortableBlockCard key={block.id} block={block} />
+          ))}
+          {blocks.length === 0 ? <div className={styles.emptyTarget} aria-hidden /> : null}
+        </div>
+      </SortableContext>
+    </section>
+  );
+}
+
+function SortingFixture() {
+  const [activePath, setActivePath] = useState<NestedTabsPath>([PAGE_TWO, BLOCK_INTRO]);
+  const [regions, setRegions] = useState<Record<DemoRegionId, DemoBlock[]>>(initialRegionBlocks);
+  const [draggedId, setDraggedId] = useState<string | null>(null);
+  const [outcome, setOutcome] = useState('Ready');
+  const draggedBlock = draggedId
+    ? (demoRegions.flatMap((region) => regions[region.id]).find((block) => block.id === draggedId) ?? null)
+    : null;
+  const sourceRegion = draggedId ? findBlockRegion(regions, draggedId) : undefined;
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  function handleDragStart({ active }: DragStartEvent) {
+    setDraggedId(String(active.id));
+    setOutcome('Dragging does not change the active path.');
+  }
+
+  function handleDragEnd({ active, over }: DragEndEvent) {
+    const blockId = String(active.id);
+    const from = findBlockRegion(regions, blockId);
+    const overId = over ? String(over.id) : undefined;
+    const to = overId?.startsWith('region:')
+      ? (overId.slice('region:'.length) as DemoRegionId)
+      : overId
+        ? findBlockRegion(regions, overId)
+        : undefined;
+    const block = from ? regions[from].find((candidate) => candidate.id === blockId) : undefined;
+
+    setDraggedId(null);
+    if (!from || !to || !block || !overId) {
+      setOutcome('No Page-local Block region accepted that drop.');
+      return;
+    }
+
+    const definition = demoRegions.find((region) => region.id === to);
+    if (!definition || !canRegionAccept(definition, regions[to], block, from)) {
+      setOutcome(`${definition?.label ?? 'That target'} does not accept ${block.kind} blocks here.`);
+      return;
+    }
+
+    if (from === to) {
+      const fromIndex = regions[from].findIndex((candidate) => candidate.id === blockId);
+      const toIndex = overId.startsWith('region:')
+        ? regions[to].length - 1
+        : regions[to].findIndex((candidate) => candidate.id === overId);
+      if (fromIndex !== toIndex && toIndex >= 0) {
+        setRegions((current) => ({
+          ...current,
+          [from]: arrayMove(current[from], fromIndex, toIndex),
+        }));
+        setOutcome(`${block.label} reordered inside ${definition.label}.`);
+      }
+      return;
+    }
+
+    const insertAt = overId.startsWith('region:')
+      ? regions[to].length
+      : Math.max(
+          0,
+          regions[to].findIndex((candidate) => candidate.id === overId)
+        );
+    setRegions((current) => {
+      const nextSource = current[from].filter((candidate) => candidate.id !== blockId);
+      const nextTarget = [...current[to]];
+      nextTarget.splice(insertAt, 0, block);
+      return { ...current, [from]: nextSource, [to]: nextTarget };
+    });
+    setOutcome(`${block.label} moved to ${definition.label}. The active path stayed on the Block.`);
+  }
+
+  return (
+    <NestedTabs activePath={activePath} ariaLabel="Sortable Rulebook editor" className={styles.fixedHeight}>
+      {pageLevel({ onNavigate: setActivePath })}
+      {sortingDetailLevel({ regions, onNavigate: setActivePath })}
+      <NestedTabs.ContentPanel aria-label="Sortable Page regions">
+        <div className={styles.panel}>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragCancel={() => setDraggedId(null)}
+            onDragEnd={handleDragEnd}
+          >
+            <div className={styles.dragRegions}>
+              {demoRegions.map((definition) => (
+                <SortableRegion
+                  key={definition.id}
+                  definition={definition}
+                  blocks={regions[definition.id]}
+                  activeBlock={draggedBlock}
+                  sourceRegion={sourceRegion}
+                />
+              ))}
+            </div>
+          </DndContext>
+          <p className={styles.visuallyHidden} role="status">
+            {outcome}
+          </p>
+        </div>
+      </NestedTabs.ContentPanel>
+    </NestedTabs>
+  );
+}
+
+const meta = preview.meta({
+  title: 'Nested Tabs',
+  component: NestedTabs,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'NestedTabs renders two connected icon-only navigation Levels beside a caller-owned ContentPanel. The caller owns path and navigation state; Items remain semantic links.',
+      },
+    },
+  },
+});
+
+export const PageDetailsActive = meta.story({
+  render: () => (
+    <main className={styles.stage}>
+      <HierarchyFixture initialPath={[PAGE_TWO, DETAILS]} />
+    </main>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('link', { name: 'Article layout' })).toHaveAttribute('data-path-state', 'ancestor');
+    await expect(canvas.getByRole('link', { name: 'Page details' })).toHaveAttribute('aria-current', 'page');
+    await expect(canvas.queryByRole('tab')).not.toBeInTheDocument();
+  },
+});
+
+export const ControlRegionActive = meta.story({
+  render: () => (
+    <main className={styles.stage}>
+      <HierarchyFixture initialPath={[PAGE_TWO, CONTROL_RULES]} />
+    </main>
+  ),
+});
+
+export const BlockActive = meta.story({
+  render: () => (
+    <main className={styles.stage}>
+      <HierarchyFixture initialPath={[PAGE_TWO, BLOCK_IMAGE]} />
+    </main>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('link', { name: 'Illustration block' })).toHaveAttribute('aria-current', 'page');
+    await expect(canvas.getByRole('list', { name: 'Opening region' }).parentElement).toHaveAttribute(
+      'data-contains-active-item',
+      'true'
+    );
+  },
+});
+
+export const SamePageBlockSorting = meta.story({
+  render: () => (
+    <main className={styles.stage}>
+      <SortingFixture />
+    </main>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('link', { name: 'Introduction block' })).toHaveAttribute('aria-current', 'page');
+    await expect(canvas.getByRole('button', { name: 'Reorder Introduction block' })).toBeVisible();
+    await expect(canvasElement.querySelectorAll('[data-region]')).toHaveLength(4);
+    await expect(canvasElement.querySelector('[data-nested-tabs-level] [data-region]')).toBeNull();
+  },
+});
+
+export const GroupContainmentComparison = meta.story({
+  render: () => (
+    <main className={styles.comparison}>
+      <section className={styles.comparisonCase}>
+        <p className={styles.caseLabel}>Derived Group emphasis</p>
+        <HierarchyFixture initialPath={[PAGE_TWO, BLOCK_IMAGE]} tools={false} />
+      </section>
+      <section className={styles.comparisonCase}>
+        <p className={styles.caseLabel}>State exposed, no visual emphasis</p>
+        <HierarchyFixture initialPath={[PAGE_TWO, BLOCK_IMAGE]} className={styles.withoutGroupEmphasis} tools={false} />
+      </section>
+    </main>
+  ),
+});
+
+function OverflowFixture() {
+  const [activePath, setActivePath] = useState<NestedTabsPath>(['page-10', 'block-12']);
+  return (
+    <NestedTabs activePath={activePath} ariaLabel="Overflowing rulebook editor" className={styles.fixedHeight}>
+      <NestedTabs.Level label="Many Pages">
+        {Array.from({ length: 14 }, (_, index) => {
+          const id = `page-${index + 1}`;
+          return pathItem({
+            key: id,
+            path: [id],
+            label: `Chapter ${index + 1}: A deliberately long Page label`,
+            icon: index % 3 === 0 ? <Circle /> : index % 3 === 1 ? <Triangle /> : <Hexagon />,
+            onNavigate: setActivePath,
+          });
+        })}
+        <NestedTabs.Tools>
+          <ActionIcon variant="subtle" aria-label="Add page">
+            <Plus aria-hidden />
+          </ActionIcon>
+        </NestedTabs.Tools>
+      </NestedTabs.Level>
+      <NestedTabs.Level label="Current Page">
+        {pathItem({
+          path: ['page-10', DETAILS],
+          label: 'Page details with a deliberately long label',
+          icon: <FileText />,
+          onNavigate: setActivePath,
+        })}
+        <NestedTabs.Group label="A long structural region label" icon={<Rows3 />}>
+          {Array.from({ length: 16 }, (_, index) => {
+            const id = `block-${index + 1}`;
+            return pathItem({
+              key: id,
+              path: ['page-10', id],
+              label: `Block ${index + 1}: long descriptive name`,
+              icon: index % 2 === 0 ? <Type /> : <Image />,
+              onNavigate: setActivePath,
+            });
+          })}
+        </NestedTabs.Group>
+      </NestedTabs.Level>
+      <NestedTabs.ContentPanel aria-label="Tall editor content">
+        <SurfaceFiller height={1200} />
+      </NestedTabs.ContentPanel>
+    </NestedTabs>
+  );
+}
+
+export const OverflowAndLongLabels = meta.story({
+  render: () => (
+    <main className={styles.stage}>
+      <OverflowFixture />
+    </main>
+  ),
+});
+
+export const NarrowContainer = meta.story({
+  globals: { viewport: { value: 'appMobile' } },
+  render: () => (
+    <main className={styles.stage}>
+      <HierarchyFixture initialPath={[PAGE_TWO, BLOCK_LIST]} />
+    </main>
+  ),
+});
+
+export const LevelWithoutTools = meta.story({
+  render: () => (
+    <main className={styles.stage}>
+      <HierarchyFixture initialPath={[PAGE_TWO, DETAILS]} tools={false} />
+    </main>
+  ),
+});
+
+export const ReducedMotion = meta.story({
+  render: () => (
+    <main className={styles.stage}>
+      <HierarchyFixture initialPath={[PAGE_TWO, DETAILS]} className={styles.reducedMotion} />
+    </main>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('link', { name: 'Search and sharing' }));
+    await expect(canvas.getByRole('link', { name: 'Search and sharing' })).toHaveAttribute('aria-current', 'page');
+  },
+});

--- a/src/app/ui/surface/NestedTabs.stories.tsx
+++ b/src/app/ui/surface/NestedTabs.stories.tsx
@@ -1,19 +1,3 @@
-import {
-  closestCenter,
-  DndContext,
-  KeyboardSensor,
-  PointerSensor,
-  useDroppable,
-  useSensor,
-  useSensors,
-} from '@dnd-kit/core';
-import type { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
-import {
-  arrayMove,
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable';
 import preview from '@sb/preview';
 import {
   Circle,
@@ -30,25 +14,23 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import type { Key, MouseEvent, ReactNode } from 'react';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, within } from 'storybook/test';
 
-import { SortableItem } from '../control/SortableItem';
-import { SortableReorderHandle } from '../control/SortableReorderHandle';
 import { NestedTabs } from './NestedTabs';
 import type { NestedTabsPath } from './NestedTabs';
 import styles from './NestedTabs.stories.module.css';
 import { SurfaceFiller } from './SurfaceFiller.stories.fixture';
 
-const PAGE_ONE = 'p-a7';
-const PAGE_TWO = 'p-k4';
-const PAGE_THREE = 'p-r9';
+const ROOT_ONE = 'r-a7';
+const ROOT_TWO = 'r-k4';
+const ROOT_THREE = 'r-r9';
 
-const DETAILS = 'details';
-const CONTROL_SEO = 'c-n3';
-const CONTROL_RULES = 'c-t8';
-const BLOCK_INTRO = 'b-h2';
-const BLOCK_IMAGE = 'b-q5';
-const BLOCK_LIST = 'b-w7';
+const NESTED_ONE = 'n-m2';
+const NESTED_TWO = 'n-n3';
+const NESTED_THREE = 'n-t8';
+const GROUPED_ONE = 'g-h2';
+const GROUPED_TWO = 'g-q5';
+const GROUPED_THREE = 'g-w7';
 
 interface PathItemProps {
   key?: Key;
@@ -69,7 +51,7 @@ function pathItem({ key, path, label, icon, onNavigate }: PathItemProps) {
       icon={icon}
       onClick={(event: MouseEvent<HTMLAnchorElement>) => {
         event.preventDefault();
-        onNavigate(path.length === 1 ? [path[0] ?? PAGE_ONE, DETAILS] : path);
+        onNavigate(path.length === 1 ? [path[0] ?? ROOT_ONE, NESTED_ONE] : path);
       }}
     />
   );
@@ -78,9 +60,9 @@ function pathItem({ key, path, label, icon, onNavigate }: PathItemProps) {
 function rootLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }) {
   return (
     <NestedTabs.Level label="Root level">
-      {pathItem({ path: [PAGE_ONE], label: 'Root item A', icon: <Triangle />, onNavigate })}
-      {pathItem({ path: [PAGE_TWO], label: 'Root item B', icon: <Hexagon />, onNavigate })}
-      {pathItem({ path: [PAGE_THREE], label: 'Root item C', icon: <Square />, onNavigate })}
+      {pathItem({ path: [ROOT_ONE], label: 'Root item A', icon: <Triangle />, onNavigate })}
+      {pathItem({ path: [ROOT_TWO], label: 'Root item B', icon: <Hexagon />, onNavigate })}
+      {pathItem({ path: [ROOT_THREE], label: 'Root item C', icon: <Square />, onNavigate })}
       <NestedTabs.Tools>
         <SurfaceFiller height={24} width={24} />
       </NestedTabs.Tools>
@@ -91,28 +73,28 @@ function rootLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }) 
 function nestedLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }) {
   return (
     <NestedTabs.Level label="Nested Level">
-      {pathItem({ path: [PAGE_TWO, DETAILS], label: 'Nested item A', icon: <FileText />, onNavigate })}
+      {pathItem({ path: [ROOT_TWO, NESTED_ONE], label: 'Nested item A', icon: <FileText />, onNavigate })}
       {pathItem({
-        path: [PAGE_TWO, CONTROL_SEO],
+        path: [ROOT_TWO, NESTED_TWO],
         label: 'Nested item B',
         icon: <SlidersHorizontal />,
         onNavigate,
       })}
       {pathItem({
-        path: [PAGE_TWO, CONTROL_RULES],
+        path: [ROOT_TWO, NESTED_THREE],
         label: 'Nested item C',
         icon: <Settings2 />,
         onNavigate,
       })}
       <NestedTabs.Group label="Group A" icon={<Rows3 />}>
         {pathItem({
-          path: [PAGE_TWO, BLOCK_INTRO],
+          path: [ROOT_TWO, GROUPED_ONE],
           label: 'Grouped item A',
           icon: <Type />,
           onNavigate,
         })}
         {pathItem({
-          path: [PAGE_TWO, BLOCK_IMAGE],
+          path: [ROOT_TWO, GROUPED_TWO],
           label: 'Grouped item B',
           icon: <Image />,
           onNavigate,
@@ -120,7 +102,7 @@ function nestedLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }
       </NestedTabs.Group>
       <NestedTabs.Group label="Group B" icon={<List />}>
         {pathItem({
-          path: [PAGE_TWO, BLOCK_LIST],
+          path: [ROOT_TWO, GROUPED_THREE],
           label: 'Grouped item C',
           icon: <List />,
           onNavigate,
@@ -134,295 +116,22 @@ function PanelFixture() {
   return <SurfaceFiller height={420} />;
 }
 
-function HierarchyFixture({
-  initialPath,
-  className,
-  tools = true,
-}: {
-  initialPath: NestedTabsPath;
-  className?: string;
-  tools?: boolean;
-}) {
+function HierarchyFixture({ initialPath, tools = true }: { initialPath: NestedTabsPath; tools?: boolean }) {
   const [activePath, setActivePath] = useState<NestedTabsPath>(initialPath);
   return (
-    <NestedTabs activePath={activePath} ariaLabel="Nested navigation" className={className}>
+    <NestedTabs activePath={activePath} ariaLabel="Nested navigation">
       {tools ? (
         rootLevel({ onNavigate: setActivePath })
       ) : (
         <NestedTabs.Level label="Root level">
-          {pathItem({ path: [PAGE_ONE], label: 'Root item A', icon: <Triangle />, onNavigate: setActivePath })}
-          {pathItem({ path: [PAGE_TWO], label: 'Root item B', icon: <Hexagon />, onNavigate: setActivePath })}
-          {pathItem({ path: [PAGE_THREE], label: 'Root item C', icon: <Square />, onNavigate: setActivePath })}
+          {pathItem({ path: [ROOT_ONE], label: 'Root item A', icon: <Triangle />, onNavigate: setActivePath })}
+          {pathItem({ path: [ROOT_TWO], label: 'Root item B', icon: <Hexagon />, onNavigate: setActivePath })}
+          {pathItem({ path: [ROOT_THREE], label: 'Root item C', icon: <Square />, onNavigate: setActivePath })}
         </NestedTabs.Level>
       )}
       {nestedLevel({ onNavigate: setActivePath })}
       <NestedTabs.ContentPanel aria-label="Example content">
         <PanelFixture />
-      </NestedTabs.ContentPanel>
-    </NestedTabs>
-  );
-}
-
-type DemoBlockKind = 'text' | 'image' | 'list';
-type DemoRegionId = 'opening' | 'aside' | 'references' | 'notes';
-
-interface DemoBlock {
-  id: string;
-  label: string;
-  kind: DemoBlockKind;
-}
-
-interface DemoRegionDefinition {
-  id: DemoRegionId;
-  label: string;
-  accepts: readonly DemoBlockKind[];
-  capacity: number;
-}
-
-const demoRegions: readonly DemoRegionDefinition[] = [
-  {
-    id: 'opening',
-    label: 'Group A',
-    accepts: ['text', 'image'],
-    capacity: 4,
-  },
-  { id: 'notes', label: 'Group B', accepts: ['text'], capacity: 2 },
-  { id: 'aside', label: 'Group C', accepts: ['image'], capacity: 1 },
-  {
-    id: 'references',
-    label: 'Group D',
-    accepts: ['list'],
-    capacity: 3,
-  },
-];
-
-const initialRegionBlocks: Record<DemoRegionId, DemoBlock[]> = {
-  opening: [
-    { id: BLOCK_INTRO, label: 'Grouped item A', kind: 'text' },
-    { id: BLOCK_IMAGE, label: 'Grouped item B', kind: 'image' },
-  ],
-  aside: [{ id: 'b-z4', label: 'Grouped item D', kind: 'image' }],
-  references: [{ id: BLOCK_LIST, label: 'Grouped item C', kind: 'list' }],
-  notes: [],
-};
-
-function blockIcon(kind: DemoBlockKind) {
-  if (kind === 'image') {
-    return <Image />;
-  }
-  if (kind === 'list') {
-    return <List />;
-  }
-  return <Type />;
-}
-
-function findBlockRegion(regions: Record<DemoRegionId, DemoBlock[]>, blockId: string): DemoRegionId | undefined {
-  return demoRegions.find((region) => regions[region.id].some((block) => block.id === blockId))?.id;
-}
-
-function canRegionAccept(
-  definition: DemoRegionDefinition,
-  blocks: readonly DemoBlock[],
-  block: DemoBlock,
-  sourceRegion: DemoRegionId
-) {
-  const keepsSameCount = sourceRegion === definition.id;
-  return definition.accepts.includes(block.kind) && (keepsSameCount || blocks.length < definition.capacity);
-}
-
-function sortingNestedLevel({
-  regions,
-  onNavigate,
-}: {
-  regions: Record<DemoRegionId, DemoBlock[]>;
-  onNavigate: PathItemProps['onNavigate'];
-}) {
-  return (
-    <NestedTabs.Level label="Nested Level">
-      {pathItem({ path: [PAGE_TWO, DETAILS], label: 'Nested item A', icon: <FileText />, onNavigate })}
-      {pathItem({
-        path: [PAGE_TWO, CONTROL_RULES],
-        label: 'Nested item B',
-        icon: <Settings2 />,
-        onNavigate,
-      })}
-      {demoRegions.map((region) => (
-        <NestedTabs.Group key={region.id} label={region.label} icon={<Rows3 />}>
-          {regions[region.id].map((block) =>
-            pathItem({
-              key: block.id,
-              path: [PAGE_TWO, block.id],
-              label: block.label,
-              icon: blockIcon(block.kind),
-              onNavigate,
-            })
-          )}
-        </NestedTabs.Group>
-      ))}
-    </NestedTabs.Level>
-  );
-}
-
-function SortableBlockCard({ block }: { block: DemoBlock }) {
-  return (
-    <SortableItem id={block.id}>
-      {({ setActivatorNodeRef, attributes, listeners }) => (
-        <div className={styles.sortableBlock} data-block-id={block.id}>
-          <SortableReorderHandle
-            label={`Reorder ${block.label}`}
-            setActivatorNodeRef={setActivatorNodeRef}
-            attributes={attributes}
-            listeners={listeners}
-          />
-          <SurfaceFiller className={styles.sortableBlockContent} height={32} />
-        </div>
-      )}
-    </SortableItem>
-  );
-}
-
-function SortableRegion({
-  definition,
-  blocks,
-  activeBlock,
-  sourceRegion,
-}: {
-  definition: DemoRegionDefinition;
-  blocks: DemoBlock[];
-  activeBlock: DemoBlock | null;
-  sourceRegion: DemoRegionId | undefined;
-}) {
-  const { setNodeRef, isOver } = useDroppable({
-    id: `region:${definition.id}`,
-  });
-  const canAccept =
-    activeBlock && sourceRegion ? canRegionAccept(definition, blocks, activeBlock, sourceRegion) : undefined;
-  const dropState =
-    activeBlock && (isOver || definition.id !== sourceRegion) ? (canAccept ? 'valid' : 'invalid') : undefined;
-
-  return (
-    <section
-      ref={setNodeRef}
-      className={styles.dragRegion}
-      data-region={definition.id}
-      data-drop-state={dropState}
-      aria-label={definition.label}
-    >
-      <SortableContext items={blocks.map((block) => block.id)} strategy={verticalListSortingStrategy}>
-        <div className={styles.sortableBlocks}>
-          {blocks.map((block) => (
-            <SortableBlockCard key={block.id} block={block} />
-          ))}
-          {blocks.length === 0 ? <div className={styles.emptyTarget} aria-hidden /> : null}
-        </div>
-      </SortableContext>
-    </section>
-  );
-}
-
-function SortingFixture() {
-  const [activePath, setActivePath] = useState<NestedTabsPath>([PAGE_TWO, BLOCK_INTRO]);
-  const [regions, setRegions] = useState<Record<DemoRegionId, DemoBlock[]>>(initialRegionBlocks);
-  const [draggedId, setDraggedId] = useState<string | null>(null);
-  const [outcome, setOutcome] = useState('Ready');
-  const draggedBlock = draggedId
-    ? (demoRegions.flatMap((region) => regions[region.id]).find((block) => block.id === draggedId) ?? null)
-    : null;
-  const sourceRegion = draggedId ? findBlockRegion(regions, draggedId) : undefined;
-  const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
-    })
-  );
-
-  function handleDragStart({ active }: DragStartEvent) {
-    setDraggedId(String(active.id));
-    setOutcome('Dragging does not change the active path.');
-  }
-
-  function handleDragEnd({ active, over }: DragEndEvent) {
-    const blockId = String(active.id);
-    const from = findBlockRegion(regions, blockId);
-    const overId = over ? String(over.id) : undefined;
-    const to = overId?.startsWith('region:')
-      ? (overId.slice('region:'.length) as DemoRegionId)
-      : overId
-        ? findBlockRegion(regions, overId)
-        : undefined;
-    const block = from ? regions[from].find((candidate) => candidate.id === blockId) : undefined;
-
-    setDraggedId(null);
-    if (!from || !to || !block || !overId) {
-      setOutcome('No compatible Group accepted that drop.');
-      return;
-    }
-
-    const definition = demoRegions.find((region) => region.id === to);
-    if (!definition || !canRegionAccept(definition, regions[to], block, from)) {
-      setOutcome(`${definition?.label ?? 'That target'} does not accept ${block.kind} items here.`);
-      return;
-    }
-
-    if (from === to) {
-      const fromIndex = regions[from].findIndex((candidate) => candidate.id === blockId);
-      const toIndex = overId.startsWith('region:')
-        ? regions[to].length - 1
-        : regions[to].findIndex((candidate) => candidate.id === overId);
-      if (fromIndex !== toIndex && toIndex >= 0) {
-        setRegions((current) => ({
-          ...current,
-          [from]: arrayMove(current[from], fromIndex, toIndex),
-        }));
-        setOutcome(`${block.label} reordered inside ${definition.label}.`);
-      }
-      return;
-    }
-
-    const insertAt = overId.startsWith('region:')
-      ? regions[to].length
-      : Math.max(
-          0,
-          regions[to].findIndex((candidate) => candidate.id === overId)
-        );
-    setRegions((current) => {
-      const nextSource = current[from].filter((candidate) => candidate.id !== blockId);
-      const nextTarget = [...current[to]];
-      nextTarget.splice(insertAt, 0, block);
-      return { ...current, [from]: nextSource, [to]: nextTarget };
-    });
-    setOutcome(`${block.label} moved to ${definition.label}. The active path stayed on the Item.`);
-  }
-
-  return (
-    <NestedTabs activePath={activePath} ariaLabel="Sortable nested navigation" className={styles.fixedHeight}>
-      {rootLevel({ onNavigate: setActivePath })}
-      {sortingNestedLevel({ regions, onNavigate: setActivePath })}
-      <NestedTabs.ContentPanel aria-label="Sorting fixture">
-        <div className={styles.panel}>
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragStart={handleDragStart}
-            onDragCancel={() => setDraggedId(null)}
-            onDragEnd={handleDragEnd}
-          >
-            <div className={styles.dragRegions}>
-              {demoRegions.map((definition) => (
-                <SortableRegion
-                  key={definition.id}
-                  definition={definition}
-                  blocks={regions[definition.id]}
-                  activeBlock={draggedBlock}
-                  sourceRegion={sourceRegion}
-                />
-              ))}
-            </div>
-          </DndContext>
-          <p className={styles.visuallyHidden} role="status">
-            {outcome}
-          </p>
-        </div>
       </NestedTabs.ContentPanel>
     </NestedTabs>
   );
@@ -445,7 +154,7 @@ const meta = preview.meta({
 export const NestedItemActive = meta.story({
   render: () => (
     <main className={styles.stage}>
-      <HierarchyFixture initialPath={[PAGE_TWO, DETAILS]} />
+      <HierarchyFixture initialPath={[ROOT_TWO, NESTED_ONE]} />
     </main>
   ),
   play: async ({ canvasElement }) => {
@@ -456,18 +165,10 @@ export const NestedItemActive = meta.story({
   },
 });
 
-export const DirectNestedItemActive = meta.story({
-  render: () => (
-    <main className={styles.stage}>
-      <HierarchyFixture initialPath={[PAGE_TWO, CONTROL_RULES]} />
-    </main>
-  ),
-});
-
 export const GroupedItemActive = meta.story({
   render: () => (
     <main className={styles.stage}>
-      <HierarchyFixture initialPath={[PAGE_TWO, BLOCK_IMAGE]} />
+      <HierarchyFixture initialPath={[ROOT_TWO, GROUPED_TWO]} />
     </main>
   ),
   play: async ({ canvasElement }) => {
@@ -480,47 +181,18 @@ export const GroupedItemActive = meta.story({
   },
 });
 
-export const CallerOwnedSorting = meta.story({
-  render: () => (
-    <main className={styles.stage}>
-      <SortingFixture />
-    </main>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    await expect(canvas.getByRole('link', { name: 'Grouped item A' })).toHaveAttribute('aria-current', 'page');
-    await expect(canvas.getByRole('button', { name: 'Reorder Grouped item A' })).toBeVisible();
-    await expect(canvasElement.querySelectorAll('[data-region]')).toHaveLength(4);
-    await expect(canvasElement.querySelector('[data-nested-tabs-level] [data-region]')).toBeNull();
-  },
-});
-
-export const GroupContainmentComparison = meta.story({
-  render: () => (
-    <main className={styles.comparison}>
-      <section className={styles.comparisonCase}>
-        <p className={styles.caseLabel}>Derived Group emphasis</p>
-        <HierarchyFixture initialPath={[PAGE_TWO, BLOCK_IMAGE]} tools={false} />
-      </section>
-      <section className={styles.comparisonCase}>
-        <p className={styles.caseLabel}>Uniform Group emphasis</p>
-        <HierarchyFixture initialPath={[PAGE_TWO, BLOCK_IMAGE]} className={styles.withoutGroupEmphasis} tools={false} />
-      </section>
-    </main>
-  ),
-});
-
-function OverflowFixture() {
-  const [activePath, setActivePath] = useState<NestedTabsPath>(['root-10', 'nested-12']);
+function ManyRootItemsFixture() {
+  const [activePath, setActivePath] = useState<NestedTabsPath>(['root-2', NESTED_ONE]);
+  const activeRoot = activePath[0] ?? 'root-2';
   return (
     <NestedTabs activePath={activePath} ariaLabel="Overflowing nested navigation" className={styles.fixedHeight}>
       <NestedTabs.Level label="Root level">
-        {Array.from({ length: 14 }, (_, index) => {
+        {Array.from({ length: 20 }, (_, index) => {
           const id = `root-${index + 1}`;
           return pathItem({
             key: id,
             path: [id],
-            label: `Root item ${index + 1}: deliberately long label`,
+            label: `Root item ${index + 1}`,
             icon: index % 3 === 0 ? <Circle /> : index % 3 === 1 ? <Triangle /> : <Hexagon />,
             onNavigate: setActivePath,
           });
@@ -531,44 +203,49 @@ function OverflowFixture() {
       </NestedTabs.Level>
       <NestedTabs.Level label="Nested Level">
         {pathItem({
-          path: ['root-10', DETAILS],
-          label: 'A direct nested Item with a deliberately long label',
+          path: [activeRoot, NESTED_ONE],
+          label: 'Nested item A',
           icon: <FileText />,
           onNavigate: setActivePath,
         })}
-        <NestedTabs.Group label="A Group with a deliberately long label" icon={<Rows3 />}>
-          {Array.from({ length: 16 }, (_, index) => {
-            const id = `nested-${index + 1}`;
-            return pathItem({
-              key: id,
-              path: ['root-10', id],
-              label: `Grouped item ${index + 1}: long descriptive name`,
-              icon: index % 2 === 0 ? <Type /> : <Image />,
-              onNavigate: setActivePath,
-            });
-          })}
-        </NestedTabs.Group>
+        {pathItem({
+          path: [activeRoot, NESTED_TWO],
+          label: 'Nested item B',
+          icon: <SlidersHorizontal />,
+          onNavigate: setActivePath,
+        })}
+        {pathItem({
+          path: [activeRoot, NESTED_THREE],
+          label: 'Nested item C',
+          icon: <Settings2 />,
+          onNavigate: setActivePath,
+        })}
       </NestedTabs.Level>
-      <NestedTabs.ContentPanel aria-label="Tall content">
-        <SurfaceFiller height={1200} />
+      <NestedTabs.ContentPanel aria-label="Example content">
+        <PanelFixture />
       </NestedTabs.ContentPanel>
     </NestedTabs>
   );
 }
 
-export const OverflowAndLongLabels = meta.story({
+export const ManyRootItems = meta.story({
   render: () => (
     <main className={styles.stage}>
-      <OverflowFixture />
+      <ManyRootItemsFixture />
     </main>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const rootLevel = canvas.getByRole('navigation', { name: 'Root level' });
+    await expect(rootLevel.querySelectorAll('[data-nested-tabs-item]')).toHaveLength(20);
+  },
 });
 
 export const NarrowContainer = meta.story({
   globals: { viewport: { value: 'appMobile' } },
   render: () => (
     <main className={styles.stage}>
-      <HierarchyFixture initialPath={[PAGE_TWO, BLOCK_LIST]} />
+      <HierarchyFixture initialPath={[ROOT_TWO, GROUPED_THREE]} />
     </main>
   ),
 });
@@ -576,20 +253,7 @@ export const NarrowContainer = meta.story({
 export const LevelWithoutTools = meta.story({
   render: () => (
     <main className={styles.stage}>
-      <HierarchyFixture initialPath={[PAGE_TWO, DETAILS]} tools={false} />
+      <HierarchyFixture initialPath={[ROOT_TWO, NESTED_ONE]} tools={false} />
     </main>
   ),
-});
-
-export const ReducedMotion = meta.story({
-  render: () => (
-    <main className={styles.stage}>
-      <HierarchyFixture initialPath={[PAGE_TWO, DETAILS]} className={styles.reducedMotion} />
-    </main>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('link', { name: 'Nested item B' }));
-    await expect(canvas.getByRole('link', { name: 'Nested item B' })).toHaveAttribute('aria-current', 'page');
-  },
 });

--- a/src/app/ui/surface/NestedTabs.stories.tsx
+++ b/src/app/ui/surface/NestedTabs.stories.tsx
@@ -75,12 +75,12 @@ function pathItem({ key, path, label, icon, onNavigate }: PathItemProps) {
   );
 }
 
-function pageLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }) {
+function rootLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }) {
   return (
-    <NestedTabs.Level label="Pages">
-      {pathItem({ path: [PAGE_ONE], label: 'Cover layout', icon: <Triangle />, onNavigate })}
-      {pathItem({ path: [PAGE_TWO], label: 'Article layout', icon: <Hexagon />, onNavigate })}
-      {pathItem({ path: [PAGE_THREE], label: 'Reference layout', icon: <Square />, onNavigate })}
+    <NestedTabs.Level label="Root level">
+      {pathItem({ path: [PAGE_ONE], label: 'Root item A', icon: <Triangle />, onNavigate })}
+      {pathItem({ path: [PAGE_TWO], label: 'Root item B', icon: <Hexagon />, onNavigate })}
+      {pathItem({ path: [PAGE_THREE], label: 'Root item C', icon: <Square />, onNavigate })}
       <NestedTabs.Tools>
         <SurfaceFiller height={24} width={24} />
       </NestedTabs.Tools>
@@ -88,40 +88,40 @@ function pageLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }) 
   );
 }
 
-function detailLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }) {
+function nestedLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }) {
   return (
-    <NestedTabs.Level label="Page">
-      {pathItem({ path: [PAGE_TWO, DETAILS], label: 'Page details', icon: <FileText />, onNavigate })}
+    <NestedTabs.Level label="Nested Level">
+      {pathItem({ path: [PAGE_TWO, DETAILS], label: 'Nested item A', icon: <FileText />, onNavigate })}
       {pathItem({
         path: [PAGE_TWO, CONTROL_SEO],
-        label: 'Search and sharing',
+        label: 'Nested item B',
         icon: <SlidersHorizontal />,
         onNavigate,
       })}
       {pathItem({
         path: [PAGE_TWO, CONTROL_RULES],
-        label: 'Rule presentation',
+        label: 'Nested item C',
         icon: <Settings2 />,
         onNavigate,
       })}
-      <NestedTabs.Group label="Opening region" icon={<Rows3 />}>
+      <NestedTabs.Group label="Group A" icon={<Rows3 />}>
         {pathItem({
           path: [PAGE_TWO, BLOCK_INTRO],
-          label: 'Introduction block',
+          label: 'Grouped item A',
           icon: <Type />,
           onNavigate,
         })}
         {pathItem({
           path: [PAGE_TWO, BLOCK_IMAGE],
-          label: 'Illustration block',
+          label: 'Grouped item B',
           icon: <Image />,
           onNavigate,
         })}
       </NestedTabs.Group>
-      <NestedTabs.Group label="Reference region" icon={<List />}>
+      <NestedTabs.Group label="Group B" icon={<List />}>
         {pathItem({
           path: [PAGE_TWO, BLOCK_LIST],
-          label: 'Reference list block',
+          label: 'Grouped item C',
           icon: <List />,
           onNavigate,
         })}
@@ -145,18 +145,18 @@ function HierarchyFixture({
 }) {
   const [activePath, setActivePath] = useState<NestedTabsPath>(initialPath);
   return (
-    <NestedTabs activePath={activePath} ariaLabel="Rulebook editor" className={className}>
+    <NestedTabs activePath={activePath} ariaLabel="Nested navigation" className={className}>
       {tools ? (
-        pageLevel({ onNavigate: setActivePath })
+        rootLevel({ onNavigate: setActivePath })
       ) : (
-        <NestedTabs.Level label="Pages">
-          {pathItem({ path: [PAGE_ONE], label: 'Cover layout', icon: <Triangle />, onNavigate: setActivePath })}
-          {pathItem({ path: [PAGE_TWO], label: 'Article layout', icon: <Hexagon />, onNavigate: setActivePath })}
-          {pathItem({ path: [PAGE_THREE], label: 'Reference layout', icon: <Square />, onNavigate: setActivePath })}
+        <NestedTabs.Level label="Root level">
+          {pathItem({ path: [PAGE_ONE], label: 'Root item A', icon: <Triangle />, onNavigate: setActivePath })}
+          {pathItem({ path: [PAGE_TWO], label: 'Root item B', icon: <Hexagon />, onNavigate: setActivePath })}
+          {pathItem({ path: [PAGE_THREE], label: 'Root item C', icon: <Square />, onNavigate: setActivePath })}
         </NestedTabs.Level>
       )}
-      {detailLevel({ onNavigate: setActivePath })}
-      <NestedTabs.ContentPanel aria-label="Editor controls">
+      {nestedLevel({ onNavigate: setActivePath })}
+      <NestedTabs.ContentPanel aria-label="Example content">
         <PanelFixture />
       </NestedTabs.ContentPanel>
     </NestedTabs>
@@ -182,15 +182,15 @@ interface DemoRegionDefinition {
 const demoRegions: readonly DemoRegionDefinition[] = [
   {
     id: 'opening',
-    label: 'Opening region',
+    label: 'Group A',
     accepts: ['text', 'image'],
     capacity: 4,
   },
-  { id: 'notes', label: 'Notes region', accepts: ['text'], capacity: 2 },
-  { id: 'aside', label: 'Aside region', accepts: ['image'], capacity: 1 },
+  { id: 'notes', label: 'Group B', accepts: ['text'], capacity: 2 },
+  { id: 'aside', label: 'Group C', accepts: ['image'], capacity: 1 },
   {
     id: 'references',
-    label: 'Reference region',
+    label: 'Group D',
     accepts: ['list'],
     capacity: 3,
   },
@@ -198,11 +198,11 @@ const demoRegions: readonly DemoRegionDefinition[] = [
 
 const initialRegionBlocks: Record<DemoRegionId, DemoBlock[]> = {
   opening: [
-    { id: BLOCK_INTRO, label: 'Introduction block', kind: 'text' },
-    { id: BLOCK_IMAGE, label: 'Illustration block', kind: 'image' },
+    { id: BLOCK_INTRO, label: 'Grouped item A', kind: 'text' },
+    { id: BLOCK_IMAGE, label: 'Grouped item B', kind: 'image' },
   ],
-  aside: [{ id: 'b-z4', label: 'Aside illustration', kind: 'image' }],
-  references: [{ id: BLOCK_LIST, label: 'Reference list block', kind: 'list' }],
+  aside: [{ id: 'b-z4', label: 'Grouped item D', kind: 'image' }],
+  references: [{ id: BLOCK_LIST, label: 'Grouped item C', kind: 'list' }],
   notes: [],
 };
 
@@ -230,7 +230,7 @@ function canRegionAccept(
   return definition.accepts.includes(block.kind) && (keepsSameCount || blocks.length < definition.capacity);
 }
 
-function sortingDetailLevel({
+function sortingNestedLevel({
   regions,
   onNavigate,
 }: {
@@ -238,11 +238,11 @@ function sortingDetailLevel({
   onNavigate: PathItemProps['onNavigate'];
 }) {
   return (
-    <NestedTabs.Level label="Page">
-      {pathItem({ path: [PAGE_TWO, DETAILS], label: 'Page details', icon: <FileText />, onNavigate })}
+    <NestedTabs.Level label="Nested Level">
+      {pathItem({ path: [PAGE_TWO, DETAILS], label: 'Nested item A', icon: <FileText />, onNavigate })}
       {pathItem({
         path: [PAGE_TWO, CONTROL_RULES],
-        label: 'Rule presentation',
+        label: 'Nested item B',
         icon: <Settings2 />,
         onNavigate,
       })}
@@ -354,13 +354,13 @@ function SortingFixture() {
 
     setDraggedId(null);
     if (!from || !to || !block || !overId) {
-      setOutcome('No Page-local Block region accepted that drop.');
+      setOutcome('No compatible Group accepted that drop.');
       return;
     }
 
     const definition = demoRegions.find((region) => region.id === to);
     if (!definition || !canRegionAccept(definition, regions[to], block, from)) {
-      setOutcome(`${definition?.label ?? 'That target'} does not accept ${block.kind} blocks here.`);
+      setOutcome(`${definition?.label ?? 'That target'} does not accept ${block.kind} items here.`);
       return;
     }
 
@@ -391,14 +391,14 @@ function SortingFixture() {
       nextTarget.splice(insertAt, 0, block);
       return { ...current, [from]: nextSource, [to]: nextTarget };
     });
-    setOutcome(`${block.label} moved to ${definition.label}. The active path stayed on the Block.`);
+    setOutcome(`${block.label} moved to ${definition.label}. The active path stayed on the Item.`);
   }
 
   return (
-    <NestedTabs activePath={activePath} ariaLabel="Sortable Rulebook editor" className={styles.fixedHeight}>
-      {pageLevel({ onNavigate: setActivePath })}
-      {sortingDetailLevel({ regions, onNavigate: setActivePath })}
-      <NestedTabs.ContentPanel aria-label="Sortable Page regions">
+    <NestedTabs activePath={activePath} ariaLabel="Sortable nested navigation" className={styles.fixedHeight}>
+      {rootLevel({ onNavigate: setActivePath })}
+      {sortingNestedLevel({ regions, onNavigate: setActivePath })}
+      <NestedTabs.ContentPanel aria-label="Sorting fixture">
         <div className={styles.panel}>
           <DndContext
             sensors={sensors}
@@ -442,7 +442,7 @@ const meta = preview.meta({
   },
 });
 
-export const PageDetailsActive = meta.story({
+export const NestedItemActive = meta.story({
   render: () => (
     <main className={styles.stage}>
       <HierarchyFixture initialPath={[PAGE_TWO, DETAILS]} />
@@ -450,13 +450,13 @@ export const PageDetailsActive = meta.story({
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByRole('link', { name: 'Article layout' })).toHaveAttribute('data-path-state', 'ancestor');
-    await expect(canvas.getByRole('link', { name: 'Page details' })).toHaveAttribute('aria-current', 'page');
+    await expect(canvas.getByRole('link', { name: 'Root item B' })).toHaveAttribute('data-path-state', 'ancestor');
+    await expect(canvas.getByRole('link', { name: 'Nested item A' })).toHaveAttribute('aria-current', 'page');
     await expect(canvas.queryByRole('tab')).not.toBeInTheDocument();
   },
 });
 
-export const ControlRegionActive = meta.story({
+export const DirectNestedItemActive = meta.story({
   render: () => (
     <main className={styles.stage}>
       <HierarchyFixture initialPath={[PAGE_TWO, CONTROL_RULES]} />
@@ -464,7 +464,7 @@ export const ControlRegionActive = meta.story({
   ),
 });
 
-export const BlockActive = meta.story({
+export const GroupedItemActive = meta.story({
   render: () => (
     <main className={styles.stage}>
       <HierarchyFixture initialPath={[PAGE_TWO, BLOCK_IMAGE]} />
@@ -472,15 +472,15 @@ export const BlockActive = meta.story({
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByRole('link', { name: 'Illustration block' })).toHaveAttribute('aria-current', 'page');
-    await expect(canvas.getByRole('list', { name: 'Opening region' }).parentElement).toHaveAttribute(
+    await expect(canvas.getByRole('link', { name: 'Grouped item B' })).toHaveAttribute('aria-current', 'page');
+    await expect(canvas.getByRole('list', { name: 'Group A' }).parentElement).toHaveAttribute(
       'data-contains-active-item',
       'true'
     );
   },
 });
 
-export const SamePageBlockSorting = meta.story({
+export const CallerOwnedSorting = meta.story({
   render: () => (
     <main className={styles.stage}>
       <SortingFixture />
@@ -488,8 +488,8 @@ export const SamePageBlockSorting = meta.story({
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByRole('link', { name: 'Introduction block' })).toHaveAttribute('aria-current', 'page');
-    await expect(canvas.getByRole('button', { name: 'Reorder Introduction block' })).toBeVisible();
+    await expect(canvas.getByRole('link', { name: 'Grouped item A' })).toHaveAttribute('aria-current', 'page');
+    await expect(canvas.getByRole('button', { name: 'Reorder Grouped item A' })).toBeVisible();
     await expect(canvasElement.querySelectorAll('[data-region]')).toHaveLength(4);
     await expect(canvasElement.querySelector('[data-nested-tabs-level] [data-region]')).toBeNull();
   },
@@ -511,16 +511,16 @@ export const GroupContainmentComparison = meta.story({
 });
 
 function OverflowFixture() {
-  const [activePath, setActivePath] = useState<NestedTabsPath>(['page-10', 'block-12']);
+  const [activePath, setActivePath] = useState<NestedTabsPath>(['root-10', 'nested-12']);
   return (
-    <NestedTabs activePath={activePath} ariaLabel="Overflowing rulebook editor" className={styles.fixedHeight}>
-      <NestedTabs.Level label="Many Pages">
+    <NestedTabs activePath={activePath} ariaLabel="Overflowing nested navigation" className={styles.fixedHeight}>
+      <NestedTabs.Level label="Root level">
         {Array.from({ length: 14 }, (_, index) => {
-          const id = `page-${index + 1}`;
+          const id = `root-${index + 1}`;
           return pathItem({
             key: id,
             path: [id],
-            label: `Chapter ${index + 1}: A deliberately long Page label`,
+            label: `Root item ${index + 1}: deliberately long label`,
             icon: index % 3 === 0 ? <Circle /> : index % 3 === 1 ? <Triangle /> : <Hexagon />,
             onNavigate: setActivePath,
           });
@@ -529,27 +529,27 @@ function OverflowFixture() {
           <SurfaceFiller height={24} width={24} />
         </NestedTabs.Tools>
       </NestedTabs.Level>
-      <NestedTabs.Level label="Current Page">
+      <NestedTabs.Level label="Nested Level">
         {pathItem({
-          path: ['page-10', DETAILS],
-          label: 'Page details with a deliberately long label',
+          path: ['root-10', DETAILS],
+          label: 'A direct nested Item with a deliberately long label',
           icon: <FileText />,
           onNavigate: setActivePath,
         })}
-        <NestedTabs.Group label="A long structural region label" icon={<Rows3 />}>
+        <NestedTabs.Group label="A Group with a deliberately long label" icon={<Rows3 />}>
           {Array.from({ length: 16 }, (_, index) => {
-            const id = `block-${index + 1}`;
+            const id = `nested-${index + 1}`;
             return pathItem({
               key: id,
-              path: ['page-10', id],
-              label: `Block ${index + 1}: long descriptive name`,
+              path: ['root-10', id],
+              label: `Grouped item ${index + 1}: long descriptive name`,
               icon: index % 2 === 0 ? <Type /> : <Image />,
               onNavigate: setActivePath,
             });
           })}
         </NestedTabs.Group>
       </NestedTabs.Level>
-      <NestedTabs.ContentPanel aria-label="Tall editor content">
+      <NestedTabs.ContentPanel aria-label="Tall content">
         <SurfaceFiller height={1200} />
       </NestedTabs.ContentPanel>
     </NestedTabs>
@@ -589,7 +589,7 @@ export const ReducedMotion = meta.story({
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('link', { name: 'Search and sharing' }));
-    await expect(canvas.getByRole('link', { name: 'Search and sharing' })).toHaveAttribute('aria-current', 'page');
+    await userEvent.click(canvas.getByRole('link', { name: 'Nested item B' }));
+    await expect(canvas.getByRole('link', { name: 'Nested item B' })).toHaveAttribute('aria-current', 'page');
   },
 });

--- a/src/app/ui/surface/NestedTabs.stories.tsx
+++ b/src/app/ui/surface/NestedTabs.stories.tsx
@@ -159,9 +159,15 @@ export const NestedItemActive = meta.story({
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const levels = canvas.getAllByRole('navigation');
     await expect(canvas.getByRole('link', { name: 'Root item B' })).toHaveAttribute('data-path-state', 'ancestor');
     await expect(canvas.getByRole('link', { name: 'Nested item A' })).toHaveAttribute('aria-current', 'page');
     await expect(canvas.queryByRole('tab')).not.toBeInTheDocument();
+    for (const level of levels) {
+      const items = level.querySelector(':scope > ul');
+      await expect(items).not.toBeNull();
+      await expect(getComputedStyle(items as HTMLElement).overflowX).toBe('hidden');
+    }
   },
 });
 

--- a/src/app/ui/surface/NestedTabs.stories.tsx
+++ b/src/app/ui/surface/NestedTabs.stories.tsx
@@ -14,7 +14,6 @@ import {
   sortableKeyboardCoordinates,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
-import { ActionIcon } from '@mantine/core';
 import preview from '@sb/preview';
 import {
   Circle,
@@ -22,7 +21,6 @@ import {
   Hexagon,
   Image,
   List,
-  Plus,
   Rows3,
   Settings2,
   SlidersHorizontal,
@@ -84,9 +82,7 @@ function pageLevel({ onNavigate }: { onNavigate: PathItemProps['onNavigate'] }) 
       {pathItem({ path: [PAGE_TWO], label: 'Article layout', icon: <Hexagon />, onNavigate })}
       {pathItem({ path: [PAGE_THREE], label: 'Reference layout', icon: <Square />, onNavigate })}
       <NestedTabs.Tools>
-        <ActionIcon variant="subtle" aria-label="Add page">
-          <Plus aria-hidden />
-        </ActionIcon>
+        <SurfaceFiller height={24} width={24} />
       </NestedTabs.Tools>
     </NestedTabs.Level>
   );
@@ -530,9 +526,7 @@ function OverflowFixture() {
           });
         })}
         <NestedTabs.Tools>
-          <ActionIcon variant="subtle" aria-label="Add page">
-            <Plus aria-hidden />
-          </ActionIcon>
+          <SurfaceFiller height={24} width={24} />
         </NestedTabs.Tools>
       </NestedTabs.Level>
       <NestedTabs.Level label="Current Page">

--- a/src/app/ui/surface/NestedTabs.stories.tsx
+++ b/src/app/ui/surface/NestedTabs.stories.tsx
@@ -503,7 +503,7 @@ export const GroupContainmentComparison = meta.story({
         <HierarchyFixture initialPath={[PAGE_TWO, BLOCK_IMAGE]} tools={false} />
       </section>
       <section className={styles.comparisonCase}>
-        <p className={styles.caseLabel}>State exposed, no visual emphasis</p>
+        <p className={styles.caseLabel}>Uniform Group emphasis</p>
         <HierarchyFixture initialPath={[PAGE_TWO, BLOCK_IMAGE]} className={styles.withoutGroupEmphasis} tools={false} />
       </section>
     </main>

--- a/src/app/ui/surface/NestedTabs.stories.tsx
+++ b/src/app/ui/surface/NestedTabs.stories.tsx
@@ -245,6 +245,8 @@ export const ManyRootItems = meta.story({
     await userEvent.click(canvas.getByRole('link', { name: 'Root item 20' }));
     await expect(canvas.getByRole('link', { name: 'Root item 20' })).toHaveAttribute('data-path-state', 'ancestor');
     await expect(canvas.getByRole('link', { name: 'Nested item A' })).toHaveAttribute('aria-current', 'page');
+    await expect(rootItems).toHaveAttribute('data-scroll-before');
+    await expect(rootItems).not.toHaveAttribute('data-scroll-after');
   },
 });
 

--- a/src/app/ui/surface/NestedTabs.test.tsx
+++ b/src/app/ui/surface/NestedTabs.test.tsx
@@ -89,6 +89,42 @@ afterEach(async () => {
 });
 
 describe('NestedTabs', () => {
+  it('accepts compound children retained across a module refresh', async () => {
+    vi.resetModules();
+    const { NestedTabs: ReloadedNestedTabs } = await import('./NestedTabs');
+
+    expect(ReloadedNestedTabs.Level).not.toBe(NestedTabs.Level);
+
+    await act(async () =>
+      root?.render(
+        <MantineProvider theme={appContentTheme}>
+          <ReloadedNestedTabs activePath={['root', 'nested']} ariaLabel="Refreshed navigator">
+            <NestedTabs.Level label="Root level">
+              <NestedTabs.Item as="a" href="#root" path={['root']} label="Root item" icon={<span>R</span>} />
+              <NestedTabs.Tools>
+                <button type="button">Root tool</button>
+              </NestedTabs.Tools>
+            </NestedTabs.Level>
+            <NestedTabs.Level label="Nested level">
+              <ReloadedNestedTabs.Group label="Refreshed group">
+                <NestedTabs.Item
+                  as="a"
+                  href="#nested"
+                  path={['root', 'nested']}
+                  label="Nested item"
+                  icon={<span>N</span>}
+                />
+              </ReloadedNestedTabs.Group>
+            </NestedTabs.Level>
+            <NestedTabs.ContentPanel aria-label="Refreshed content">Content</NestedTabs.ContentPanel>
+          </ReloadedNestedTabs>
+        </MantineProvider>
+      )
+    );
+
+    expect(container?.querySelector('[aria-label="Refreshed navigator"]')).not.toBeNull();
+  });
+
   it('preserves typed TanStack Link destination props', () => {
     const typedItem = (
       <NestedTabs.Item

--- a/src/app/ui/surface/NestedTabs.test.tsx
+++ b/src/app/ui/surface/NestedTabs.test.tsx
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { MantineProvider } from '@mantine/core';
+import { Link } from '@tanstack/react-router';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { appContentTheme } from '../theme';
+import { NestedTabs } from './NestedTabs';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+let container: HTMLDivElement | undefined;
+let root: Root | undefined;
+
+function Fixture({ activePath = ['page-2', 'block-b'] }: { activePath?: readonly string[] }) {
+  return (
+    <MantineProvider theme={appContentTheme}>
+      <NestedTabs activePath={activePath} ariaLabel="Example navigator">
+        <NestedTabs.Level label="Pages">
+          <NestedTabs.Item as="a" href="#page-1" path={['page-1']} label="Page 1" icon={<span>1</span>} />
+          <NestedTabs.Item as="a" href="#page-2" path={['page-2']} label="Page 2" icon={<span>2</span>} />
+          <NestedTabs.Tools>
+            <button type="button">Add page</button>
+          </NestedTabs.Tools>
+        </NestedTabs.Level>
+        <NestedTabs.Level label="Page">
+          <NestedTabs.Item as="a" href="#details" path={['page-2', 'details']} label="Details" icon={<span>D</span>} />
+          <NestedTabs.Group label="Main content" icon={<span>G</span>}>
+            <NestedTabs.Item
+              as="a"
+              href="#block-a"
+              path={['page-2', 'block-a']}
+              label="Block a"
+              icon={<span>A</span>}
+            />
+            <NestedTabs.Item
+              as="a"
+              href="#block-b"
+              path={['page-2', 'block-b']}
+              label="Block b"
+              icon={<span>B</span>}
+            />
+          </NestedTabs.Group>
+        </NestedTabs.Level>
+        <NestedTabs.ContentPanel aria-label="Editor panel">
+          <p>Editor</p>
+        </NestedTabs.ContentPanel>
+      </NestedTabs>
+    </MantineProvider>
+  );
+}
+
+function item(label: string) {
+  const match = container?.querySelector(`[data-nested-tabs-item][aria-label="${label}"]`);
+  if (!(match instanceof HTMLAnchorElement)) {
+    throw new Error(`Missing NestedTabs Item: ${label}`);
+  }
+  return match;
+}
+
+beforeEach(async () => {
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => root?.render(<Fixture />));
+});
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => root?.unmount());
+  }
+  container?.remove();
+  container = undefined;
+  root = undefined;
+});
+
+describe('NestedTabs', () => {
+  it('preserves typed TanStack Link destination props', () => {
+    const typedItem = (
+      <NestedTabs.Item
+        as={Link}
+        to="/preview/sheet/$factionSlug"
+        params={{ factionSlug: 'atreides' }}
+        search={{ mode: 'db' }}
+        path={['page-2', 'preview']}
+        label="Preview"
+        icon={<span>P</span>}
+      />
+    );
+
+    expect(typedItem.props.to).toBe('/preview/sheet/$factionSlug');
+  });
+
+  it('marks the active path without assigning tab semantics', () => {
+    expect(item('Page 1').dataset.pathState).toBe('inactive');
+    expect(item('Page 2').dataset.pathState).toBe('ancestor');
+    expect(item('Block b').dataset.pathState).toBe('active');
+    expect(item('Block b').getAttribute('aria-current')).toBe('page');
+    expect(item('Page 2').hasAttribute('aria-current')).toBe(false);
+    expect(container?.querySelector('[role="tab"]')).toBeNull();
+    expect(container?.querySelectorAll('nav')).toHaveLength(2);
+  });
+
+  it('derives containing Group state from its active descendant', () => {
+    expect(container?.querySelector('[data-contains-active-item="true"]')).not.toBeNull();
+    expect(container?.querySelector('[data-contains-active-item="true"]')?.hasAttribute('aria-current')).toBe(false);
+  });
+
+  it('uses the required label as the icon-only link accessible name', () => {
+    expect(item('Details').textContent).toBe('D');
+    expect(item('Details').getAttribute('aria-label')).toBe('Details');
+  });
+
+  it('keeps tools at Level scope and panel content in a labelled section', () => {
+    expect(container?.querySelector('button')?.textContent).toBe('Add page');
+    expect(container?.querySelector('section[aria-label="Editor panel"]')?.textContent).toBe('Editor');
+  });
+
+  it('draws one connected contour for each nested transition', () => {
+    expect(container?.querySelectorAll('[data-nested-tabs-surface]')).toHaveLength(2);
+    expect(container?.querySelector('[data-nested-tabs-surface="level"] path')).not.toBeNull();
+    expect(container?.querySelector('[data-nested-tabs-surface="panel"] path')).not.toBeNull();
+  });
+});

--- a/src/app/ui/surface/NestedTabs.tsx
+++ b/src/app/ui/surface/NestedTabs.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react';
 import type {
   ComponentPropsWithoutRef,
+  Context,
   ElementType,
   PropsWithChildren,
   ReactElement,
@@ -31,7 +32,35 @@ interface NestedTabsContextValue {
   levelIndex: number;
 }
 
-const NestedTabsContext = createContext<NestedTabsContextValue | null>(null);
+const NESTED_TABS_CONTEXT_KEY = Symbol.for('dunezone.nested-tabs-context');
+
+type NestedTabsGlobal = typeof globalThis & {
+  [NESTED_TABS_CONTEXT_KEY]?: Context<NestedTabsContextValue | null>;
+};
+
+const nestedTabsGlobal = globalThis as NestedTabsGlobal;
+const NestedTabsContext =
+  nestedTabsGlobal[NESTED_TABS_CONTEXT_KEY] ?? createContext<NestedTabsContextValue | null>(null);
+nestedTabsGlobal[NESTED_TABS_CONTEXT_KEY] = NestedTabsContext;
+
+const NESTED_TABS_CHILD_KIND = Symbol.for('dunezone.nested-tabs-child-kind');
+
+type NestedTabsChildKind = 'item' | 'group' | 'tools' | 'level' | 'content-panel';
+
+type NestedTabsChildComponent = {
+  [NESTED_TABS_CHILD_KIND]?: NestedTabsChildKind;
+};
+
+function markNestedTabsChild(component: object, kind: NestedTabsChildKind) {
+  Object.defineProperty(component, NESTED_TABS_CHILD_KIND, { value: kind });
+}
+
+function nestedTabsChildKind(child: ReactElement): NestedTabsChildKind | null {
+  if ((typeof child.type !== 'function' && typeof child.type !== 'object') || child.type === null) {
+    return null;
+  }
+  return (child.type as NestedTabsChildComponent)[NESTED_TABS_CHILD_KIND] ?? null;
+}
 
 interface NestedTabsLayerGeometry {
   width: number;
@@ -166,6 +195,7 @@ function useNestedTabsLayerGeometry({
     }
 
     let animationFrame = 0;
+    let scrollingTimer = 0;
     const measure = () => {
       const rootRect = root.getBoundingClientRect();
       const itemsRect = items.getBoundingClientRect();
@@ -203,6 +233,12 @@ function useNestedTabsLayerGeometry({
       cancelAnimationFrame(animationFrame);
       animationFrame = requestAnimationFrame(measure);
     };
+    const handleScroll = () => {
+      items.setAttribute('data-scrolling', '');
+      window.clearTimeout(scrollingTimer);
+      scrollingTimer = window.setTimeout(() => items.removeAttribute('data-scrolling'), 650);
+      scheduleMeasure();
+    };
 
     const revealActiveItem = () => {
       const itemsRect = items.getBoundingClientRect();
@@ -216,14 +252,19 @@ function useNestedTabsLayerGeometry({
         items.scrollTop += tabRect.bottom - revealBottom;
       }
     };
+    const revealActiveItemAfterResize = () => {
+      revealActiveItem();
+      scheduleMeasure();
+    };
 
     revealActiveItem();
     measure();
-    items.addEventListener('scroll', scheduleMeasure, { passive: true });
+    items.addEventListener('scroll', handleScroll, { passive: true });
     const mutationObserver = new MutationObserver(scheduleMeasure);
     mutationObserver.observe(level, { childList: true, subtree: true });
 
-    const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(scheduleMeasure);
+    const resizeObserver =
+      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(revealActiveItemAfterResize);
     resizeObserver?.observe(root);
     resizeObserver?.observe(items);
     resizeObserver?.observe(target);
@@ -231,7 +272,9 @@ function useNestedTabsLayerGeometry({
 
     return () => {
       cancelAnimationFrame(animationFrame);
-      items.removeEventListener('scroll', scheduleMeasure);
+      window.clearTimeout(scrollingTimer);
+      items.removeAttribute('data-scrolling');
+      items.removeEventListener('scroll', handleScroll);
       mutationObserver.disconnect();
       resizeObserver?.disconnect();
     };
@@ -398,11 +441,11 @@ function descendantItemPaths(children: ReactNode): NestedTabsPath[] {
     if (!isValidElement(child)) {
       return;
     }
-    if (child.type === Item) {
+    if (nestedTabsChildKind(child) === 'item') {
       paths.push((child.props as NestedTabsItemOwnProps).path);
       return;
     }
-    if (child.type === Group) {
+    if (nestedTabsChildKind(child) === 'group') {
       paths.push(...descendantItemPaths((child.props as NestedTabsGroupProps).children));
     }
   });
@@ -455,7 +498,7 @@ function splitLevelChildren(children: ReactNode) {
   let tools: ReactNode = null;
 
   Children.forEach(children, (child) => {
-    if (isValidElement<NestedTabsToolsProps>(child) && child.type === Tools) {
+    if (isValidElement<NestedTabsToolsProps>(child) && nestedTabsChildKind(child) === 'tools') {
       if (tools !== null) {
         throw new Error('[NestedTabs.Level] accepts at most one direct NestedTabs.Tools child.');
       }
@@ -507,11 +550,11 @@ function splitRootChildren(children: ReactNode) {
     if (!isValidElement(child)) {
       return;
     }
-    if (child.type === Level) {
+    if (nestedTabsChildKind(child) === 'level') {
       levels.push(child as ReactElement<NestedTabsLevelProps>);
       return;
     }
-    if (child.type === ContentPanel) {
+    if (nestedTabsChildKind(child) === 'content-panel') {
       panels.push(child as ReactElement<NestedTabsContentPanelProps>);
       return;
     }
@@ -570,6 +613,12 @@ type NestedTabsComponent = ((props: NestedTabsProps) => ReactNode) & {
   Tools: typeof Tools;
   ContentPanel: typeof ContentPanel;
 };
+
+markNestedTabsChild(Item, 'item');
+markNestedTabsChild(Group, 'group');
+markNestedTabsChild(Tools, 'tools');
+markNestedTabsChild(Level, 'level');
+markNestedTabsChild(ContentPanel, 'content-panel');
 
 export const NestedTabs = Object.assign(NestedTabsBase, {
   Level,

--- a/src/app/ui/surface/NestedTabs.tsx
+++ b/src/app/ui/surface/NestedTabs.tsx
@@ -53,14 +53,27 @@ function buildNestedTabsLayerPath({
   startX: number;
   endX: number;
   tabLeft: number;
-  tabTop: number;
-  tabBottom: number;
+  tabTop: number | null;
+  tabBottom: number | null;
   radius: number;
   roundEndCorners: boolean;
 }) {
+  const endRadius = roundEndCorners ? radius : 0;
+  if (tabTop === null || tabBottom === null) {
+    return [
+      `M ${startX} 0`,
+      `H ${endX - endRadius}`,
+      `Q ${endX} 0 ${endX} ${endRadius}`,
+      `V ${height - endRadius}`,
+      `Q ${endX} ${height} ${endX - endRadius} ${height}`,
+      `H ${startX}`,
+      'V 0',
+      'Z',
+    ].join(' ');
+  }
+
   const joinRadius = Math.min(3, radius);
   const tabRadius = Math.min(radius, (tabBottom - tabTop) / 2, (startX - tabLeft) / 2);
-  const endRadius = roundEndCorners ? radius : 0;
   const touchesTop = tabTop <= 0.5;
   const touchesBottom = tabBottom >= height - 0.5;
 
@@ -138,6 +151,7 @@ function useNestedTabsLayerGeometry({
     void pathKey;
     const root = rootRef.current;
     const level = root?.querySelector<HTMLElement>(`[data-nested-tabs-level="${levelIndex + 1}"]`);
+    const items = level?.querySelector<HTMLElement>('[data-nested-tabs-items]');
     const target = root?.querySelector<HTMLElement>(
       levelIndex === 0 ? '[data-nested-tabs-level="2"]' : '[data-nested-tabs-content]'
     );
@@ -146,7 +160,7 @@ function useNestedTabsLayerGeometry({
         ? '[data-nested-tabs-item][data-path-state="ancestor"], [data-nested-tabs-item][data-path-state="active"]'
         : '[data-nested-tabs-item][data-path-state="active"]'
     );
-    if (!root || !level || !target || !activeItem) {
+    if (!root || !level || !items || !target || !activeItem) {
       setGeometry(null);
       return;
     }
@@ -154,6 +168,7 @@ function useNestedTabsLayerGeometry({
     let animationFrame = 0;
     const measure = () => {
       const rootRect = root.getBoundingClientRect();
+      const itemsRect = items.getBoundingClientRect();
       const targetRect = target.getBoundingClientRect();
       const tabRect = activeItem.getBoundingClientRect();
       const devicePixelRatio = window.devicePixelRatio || 1;
@@ -163,8 +178,9 @@ function useNestedTabsLayerGeometry({
       const startX = round(targetRect.left - rootRect.left);
       const endX = round((levelIndex === 0 ? targetRect.right : rootRect.right) - rootRect.left);
       const tabLeft = round(tabRect.left - rootRect.left);
-      const tabTop = round(tabRect.top - rootRect.top);
-      const tabBottom = round(tabRect.bottom - rootRect.top);
+      const tabIsVisible = tabRect.top >= itemsRect.top - 0.5 && tabRect.bottom <= itemsRect.bottom + 0.5;
+      const tabTop = tabIsVisible ? round(tabRect.top - rootRect.top) : null;
+      const tabBottom = tabIsVisible ? round(tabRect.bottom - rootRect.top) : null;
       const configuredRadius = Number.parseFloat(getComputedStyle(root).getPropertyValue('--nested-tabs-radius'));
       const radius = Number.isFinite(configuredRadius) ? configuredRadius : 8;
       const path = buildNestedTabsLayerPath({
@@ -185,19 +201,34 @@ function useNestedTabsLayerGeometry({
       animationFrame = requestAnimationFrame(measure);
     };
 
+    const revealActiveItem = () => {
+      const itemsRect = items.getBoundingClientRect();
+      const tabRect = activeItem.getBoundingClientRect();
+      const neighborSpace = Math.min(tabRect.height + 6, Math.max(0, (itemsRect.height - tabRect.height) / 2));
+      const revealTop = itemsRect.top + neighborSpace;
+      const revealBottom = itemsRect.bottom - neighborSpace;
+      if (tabRect.top < revealTop) {
+        items.scrollTop -= revealTop - tabRect.top;
+      } else if (tabRect.bottom > revealBottom) {
+        items.scrollTop += tabRect.bottom - revealBottom;
+      }
+    };
+
+    revealActiveItem();
     measure();
-    level.addEventListener('scroll', scheduleMeasure, { passive: true });
+    items.addEventListener('scroll', scheduleMeasure, { passive: true });
     const mutationObserver = new MutationObserver(scheduleMeasure);
     mutationObserver.observe(level, { childList: true, subtree: true });
 
     const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(scheduleMeasure);
     resizeObserver?.observe(root);
+    resizeObserver?.observe(items);
     resizeObserver?.observe(target);
     resizeObserver?.observe(activeItem);
 
     return () => {
       cancelAnimationFrame(animationFrame);
-      level.removeEventListener('scroll', scheduleMeasure);
+      items.removeEventListener('scroll', scheduleMeasure);
       mutationObserver.disconnect();
       resizeObserver?.disconnect();
     };
@@ -445,7 +476,9 @@ function NestedTabsLevelView({
   return (
     <NestedTabsContext.Provider value={{ activePath, levelIndex }}>
       <nav className={styles.level} aria-label={label} data-nested-tabs-level={levelIndex + 1}>
-        <ul className={styles.levelItems}>{entries}</ul>
+        <ul className={styles.levelItems} data-nested-tabs-items>
+          {entries}
+        </ul>
         <div className={styles.levelFooter}>
           {tools ? <div className={styles.levelTools}>{tools}</div> : null}
           <span className={styles.levelLabel} aria-hidden>

--- a/src/app/ui/surface/NestedTabs.tsx
+++ b/src/app/ui/surface/NestedTabs.tsx
@@ -171,6 +171,9 @@ function useNestedTabsLayerGeometry({
       const itemsRect = items.getBoundingClientRect();
       const targetRect = target.getBoundingClientRect();
       const tabRect = activeItem.getBoundingClientRect();
+      const scrollEnd = items.scrollHeight - items.clientHeight;
+      items.toggleAttribute('data-scroll-before', items.scrollTop > 1);
+      items.toggleAttribute('data-scroll-after', items.scrollTop < scrollEnd - 1);
       const devicePixelRatio = window.devicePixelRatio || 1;
       const round = (number: number) => Math.round(number * devicePixelRatio) / devicePixelRatio;
       const width = round(rootRect.width);

--- a/src/app/ui/surface/NestedTabs.tsx
+++ b/src/app/ui/surface/NestedTabs.tsx
@@ -1,0 +1,544 @@
+import { Tooltip } from '@mantine/core';
+import type { Link, LinkComponentProps, RegisteredRouter } from '@tanstack/react-router';
+import clsx from 'clsx';
+import {
+  Children,
+  createContext,
+  createElement,
+  isValidElement,
+  useContext,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
+import type {
+  ComponentPropsWithoutRef,
+  ElementType,
+  PropsWithChildren,
+  ReactElement,
+  ReactNode,
+  RefObject,
+} from 'react';
+
+import styles from './NestedTabs.module.css';
+import { PaintedSurfaceBoundary } from './Surface';
+
+export type NestedTabsPath = readonly string[];
+
+interface NestedTabsContextValue {
+  activePath: NestedTabsPath;
+  levelIndex: number;
+}
+
+const NestedTabsContext = createContext<NestedTabsContextValue | null>(null);
+
+interface NestedTabsLayerGeometry {
+  width: number;
+  height: number;
+  path: string;
+}
+
+function buildNestedTabsLayerPath({
+  height,
+  startX,
+  endX,
+  tabLeft,
+  tabTop,
+  tabBottom,
+  radius,
+  roundEndCorners,
+}: {
+  height: number;
+  startX: number;
+  endX: number;
+  tabLeft: number;
+  tabTop: number;
+  tabBottom: number;
+  radius: number;
+  roundEndCorners: boolean;
+}) {
+  const joinRadius = Math.min(3, radius);
+  const tabRadius = Math.min(radius, (tabBottom - tabTop) / 2, (startX - tabLeft) / 2);
+  const endRadius = roundEndCorners ? radius : 0;
+  const touchesTop = tabTop <= 0.5;
+  const touchesBottom = tabBottom >= height - 0.5;
+
+  if (touchesTop) {
+    return [
+      `M ${tabLeft} 0`,
+      `H ${endX - endRadius}`,
+      `Q ${endX} 0 ${endX} ${endRadius}`,
+      `V ${height - endRadius}`,
+      `Q ${endX} ${height} ${endX - endRadius} ${height}`,
+      `H ${startX}`,
+      `V ${tabBottom + joinRadius}`,
+      `Q ${startX} ${tabBottom} ${startX - joinRadius} ${tabBottom}`,
+      `H ${tabLeft + tabRadius}`,
+      `Q ${tabLeft} ${tabBottom} ${tabLeft} ${tabBottom - tabRadius}`,
+      'V 0',
+      'Z',
+    ].join(' ');
+  }
+
+  if (touchesBottom) {
+    return [
+      `M ${startX} 0`,
+      `H ${endX - endRadius}`,
+      `Q ${endX} 0 ${endX} ${endRadius}`,
+      `V ${height - endRadius}`,
+      `Q ${endX} ${height} ${endX - endRadius} ${height}`,
+      `H ${tabLeft}`,
+      `V ${tabTop + tabRadius}`,
+      `Q ${tabLeft} ${tabTop} ${tabLeft + tabRadius} ${tabTop}`,
+      `H ${startX - joinRadius}`,
+      `Q ${startX} ${tabTop} ${startX} ${tabTop - joinRadius}`,
+      'V 0',
+      'Z',
+    ].join(' ');
+  }
+
+  return [
+    `M ${startX} 0`,
+    `H ${endX - endRadius}`,
+    `Q ${endX} 0 ${endX} ${endRadius}`,
+    `V ${height - endRadius}`,
+    `Q ${endX} ${height} ${endX - endRadius} ${height}`,
+    `H ${startX}`,
+    `V ${tabBottom + joinRadius}`,
+    `Q ${startX} ${tabBottom} ${startX - joinRadius} ${tabBottom}`,
+    `H ${tabLeft + tabRadius}`,
+    `Q ${tabLeft} ${tabBottom} ${tabLeft} ${tabBottom - tabRadius}`,
+    `V ${tabTop + tabRadius}`,
+    `Q ${tabLeft} ${tabTop} ${tabLeft + tabRadius} ${tabTop}`,
+    `H ${startX - joinRadius}`,
+    `Q ${startX} ${tabTop} ${startX} ${tabTop - joinRadius}`,
+    'V 0',
+    'Z',
+  ].join(' ');
+}
+
+function sameLayerGeometry(current: NestedTabsLayerGeometry | null, next: NestedTabsLayerGeometry) {
+  return current?.width === next.width && current.height === next.height && current.path === next.path;
+}
+
+function useNestedTabsLayerGeometry({
+  activePath,
+  rootRef,
+  levelIndex,
+}: {
+  activePath: NestedTabsPath;
+  rootRef: RefObject<HTMLDivElement | null>;
+  levelIndex: number;
+}) {
+  const [geometry, setGeometry] = useState<NestedTabsLayerGeometry | null>(null);
+  const pathKey = activePath.join('/');
+
+  useLayoutEffect(() => {
+    void pathKey;
+    const root = rootRef.current;
+    const level = root?.querySelector<HTMLElement>(`[data-nested-tabs-level="${levelIndex + 1}"]`);
+    const target = root?.querySelector<HTMLElement>(
+      levelIndex === 0 ? '[data-nested-tabs-level="2"]' : '[data-nested-tabs-content]'
+    );
+    const activeItem = level?.querySelector<HTMLElement>(
+      levelIndex === 0
+        ? '[data-nested-tabs-item][data-path-state="ancestor"], [data-nested-tabs-item][data-path-state="active"]'
+        : '[data-nested-tabs-item][data-path-state="active"]'
+    );
+    if (!root || !level || !target || !activeItem) {
+      setGeometry(null);
+      return;
+    }
+
+    let animationFrame = 0;
+    const measure = () => {
+      const rootRect = root.getBoundingClientRect();
+      const targetRect = target.getBoundingClientRect();
+      const tabRect = activeItem.getBoundingClientRect();
+      const devicePixelRatio = window.devicePixelRatio || 1;
+      const round = (number: number) => Math.round(number * devicePixelRatio) / devicePixelRatio;
+      const width = round(rootRect.width);
+      const height = round(rootRect.height);
+      const startX = round(targetRect.left - rootRect.left);
+      const endX = round((levelIndex === 0 ? targetRect.right : rootRect.right) - rootRect.left);
+      const tabLeft = round(tabRect.left - rootRect.left);
+      const tabTop = round(tabRect.top - rootRect.top);
+      const tabBottom = round(tabRect.bottom - rootRect.top);
+      const configuredRadius = Number.parseFloat(getComputedStyle(root).getPropertyValue('--nested-tabs-radius'));
+      const radius = Number.isFinite(configuredRadius) ? configuredRadius : 8;
+      const path = buildNestedTabsLayerPath({
+        height,
+        startX,
+        endX,
+        tabLeft,
+        tabTop,
+        tabBottom,
+        radius,
+        roundEndCorners: levelIndex === 1,
+      });
+      const next = { width, height, path };
+      setGeometry((current) => (sameLayerGeometry(current, next) ? current : next));
+    };
+    const scheduleMeasure = () => {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = requestAnimationFrame(measure);
+    };
+
+    measure();
+    level.addEventListener('scroll', scheduleMeasure, { passive: true });
+    const mutationObserver = new MutationObserver(scheduleMeasure);
+    mutationObserver.observe(level, { childList: true, subtree: true });
+
+    const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(scheduleMeasure);
+    resizeObserver?.observe(root);
+    resizeObserver?.observe(target);
+    resizeObserver?.observe(activeItem);
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      level.removeEventListener('scroll', scheduleMeasure);
+      mutationObserver.disconnect();
+      resizeObserver?.disconnect();
+    };
+  }, [levelIndex, pathKey, rootRef]);
+
+  return geometry;
+}
+
+function NestedTabsConnectedSurface({
+  geometry,
+  layer,
+}: {
+  geometry: NestedTabsLayerGeometry | null;
+  layer: 'level' | 'panel';
+}) {
+  const instanceId = useId().replaceAll(':', '');
+  const clipId = `nested-tabs-${layer}-clip-${instanceId}`;
+  const shadowId = `nested-tabs-${layer}-shadow-${instanceId}`;
+
+  return (
+    <div className={styles.surfaceLayer} data-nested-tabs-surface={layer} aria-hidden>
+      {geometry ? (
+        <>
+          <svg className={styles.definitions} width="0" height="0" aria-hidden="true" focusable="false">
+            <defs>
+              <clipPath id={clipId} clipPathUnits="userSpaceOnUse">
+                <path d={geometry.path} />
+              </clipPath>
+              <filter id={shadowId} x="-20%" y="-20%" width="140%" height="140%" colorInterpolationFilters="sRGB">
+                <feGaussianBlur in="SourceAlpha" stdDeviation="10" result="shadowBlur" />
+                <feComposite in="shadowBlur" in2="SourceAlpha" operator="out" result="outsideShadowAlpha" />
+                <feFlood floodColor="#000000" floodOpacity="0.165" result="shadowColor" />
+                <feComposite in="shadowColor" in2="outsideShadowAlpha" operator="in" result="shadow" />
+              </filter>
+            </defs>
+          </svg>
+          <svg
+            className={styles.geometryShadow}
+            viewBox={`0 0 ${geometry.width} ${geometry.height}`}
+            preserveAspectRatio="none"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d={geometry.path} filter={`url(#${shadowId})`} />
+          </svg>
+          <div className={styles.glassSurface} style={{ clipPath: `url(#${clipId})` }} />
+          <svg
+            className={styles.geometryContour}
+            viewBox={`0 0 ${geometry.width} ${geometry.height}`}
+            preserveAspectRatio="none"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d={geometry.path} />
+          </svg>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function useNestedTabsContext(component: string) {
+  const context = useContext(NestedTabsContext);
+  if (!context) {
+    throw new Error(`[NestedTabs.${component}] must be rendered inside NestedTabs.Level.`);
+  }
+  return context;
+}
+
+function pathsEqual(left: NestedTabsPath, right: NestedTabsPath) {
+  return left.length === right.length && left.every((part, index) => part === right[index]);
+}
+
+function isPathPrefix(prefix: NestedTabsPath, path: NestedTabsPath) {
+  return prefix.length < path.length && prefix.every((part, index) => part === path[index]);
+}
+
+type ItemPathState = 'active' | 'ancestor' | 'inactive';
+
+function itemPathState(path: NestedTabsPath, activePath: NestedTabsPath): ItemPathState {
+  if (pathsEqual(path, activePath)) {
+    return 'active';
+  }
+  if (isPathPrefix(path, activePath)) {
+    return 'ancestor';
+  }
+  return 'inactive';
+}
+
+interface NestedTabsItemOwnProps {
+  path: NestedTabsPath;
+  label: string;
+  icon: ReactNode;
+  className?: string;
+}
+
+export type NestedTabsItemProps<Root extends ElementType> = NestedTabsItemOwnProps &
+  Omit<ComponentPropsWithoutRef<Root>, keyof NestedTabsItemOwnProps | 'as' | 'children' | 'aria-label' | 'title'> & {
+    as: Root;
+  };
+
+export type NestedTabsRouterItemProps<
+  TFrom extends string = string,
+  TTo extends string | undefined = undefined,
+  TMaskFrom extends string = TFrom,
+  TMaskTo extends string = '',
+> = NestedTabsItemOwnProps &
+  LinkComponentProps<'a', RegisteredRouter, TFrom, TTo, TMaskFrom, TMaskTo> & {
+    as: typeof Link;
+    children?: never;
+    'aria-label'?: never;
+    title?: never;
+  };
+
+function Item<
+  const TFrom extends string = string,
+  const TTo extends string | undefined = undefined,
+  const TMaskFrom extends string = TFrom,
+  const TMaskTo extends string = '',
+>(props: NestedTabsRouterItemProps<TFrom, TTo, TMaskFrom, TMaskTo>): ReactElement;
+function Item<Root extends ElementType>(props: NestedTabsItemProps<Root>): ReactElement;
+function Item<Root extends ElementType>({
+  as: Root,
+  path,
+  label,
+  icon,
+  className,
+  ...rootProps
+}: NestedTabsItemProps<Root>) {
+  const { activePath } = useNestedTabsContext('Item');
+  const pathState = itemPathState(path, activePath);
+  const itemRoot = createElement(
+    Root,
+    {
+      ...rootProps,
+      className: clsx(styles.item, className),
+      'aria-current': pathState === 'active' ? 'page' : undefined,
+      'aria-label': label,
+      'data-nested-tabs-item': true,
+      'data-path-state': pathState,
+    } as ComponentPropsWithoutRef<Root>,
+    <span className={styles.itemIcon} aria-hidden>
+      {icon}
+    </span>
+  );
+
+  return (
+    <li className={styles.itemSlot}>
+      <Tooltip label={label} position="right" openDelay={350} withArrow>
+        {itemRoot}
+      </Tooltip>
+    </li>
+  );
+}
+
+export interface NestedTabsGroupProps extends PropsWithChildren {
+  label: string;
+  icon?: ReactNode;
+}
+
+function descendantItemPaths(children: ReactNode): NestedTabsPath[] {
+  const paths: NestedTabsPath[] = [];
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) {
+      return;
+    }
+    if (child.type === Item) {
+      paths.push((child.props as NestedTabsItemOwnProps).path);
+      return;
+    }
+    if (child.type === Group) {
+      paths.push(...descendantItemPaths((child.props as NestedTabsGroupProps).children));
+    }
+  });
+  return paths;
+}
+
+function Group({ label, icon, children }: NestedTabsGroupProps) {
+  const { activePath } = useNestedTabsContext('Group');
+  const containsActiveItem = descendantItemPaths(children).some((path) => pathsEqual(path, activePath));
+
+  return (
+    <li className={styles.group} data-contains-active-item={containsActiveItem || undefined}>
+      <Tooltip label={label} position="right" openDelay={350} withArrow>
+        <span className={styles.groupAdornment} aria-hidden>
+          {icon ?? <span className={styles.groupMarker} />}
+        </span>
+      </Tooltip>
+      <ul className={styles.groupItems} aria-label={label}>
+        {children}
+      </ul>
+    </li>
+  );
+}
+
+export interface NestedTabsToolsProps extends PropsWithChildren {}
+
+function Tools(_: NestedTabsToolsProps): null {
+  return null;
+}
+
+export interface NestedTabsLevelProps extends PropsWithChildren {
+  label: string;
+}
+
+function Level(_: NestedTabsLevelProps): null {
+  return null;
+}
+
+export interface NestedTabsContentPanelProps extends PropsWithChildren {
+  'aria-label'?: string;
+  'aria-labelledby'?: string;
+}
+
+function ContentPanel(_: NestedTabsContentPanelProps): null {
+  return null;
+}
+
+function splitLevelChildren(children: ReactNode) {
+  const entries: ReactNode[] = [];
+  let tools: ReactNode = null;
+
+  Children.forEach(children, (child) => {
+    if (isValidElement<NestedTabsToolsProps>(child) && child.type === Tools) {
+      if (tools !== null) {
+        throw new Error('[NestedTabs.Level] accepts at most one direct NestedTabs.Tools child.');
+      }
+      tools = child.props.children;
+      return;
+    }
+    entries.push(child);
+  });
+
+  return { entries, tools };
+}
+
+function NestedTabsLevelView({
+  activePath,
+  levelIndex,
+  label,
+  children,
+}: NestedTabsLevelProps & { activePath: NestedTabsPath; levelIndex: number }) {
+  const { entries, tools } = splitLevelChildren(children);
+
+  return (
+    <NestedTabsContext.Provider value={{ activePath, levelIndex }}>
+      <nav className={styles.level} aria-label={label} data-nested-tabs-level={levelIndex + 1}>
+        <ul className={styles.levelItems}>{entries}</ul>
+        <div className={styles.levelFooter}>
+          <span className={styles.levelLabel} aria-hidden>
+            {label}
+          </span>
+          {tools ? <div className={styles.levelTools}>{tools}</div> : null}
+        </div>
+      </nav>
+    </NestedTabsContext.Provider>
+  );
+}
+
+export interface NestedTabsProps extends PropsWithChildren {
+  activePath: NestedTabsPath;
+  ariaLabel: string;
+  className?: string;
+}
+
+function splitRootChildren(children: ReactNode) {
+  const levels: ReactElement<NestedTabsLevelProps>[] = [];
+  const panels: ReactElement<NestedTabsContentPanelProps>[] = [];
+
+  Children.forEach(children, (child) => {
+    if (!isValidElement(child)) {
+      return;
+    }
+    if (child.type === Level) {
+      levels.push(child as ReactElement<NestedTabsLevelProps>);
+      return;
+    }
+    if (child.type === ContentPanel) {
+      panels.push(child as ReactElement<NestedTabsContentPanelProps>);
+      return;
+    }
+    throw new Error('[NestedTabs] direct children must be NestedTabs.Level or NestedTabs.ContentPanel.');
+  });
+
+  if (levels.length !== 2) {
+    throw new Error(`[NestedTabs] accepts exactly two NestedTabs.Level children; received ${levels.length}.`);
+  }
+  if (panels.length !== 1) {
+    throw new Error(`[NestedTabs] accepts exactly one NestedTabs.ContentPanel child; received ${panels.length}.`);
+  }
+
+  return { levels, panel: panels[0] };
+}
+
+function NestedTabsBase({ activePath, ariaLabel, className, children }: NestedTabsProps) {
+  const { levels, panel } = splitRootChildren(children);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const levelGeometry = useNestedTabsLayerGeometry({ activePath, rootRef, levelIndex: 0 });
+  const panelGeometry = useNestedTabsLayerGeometry({ activePath, rootRef, levelIndex: 1 });
+
+  return (
+    <aside className={clsx(styles.host, className)} aria-label={ariaLabel}>
+      <div ref={rootRef} className={styles.root}>
+        <div className={styles.baseSurface} aria-hidden />
+        <NestedTabsConnectedSurface geometry={levelGeometry} layer="level" />
+        <NestedTabsConnectedSurface geometry={panelGeometry} layer="panel" />
+        {levels.map((level, index) => (
+          <NestedTabsLevelView
+            activePath={activePath}
+            levelIndex={index}
+            label={level.props.label}
+            key={level.key ?? index}
+          >
+            {level.props.children}
+          </NestedTabsLevelView>
+        ))}
+        <section
+          className={styles.contentPanel}
+          data-nested-tabs-content
+          aria-label={panel.props['aria-label']}
+          aria-labelledby={panel.props['aria-labelledby']}
+        >
+          <PaintedSurfaceBoundary>{panel.props.children}</PaintedSurfaceBoundary>
+        </section>
+      </div>
+    </aside>
+  );
+}
+
+type NestedTabsComponent = ((props: NestedTabsProps) => ReactNode) & {
+  Level: typeof Level;
+  Item: typeof Item;
+  Group: typeof Group;
+  Tools: typeof Tools;
+  ContentPanel: typeof ContentPanel;
+};
+
+export const NestedTabs = Object.assign(NestedTabsBase, {
+  Level,
+  Item,
+  Group,
+  Tools,
+  ContentPanel,
+}) as NestedTabsComponent;

--- a/src/app/ui/surface/NestedTabs.tsx
+++ b/src/app/ui/surface/NestedTabs.tsx
@@ -413,12 +413,12 @@ interface NestedTabsItemOwnProps {
   className?: string;
 }
 
-export type NestedTabsItemProps<Root extends ElementType> = NestedTabsItemOwnProps &
+type NestedTabsItemProps<Root extends ElementType> = NestedTabsItemOwnProps &
   Omit<ComponentPropsWithoutRef<Root>, keyof NestedTabsItemOwnProps | 'as' | 'children' | 'aria-label' | 'title'> & {
     as: Root;
   };
 
-export type NestedTabsRouterItemProps<
+type NestedTabsRouterItemProps<
   TFrom extends string = string,
   TTo extends string | undefined = undefined,
   TMaskFrom extends string = TFrom,
@@ -472,7 +472,7 @@ function Item<Root extends ElementType>({
   );
 }
 
-export interface NestedTabsGroupProps extends PropsWithChildren {
+interface NestedTabsGroupProps extends PropsWithChildren {
   label: string;
   icon?: ReactNode;
 }
@@ -512,13 +512,13 @@ function Group({ label, icon, children }: NestedTabsGroupProps) {
   );
 }
 
-export interface NestedTabsToolsProps extends PropsWithChildren {}
+interface NestedTabsToolsProps extends PropsWithChildren {}
 
 function Tools(_: NestedTabsToolsProps): null {
   return null;
 }
 
-export interface NestedTabsLevelProps extends PropsWithChildren {
+interface NestedTabsLevelProps extends PropsWithChildren {
   label: string;
 }
 
@@ -526,7 +526,7 @@ function Level(_: NestedTabsLevelProps): null {
   return null;
 }
 
-export interface NestedTabsContentPanelProps extends PropsWithChildren {
+interface NestedTabsContentPanelProps extends PropsWithChildren {
   'aria-label'?: string;
   'aria-labelledby'?: string;
 }

--- a/src/app/ui/surface/NestedTabs.tsx
+++ b/src/app/ui/surface/NestedTabs.tsx
@@ -29,6 +29,7 @@ export type NestedTabsPath = readonly string[];
 
 interface NestedTabsContextValue {
   activePath: NestedTabsPath;
+  isScrolling: boolean;
   levelIndex: number;
 }
 
@@ -195,7 +196,6 @@ function useNestedTabsLayerGeometry({
     }
 
     let animationFrame = 0;
-    let scrollingTimer = 0;
     const measure = () => {
       const rootRect = root.getBoundingClientRect();
       const itemsRect = items.getBoundingClientRect();
@@ -234,9 +234,6 @@ function useNestedTabsLayerGeometry({
       animationFrame = requestAnimationFrame(measure);
     };
     const handleScroll = () => {
-      items.setAttribute('data-scrolling', '');
-      window.clearTimeout(scrollingTimer);
-      scrollingTimer = window.setTimeout(() => items.removeAttribute('data-scrolling'), 650);
       scheduleMeasure();
     };
 
@@ -272,8 +269,6 @@ function useNestedTabsLayerGeometry({
 
     return () => {
       cancelAnimationFrame(animationFrame);
-      window.clearTimeout(scrollingTimer);
-      items.removeAttribute('data-scrolling');
       items.removeEventListener('scroll', handleScroll);
       mutationObserver.disconnect();
       resizeObserver?.disconnect();
@@ -344,6 +339,53 @@ function useNestedTabsContext(component: string) {
   return context;
 }
 
+function NestedTabsTooltip({
+  label,
+  isScrolling,
+  children,
+}: {
+  label: string;
+  isScrolling: boolean;
+  children: ReactElement;
+}) {
+  const [opened, setOpened] = useState(false);
+  const openTimer = useRef(0);
+
+  useLayoutEffect(() => {
+    if (isScrolling) {
+      window.clearTimeout(openTimer.current);
+      setOpened(false);
+    }
+    return () => window.clearTimeout(openTimer.current);
+  }, [isScrolling]);
+
+  const handleMouseEnter = () => {
+    if (isScrolling) {
+      return;
+    }
+    window.clearTimeout(openTimer.current);
+    openTimer.current = window.setTimeout(() => setOpened(true), 350);
+  };
+  const handleMouseLeave = () => {
+    window.clearTimeout(openTimer.current);
+    setOpened(false);
+  };
+
+  return (
+    <Tooltip
+      label={label}
+      position="right"
+      withArrow
+      opened={opened && !isScrolling}
+      events={{ hover: false, focus: false, touch: false }}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+    </Tooltip>
+  );
+}
+
 function pathsEqual(left: NestedTabsPath, right: NestedTabsPath) {
   return left.length === right.length && left.every((part, index) => part === right[index]);
 }
@@ -404,7 +446,7 @@ function Item<Root extends ElementType>({
   className,
   ...rootProps
 }: NestedTabsItemProps<Root>) {
-  const { activePath } = useNestedTabsContext('Item');
+  const { activePath, isScrolling } = useNestedTabsContext('Item');
   const pathState = itemPathState(path, activePath);
   const itemRoot = createElement(
     Root,
@@ -423,9 +465,9 @@ function Item<Root extends ElementType>({
 
   return (
     <li className={styles.itemSlot}>
-      <Tooltip label={label} position="right" openDelay={350} withArrow>
+      <NestedTabsTooltip label={label} isScrolling={isScrolling}>
         {itemRoot}
-      </Tooltip>
+      </NestedTabsTooltip>
     </li>
   );
 }
@@ -453,16 +495,16 @@ function descendantItemPaths(children: ReactNode): NestedTabsPath[] {
 }
 
 function Group({ label, icon, children }: NestedTabsGroupProps) {
-  const { activePath } = useNestedTabsContext('Group');
+  const { activePath, isScrolling } = useNestedTabsContext('Group');
   const containsActiveItem = descendantItemPaths(children).some((path) => pathsEqual(path, activePath));
 
   return (
     <li className={styles.group} data-contains-active-item={containsActiveItem || undefined}>
-      <Tooltip label={label} position="right" openDelay={350} withArrow>
+      <NestedTabsTooltip label={label} isScrolling={isScrolling}>
         <span className={styles.groupAdornment} aria-hidden>
           {icon ?? <span className={styles.groupMarker} />}
         </span>
-      </Tooltip>
+      </NestedTabsTooltip>
       <ul className={styles.groupItems} aria-label={label}>
         {children}
       </ul>
@@ -518,11 +560,31 @@ function NestedTabsLevelView({
   children,
 }: NestedTabsLevelProps & { activePath: NestedTabsPath; levelIndex: number }) {
   const { entries, tools } = splitLevelChildren(children);
+  const [isScrolling, setIsScrolling] = useState(false);
+  const scrollingTimer = useRef(0);
+
+  useLayoutEffect(
+    () => () => {
+      window.clearTimeout(scrollingTimer.current);
+    },
+    []
+  );
+
+  const handleScroll = () => {
+    setIsScrolling(true);
+    window.clearTimeout(scrollingTimer.current);
+    scrollingTimer.current = window.setTimeout(() => setIsScrolling(false), 650);
+  };
 
   return (
-    <NestedTabsContext.Provider value={{ activePath, levelIndex }}>
+    <NestedTabsContext.Provider value={{ activePath, isScrolling, levelIndex }}>
       <nav className={styles.level} aria-label={label} data-nested-tabs-level={levelIndex + 1}>
-        <ul className={styles.levelItems} data-nested-tabs-items>
+        <ul
+          className={styles.levelItems}
+          data-nested-tabs-items
+          data-scrolling={isScrolling || undefined}
+          onScroll={handleScroll}
+        >
           {entries}
         </ul>
         <div className={styles.levelFooter}>

--- a/src/app/ui/surface/NestedTabs.tsx
+++ b/src/app/ui/surface/NestedTabs.tsx
@@ -15,11 +15,13 @@ import {
 import type {
   ComponentPropsWithoutRef,
   Context,
+  Dispatch,
   ElementType,
   PropsWithChildren,
   ReactElement,
   ReactNode,
   RefObject,
+  SetStateAction,
 } from 'react';
 
 import styles from './NestedTabs.module.css';
@@ -57,7 +59,7 @@ function markNestedTabsChild(component: object, kind: NestedTabsChildKind) {
 }
 
 function nestedTabsChildKind(child: ReactElement): NestedTabsChildKind | null {
-  if ((typeof child.type !== 'function' && typeof child.type !== 'object') || child.type === null) {
+  if (Object(child.type) !== child.type) {
     return null;
   }
   return (child.type as NestedTabsChildComponent)[NESTED_TABS_CHILD_KIND] ?? null;
@@ -165,6 +167,133 @@ function sameLayerGeometry(current: NestedTabsLayerGeometry | null, next: Nested
   return current?.width === next.width && current.height === next.height && current.path === next.path;
 }
 
+interface NestedTabsGeometryElements {
+  root: HTMLDivElement;
+  level: HTMLElement;
+  items: HTMLElement;
+  target: HTMLElement;
+  activeItem: HTMLElement;
+}
+
+function nestedTabsGeometryElements(root: HTMLDivElement, levelIndex: number): NestedTabsGeometryElements | null {
+  const level = root.querySelector<HTMLElement>(`[data-nested-tabs-level="${levelIndex + 1}"]`);
+  if (!level) {
+    return null;
+  }
+  const items = level.querySelector<HTMLElement>('[data-nested-tabs-items]');
+  if (!items) {
+    return null;
+  }
+  const target = root.querySelector<HTMLElement>(
+    levelIndex === 0 ? '[data-nested-tabs-level="2"]' : '[data-nested-tabs-content]'
+  );
+  if (!target) {
+    return null;
+  }
+  const activeItem = level.querySelector<HTMLElement>(
+    levelIndex === 0
+      ? '[data-nested-tabs-item][data-path-state="ancestor"], [data-nested-tabs-item][data-path-state="active"]'
+      : '[data-nested-tabs-item][data-path-state="active"]'
+  );
+  if (!activeItem) {
+    return null;
+  }
+  return { root, level, items, target, activeItem };
+}
+
+function measureNestedTabsLayer(
+  { root, items, target, activeItem }: NestedTabsGeometryElements,
+  levelIndex: number
+): NestedTabsLayerGeometry {
+  const rootRect = root.getBoundingClientRect();
+  const itemsRect = items.getBoundingClientRect();
+  const targetRect = target.getBoundingClientRect();
+  const tabRect = activeItem.getBoundingClientRect();
+  const scrollEnd = items.scrollHeight - items.clientHeight;
+  items.toggleAttribute('data-scroll-before', items.scrollTop > 1);
+  items.toggleAttribute('data-scroll-after', items.scrollTop < scrollEnd - 1);
+  const devicePixelRatio = window.devicePixelRatio || 1;
+  const round = (number: number) => Math.round(number * devicePixelRatio) / devicePixelRatio;
+  const width = round(rootRect.width);
+  const height = round(rootRect.height);
+  const startX = round(targetRect.left - rootRect.left);
+  const endX = round((levelIndex === 0 ? targetRect.right : rootRect.right) - rootRect.left);
+  const tabLeft = round(tabRect.left - rootRect.left);
+  const tabIsVisible = tabRect.top >= itemsRect.top - 0.5 && tabRect.bottom <= itemsRect.bottom + 0.5;
+  const tabTop = tabIsVisible ? round(tabRect.top - rootRect.top) : null;
+  const tabBottom = tabIsVisible ? round(tabRect.bottom - rootRect.top) : null;
+  const configuredRadius = Number.parseFloat(getComputedStyle(root).getPropertyValue('--nested-tabs-radius'));
+  const radius = Number.isFinite(configuredRadius) ? configuredRadius : 8;
+  const path = buildNestedTabsLayerPath({
+    height,
+    startX,
+    endX,
+    tabLeft,
+    tabTop,
+    tabBottom,
+    radius,
+    roundEndCorners: levelIndex === 1,
+  });
+  return { width, height, path };
+}
+
+function revealNestedTabsActiveItem({ items, activeItem }: NestedTabsGeometryElements) {
+  const itemsRect = items.getBoundingClientRect();
+  const tabRect = activeItem.getBoundingClientRect();
+  const neighborSpace = Math.min(tabRect.height + 6, Math.max(0, (itemsRect.height - tabRect.height) / 2));
+  const revealTop = itemsRect.top + neighborSpace;
+  const revealBottom = itemsRect.bottom - neighborSpace;
+  if (tabRect.top < revealTop) {
+    items.scrollTop -= revealTop - tabRect.top;
+  } else if (tabRect.bottom > revealBottom) {
+    items.scrollTop += tabRect.bottom - revealBottom;
+  }
+}
+
+function observeNestedTabsLayerGeometry({
+  elements,
+  levelIndex,
+  setGeometry,
+}: {
+  elements: NestedTabsGeometryElements;
+  levelIndex: number;
+  setGeometry: Dispatch<SetStateAction<NestedTabsLayerGeometry | null>>;
+}) {
+  const { root, level, items, target, activeItem } = elements;
+  let animationFrame = 0;
+  const measure = () => {
+    const next = measureNestedTabsLayer(elements, levelIndex);
+    setGeometry((current) => (sameLayerGeometry(current, next) ? current : next));
+  };
+  const scheduleMeasure = () => {
+    cancelAnimationFrame(animationFrame);
+    animationFrame = requestAnimationFrame(measure);
+  };
+  const revealActiveItemAfterResize = () => {
+    revealNestedTabsActiveItem(elements);
+    scheduleMeasure();
+  };
+
+  revealNestedTabsActiveItem(elements);
+  measure();
+  items.addEventListener('scroll', scheduleMeasure, { passive: true });
+  const mutationObserver = new MutationObserver(scheduleMeasure);
+  mutationObserver.observe(level, { childList: true, subtree: true });
+
+  const resizeObserver = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(revealActiveItemAfterResize);
+  resizeObserver?.observe(root);
+  resizeObserver?.observe(items);
+  resizeObserver?.observe(target);
+  resizeObserver?.observe(activeItem);
+
+  return () => {
+    cancelAnimationFrame(animationFrame);
+    items.removeEventListener('scroll', scheduleMeasure);
+    mutationObserver.disconnect();
+    resizeObserver?.disconnect();
+  };
+}
+
 function useNestedTabsLayerGeometry({
   activePath,
   rootRef,
@@ -180,99 +309,16 @@ function useNestedTabsLayerGeometry({
   useLayoutEffect(() => {
     void pathKey;
     const root = rootRef.current;
-    const level = root?.querySelector<HTMLElement>(`[data-nested-tabs-level="${levelIndex + 1}"]`);
-    const items = level?.querySelector<HTMLElement>('[data-nested-tabs-items]');
-    const target = root?.querySelector<HTMLElement>(
-      levelIndex === 0 ? '[data-nested-tabs-level="2"]' : '[data-nested-tabs-content]'
-    );
-    const activeItem = level?.querySelector<HTMLElement>(
-      levelIndex === 0
-        ? '[data-nested-tabs-item][data-path-state="ancestor"], [data-nested-tabs-item][data-path-state="active"]'
-        : '[data-nested-tabs-item][data-path-state="active"]'
-    );
-    if (!root || !level || !items || !target || !activeItem) {
+    if (!root) {
       setGeometry(null);
       return;
     }
-
-    let animationFrame = 0;
-    const measure = () => {
-      const rootRect = root.getBoundingClientRect();
-      const itemsRect = items.getBoundingClientRect();
-      const targetRect = target.getBoundingClientRect();
-      const tabRect = activeItem.getBoundingClientRect();
-      const scrollEnd = items.scrollHeight - items.clientHeight;
-      items.toggleAttribute('data-scroll-before', items.scrollTop > 1);
-      items.toggleAttribute('data-scroll-after', items.scrollTop < scrollEnd - 1);
-      const devicePixelRatio = window.devicePixelRatio || 1;
-      const round = (number: number) => Math.round(number * devicePixelRatio) / devicePixelRatio;
-      const width = round(rootRect.width);
-      const height = round(rootRect.height);
-      const startX = round(targetRect.left - rootRect.left);
-      const endX = round((levelIndex === 0 ? targetRect.right : rootRect.right) - rootRect.left);
-      const tabLeft = round(tabRect.left - rootRect.left);
-      const tabIsVisible = tabRect.top >= itemsRect.top - 0.5 && tabRect.bottom <= itemsRect.bottom + 0.5;
-      const tabTop = tabIsVisible ? round(tabRect.top - rootRect.top) : null;
-      const tabBottom = tabIsVisible ? round(tabRect.bottom - rootRect.top) : null;
-      const configuredRadius = Number.parseFloat(getComputedStyle(root).getPropertyValue('--nested-tabs-radius'));
-      const radius = Number.isFinite(configuredRadius) ? configuredRadius : 8;
-      const path = buildNestedTabsLayerPath({
-        height,
-        startX,
-        endX,
-        tabLeft,
-        tabTop,
-        tabBottom,
-        radius,
-        roundEndCorners: levelIndex === 1,
-      });
-      const next = { width, height, path };
-      setGeometry((current) => (sameLayerGeometry(current, next) ? current : next));
-    };
-    const scheduleMeasure = () => {
-      cancelAnimationFrame(animationFrame);
-      animationFrame = requestAnimationFrame(measure);
-    };
-    const handleScroll = () => {
-      scheduleMeasure();
-    };
-
-    const revealActiveItem = () => {
-      const itemsRect = items.getBoundingClientRect();
-      const tabRect = activeItem.getBoundingClientRect();
-      const neighborSpace = Math.min(tabRect.height + 6, Math.max(0, (itemsRect.height - tabRect.height) / 2));
-      const revealTop = itemsRect.top + neighborSpace;
-      const revealBottom = itemsRect.bottom - neighborSpace;
-      if (tabRect.top < revealTop) {
-        items.scrollTop -= revealTop - tabRect.top;
-      } else if (tabRect.bottom > revealBottom) {
-        items.scrollTop += tabRect.bottom - revealBottom;
-      }
-    };
-    const revealActiveItemAfterResize = () => {
-      revealActiveItem();
-      scheduleMeasure();
-    };
-
-    revealActiveItem();
-    measure();
-    items.addEventListener('scroll', handleScroll, { passive: true });
-    const mutationObserver = new MutationObserver(scheduleMeasure);
-    mutationObserver.observe(level, { childList: true, subtree: true });
-
-    const resizeObserver =
-      typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(revealActiveItemAfterResize);
-    resizeObserver?.observe(root);
-    resizeObserver?.observe(items);
-    resizeObserver?.observe(target);
-    resizeObserver?.observe(activeItem);
-
-    return () => {
-      cancelAnimationFrame(animationFrame);
-      items.removeEventListener('scroll', handleScroll);
-      mutationObserver.disconnect();
-      resizeObserver?.disconnect();
-    };
+    const elements = nestedTabsGeometryElements(root, levelIndex);
+    if (!elements) {
+      setGeometry(null);
+      return;
+    }
+    return observeNestedTabsLayerGeometry({ elements, levelIndex, setGeometry });
   }, [levelIndex, pathKey, rootRef]);
 
   return geometry;

--- a/src/app/ui/surface/NestedTabs.tsx
+++ b/src/app/ui/surface/NestedTabs.tsx
@@ -447,10 +447,10 @@ function NestedTabsLevelView({
       <nav className={styles.level} aria-label={label} data-nested-tabs-level={levelIndex + 1}>
         <ul className={styles.levelItems}>{entries}</ul>
         <div className={styles.levelFooter}>
+          {tools ? <div className={styles.levelTools}>{tools}</div> : null}
           <span className={styles.levelLabel} aria-hidden>
             {label}
           </span>
-          {tools ? <div className={styles.levelTools}>{tools}</div> : null}
         </div>
       </nav>
     </NestedTabsContext.Provider>

--- a/src/app/ui/surface/index.ts
+++ b/src/app/ui/surface/index.ts
@@ -1,1 +1,3 @@
 export { DetachedSurfaceBoundary, Surface } from './Surface';
+export { NestedTabs } from './NestedTabs';
+export type { NestedTabsPath } from './NestedTabs';


### PR DESCRIPTION
Closes #785

## What changed

- Adds the NestedTabs Surface with compound Level, Item, Group, Tools, and ContentPanel children.
- Keeps active-path and link ownership at the caller membrane while the Surface owns connected geometry, transitions, tooltips, and rail overflow.
- Treats Groups as labelled structure rather than destinations, including active-descendant awareness.
- Covers the accepted states with five domain-agnostic Storybook stories and focused unit tests.

## Accepted boundaries

- This first version supports exactly two levels. #792 tracks the general two-to-four-level design.
- Route components remain responsible for URL and state synchronization.
- Drag-and-drop remains caller-owned and will be evaluated when a real editor integration exercises it.
- No interaction state remains unresolved for the Storybook prototype.

## Verification

- bun run format:check
- bun run lint
- bun run typecheck
- bun run knip
- bun run test -- NestedTabs.test.tsx
- bun run storybook:test -- NestedTabs
- bun run check:css-orphans
- git diff --check

Publisher release verification reaches the application prerender, then stops because this worktree has no Convex URL in .env.local. It produced no generated diff.

## Visual proof

NestedTabs does not exist on main, so there is no honest visual baseline. This accepted Storybook state is direct runtime evidence for the new component. It also shows the grouped active item and active-descendant assertions passing.

![Accepted NestedTabs grouped-item state](https://github.com/ndelangen/dunezone/releases/download/proof-assets/pr-808-nested-tabs-accepted.jpg)