### PR TITLE
Four page stories assert behaviour the page itself owns

### DIFF
--- a/src/app/routes/-assets.stories.tsx
+++ b/src/app/routes/-assets.stories.tsx
@@ -1,5 +1,5 @@
 import preview from '@sb/preview';
-import { expect, within } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 
 import { pageStoryMeta } from './-storybookConfig';
 
@@ -84,5 +84,60 @@ export const CreateStormCardNoEditor = meta.story({
     const page = within(canvasElement.ownerDocument.body);
     await expect(page.findByRole('heading', { name: 'Storm cards' }, { timeout: 30_000 })).resolves.toBeVisible();
     await expect(page.findByRole('heading', { name: 'No editor yet' }, { timeout: 30_000 })).resolves.toBeVisible();
+  },
+});
+
+/**
+ * Creating a card saves it and hands the author to its editor at the slug the server minted.
+ *
+ * The navigation is the proof rather than the badge: a resolved promise alone would let the toolbar read "Saved", but the route cannot reach the edit page without a real id and slug coming back.
+ * "Delete card" is what tells the two pages apart, since only the editor carries a destructive action.
+ */
+export const CreateTreacheryCardSaves = meta.story({
+  args: { path: '/assets/card-treachery/create' },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    const name = await page.findByRole('textbox', { name: 'Name' }, { timeout: 30_000 });
+    await userEvent.type(name, 'Storybook Lasgun');
+    await userEvent.click(page.getByRole('button', { name: 'Save card' }));
+    await expect(page.findByRole('button', { name: 'Delete card' }, { timeout: 30_000 })).resolves.toBeVisible();
+  },
+});
+
+/**
+ * A validation chip moves the editor to the chapter that warning belongs to.
+ *
+ * The routing is the route's own: `ValidationHeader` reports which warning was chosen and this page decides `setChapter(warning.chapter)`, so the chapter key travels from the draft's warnings through the header and back into route state.
+ * Asserting the Body field is absent first is what stops this passing whatever the chip does.
+ */
+export const CreateTreacheryCardChapterJump = meta.story({
+  args: { path: '/assets/card-treachery/create' },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await page.findByRole('textbox', { name: 'Name' }, { timeout: 30_000 });
+    expect(page.queryByRole('textbox', { name: 'Body' })).toBeNull();
+    const chip = await page.findByRole('button', { name: /Body/ }, { timeout: 30_000 });
+    await userEvent.click(chip);
+    await expect(page.findByRole('textbox', { name: 'Body' }, { timeout: 30_000 })).resolves.toBeVisible();
+  },
+});
+
+/**
+ * A deck's composition counts are server state, written on commit rather than held until Save.
+ *
+ * The rail's total is the proof and the count field is not: `MemberCountInput` keeps what you typed in its own state and reclaims it on commit, so the field would read the new number whether or not anything was written.
+ * The total is reduced from the members the page query returns, so it can only move once the mutation has landed and the query has re-run.
+ */
+export const EditDeckMemberCountWrites = meta.story({
+  args: { path: '/assets/deck/house-treachery/edit' },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(page.findByText('3 cards across 1 title', {}, { timeout: 30_000 })).resolves.toBeVisible();
+    await userEvent.click(await page.findByRole('tab', { name: 'Cards' }, { timeout: 30_000 }));
+    const copies = await page.findByRole('textbox', { name: /^Copies of / }, { timeout: 30_000 });
+    await userEvent.clear(copies);
+    await userEvent.type(copies, '2');
+    await userEvent.tab();
+    await expect(page.findByText('2 cards across 1 title', {}, { timeout: 30_000 })).resolves.toBeVisible();
   },
 });

--- a/src/app/routes/-rulesets.stories.tsx
+++ b/src/app/routes/-rulesets.stories.tsx
@@ -1,4 +1,5 @@
 import preview from '@sb/preview';
+import { expect, within } from 'storybook/test';
 
 import { pageStoryMeta } from './-storybookConfig';
 
@@ -19,6 +20,16 @@ export const AskQuestion = meta.story({
  */
 export const AskQuestionMissingRuleset = meta.story({
   args: { path: '/rulesets/there-is-no-such-ruleset/faq/create' },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(page.findByRole('heading', { name: 'Ask a question' }, { timeout: 30_000 })).resolves.toBeVisible();
+    /* Not merely that something rendered: the router's default renders too, and without the route's
+       own frame this page shows its unstyled block with no way out. The alert's own title and a way
+       back that lives in the band are what only the frame produces. */
+    await expect(page.findByText('This ruleset could not be loaded', {}, { timeout: 30_000 })).resolves.toBeVisible();
+    const back = await page.findByRole('link', { name: 'Back to rulesets' }, { timeout: 30_000 });
+    expect(back.closest('main')).toBeNull();
+  },
 });
 export const Question = meta.story({
   args: { path: '/rulesets/classicrules/faq/when-does-the-storm-move' },


### PR DESCRIPTION
Closes [#769](https://github.com/ndelangen/dunezone/issues/769).

Four page stories gain assertions. No source file changes.

## How the four were chosen

Every page story was surveyed against the ticket's rules, and every candidate was then handed to an independent reviewer told to refute it: does the behaviour exist, is it page-owned rather than a widget's, would the assertion pass even with the behaviour removed, is the tier right, and would this read as contract-level coverage or as ceremony. Thirty-three candidates were judged. Sixteen survived, seventeen were refuted, and four were built.

The seventeen refusals did more for this PR than the sixteen survivors. Several died on the ceremony bar rather than on mechanics, which is the ticket's actual constraint, and one died because the repo had already ruled against that exact play in writing.

## What was built

| story | behaviour kind | the assertion, and why it is not the obvious one |
|---|---|---|
| `Assets/CreateTreacheryCardSaves` | primary mutation, then navigation | Asserts a `Delete card` control, which only the editor carries. The toolbar badge would read "Saved" from a resolved promise alone; the route cannot reach the edit page without a real id and slug coming back. |
| `Assets/CreateTreacheryCardChapterJump` | mode switching | Asserts the Body field is absent, then present after the chip. The chapter routing is the route's own: `ValidationHeader` only reports which warning was chosen and the page decides `setChapter(warning.chapter)`. |
| `Assets/EditDeckMemberCountWrites` | mutation-driven query refresh | Asserts the rail total, **not** the count field. `MemberCountInput` keeps what you typed in its own state and reclaims it on commit, so asserting the field would pass whether or not anything was written. The total is reduced from the members the page query returns. |
| `Rulesets/AskQuestionMissingRuleset` | the route's own error frame | Gains the assertions it shipped without in #800, where I verified it by hand instead. Asserts the alert's own title and that the way back lives outside `main`, because the router's default renders too. |

## Every one was run against the behaviour removed

Not reasoned about. Each behaviour was deliberately broken in the source, the suite re-run, and the source restored.

| story | with the behaviour | with it removed |
|---|---|---|
| `CreateTreacheryCardSaves` | pass | **fail** (navigate disabled in `onSuccess`) |
| `CreateTreacheryCardChapterJump` | pass | **fail** (`onFocusWarning` made a no-op) |
| `EditDeckMemberCountWrites` | pass | **fail** (`onCountChange` mutation disabled) |
| `AskQuestionMissingRuleset` | pass | **fail** (`errorComponent` removed) |

## Deliberate omissions

The two the ticket and the review specifically asked about:

**The homepage's staged pending and error stories, deferred here from #797, are not built.** They are feasible without seam work, so they do not trip the split condition, but they are not worth building: `PageMessage.stories.tsx` already exports `Loading`, `Failed` and `NoWayBack`, which are the exact frames the homepage uses, and the page-owned residue is two lines of route config shared by eleven routes for `errorComponent` and five for `pendingComponent`. Verified both counts. If that wiring is worth guarding it wants one cheap check across all sixteen, not two mock-driven stories on the one route where nothing page-owned happens. Raising that shape rather than building these.

**Login gates that read the profile session remain uncoverable.** `parameters.identity: null` leaves `profiles.session` unresolved rather than answering signed out, so a route gating on `profile.data === null` renders its editor in a story while gating correctly in production. The affected pages are the five asset create routes, `rulesets/create`, `groups/create`, `admin/migrations` and `profiles/$profileSlug/edit`. Routes gating on `!profile.data?.x` or on server-derived `viewerAccess.viewer.kind` are unaffected, which is why `Assets/EditDeckSignedOut` works. This list is also posted on #769 so it survives this PR's merge as tracked work.

Others, with the reason rather than a shrug:

- **Held deletion** is not played. The repo already decided this: `ConfirmDeleteAction.stories.tsx` says the full hold is pinned by the unit suite with fake timers because a story should not sit through it.
- **Group membership moderation** would need story-local seeding of a second user and a pending row, and what it would prove is a mutation-driven refresh already covered on the deck editor.
- **`/__icons` search** is unlinked developer tooling, reads nothing from the seeded database, and is the archetypal read-only story the ticket says to leave alone.
- **The other four asset editors and four create twins** are omitted on purpose: they differ from the covered ones in their widget and their nouns, not in their route-owned behaviour. Covering the contract once is the contract; covering it five times is the matrix the ticket rules out.
- **Rename-and-follow-slug** appears on four pages. It is not covered because the observable in a story is the page's own name refreshing from the query, which is the kind already covered, and the slug change itself is not observable without asserting the URL.

## Verified

Gates run individually and read from bare exit codes, not through a pipe: `lint` 0, `format:check` 0, `typecheck` 0, `publisher:typecheck` 0, `test` 0 (767), `storybook:test` 0 (460, up 4), `check:prose` 0, `knip` 0, `check:app-layout` 0, `check:css-orphans` 0, `check` 0 with no capture-bundle changes.

Worktree off `e50938b2df4` with its own install. The end-to-end suite is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for creating and saving cards, navigating to relevant chapters from validation warnings, and updating deck member counts.
  * Added coverage for missing ruleset errors, including visible messaging and back-link placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->